### PR TITLE
docs: lead with install-and-run, drop the v2-unstable framing

### DIFF
--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -12,4 +12,10 @@ code_blocks = false
 
 [MD033]
 # Allow the HTML used for the README feature-wall layout
-allowed_elements = ["table", "tr", "td", "img", "picture", "source", "a", "br", "div"]
+allowed_elements = [
+  "table", "tr", "td", "img", "picture", "source", "a", "br", "div",
+  # The README collapses its secondary install routes behind a disclosure;
+  # <summary> takes <b> rather than ** because markdown emphasis inside raw
+  # HTML renders inconsistently.
+  "details", "summary", "b",
+]

--- a/README.md
+++ b/README.md
@@ -4,139 +4,23 @@
   <img src="./website/assets/logo.svg" alt="thurbox" width="340">
 </div>
 
-Run any coding-agent CLI in persistent terminal sessions.
-Thurbox is a multi-session TUI orchestrator that launches
-Claude Code, Codex, Antigravity, opencode, aider — or any agent
-you describe — inside persistent tmux panes that survive
-crashes, restarts, and reboots. Sessions, agents, and git
-worktrees are first-class citizens.
+Run any coding-agent CLI — Claude Code, Codex, Antigravity, opencode, aider, or
+one you describe yourself — side by side in persistent tmux sessions, each on
+its own git worktree. Sessions survive crashes, restarts and reboots.
 
-**v2's headline feature: the whole interface is yours to shape.** There is no
-built-in UI compiled into the binary any more. thurbox boots a kernel, reads a
-directory of Lua files, and draws whatever it finds — so every pane, including
-the session list, is a file you can move, turn off, delete, rewrite, or install
-from someone else. The agents, hosts, themes, keybindings and settings behind
-it are data files you edit too. No fork, no recompile, no restart.
-
-**[Customization →](#customization)**
+And every pane you see is a **Lua file in a directory you own** — the session
+list included. Move it, turn it off, rewrite it, or install one somebody else
+wrote. No fork, no recompile, no restart. **[Customization →](#customization)**
 
 [![CI](https://github.com/Thurbeen/thurbox/workflows/CI/badge.svg)](https://github.com/Thurbeen/thurbox/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Website](https://img.shields.io/badge/Website-thurbox.thurbeen.eu-blue)](https://thurbox.thurbeen.eu/)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=Thurbeen_thurbox&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=Thurbeen_thurbox)
 
-> [!IMPORTANT]
-> **v2 is unstable. The latest stable release is v1 —
-> [v1.8.7](https://github.com/Thurbeen/thurbox/releases/tag/v1.8.7).**
-> v2 is published and usable, but it is still moving: the plugin kernel, the
-> `thurbox.*` snapshot shape and the bundled panes are all subject to change
-> between releases, and a change there can break panes you wrote or installed.
-> Use it if you want the customizable interface and can absorb that; stay on v1
-> if you want the version that does not move under you.
->
-> **v2 is also not a drop-in v1.** The interface is now Lua plugins on
-> a Rust kernel — which is what makes it fully customizable, and is also why some
-> v1 surfaces did not come with it. They were compiled-in panes; they are panes
-> anyone can write now, and two of them have already been rewritten that way:
->
-> | Gone from the binary | v1 chord | Where it lives now |
-> |---|---|---|
-> | Code review | `Ctrl+X` / `F7` | the [`thurbox-code-review`](https://github.com/Thurbeen/thurbox-code-review) plugin |
-> | File viewer | `Ctrl+E` / `F3` | nothing yet |
-> | Info panel | `Ctrl+B` / `F2` | the [`thurbox-info-panel`](https://github.com/Thurbeen/thurbox-info-panel) plugin |
-> | Tasks panel | `Ctrl+W` / `F5` | `thurbox-cli task` |
-> | Automations pane | `Ctrl+P` | `thurbox-cli automation` |
->
-> Installing a plugin is a clone:
->
-> ```bash
-> thurbox-cli plugin install git+https://github.com/Thurbeen/thurbox-code-review
-> thurbox-cli plugin install git+https://github.com/Thurbeen/thurbox-info-panel
-> ```
->
-> The review pane takes the centre slot beside the agent and reclaims `Ctrl+X` /
-> `F7` on its own; the info panel wants one line in your `layout.lua` to give the
-> column a place (its README has it).
->
-> Each freed chord is otherwise deliberately left **unbound** rather than reused,
-> so no muscle memory quietly does something else. Everything outside the
-> interface — sessions, agents, worktrees, remote hosts, automations, your
-> database — is unchanged.
->
-> The table above lists only what *left*. For the full map — what is bundled,
-> what installs, what is owed, and what v2 gained — see
-> [What v1 had, and where it is in v2](#what-v1-had-and-where-it-is-in-v2).
->
-> **Upgrading to v2 is never automatic.** Auto-update does not cross a major
-> version: a 1.x install is told 2.x exists and keeps updating along 1.x. You
-> cross on purpose, with `thurbox-cli update --force` or a fresh install. And the
-> first v2 launch of a profile with v1 history asks once, before anything changes
-> — answering `q` there prints the reinstall command for 1.x.
->
-> **To go back to v1** — the stable line:
->
-> ```bash
-> # export, not a prefix: `VERSION=… curl | sh` binds it to curl, not to the sh
-> export VERSION=v1.8.7
-> curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh
-> ```
->
-> ```powershell
-> $env:THURBOX_VERSION = 'v1.8.7'
-> irm https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.ps1 | iex
-> ```
->
-> v1 is maintained on the
-> [`v1.x`](https://github.com/Thurbeen/thurbox/tree/v1.x) branch; 1.x patches are
-> on the [releases page](https://github.com/Thurbeen/thurbox/releases).
-
 ![Thurbox Demo](./docs/media/thurbox-demo.gif)
 
 ## Installation
 
-> [!IMPORTANT]
-> **Install v1 unless you specifically want v2's customizable interface.** v1.8.7
-> is the latest stable release; v2 is the newest one, and it is unstable. Every
-> installer takes the *newest* release unless you pin a version, so the
-> recommended commands below pin it. The package-manager channels (winget,
-> Chocolatey, Homebrew, AUR) publish only the newest release and **cannot** pin
-> v1 — on those channels the shell/PowerShell installers are the way to v1.
-
-> [!NOTE]
-> **Windows uses psmux, not tmux.** Every Windows route needs
-> [psmux](https://github.com/psmux/psmux), a drop-in tmux clone on ConPTY that
-> speaks the same control-mode protocol, installed separately. (A WSL distro is
-> a remote host and runs tmux inside the distro.) psmux is the newer of the two
-> and a bit less stable, so please report anything you hit.
-
-### Recommended: v1, the stable line
-
-**Linux / macOS:**
-
-```bash
-export VERSION=v1.8.7
-curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh
-```
-
-**Windows (PowerShell):**
-
-```powershell
-$env:THURBOX_VERSION = 'v1.8.7'
-irm https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.ps1 | iex
-```
-
-> [!WARNING]
-> **`export` / `$env:` on its own line is not a style choice.** In
-> `VERSION=v1.8.7 curl … | sh` the assignment binds to `curl`, and the `sh`
-> reading from the pipe never sees it — you get the newest release, silently.
-> Set the variable first, on its own line.
-
-That install stays on v1: thurbox's auto-update **never crosses a major
-version**, so a 1.x binary will not wake up running 2.x. It still *reports* that
-2.x exists; `thurbox-cli update --force` is the deliberate way across.
-
-### The newest release (v2, unstable)
-
 **Linux / macOS:**
 
 ```bash
@@ -149,99 +33,173 @@ curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/insta
 irm https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.ps1 | iex
 ```
 
-Installs the latest release — currently the unstable v2 — with checksum
-verification and platform auto-detection, to `~/.local/bin` on Linux/macOS and
-`%LOCALAPPDATA%\Programs\thurbox` (added to your user `PATH`) on Windows.
+That installs both binaries — `thurbox` (the TUI) and `thurbox-cli` (the
+headless one) — with checksum verification and platform auto-detection, to
+`~/.local/bin` on Linux/macOS and `%LOCALAPPDATA%\Programs\thurbox` (added to
+your user `PATH`) on Windows.
 
-**Other options:**
+You also need **tmux ≥ 3.2** (or [psmux](https://github.com/psmux/psmux) on
+native Windows), **git**, and at least one coding-agent CLI — see
+[Prerequisites](#prerequisites).
 
-```bash
-# Custom directory
-export INSTALL_DIR=/usr/local/bin
-curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh
+<details>
+<summary><b>Other ways to install</b> — Homebrew · AUR · winget · Chocolatey · from source</summary>
 
-# Pin any version — PowerShell uses $env:THURBOX_VERSION / $env:THURBOX_INSTALL_DIR
-export VERSION=v1.0.0
-curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh
-```
-
-**winget (Windows):**
-
-```powershell
-winget install Thurbeen.thurbox
-```
-
-Installs the prebuilt x86_64 Windows binaries (`thurbox.exe` +
-`thurbox-cli.exe`) from the GitHub Release as portable commands on your `PATH`.
-Needs [psmux](https://github.com/psmux/psmux) as the multiplexer (installed
-separately). Live on
-[`microsoft/winget-pkgs`](https://github.com/microsoft/winget-pkgs).
-
-**Chocolatey (Windows):**
-
-```powershell
-choco install thurbox
-```
-
-Installs the prebuilt x86_64 Windows binaries (`thurbox.exe` +
-`thurbox-cli.exe`) from the GitHub Release and shims them onto your `PATH`.
-Needs [psmux](https://github.com/psmux/psmux) as the multiplexer (installed
-separately — there is no Chocolatey package for it).
-
-> [!TIP]
-> **On Windows, `irm … install.ps1 | iex` is the recommended route** — and the
-> only Windows route that can install v1. Both winget-pkgs and the Chocolatey
-> community repo are *manually moderated* and rate-limited, so thurbox publishes
-> to each **at most once every 30 days** (intermediate releases are coalesced
-> into the next submission). Those channels carry only the newest release,
-> lagging behind it; the PowerShell installer and
-> [GitHub Releases](https://github.com/Thurbeen/thurbox/releases) have every
-> version immediately.
-
-**Homebrew (macOS / Linux):**
+**Homebrew (macOS Apple Silicon / Linux x86_64):**
 
 ```bash
 brew install thurbeen/thurbox/thurbox
 ```
 
-Installs the prebuilt release binaries (`thurbox` + `thurbox-cli`)
-from the [tap](https://github.com/Thurbeen/homebrew-thurbox), with
-`tmux` and `git` pulled in as dependencies. Supports macOS arm64
-(Apple Silicon) and Linux x86_64.
+Prebuilt binaries from the [tap](https://github.com/Thurbeen/homebrew-thurbox),
+with `tmux` and `git` pulled in as dependencies.
 
 **Arch Linux (AUR):**
-
-Thurbox is on the AUR as
-[`thurbox`](https://aur.archlinux.org/packages/thurbox) (builds
-from source) and
-[`thurbox-bin`](https://aur.archlinux.org/packages/thurbox-bin)
-(prebuilt release binary). Install with your AUR helper:
 
 ```bash
 paru -S thurbox-bin   # prebuilt binary (fastest)
 paru -S thurbox       # build from source
 ```
 
-`tmux` is pulled in as a dependency. (Swap `paru` for `yay` or
-your preferred helper.)
+(Swap `paru` for `yay` or your preferred helper.)
+
+**winget / Chocolatey (Windows x86_64):**
+
+```powershell
+winget install Thurbeen.thurbox
+choco install thurbox
+```
+
+Both install the prebuilt `thurbox.exe` + `thurbox-cli.exe` onto your `PATH` and
+need [psmux](https://github.com/psmux/psmux) installed separately. Both channels
+are manually moderated, so thurbox publishes to each at most once every 30 days
+— they trail the newest release. The PowerShell installer and
+[GitHub Releases](https://github.com/Thurbeen/thurbox/releases) have every
+version immediately.
 
 **From source:**
 
 ```bash
-sudo pacman -S --needed git tmux rust   # Arch deps; use your distro's equivalent
 git clone https://github.com/Thurbeen/thurbox.git
 cd thurbox
-git checkout v1.x                       # omit for the unstable v2 on main
-cargo build --release
-# binary at target/release/thurbox
+cargo build --release   # binaries at target/release/
 ```
 
-See [Prerequisites](#prerequisites) for required tooling.
+**Pin a version or change the install directory:**
+
+```bash
+# `export` on its own line: in `VERSION=… curl … | sh` the assignment binds to
+# curl, and the sh reading from the pipe never sees it.
+export VERSION=v2.5.4
+export INSTALL_DIR=/usr/local/bin
+curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh
+```
+
+PowerShell uses `$env:THURBOX_VERSION` / `$env:THURBOX_INSTALL_DIR` the same way.
+
+</details>
 
 **Contributing / hacking on thurbox?** The dev environment is a reproducible Nix
 flake (`nix develop` / `direnv allow`) with `just` tasks and an isolated runtime
 sandbox (`scripts/dev/sandbox.sh`) — see
 [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md).
+
+## Prerequisites
+
+- **tmux >= 3.2** (Linux / macOS), or **[psmux](https://github.com/psmux/psmux)**
+  on native Windows — a drop-in tmux clone thurbox drives identically
+- **A coding-agent CLI** — e.g.
+  [claude](https://github.com/anthropics/claude-code), codex,
+  antigravity, opencode, or aider (whichever agents you plan to run)
+- **git** (required for worktree features)
+- **Rust 1.75+** (only to build from source)
+
+## Getting Started
+
+Run it:
+
+```bash
+thurbox
+```
+
+That is the whole setup. On first launch thurbox seeds its config — the agents
+it knows, the themes, and the interface itself — into `~/.config/thurbox/`, then
+draws a session list on the left and an agent terminal on the right.
+
+1. **Create your first session** — press `Ctrl+N` to open the repo picker.
+   Toggle repos with `Space`; press `w` on a repo to mark it as worktree mode
+   (you'll be prompted for a base branch and new branch name). Confirm with
+   `Enter`, name the session, then pick an **agent**. The agent picker is
+   skipped when only one agent is defined.
+2. **Work with the agent** — the right pane is a live agent session. All keys
+   are forwarded to it; `Ctrl+C` copies if you have a selection, otherwise sends
+   SIGINT.
+3. **Navigate** — `Ctrl+J` / `Ctrl+K` move between sessions, `Ctrl+L` /
+   `Ctrl+H` cycle focus between panes, `Ctrl+/` searches sessions *and the text
+   on their screens*. `Ctrl+O` opens the session's worktree in your editor.
+4. **Quit without killing** — `Ctrl+Q` detaches. Tmux keeps every agent
+   running; relaunch `thurbox` and they are all still there. (Prefer raw tmux?
+   `tmux -L thurbox attach`.)
+5. **Make it yours** — `Ctrl+,` then `]` lists every pane and lets you turn one
+   off; `Ctrl+Y` changes the palette; `F1` rebinds any chord. `F10` reloads the
+   interface from disk.
+
+`F1` is the authoritative key list — it renders the live registry, so it cannot
+drift. The full table is in [Keybindings](#keybindings).
+
+## Just ask for it
+
+Thurbox runs coding agents, and the two things you would otherwise script by
+hand — *fleets of sessions* and *the interface itself* — are both reachable in
+plain English from inside a session. `thurbox-cli` is installed beside
+`thurbox`, so it is already on the agent's `PATH`, and the interface is a
+directory of text files it can read.
+
+### Orchestrate sessions
+
+`thurbox-cli` creates, prompts, forks and tears down sessions headlessly, so an
+agent can spin up a fleet for you. From any session, ask:
+
+> - *Using `thurbox-cli`, start refactor sessions for this repo — one per
+>   crate, each on its own worktree branch off `main`, and send each one a
+>   prompt to refactor its crate. Then show me `thurbox-cli session list`.*
+> - *Spawn a reviewer session on this repo with no worktree, and send it
+>   standing instructions to review every file I change.*
+> - *Create a nightly automation that sends "triage new issues" to the `triage`
+>   session on weekdays at 09:00.*
+
+The agent discovers the surface itself with `thurbox-cli --help`; the commands
+it will reach for are `session create` (with `--worktree-branch`, `--agent`,
+`--host`, `--add-repo`), `session send`, `session list` and `automation create`
+— all documented under [Headless CLI](#headless-cli-thurbox-cli). Everything it
+does shows up in your running TUI within a tick, because both binaries share one
+SQLite database.
+
+Prefer a script? [Recipe: provision a monorepo headless](#recipe-provision-a-monorepo-headless)
+does the same thing in bash.
+
+### Reshape the interface
+
+Every pane is a Lua file, so changing the UI is also just a request. From any
+session, ask:
+
+> - *Add my project logs within a dedicated pane on the right in the thurbox
+>   UI.*
+> - *Add a pane on the left with CPU and RAM usage. There is a `top` example
+>   plugin — install it and give it a slot in the layout.*
+> - *Move the search strip to the bottom and make the session column 30% wide.*
+> - *The session list is too noisy — drop the repo group headers and show the
+>   branch instead of the agent name.*
+> - *Install the info panel plugin.*
+
+That works from **any** session, in whichever CLI you run, because thurbox ships
+a built-in `ui-skill` extension: a `thurbox-ui` skill that loads only when the
+request is about the interface. It tells the agent that `thurbox-cli plugin dir`
+finds the directory, that `thurbox-cli plugin check` verifies its own work, and
+warns it off the mistakes that are invisible until runtime. Press `F10` and the
+change is on your screen.
+
+[More on what that looks like →](#ask-the-agent-to-do-it)
 
 ## Why Thurbox
 
@@ -267,6 +225,9 @@ adds:
 - **Git worktree isolation** — each session can spawn on a fresh
   worktree; `Ctrl+S` syncs them with their base branch and asks the
   agent to resolve rebase conflicts automatically.
+- **Scriptable, or just askable** — `thurbox-cli` drives the same
+  sessions headlessly, so an agent *inside* a session can spin up a
+  fleet on your behalf. [More →](#just-ask-for-it)
 
 ## Comparison
 
@@ -651,32 +612,26 @@ to the next session you create. Whole workflows are a layer above all of this �
 
 ### Ask the agent to do it
 
-You do not have to learn Lua to change the interface. thurbox runs coding
-agents, and the interface is a directory of plain text files those agents can
-read — so the shortest path to a change is usually to point a session at that
-directory and ask in English:
+You do not have to learn Lua to change the interface — [Just ask for
+it](#just-ask-for-it) above has the prompts, and they work from any session
+because the built-in `ui-skill` extension teaches whichever CLI you run how the
+interface is put together.
+
+Want the agent looking at the files directly instead? Point a session at the
+directory:
 
 ```bash
 thurbox-cli plugin dir          # prints the directory
 thurbox-cli session create --name ui --repo-path ~/.config/thurbox/ui
 ```
 
-Then prompts like these do the whole job:
+The directory ships an **`AGENTS.md`** that any coding CLI loads as context
+without being asked. It is what stops "install a plugin" being read as an npm
+request, tells the agent that `thurbox-cli plugin check` is how it verifies its
+own work, and warns it off the mistakes that are invisible until runtime. Press
+`F10` and the change is on your screen.
 
-> - *Install the info panel plugin.*
-> - *Add a new pane on the left with CPU and RAM usage. There is a `top` example
->   plugin — install it and give it a slot in the layout.*
-> - *Move the search strip to the bottom, and make the session column 30% wide.*
-> - *The session list is too noisy — drop the repo group headers and show the
->   branch instead of the agent name.*
-
-That works because the directory ships an **`AGENTS.md`** that any coding CLI
-loads as context without being asked. It is what stops "install a plugin" being
-read as an npm request, tells the agent that `thurbox-cli plugin check` is how
-it verifies its own work, and warns it off the mistakes that are invisible until
-runtime. Press `F10` and the change is on your screen.
-
-#### What that second prompt actually does
+#### What a prompt like "add a CPU/RAM pane on the left" actually does
 
 Worth seeing once, because **every** interface change has this shape — a pane,
 and a slot for it:
@@ -819,16 +774,6 @@ a different name — possible on equal terms.
   dot) and `ui-skill` (whichever agent you run learns how to edit thurbox's own
   interface, from any session).
 
-## Prerequisites
-
-- **tmux >= 3.2** (Linux / macOS), or **[psmux](https://github.com/psmux/psmux)**
-  on native Windows — a drop-in tmux clone thurbox drives identically
-- **A coding-agent CLI** — e.g.
-  [claude](https://github.com/anthropics/claude-code), codex,
-  antigravity, opencode, or aider (whichever agents you plan to run)
-- **git** (required for worktree features)
-- **Rust 1.75+** (only to build from source)
-
 ## Uninstall
 
 Remove the binary, depending on how you installed it:
@@ -853,36 +798,6 @@ session history, theme, and `agents.toml`):
 ```bash
 rm -rf ~/.local/share/thurbox ~/.config/thurbox
 ```
-
-## Getting Started
-
-1. **Launch** — run `thurbox`. You'll see a sidebar on the left
-   listing your sessions and a terminal panel on the right — that is
-   the *default* arrangement, materialised into
-   `~/.config/thurbox/ui/` on first run, and every part of it is
-   yours to change.
-2. **Create your first session** — press `Ctrl+N` to open the repo
-   picker. Toggle repos with `Space`; press `w` on a repo to mark
-   it as worktree mode (you'll be prompted for a base branch and
-   new branch name). Confirm with `Enter`, name the session, then
-   pick an **agent**. The agent picker is skipped when only one
-   agent is defined.
-3. **Work with the agent** — the right pane is a live agent
-   session. All keys are forwarded to the PTY; `Ctrl+C` copies if
-   you have a selection, otherwise sends SIGINT.
-4. **Navigate** — `Ctrl+J` / `Ctrl+K` move between sessions in the
-   sidebar; `Ctrl+L` / `Ctrl+H` cycle focus between panes.
-   `Ctrl+O` opens the session's worktree in your editor.
-5. **Quit without killing** — `Ctrl+Q` detaches all sessions.
-   Tmux keeps them running; relaunch `thurbox` and they resume.
-6. **Make it yours** — `Ctrl+,` then `]` lists every pane and lets
-   you turn one off; `Ctrl+Y` changes the palette; `F1` rebinds any
-   chord. When you want to go further, the panes are Lua files in
-   the directory `thurbox-cli plugin dir` prints, and `F10` reloads
-   them.
-
-See the full [keybindings](#keybindings) below, and
-[Customization](#customization) for the rest.
 
 ## Agents
 
@@ -1369,11 +1284,15 @@ architectural decisions with rationale, see
 [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md); for the kernel itself, see
 [docs/V2-KERNEL.md](docs/V2-KERNEL.md).
 
-**Moving from v1?** v2 is the unstable line: some panes are owed rather than
-ported, some moved to `thurbox-cli`, and the kernel's plugin contract can still
-change between releases. The note at the top of this file has the list, what
-asks you before anything changes, and how to stay on the stable v1 — which is
-maintained on the `v1.x` branch.
+**Moving from v1?** The interface is Lua plugins now, so a few v1 panes are
+installable rather than compiled in and two moved to `thurbox-cli` —
+[What v1 had, and where it is in v2](#what-v1-had-and-where-it-is-in-v2) is the
+full map. Everything outside the interface — sessions, agents, worktrees, remote
+hosts, automations, your database — is unchanged. Auto-update never crosses a
+major version, so a 1.x install is told 2.x exists and stays where it is;
+`thurbox-cli update --force` is the deliberate way across, and the first v2
+launch of a profile with v1 history asks once before anything changes. v1 is
+maintained on the [`v1.x`](https://github.com/Thurbeen/thurbox/tree/v1.x) branch.
 
 ## Documentation
 

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -1,10 +1,16 @@
 # Writing a thurbox plugin
 
-> **The API is public but unstable.** It will change without a deprecation
-> period until it settles. Plugins are **trusted code**: they run in-process
-> with whatever capabilities the kernel grants, exactly like the shell
-> extensions under `extensions/`. Install one the way you would install a shell
-> script from a stranger — which is to say, read it first.
+> **The API is settled in its essentials, not frozen.** The four node kinds and
+> the snapshot-read/command-write split are load-bearing and asserted by tests.
+> What still moves is the published `thurbox.*` shape: a field can be added,
+> renamed or dropped in a minor release. `plugins.lock` records the commit each
+> installed pane resolved to, so pin what you install and re-run
+> `thurbox-cli plugin check` after an upgrade.
+>
+> **Plugins are trusted code.** They run in-process with whatever capabilities
+> the kernel grants, exactly like the shell extensions under `extensions/`.
+> Install one the way you would install a shell script from a stranger — which
+> is to say, read it first.
 
 A plugin is one `.lua` file. Drop it in your plugin directory and it loads on the
 next save; there is no build step and no restart.

--- a/website/css/landing.css
+++ b/website/css/landing.css
@@ -1368,3 +1368,24 @@ main {
 .ui-lab__demo pre {
   max-width: 68ch;
 }
+
+/* ---- "Just ask for it" cards ----
+   Two parallel categories in a .grid-2 of .card, each holding a prose lede,
+   a .prompts list and a footer link. .card sets `p { margin-bottom: 0 }` so
+   the cards read as one block by default; these rules put the spacing back
+   between the three parts and pin the footer link to the bottom, so two cards
+   of unequal prompt count still line their links up. */
+.ask-card {
+  display: flex;
+  flex-direction: column;
+}
+
+.ask-card > p:not(.ask-card__more),
+.ask-card .prompts {
+  margin-bottom: var(--space-md);
+}
+
+.ask-card__more {
+  margin-top: auto;
+  font-size: 0.9rem;
+}

--- a/website/docs/extension-flow.html
+++ b/website/docs/extension-flow.html
@@ -181,6 +181,6 @@ thurbox-cli extension uninstall flow    # --purge also deletes ~/.config/thurbox
             ,
             <code>parse-result.sh</code>
             ). The
-            <a href="features.html#flow-extension">Features</a>
-            page covers the design rationale.
+            <a href="extensions.html#manifest">Extensions</a>
+            page covers the manifest format and the install/self-heal model behind it.
           </p>

--- a/website/docs/faq.html
+++ b/website/docs/faq.html
@@ -62,13 +62,15 @@ breadcrumb: 'FAQ'
 
 <h2 id="which-version">Which version should I install?</h2>
 <p>
-  <strong>1.x is the latest stable line</strong> (newest release
-  <a href="https://github.com/Thurbeen/thurbox/releases/tag/v1.8.7">v1.8.7</a>), and the one to run
-  if you want a version that does not change under you. <strong>2.x is unstable</strong>: it is
-  where the customizable Lua interface lives, but its kernel, the snapshot panes read, and the panes
-  it ships can still change between releases &mdash; which can break panes you wrote or installed.
-  Every installer takes the newest release unless you pin a version, so 2.x is what you get by
-  default. Pinning v1 is one line before the installer:
+  <strong>The newest one</strong>, which is what every installer gives you by default &mdash; no
+  pin, no flags. 2.x is the current line: it is where the customizable Lua interface lives, and
+  where new features land.
+</p>
+<p>
+  1.x is still maintained on the <code>v1.x</code> branch and still gets bug and security fixes. Run
+  it if you want a pane 2.x does not have &mdash; the file viewer has no replacement yet, and code
+  review and the info panel are plugins you install rather than built-ins. Pinning it is one line
+  before the installer:
 </p>
 <pre data-wrap><code class="language-bash">export VERSION=v1.8.7
 curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh</code></pre>
@@ -153,7 +155,7 @@ irm https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.ps1 
         "name": "Which version should I install?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "1.x is the latest stable line (newest release v1.8.7), and the recommended one to install if you want a version that does not change under you. 2.x is unstable: it is where the customizable Lua interface lives, but its kernel, the snapshot panes read, and the panes it ships can still change between releases — which can break panes you wrote or installed. Every installer takes the newest release unless you pin a version, so 2.x is what you get by default. To install v1, set the version on its own line first and then run the installer: export VERSION=v1.8.7 followed by curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh on Linux or macOS, or $env:THURBOX_VERSION = 'v1.8.7' followed by irm https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.ps1 | iex on Windows. That pin holds, because thurbox auto-update never crosses a major version: a 1.x install is told 2.x exists and is never moved onto it. The package-manager channels (winget, Chocolatey, Homebrew, AUR) publish only the newest release and cannot pin v1."
+          "text": "The newest one, which is what every installer gives you by default — no pin, no flags. 2.x is the current line: it is where the customizable Lua interface lives, and where new features land. 1.x is still maintained on the v1.x branch and still gets bug and security fixes; run it if you want a pane 2.x does not have — the file viewer has no replacement yet, and code review and the info panel are plugins you install rather than built-ins. To install v1, set the version on its own line first and then run the installer: export VERSION=v1.8.7 followed by curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh on Linux or macOS, or $env:THURBOX_VERSION = 'v1.8.7' followed by irm https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.ps1 | iex on Windows. That pin holds, because thurbox auto-update never crosses a major version: a 1.x install is told 2.x exists and is never moved onto it. The package-manager channels (winget, Chocolatey, Homebrew, AUR) publish only the newest release and cannot pin v1."
         }
       },
       {

--- a/website/docs/index.html
+++ b/website/docs/index.html
@@ -92,7 +92,7 @@ currentPage: 'index'
                 <div class="card-icon" aria-hidden="true">&#x21BA;</div>
                 <h3>Using v1</h3>
                 <p>
-                  1.x is the latest stable line, and still maintained. What it has that the current
+                  1.x is still maintained for bug and security fixes. What it has that the current
                   interface does not, and how to stay on it.
                 </p>
               </div>

--- a/website/docs/installation.html
+++ b/website/docs/installation.html
@@ -12,51 +12,24 @@ breadcrumb: 'Installation'
             <a href="#from-binary" class="heading-anchor">#</a>
           </h2>
 
-          <div class="info-box warning">
-            <p>
-              <strong>The newest release is 2.x, and 2.x is unstable.</strong>
-              Every route on this page installs it by default. The latest stable release is
-              <a href="https://github.com/Thurbeen/thurbox/releases/tag/v1.8.7">v1.8.7</a>
-              on the 1.x line, and it is the
-              <strong>recommended</strong>
-              one unless you specifically want 2.x&rsquo;s customizable Lua interface. Only the
-              shell and PowerShell installers can pin it; the package-manager channels below
-              always carry the newest release. See
-              <a href="v1.html">using v1</a>.
-            </p>
-          </div>
-
-          <h3 id="recommended-v1">Recommended: install v1, the stable line</h3>
-          <p>Linux and macOS:</p>
-          <pre data-wrap><code class="language-bash">export VERSION=v1.8.7
-curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh</code></pre>
-          <p>Windows (PowerShell 5.1+):</p>
-          <pre data-wrap><code class="language-powershell">$env:THURBOX_VERSION = 'v1.8.7'
-irm https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.ps1 | iex</code></pre>
           <p>
-            The pin holds after install: thurbox&rsquo;s auto-update
-            <strong>never crosses a major version</strong>, so a 1.x install is told that 2.x
-            exists and is never moved onto it.
-            <code>thurbox-cli update --force</code>
-            is the deliberate way across. (That guard is in the binary, and releases up to v1.8.7
-            predate it &mdash; if you are already running 1.8.x, set
-            <code>auto_update = false</code>
-            until a 1.x patch carrying it ships.)
-          </p>
-
-          <h3 id="newest-release">The newest release (2.x, unstable)</h3>
-          <p>
-            The install script downloads the latest release, detects your platform, and verifies
-            checksums automatically.
+            One command on Linux and macOS. The install script downloads the latest release,
+            detects your platform, verifies checksums, and installs both binaries &mdash;
+            <code>thurbox</code>
+            (the TUI) and
+            <code>thurbox-cli</code>
+            (the headless one) &mdash; to
+            <code>~/.local/bin</code>
+            .
           </p>
 
           <pre data-wrap><code class="language-bash">curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh</code></pre>
 
-          <p>
-            This installs to
-            <code>~/.local/bin</code>
-            by default. The script handles:
-          </p>
+          <p>Then run it:</p>
+
+          <pre><code class="language-bash">thurbox</code></pre>
+
+          <p>The script handles:</p>
           <ul>
             <li>Platform detection (Linux/macOS, x86_64/aarch64)</li>
             <li>Automatic version fetching with API rate limit fallback</li>
@@ -71,7 +44,8 @@ irm https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.ps1 
 
           <div class="info-box">
             <p>
-              <strong><code>export</code> is not optional here.</strong>
+              <strong><code>export</code> is not optional</strong>
+              for the environment variables below.
               In <code>VAR=x curl … | sh</code> the assignment binds to
               <code>curl</code>, and the <code>sh</code> reading from the pipe never sees it &mdash;
               so the setting is silently ignored. Export it on its own line first.
@@ -83,14 +57,14 @@ irm https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.ps1 
 curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh</code></pre>
 
           <h3 id="specific-version">Specific version</h3>
-          <pre data-wrap><code class="language-bash">export VERSION=v1.8.7
+          <pre data-wrap><code class="language-bash">export VERSION=v2.5.4
 curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh</code></pre>
           <p>
-            Pinning is how you take the stable line rather than the unstable newest release, and how
-            you
-            <a href="v1.html">stay on 1.x</a>
-            &mdash; the newest patch is on the
-            <a href="https://github.com/Thurbeen/thurbox/releases">releases page</a>.
+            Without a pin you get the newest release. Every version is on the
+            <a href="https://github.com/Thurbeen/thurbox/releases">releases page</a>
+            , including the 1.x line &mdash; see
+            <a href="v1.html">using v1</a>
+            if you need it.
           </p>
 
           <h3>Windows (PowerShell)</h3>
@@ -117,8 +91,8 @@ curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/insta
           <pre data-wrap><code class="language-powershell">irm https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.ps1 | iex</code></pre>
           <p>
             Set
-            <code>$env:THURBOX_VERSION = 'v1.8.7'</code>
-            before that line for the latest stable release instead of the newest one.
+            <code>$env:THURBOX_VERSION = 'v2.5.4'</code>
+            before that line to pin a specific version instead of taking the newest.
           </p>
 
           <h3>Available platforms</h3>
@@ -358,7 +332,7 @@ cargo build --release</code></pre>
               &mdash; press
               <code>Ctrl+N</code>
               to open the repo picker. Pick repos (optionally a worktree), name the session, then
-              choose an agent and a model.
+              choose an agent.
             </li>
             <li>
               <strong>Work with the agent</strong>
@@ -382,6 +356,20 @@ cargo build --release</code></pre>
               &mdash;
               <code>Ctrl+Q</code>
               detaches all sessions (tmux keeps them running). They resume on next launch.
+            </li>
+            <li>
+              <strong>Make it yours</strong>
+              &mdash;
+              <code>Ctrl+,</code>
+              then
+              <code>]</code>
+              lists every pane and lets you turn one off,
+              <code>Ctrl+Y</code>
+              changes the palette,
+              <code>F1</code>
+              rebinds any chord. Or just ask an agent &mdash; see
+              <a href="orchestration.html#just-ask">just ask for it</a>
+              .
             </li>
           </ol>
 

--- a/website/docs/orchestration.html
+++ b/website/docs/orchestration.html
@@ -15,6 +15,69 @@ breadcrumb: 'Orchestration'
   repo &mdash; and points at a template you can start from.
 </p>
 
+<h2 id="just-ask">
+  Start by just asking
+  <a href="#just-ask" class="heading-anchor">#</a>
+</h2>
+<p>
+  Before any of the structure below: you do not have to write the orchestration yourself.
+  <code>thurbox-cli</code>
+  is installed beside
+  <code>thurbox</code>
+  , so it is already on every session agent&rsquo;s
+  <code>PATH</code>
+  &mdash; from inside any session you can ask for a fleet in English.
+</p>
+<ul class="prompts">
+  <li>
+    Using
+    <code>thurbox-cli</code>
+    , start refactor sessions for this repo &mdash; one per crate, each on its own worktree branch
+    off
+    <code>main</code>
+    , and send each one a prompt to refactor its crate. Then show me
+    <code>thurbox-cli session list</code>
+    .
+  </li>
+  <li>
+    Spawn a reviewer session on this repo with no worktree, and send it standing instructions to
+    review every file I change.
+  </li>
+  <li>
+    Create a nightly automation that sends &ldquo;triage new issues&rdquo; to the
+    <code>triage</code>
+    session on weekdays at 09:00.
+  </li>
+</ul>
+<p>
+  The agent discovers the surface with
+  <code>thurbox-cli --help</code>
+  ; the commands it reaches for are
+  <code>session create</code>
+  (with
+  <code>--worktree-branch</code>
+  ,
+  <code>--agent</code>
+  ,
+  <code>--host</code>
+  ,
+  <code>--add-repo</code>
+  ),
+  <code>session send</code>
+  ,
+  <code>session list</code>
+  and
+  <code>automation create</code>
+  . Everything it does shows up in your running TUI within a tick, because the TUI and the CLI
+  share one SQLite database. The
+  <a href="recipes.html">recipes</a>
+  page has the same thing written as bash, if you would rather commit a script.
+</p>
+<p>
+  That covers a handful of sessions on one goal. The rest of this page is about what changes when
+  you are doing it across many repos, repeatedly.
+</p>
+
 <h2 id="problem">
   The problem
   <a href="#problem" class="heading-anchor">#</a>

--- a/website/docs/v1.html
+++ b/website/docs/v1.html
@@ -7,18 +7,17 @@ breadcrumb: 'Using v1'
 ---
 <h1>Using v1</h1>
 <p>
-  <strong>1.x is the latest stable line</strong>, and the one to run if you want a thurbox that does
-  not move under you. 2.x is published but <strong>unstable</strong>: it replaced the interface with
-  a plugin kernel that is still changing between releases. If you were using a pane 2.x no longer
-  has, you do not have to give it up &mdash; 1.x is still maintained and still gets patch releases.
+  <strong>2.x is the current line</strong>, and what every installer gives you by default. 1.x is
+  still maintained and still gets patch releases, so if you were using a pane 2.x does not have,
+  you do not have to give it up &mdash; this page is how to stay on it or go back.
 </p>
 
-<div class="info-box warning">
+<div class="info-box">
   <p>
-    <strong>The latest stable release is
+    <strong>The last 1.x release is
     <a href="https://github.com/Thurbeen/thurbox/releases/tag/v1.8.7">v1.8.7</a>.</strong>
-    Every installer takes the newest release &mdash; currently 2.x &mdash; unless you pin a version,
-    so staying here is a deliberate two-step: pin, then turn auto-update off. Both are below.
+    Every installer takes the newest release unless you pin a version, so staying here is a
+    deliberate two-step: pin, then turn auto-update off. Both are below.
   </p>
 </div>
 
@@ -153,8 +152,7 @@ irm https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.ps1 
   <li><strong>Will</strong>: bug fixes, security fixes, and fixes to the session engine, backends and
     CLI, released as 1.x patch versions from the <code>v1.x</code> branch.</li>
   <li><strong>Will not</strong>: new features. Those land on the 2.x line, where the interface is
-    a plugin set rather than a fixed set of panes &mdash; and where the plugin contract is still
-    settling, which is why 2.x is the unstable one.</li>
+    a plugin set rather than a fixed set of panes.</li>
 </ul>
 <p>
   The reference documentation on this site describes the current interface. For v1's own docs, read

--- a/website/docs/v2-interface.html
+++ b/website/docs/v2-interface.html
@@ -7,28 +7,12 @@ breadcrumb: 'Interface'
 ---
 <h1>The Interface</h1>
 <p>
-  Alongside
-  <code>thurbox</code>
-  there is
-  <code>thurbox</code>: the same session engine behind a Lua-driven renderer, where every pane
-  &mdash; the session list included &mdash; is a plugin under
+  There is no built-in UI compiled into
+  <code>thurbox</code>. The binary boots a kernel, reads a directory of Lua files, and draws
+  whatever it finds &mdash; so every pane, the session list included, is a plugin under
   <code>ui/</code>. You can edit one, replace one with a file of your own, turn one off, or delete
   it.
 </p>
-
-<div class="info-box warning">
-  <p>
-    <strong>2.x is the unstable line.</strong>
-    Everything on this page is published and usable, but it is still settling: the kernel, the
-    <code>thurbox.*</code>
-    snapshot a pane reads, and the panes thurbox ships can all change between releases, and a change
-    there can break panes you wrote or installed. The latest
-    <strong>stable</strong>
-    release is
-    <a href="https://github.com/Thurbeen/thurbox/releases/tag/v1.8.7">v1.8.7</a>, on the
-    <a href="v1.html">1.x line</a>.
-  </p>
-</div>
 
 <div class="info-box">
   <p>
@@ -57,17 +41,14 @@ breadcrumb: 'Interface'
   <a href="#ask-the-agent" class="heading-anchor">#</a>
 </h2>
 <p>
-  You do not have to learn Lua to change the interface. thurbox runs coding agents, and the
-  interface is a directory of plain text files those agents can read &mdash; so the shortest path to
-  a change is usually to point a session at that directory and ask in English.
+  You do not have to learn Lua to change the interface. From
+  <strong>any</strong>
+  session, in whichever coding CLI you run, ask in English:
 </p>
-<pre data-wrap><code class="language-bash">thurbox-cli plugin dir          # prints the directory
-thurbox-cli session create --name ui --repo-path ~/.config/thurbox/ui</code></pre>
-<p>Then prompts like these do the whole job:</p>
 <ul class="prompts">
-  <li>Install the info panel plugin.</li>
+  <li>Add my project logs within a dedicated pane on the right in the thurbox UI.</li>
   <li>
-    Add a new pane on the left with CPU and RAM usage. There is a
+    Add a pane on the left with CPU and RAM usage. There is a
     <code>top</code>
     example plugin &mdash; install it and give it a slot in the layout.
   </li>
@@ -76,12 +57,17 @@ thurbox-cli session create --name ui --repo-path ~/.config/thurbox/ui</code></pr
     The session list is too noisy &mdash; drop the repo group headers and show the branch instead of
     the agent name.
   </li>
+  <li>Install the info panel plugin.</li>
 </ul>
 <p>
-  That works because the directory ships an
-  <code>AGENTS.md</code>
-  that any coding CLI loads as context without being asked. It is what stops &ldquo;install a
-  plugin&rdquo; being read as an npm request, tells the agent that
+  That works because thurbox ships a built-in
+  <a href="extensions.html">ui-skill extension</a>
+  : a
+  <code>thurbox-ui</code>
+  skill installed into each coding CLI's own skill directory, which loads only when the request is
+  about the interface. It tells the agent that
+  <code>thurbox-cli plugin dir</code>
+  finds the directory and
   <code>thurbox-cli plugin check</code>
   is how it verifies its own work, and warns it off the mistakes that are invisible until runtime
   &mdash; building under a recursively watched directory, or writing inside a cloned plugin's own
@@ -89,9 +75,17 @@ thurbox-cli session create --name ui --repo-path ~/.config/thurbox/ui</code></pr
   <kbd>F10</kbd>
   and the change is on your screen.
 </p>
+<p>
+  Want the agent looking at the files directly instead? Point a session at the directory &mdash; it
+  ships an
+  <code>AGENTS.md</code>
+  that any coding CLI loads as context without being asked:
+</p>
+<pre data-wrap><code class="language-bash">thurbox-cli plugin dir          # prints the directory
+thurbox-cli session create --name ui --repo-path ~/.config/thurbox/ui</code></pre>
 
 <h3 id="ask-the-agent-worked">
-  What the second prompt actually does
+  What a prompt like &ldquo;add a CPU/RAM pane on the left&rdquo; actually does
   <a href="#ask-the-agent-worked" class="heading-anchor">#</a>
 </h3>
 <p>
@@ -427,9 +421,8 @@ thurbox-cli plugin install git+https://github.com/Thurbeen/thurbox-info-panel</c
   <a href="#v1" class="heading-anchor">#</a>
 </h2>
 <p>
-  It is the stable line, maintained on the <code>v1.x</code> branch and still getting patch
-  releases. The first-launch prompt prints the exact command; the short version is to pin a 1.x
-  version:
+  1.x is maintained on the <code>v1.x</code> branch and still gets patch releases. The
+  first-launch prompt prints the exact command; the short version is to pin a 1.x version:
 </p>
 <pre><code class="language-bash">export VERSION=v1.8.7
 curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh</code></pre>

--- a/website/index.html
+++ b/website/index.html
@@ -27,12 +27,11 @@ footer: true
               &mdash; the session list included. Turn one off, reorder them, or write your own.
             </p>
             <p class="hero-stability">
-              <span class="badge badge-yellow">v2 &middot; unstable</span>
-              The latest release is v2, and it is still moving &mdash; the plugin kernel, the
-              snapshot panes read, and the panes it ships can change between releases. The latest
-              <strong>stable</strong>
-              release is v1.8.7 &mdash;
-              <a href="docs/v1.html">how to stay on v1</a>.
+              <span class="badge badge-green">One command</span>
+              Install it, then run
+              <code>thurbox</code>
+              &mdash; that is the whole setup. Sessions, agents, themes and the interface itself are
+              seeded on first launch.
             </p>
             <div class="hero-ctas">
               <a href="#installation" class="btn btn-primary">Get Started</a>
@@ -122,24 +121,19 @@ footer: true
 
           <div class="install-panel" role="tabpanel" id="panel-script" aria-labelledby="tab-script">
             <p>
-              Linux &amp; macOS. Auto-detects your platform, verifies checksums, and installs to
-              <code>~/.local/bin</code>
-              . This is the
+              Linux &amp; macOS, and the
               <strong>recommended</strong>
-              command: it pins v1, the latest stable release.
-              <code>export</code>
-              goes on its own line, or the
-              <code>sh</code>
-              reading from the pipe never sees it.
-            </p>
-            <pre data-wrap><code class="language-bash">export VERSION=v1.8.7
-curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh</code></pre>
-            <p>
-              Drop the pin to take the newest release instead &mdash; currently
-              <a href="docs/v1.html">v2, which is unstable</a>
-              :
+              route. Auto-detects your platform, verifies checksums, and installs both
+              <code>thurbox</code>
+              and
+              <code>thurbox-cli</code>
+              to
+              <code>~/.local/bin</code>
+              .
             </p>
             <pre data-wrap><code class="language-bash">curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh</code></pre>
+            <p>Then run it:</p>
+            <pre><code class="language-bash">thurbox</code></pre>
           </div>
 
           <div
@@ -152,21 +146,18 @@ curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/insta
             <p>
               Native Windows (PowerShell 5.1+), and the
               <strong>recommended route</strong>
-              on Windows &mdash; unlike winget and Chocolatey it can pin a
-              version. Verifies checksums and installs to
+              on Windows &mdash; unlike winget and Chocolatey it always carries the newest release.
+              Verifies checksums and installs to
               <code>%LOCALAPPDATA%\Programs\thurbox</code>
               (added to your user
               <code>PATH</code>
-              ). The pin below takes v1, the latest stable release.
-            </p>
-            <pre data-wrap><code class="language-powershell">$env:THURBOX_VERSION = 'v1.8.7'
-irm https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.ps1 | iex</code></pre>
-            <p>
-              Drop the pin to take the newest release instead &mdash; currently
-              <a href="docs/v1.html">v2, which is unstable</a>
-              :
+              ). Needs
+              <a href="https://github.com/psmux/psmux" target="_blank" rel="noopener">psmux</a>
+              as the multiplexer (installed separately).
             </p>
             <pre data-wrap><code class="language-powershell">irm https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.ps1 | iex</code></pre>
+            <p>Then run it:</p>
+            <pre><code class="language-powershell">thurbox</code></pre>
           </div>
 
           <div class="install-panel" role="tabpanel" id="panel-winget" aria-labelledby="tab-winget" hidden>
@@ -1004,6 +995,87 @@ Ctrl+,  Settings, incl. the Interface tab</pre>
       </div>
     </section>
 
+    <!-- Just ask for it -->
+    <!-- The two things you would otherwise script by hand — fleets of sessions,
+         and the interface itself — are both reachable in plain English from
+         inside a session, because thurbox-cli is installed beside thurbox and
+         the interface is a directory of text files. Two parallel categories, so
+         a 2-up card grid rather than the numbered .step list used above. -->
+    <section class="section ask-section" id="just-ask">
+      <div class="container">
+        <p class="section-eyebrow">You are already in a coding agent</p>
+        <h2>Just ask for it</h2>
+        <p class="section-lede">
+          <code>thurbox-cli</code>
+          is installed beside
+          <code>thurbox</code>
+          and the interface is a directory of text files &mdash; so the two things you would
+          otherwise script by hand are a sentence from inside any session.
+        </p>
+
+        <div class="grid grid-2">
+          <div class="card ask-card">
+            <div class="card-icon" aria-hidden="true">&#x2263;</div>
+            <h3>Orchestrate sessions</h3>
+            <p>
+              The headless CLI creates, prompts, forks and tears down sessions, so an agent can
+              spin up a whole fleet for you. Everything it does appears in your running TUI within
+              a tick &mdash; both binaries share one SQLite database.
+            </p>
+            <ul class="prompts">
+              <li>
+                Using
+                <code>thurbox-cli</code>
+                , start refactor sessions for this repo &mdash; one per crate, each on its own
+                worktree branch off
+                <code>main</code>
+                , and send each one a prompt to refactor its crate.
+              </li>
+              <li>
+                Spawn a reviewer session on this repo with no worktree, and send it standing
+                instructions to review every file I change.
+              </li>
+              <li>
+                Create a nightly automation that sends &ldquo;triage new issues&rdquo; to the
+                <code>triage</code>
+                session on weekdays at 09:00.
+              </li>
+            </ul>
+            <p class="ask-card__more">
+              <a href="docs/orchestration.html">Orchestration patterns &rarr;</a>
+            </p>
+          </div>
+
+          <div class="card ask-card">
+            <div class="card-icon" aria-hidden="true">&#x25EB;</div>
+            <h3>Reshape the interface</h3>
+            <p>
+              Every pane is a Lua file, so changing the UI is also just a request. It works from
+              <strong>any</strong>
+              session, in whichever CLI you run, because thurbox ships a
+              <code>thurbox-ui</code>
+              skill that loads when the request is about the interface. Press
+              <kbd>F10</kbd>
+              and the change is on your screen.
+            </p>
+            <ul class="prompts">
+              <li>Add my project logs within a dedicated pane on the right in the thurbox UI.</li>
+              <li>
+                Add a pane on the left with CPU and RAM usage. There is a
+                <code>top</code>
+                example plugin &mdash; install it and give it a slot in the layout.
+              </li>
+              <li>Move the search strip to the bottom and make the session column 30% wide.</li>
+              <li>Install the info panel plugin.</li>
+            </ul>
+            <p class="ask-card__more">
+              <a href="docs/v2-interface.html#ask-the-agent">What that actually does &rarr;</a>
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+
     <!-- Feature walkthrough -->
     <section class="walkthrough section" id="walkthrough">
       <div class="container">
@@ -1151,9 +1223,9 @@ Ctrl+,  Settings, incl. the Interface tab</pre>
               <p><code>export INSTALL_DIR=/usr/local/bin</code></p>
             </div>
             <div class="install-alt-item">
-              <h4>Latest stable (v1) &mdash; recommended</h4>
-              <p><code>export VERSION=v1.8.7</code></p>
-              <p><code>$env:THURBOX_VERSION = 'v1.8.7'</code></p>
+              <h4>Pin a version</h4>
+              <p><code>export VERSION=v2.5.4</code></p>
+              <p><code>$env:THURBOX_VERSION = 'v2.5.4'</code></p>
             </div>
             <div class="install-alt-item">
               <h4>Full Guide</h4>

--- a/website/llms.txt
+++ b/website/llms.txt
@@ -10,20 +10,24 @@
 > (plus remote hosts over SSH). A headless companion binary, `thurbox-cli`,
 > drives the same sessions for scripting and automation.
 >
-> Release lines: 1.x is the latest stable line (newest release v1.8.7) and gets
-> bug and security fixes; 2.x is published but unstable — its plugin kernel, the
-> snapshot panes read, and the panes it ships can change between releases. Every
-> installer takes the newest release (2.x) unless a version is pinned, so 1.x is
-> the recommended install: run `export VERSION=v1.8.7` and then
+> Installing: run
 > `curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh`
-> on Linux/macOS, or `$env:THURBOX_VERSION = 'v1.8.7'` and then
+> on Linux/macOS, or
 > `irm https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.ps1 | iex`
-> on Windows. The version assignment must be its own line; as a pipeline prefix
-> it binds to curl, not to the sh reading from the pipe. Auto-update never
-> crosses a major version, so a 1.x install is told 2.x exists and is never moved
-> onto it; `thurbox-cli update --force` is the deliberate way across. The
-> package-manager channels (winget, Chocolatey, Homebrew, AUR) publish only the
-> newest release and cannot pin 1.x.
+> on Windows, then run `thurbox`. That is the whole setup — config, themes and
+> the interface itself are seeded on first launch. No pin or flag is needed:
+> every installer takes the newest release, which is the 2.x line.
+>
+> Release lines: 2.x is the current line and where new features land. 1.x is
+> still maintained on the `v1.x` branch for bug and security fixes; run it only
+> if you need a pane 2.x does not have (the file viewer). Pin it with
+> `export VERSION=v1.8.7` before the installer on Linux/macOS, or
+> `$env:THURBOX_VERSION = 'v1.8.7'` on Windows. The version assignment must be
+> its own line; as a pipeline prefix it binds to curl, not to the sh reading
+> from the pipe. Auto-update never crosses a major version, so a 1.x install is
+> told 2.x exists and is never moved onto it; `thurbox-cli update --force` is
+> the deliberate way across. The package-manager channels (winget, Chocolatey,
+> Homebrew, AUR) publish only the newest release and cannot pin 1.x.
 >
 > Since 2.0 its defining feature is that the interface is fully customizable:
 > no UI is compiled into the binary. thurbox boots a Rust kernel that reads a
@@ -32,8 +36,15 @@
 > rewrite, or install from someone else, with no recompile and no restart. The
 > arrangement (`ui/layout.lua`), agents (`agents.toml`), hosts (`hosts.toml`),
 > themes, keybindings and settings are all data files. Because the interface is
-> plain text in a directory, the usual way to change it is to point a coding
-> session at that directory and ask for the change in English.
+> plain text in a directory, the usual way to change it is to ask a coding
+> session for the change in English — thurbox ships a built-in `ui-skill`
+> extension that teaches whichever CLI is running how the interface is put
+> together, so "add my project logs within a dedicated pane on the right in the
+> thurbox UI" works from any session. The same holds for orchestration:
+> `thurbox-cli` is installed beside `thurbox`, so it is already on every session
+> agent's PATH, and "using thurbox-cli, start refactor sessions for this repo,
+> one per crate, each on its own worktree branch" spins up a fleet without a
+> script.
 
 ## Docs
 
@@ -42,10 +53,11 @@
 - [Features](https://thurbox.thurbeen.eu/docs/features.html): the customizable interface and a full v1-to-v2 surface map, plus sessions, agent definitions, git worktrees, remote SSH and WSL hosts, automations, tasks, global search, headless CLI.
 - [Built-in agents](https://thurbox.thurbeen.eu/docs/agents.html): every built-in coding agent (claude, codex, antigravity, opencode, aider, copilot, vibe, pi, omp) with its recommended agents.toml config, resume/fork behavior, and status support.
 - [Comparison](https://thurbox.thurbeen.eu/docs/comparison.html): how Thurbox compares to Conductor, Claude Squad, Cursor, and other parallel coding-agent tools.
-- [Installation](https://thurbox.thurbeen.eu/docs/installation.html): install via curl, Homebrew, AUR, winget, Chocolatey, or from source; prerequisites; how to pin the latest stable 1.x instead of the unstable 2.x default.
+- [Installation](https://thurbox.thurbeen.eu/docs/installation.html): install via curl, Homebrew, AUR, winget, Chocolatey, or from source; prerequisites; running it; how to pin a specific version.
+- [Orchestration](https://thurbox.thurbeen.eu/docs/orchestration.html): asking an agent to spin up a fleet with thurbox-cli, and the control-plane pattern for running agents across many repos.
 - [Configuration](https://thurbox.thurbeen.eu/docs/configuration.html): every config file and knob — agents.toml, hosts.toml, settings.toml, themes, keybindings.
 - [Deprecated surfaces](https://thurbox.thurbeen.eu/docs/deprecated.html): the six panes 1.x had that the current interface does not — code review and the info panel, now the installable thurbox-code-review and thurbox-info-panel plugins; the file viewer, with no replacement; and the tasks/automations/restore panes that moved to thurbox-cli.
-- [Using v1](https://thurbox.thurbeen.eu/docs/v1.html): thurbox 1.x is the latest stable line and is still maintained — what it has that the unstable 2.x interface does not, how to stay on it or go back, and what it will receive.
+- [Using v1](https://thurbox.thurbeen.eu/docs/v1.html): thurbox 1.x is still maintained — what it has that the current interface does not, how to stay on it or go back, and what it will receive.
 - [The Interface](https://thurbox.thurbeen.eu/docs/v2-interface.html): every pane is an editable Lua plugin — how to move, disable, replace or write one, how to have a coding agent do it for you, what the kernel refuses a plugin, and the two v1 panes (thurbox-code-review, thurbox-info-panel) you install as plugins.
 - [Architecture](https://thurbox.thurbeen.eu/docs/architecture.html): the Lua-on-Rust plugin kernel and its five rules, module isolation, the tmux session backend, and design decisions (including the Elm Architecture the interface used before 2.0).
 


### PR DESCRIPTION
## Summary

- **Drops the v2-unstable framing.** v2 is stable enough to be the recommended install, so nothing routes new users to v1 any more: the 65-line `[!IMPORTANT]` block above the README fold, the "Recommended: v1, the stable line" vs "The newest release (v2, unstable)" split, and the matching warnings on the landing page, `installation.html`, `faq.html`, `v1.html` and `v2-interface.html` are gone. 1.x is now described as maintained-for-fixes rather than as the line to install.
- **Onboarding leads with install, then run.** README order is `Installation → Prerequisites → Getting Started`. Installation is one curl line and one PowerShell line, with package managers, the source build and version pinning collapsed behind a `<details>`; Getting Started opens with `thurbox` and "that is the whole setup". The duplicate Getting Started section further down is removed.
- **Adds worked prompt examples**, for the two things people script by hand without needing to — `thurbox-cli` is installed beside `thurbox`, and the interface is a directory of text files. New "Just ask for it" section in the README, a 2-up card grid on the landing page, a "Start by just asking" section on `orchestration.html`, and the interface prompts on `v2-interface.html` now lead with the project-logs example.
- **Softens `docs/PLUGINS.md`'s plugin-API note**, split in two first: the stability half is reworded, the trusted-code half is a security caveat and is kept verbatim.
- **Drive-by fixes**: a pre-existing broken anchor (`extension-flow.html` → `features.html#flow-extension`, which does not exist), and a pre-existing copy bug on `v2-interface.html` that read "Alongside `thurbox` there is `thurbox`". `details`/`summary`/`b` added to rumdl's `MD033` for the new disclosure.

## Test plan

- `npm run lint:website` — prettier, htmlhint (23 files), stylelint, eslint all clean
- `rumdl check .` — 40 files clean
- Link/anchor checker across the whole built site: every internal link and fragment resolves, including the new `#just-ask`, `#ask-the-agent` and `orchestration.html` targets. The one pre-existing break is fixed here, so the site is now at zero.
- Served locally with `eleventy --serve` and read every changed page rendered

No Rust, Lua or packaging files touched — `check-release`'s artifact-relevance gate skips this, and `docs:` cuts no release either way.

https://claude.ai/code/session_01U9oGCDFVhoeJNoLQ7cgxWL