### PR TITLE
fix(core): give local spawns a pane id so duplicate names attach

### DIFF
--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -158,6 +158,34 @@ fn window_target(session_name: &str) -> String {
     format!("{TMUX_SESSION}:={}", agent_window_name(session_name))
 }
 
+/// Whether `pane_id` (`%N`) is alive and sits in a window named `window`.
+///
+/// The verification is what makes a *persisted* pane id safe to target: tmux
+/// reuses pane numbers after a server restart, so a stored id can point at a
+/// different window entirely (a shell, the heartbeat keeper). Checking the
+/// window name catches that; a dead or reassigned id falls back to the name.
+fn pane_matches_window(pane_id: &str, window: &str) -> bool {
+    let out =
+        local_mux_command(&["display-message", "-p", "-t", pane_id, "#{window_name}"]).output();
+    matches!(out, Ok(o) if o.status.success()
+        && String::from_utf8_lossy(&o.stdout).trim() == window)
+}
+
+/// Resolve the tmux target for a session's agent pane: the persisted pane id
+/// when it still points at this session's own `tb-` window, else the window
+/// name (the legacy path, for rows persisted with no pane id).
+///
+/// The pane id is the precise half — two sessions can share a name, and their
+/// windows then share the `tb-<name>` target, which tmux resolves to an
+/// arbitrary one of them. Every one-shot helper that acts on a session's pane
+/// goes through here so the id wins whenever it is usable.
+fn agent_target(session_name: &str, pane_id: &str) -> String {
+    if !pane_id.is_empty() && pane_matches_window(pane_id, &agent_window_name(session_name)) {
+        return pane_id.to_string();
+    }
+    window_target(session_name)
+}
+
 /// Minimum tmux version required.
 const MIN_TMUX_VERSION: (u32, u32) = (3, 2);
 
@@ -1249,9 +1277,9 @@ fn pane_is_dead(target: &str) -> bool {
 
 /// Send text immediately to a session pane (no scheduling), followed by Enter.
 ///
-/// Targets the tmux window named `tb-<session_name>` in the thurbox tmux
-/// session and uses a "paste text → brief delay → press Enter" sequence so the
-/// target app has time to process the pasted input.
+/// Targets the session's pane via `agent_target` (pane id first, window name
+/// as the legacy fallback) and uses a "paste text → brief delay → press Enter"
+/// sequence so the target app has time to process the pasted input.
 ///
 /// Refuses a pane whose process has exited. Sessions run with
 /// `remain-on-exit=on` (`SESSION_OPTS`), so a dead agent leaves its window in
@@ -1259,8 +1287,8 @@ fn pane_is_dead(target: &str) -> bool {
 /// caller reads that success as "the agent got it" — which is how the mailbox
 /// wake came to report `woke: true` at a pane nothing was listening to — so the
 /// liveness check belongs here, once, rather than in each of them.
-pub fn send_prompt_now(session_name: &str, text: &str) -> Result<()> {
-    let target = window_target(session_name);
+pub fn send_prompt_now(session_name: &str, pane_id: &str, text: &str) -> Result<()> {
+    let target = agent_target(session_name, pane_id);
     if pane_is_dead(&target) {
         bail!("session '{session_name}' has exited; its pane accepts no input");
     }
@@ -1309,13 +1337,15 @@ fn list_window_names() -> Vec<String> {
         .collect()
 }
 
-/// Whether the agent window `tb-<session_name>` currently exists in the thurbox
-/// tmux server. Used by the headless dispatcher to skip `send` automations
-/// whose target session is no longer running rather than failing into a dead
-/// pane.
-pub fn window_exists(session_name: &str) -> bool {
+/// Whether the session's agent pane currently exists in the thurbox tmux
+/// server — its persisted pane id when one is usable, the `tb-<session_name>`
+/// window otherwise. Used by the headless dispatcher to skip `send`
+/// automations whose target session is no longer running rather than failing
+/// into a dead pane.
+pub fn window_exists(session_name: &str, pane_id: &str) -> bool {
     let want = agent_window_name(session_name);
-    list_window_names().contains(&want)
+    (!pane_id.is_empty() && pane_matches_window(pane_id, &want))
+        || list_window_names().contains(&want)
 }
 
 /// Schedule a one-shot prompt delivery into a session's window after
@@ -1324,8 +1354,13 @@ pub fn window_exists(session_name: &str) -> bool {
 /// Used by the headless automation dispatcher to deliver a Spawn automation's
 /// prompt once the freshly launched agent CLI has had time to boot — offline
 /// there is no TUI deferred-input queue to lean on. Local-tmux scoped.
-pub fn send_prompt_after_delay(session_name: &str, text: &str, delay_secs: u64) -> Result<()> {
-    let target = window_target(session_name);
+pub fn send_prompt_after_delay(
+    session_name: &str,
+    pane_id: &str,
+    text: &str,
+    delay_secs: u64,
+) -> Result<()> {
+    let target = agent_target(session_name, pane_id);
     let script = deferred_prompt_script(&target, text);
     let status = local_mux_command(&["run-shell", "-b", "-d", &delay_secs.to_string(), &script])
         .status()
@@ -1465,8 +1500,8 @@ pub fn resolve_cli_binary() -> std::path::PathBuf {
 ///
 /// Returns the visible terminal text. `lines` controls how many lines of
 /// scrollback to include before the visible region (capped to a sane max).
-pub fn capture_pane_text(session_name: &str, lines: u32) -> Result<String> {
-    let target = window_target(session_name);
+pub fn capture_pane_text(session_name: &str, pane_id: &str, lines: u32) -> Result<String> {
+    let target = agent_target(session_name, pane_id);
     let lines = lines.min(MAX_CAPTURE_LINES);
     let start = format!("-{lines}");
 
@@ -1518,15 +1553,22 @@ const SESSION_OPTS: &[(&str, &str)] = &[
 /// Spawn a new tmux window running `command` with `args` in `cwd`.
 ///
 /// Thin helper for headless callers (CLI, MCP) that don't need PTY I/O
-/// streams. Returns on success once the window exists; the command runs
-/// inside it. Window name is `tb-<session_name>`.
+/// streams. Returns the new pane's id (`%N`) on success; the command runs
+/// inside it. Window name is `tb-<session_name>` — which is *not* unique (two
+/// sessions can share a name), so the returned id is what callers persist as
+/// `backend_id` and target thereafter.
+///
+/// On Windows the local mux is psmux, whose `new-window -P -F` support is
+/// unverified against the documented divergences (ADR-13) — there the id is
+/// not asked for and an empty string is returned, preserving the
+/// resolve-by-name behavior until the e2e probes cover it.
 pub fn spawn_window(
     session_name: &str,
     command: &str,
     args: &[String],
     cwd: Option<&Path>,
     env: &HashMap<String, String>,
-) -> Result<()> {
+) -> Result<String> {
     // Ensure the session exists and is configured, without opening a
     // control-mode connection (headless one-shot path).
     TmuxBackend::local().ensure_session_configured()?;
@@ -1540,6 +1582,9 @@ pub fn spawn_window(
         "-n",
         &window_name,
     ]);
+    if !cfg!(windows) {
+        tmux.args(["-P", "-F", "#{pane_id}"]);
+    }
     if let Some(dir) = cwd {
         tmux.args(["-c", &dir.to_string_lossy()]);
     }
@@ -1572,16 +1617,18 @@ pub fn spawn_window(
             stderr.trim()
         );
     }
-    Ok(())
+    if cfg!(windows) {
+        return Ok(String::new());
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
 /// Headless spawn of an agent window on a remote host over SSH.
 ///
-/// Returns the remote tmux pane id (`%N`). Unlike the local [`spawn_window`]
-/// (which leaves `backend_id` empty for the TUI to resolve by name), this drives
-/// the SSH backend's control mode to learn the real pane id up front. The
-/// control-mode connection is dropped when this returns; the remote tmux keeps
-/// the window alive for the TUI to adopt later.
+/// Returns the remote tmux pane id (`%N`), like the local [`spawn_window`] —
+/// but by driving the SSH backend's control mode rather than `new-window -P`.
+/// The control-mode connection is dropped when this returns; the remote tmux
+/// keeps the window alive for the TUI to adopt later.
 pub fn spawn_window_remote(
     host: &crate::session::HostDef,
     session_name: &str,
@@ -1632,9 +1679,11 @@ pub fn kill_pane_remote(host: &crate::session::HostDef, backend_id: &str) -> Res
     backend.kill(backend_id)
 }
 
-/// Kill the tmux window `tb-<session_name>` if it exists.
-pub fn kill_window(session_name: &str) -> Result<()> {
-    let target = window_target(session_name);
+/// Kill the session's tmux window if it exists — by its persisted pane id when
+/// one is usable (precise even when another session shares the name), by the
+/// `tb-<session_name>` window name otherwise.
+pub fn kill_window(session_name: &str, pane_id: &str) -> Result<()> {
+    let target = agent_target(session_name, pane_id);
     let output = local_mux_command(&["kill-window", "-t", &target])
         .output()
         .context("Failed to run tmux kill-window")?;
@@ -1662,8 +1711,8 @@ pub fn kill_window(session_name: &str) -> Result<()> {
 /// pane process **before** removing its cwd on Windows, where a directory that
 /// is a live process's cwd cannot be removed (`os error 32`); Unix permits it,
 /// so callers only need the returned pid on Windows.
-pub fn window_pane_pid(session_name: &str) -> Result<Option<u32>> {
-    let target = window_target(session_name);
+pub fn window_pane_pid(session_name: &str, pane_id: &str) -> Result<Option<u32>> {
+    let target = agent_target(session_name, pane_id);
     let output = local_mux_command(&["display-message", "-p", "-t", &target, "#{pane_pid}"])
         .output()
         .context("Failed to run tmux display-message for pane pid")?;

--- a/src/cli/action.rs
+++ b/src/cli/action.rs
@@ -158,14 +158,13 @@ pub(crate) fn spawn_and_deliver(
     req: SpawnRequest,
     prompt: &str,
 ) -> Result<SessionId, SpawnDeliverError> {
-    let session_id = crate::session_ops::spawn_session_headless(db, req)
-        .map_err(SpawnDeliverError::Spawn)?
-        .session_id;
-    crate::agent::tmux::send_prompt_after_delay(name, prompt, BOOT_DELAY_SECS).map_err(|e| {
-        SpawnDeliverError::Deliver {
+    let spawned =
+        crate::session_ops::spawn_session_headless(db, req).map_err(SpawnDeliverError::Spawn)?;
+    let session_id = spawned.session_id;
+    crate::agent::tmux::send_prompt_after_delay(name, &spawned.backend_id, prompt, BOOT_DELAY_SECS)
+        .map_err(|e| SpawnDeliverError::Deliver {
             session_id,
             message: format!("spawned {name} but prompt delivery failed: {e}"),
-        }
-    })?;
+        })?;
     Ok(session_id)
 }

--- a/src/cli/automations.rs
+++ b/src/cli/automations.rs
@@ -531,8 +531,10 @@ fn fire_send(
     auto: &Automation,
     session_id: SessionId,
 ) -> (AutomationRunStatus, String, Option<SessionId>) {
-    let name = match db.get_session_name(session_id) {
-        Ok(Some(name)) => name,
+    // The full row, not just the name: the persisted pane id is what
+    // disambiguates when another session shares the name.
+    let target = match db.get_session_by_id(session_id) {
+        Ok(Some(session)) => session,
         Ok(None) => {
             return (
                 AutomationRunStatus::Skipped,
@@ -543,19 +545,19 @@ fn fire_send(
         Err(e) => {
             return (
                 AutomationRunStatus::Error,
-                format!("get_session_name: {e}"),
+                format!("get_session_by_id: {e}"),
                 None,
             )
         }
     };
-    if !crate::agent::tmux::window_exists(&name) {
+    if !crate::agent::tmux::window_exists(&target.name, &target.backend_id) {
         return (
             AutomationRunStatus::Skipped,
             "target session not running".into(),
             None,
         );
     }
-    match crate::agent::tmux::send_prompt_now(&name, &auto.prompt) {
+    match crate::agent::tmux::send_prompt_now(&target.name, &target.backend_id, &auto.prompt) {
         Ok(()) => (
             AutomationRunStatus::Success,
             format!("sent to {session_id}"),
@@ -579,9 +581,11 @@ fn fire_spawn(
 ) -> (AutomationRunStatus, String, Option<SessionId>) {
     let name = format!("auto-{}", auto.id);
     // Reuse an existing session window (later fires / restored sessions).
-    if crate::agent::tmux::window_exists(&name) {
+    // Name-only targeting: the reused window's session row (and so its pane
+    // id) has no cheap lookup here, and `auto-<id>` names don't collide.
+    if crate::agent::tmux::window_exists(&name, "") {
         // The reused window's session id has no cheap lookup here.
-        return match crate::agent::tmux::send_prompt_now(&name, &auto.prompt) {
+        return match crate::agent::tmux::send_prompt_now(&name, "", &auto.prompt) {
             Ok(()) => (AutomationRunStatus::Success, format!("reused {name}"), None),
             Err(e) => (AutomationRunStatus::Error, e.to_string(), None),
         };

--- a/src/cli/messages.rs
+++ b/src/cli/messages.rs
@@ -297,7 +297,11 @@ fn enqueue_and_wake(
     if !no_wake {
         // Best-effort nudge: a missing/dead window must not fail the send (the
         // message is already durably queued for the next drain).
-        match crate::agent::tmux::send_prompt_now(&recipient.name, WAKE_TOKEN) {
+        match crate::agent::tmux::send_prompt_now(
+            &recipient.name,
+            &recipient.backend_id,
+            WAKE_TOKEN,
+        ) {
             Ok(()) => woke = true,
             Err(e) => {
                 tracing::debug!("message: wake nudge to {} failed: {e}", recipient.name)

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -224,7 +224,7 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
             if text.trim().is_empty() {
                 return Err("text must not be empty".into());
             }
-            crate::agent::tmux::send_prompt_now(&session.name, &text)
+            crate::agent::tmux::send_prompt_now(&session.name, &session.backend_id, &text)
                 .map_err(|e| format!("send_prompt_now: {e}"))?;
             Ok(CommandOutput::new(
                 json!({
@@ -237,8 +237,9 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
         }
         Action::Capture { uuid, lines } => {
             let session = resolve(db, &uuid)?;
-            let output = crate::agent::tmux::capture_pane_text(&session.name, lines)
-                .map_err(|e| format!("capture_pane_text: {e}"))?;
+            let output =
+                crate::agent::tmux::capture_pane_text(&session.name, &session.backend_id, lines)
+                    .map_err(|e| format!("capture_pane_text: {e}"))?;
             let human = output.clone();
             Ok(CommandOutput::new(
                 json!({

--- a/src/cli/tasks.rs
+++ b/src/cli/tasks.rs
@@ -321,14 +321,16 @@ fn run_task(db: &Database, task: &Task) -> Result<Value, String> {
     match &task.action {
         None => Ok(json!({ "skipped": "task is not connected to an agent", "id": task.id })),
         Some(AutomationAction::Send { session_id }) => {
-            let name = db
-                .get_session_name(*session_id)
-                .map_err(|e| format!("get_session_name: {e}"))?
+            // The full row, not just the name: the persisted pane id is what
+            // disambiguates when another session shares the name.
+            let target = db
+                .get_session_by_id(*session_id)
+                .map_err(|e| format!("get_session_by_id: {e}"))?
                 .ok_or_else(|| format!("Target session not found: {session_id}"))?;
-            if !crate::agent::tmux::window_exists(&name) {
+            if !crate::agent::tmux::window_exists(&target.name, &target.backend_id) {
                 return Err("target session not running".into());
             }
-            crate::agent::tmux::send_prompt_now(&name, &prompt)
+            crate::agent::tmux::send_prompt_now(&target.name, &target.backend_id, &prompt)
                 .map_err(|e| format!("send_prompt_now: {e}"))?;
             mark_in_progress(db, task)?;
             Ok(json!({ "sent": true, "id": task.id, "session_id": session_id.to_string() }))
@@ -348,13 +350,15 @@ fn run_task(db: &Database, task: &Task) -> Result<Value, String> {
                 .list_active_sessions()
                 .map_err(|e| format!("list_active_sessions: {e}"))?
                 .into_iter()
-                .map(|s| s.name)
-                .find(|n| task.matches_spawn_session(n) && crate::agent::tmux::window_exists(n));
-            if let Some(name) = existing {
-                crate::agent::tmux::send_prompt_now(&name, &prompt)
+                .find(|s| {
+                    task.matches_spawn_session(&s.name)
+                        && crate::agent::tmux::window_exists(&s.name, &s.backend_id)
+                });
+            if let Some(session) = existing {
+                crate::agent::tmux::send_prompt_now(&session.name, &session.backend_id, &prompt)
                     .map_err(|e| format!("send_prompt_now: {e}"))?;
                 mark_in_progress(db, task)?;
-                return Ok(json!({ "reused": name, "id": task.id }));
+                return Ok(json!({ "reused": session.name, "id": task.id }));
             }
             let req = SpawnRequest {
                 name: name.clone(),

--- a/src/coordinator/mod.rs
+++ b/src/coordinator/mod.rs
@@ -414,6 +414,14 @@ impl App {
         {
             self.dirty = true;
         }
+        // A pane the terminals had to resolve by window name gets its id
+        // persisted onto the row: names are not unique (two sessions can share
+        // one), so a legacy row stops depending on its name after one adoption.
+        for (session, pane) in self.terminals.drain_adopted_panes() {
+            if let Err(e) = self.snapshots.remember_pane(&session, &pane) {
+                tracing::warn!("could not record adopted pane for {session}: {e}");
+            }
+        }
         // A session whose agent is gone gets it back, which is what v1 does
         // at restore and what makes a session survive a reboot.
         self.respawn_missing_agents();

--- a/src/kernel/command/execute.rs
+++ b/src/kernel/command/execute.rs
@@ -125,7 +125,7 @@ pub(super) fn execute(
                 .get_session_by_id(id)
                 .map_err(|e| format!("get session: {e}"))?
                 .ok_or_else(|| format!("session not found: {id}"))?;
-            crate::agent::tmux::send_prompt_now(&session.name, text)
+            crate::agent::tmux::send_prompt_now(&session.name, &session.backend_id, text)
                 .map_err(|e| format!("send: {e}"))
         }
         Command::Reorder { delta, .. } => reorder(&db, id, *delta),
@@ -573,7 +573,7 @@ fn dispatch_task(db: &Database, task_id: i64, session: Option<&str>) -> Result<(
                 .get_session_by_id(id)
                 .map_err(|e| format!("get session: {e}"))?
                 .ok_or_else(|| format!("session not found: {id}"))?;
-            crate::agent::tmux::send_prompt_now(&target.name, &prompt)
+            crate::agent::tmux::send_prompt_now(&target.name, &target.backend_id, &prompt)
                 .map_err(|e| format!("send: {e}"))?;
         }
         None => {
@@ -590,8 +590,13 @@ fn dispatch_task(db: &Database, task_id: i64, session: Option<&str>) -> Result<(
             let spawned = crate::session_ops::spawn::spawn_session_headless(db, request)?;
             // The agent needs a moment to be ready for input; sending into a
             // shell that has not drawn its prompt loses the text.
-            crate::agent::tmux::send_prompt_after_delay(&spawned.name, &prompt, 3)
-                .map_err(|e| format!("send: {e}"))?;
+            crate::agent::tmux::send_prompt_after_delay(
+                &spawned.name,
+                &spawned.backend_id,
+                &prompt,
+                3,
+            )
+            .map_err(|e| format!("send: {e}"))?;
         }
     }
 

--- a/src/kernel/snapshot.rs
+++ b/src/kernel/snapshot.rs
@@ -734,6 +734,46 @@ impl SnapshotStore {
         Ok(())
     }
 
+    /// Record the pane id a session's agent window was adopted at.
+    ///
+    /// The migration path for rows persisted before local spawns recorded their
+    /// pane id: the interface resolved this one by window name, and a name is
+    /// not unique — persisting the id is what stops the row depending on it.
+    /// Same shape as [`Self::remember_shell`]: a targeted single-column UPDATE
+    /// plus an in-place correction of the snapshot row, since our own write
+    /// does not move `data_version`.
+    pub fn remember_pane(&mut self, session: &str, pane: &str) -> Result<(), String> {
+        let Some(database) = &self.database else {
+            return Err("no database".to_string());
+        };
+        let Some(id) = parse_id(session) else {
+            return Err(format!("not a session id: {session}"));
+        };
+        if self
+            .current
+            .sessions
+            .iter()
+            .any(|row| row.id == session && row.backend_id.as_deref() == Some(pane))
+        {
+            return Ok(());
+        }
+        let matched = database
+            .set_backend_id(id, pane)
+            .map_err(|e| format!("record agent pane: {e}"))?;
+        if !matched {
+            return Err(format!("session not found: {session}"));
+        }
+        if let Some(current) = self
+            .current
+            .sessions
+            .iter_mut()
+            .find(|row| row.id == session)
+        {
+            current.backend_id = Some(pane.to_string());
+        }
+        Ok(())
+    }
+
     /// Take a pending "focus this session" request, if another process left one.
     ///
     /// The database probe lives in [`Self::refresh`], not here: the claiming

--- a/src/kernel/terminal/mod.rs
+++ b/src/kernel/terminal/mod.rs
@@ -66,6 +66,10 @@ struct Attached {
     /// rather than assumed: the readying happens on the worker, and until it
     /// has, no second attach on that backend may start.
     readied: bool,
+    /// Whether the pane was resolved by window name rather than taken from the
+    /// row's own `backend_id` — a successful adoption is then worth persisting,
+    /// so the legacy row stops depending on its (non-unique) name.
+    via_name: bool,
     session_handle: Result<crate::agent::Session, String>,
 }
 
@@ -191,11 +195,12 @@ pub struct Terminals {
     failed: HashMap<String, Failure>,
     /// Panes found by window name, per backend: `tb-<name>` → pane id.
     ///
-    /// A **locally** created session has no pane id of its own — `spawn` leaves
-    /// it "for the TUI to resolve by name" (`session_ops::spawn`), which is what
-    /// v1 does when it adopts windows at restore. Without this the session is
-    /// real, its agent is running, and the interface says "session has no pane
-    /// yet" forever.
+    /// The legacy resolution path: rows persisted before local spawns recorded
+    /// their pane id (and psmux spawns, which cannot report one) carry no id of
+    /// their own, and are matched to a pane through this listing. Without it
+    /// such a session is real, its agent is running, and the interface says
+    /// "session has no pane yet" forever. It also validates a *carried* id —
+    /// see [`Self::pane_is_stale`].
     discovered: HashMap<String, WindowPanes>,
     /// When discovery last ran. It is a tmux round trip per backend, so it is
     /// throttled and only runs while some row actually needs resolving.
@@ -234,6 +239,9 @@ pub struct Terminals {
     /// the result is collected here.
     attaching: HashMap<String, String>,
     attached: (Sender<Attached>, Receiver<Attached>),
+    /// Panes adopted by window-name resolution, waiting for the loop to persist
+    /// their id onto the row ([`Self::drain_adopted_panes`]).
+    adopted: Vec<(String, String)>,
     /// Backends whose window list is being read on a worker.
     discovering: std::collections::HashSet<String>,
     discovered_rx: (Sender<Discovered>, Receiver<Discovered>),
@@ -277,6 +285,7 @@ impl Terminals {
             failed_version: 0,
             attaching: HashMap::new(),
             attached: std::sync::mpsc::channel(),
+            adopted: Vec::new(),
             discovering: std::collections::HashSet::new(),
             discovered_rx: std::sync::mpsc::channel(),
             runtime: tokio::runtime::Handle::try_current().ok(),
@@ -291,10 +300,10 @@ impl Terminals {
     /// (session, pane) — so a pane that cannot be adopted does not retry 20×/s,
     /// and a session whose pane only *becomes* known later is still picked up.
     ///
-    /// A row with no pane id of its own is resolved by **window name**, which is
-    /// what makes a locally created session usable: `spawn` deliberately leaves
-    /// the id empty for the interface to resolve, exactly as v1 does when it
-    /// adopts windows at restore.
+    /// A row with no pane id of its own is resolved by **window name** — the
+    /// legacy path for rows persisted before local spawns recorded their pane id
+    /// (and for psmux, which cannot report one). A successful name-resolved
+    /// adoption is queued for the loop to persist, so it happens once per row.
     pub fn sync(&mut self, snapshot: &Snapshot, rows: u16, cols: u16) {
         self.collect_discovered();
         self.collect_attached(rows, cols);
@@ -353,9 +362,9 @@ impl Terminals {
             // it, and falling through to `None` here is also what lets
             // [`Self::missing_agents`] relaunch a session whose window is gone for
             // good.
-            let candidate = match row.backend_id.clone() {
-                Some(id) if !self.pane_is_stale(row, &id) => Some(id),
-                _ => self.pane_by_name(&row.backend, &row.name),
+            let (candidate, via_name) = match row.backend_id.clone() {
+                Some(id) if !self.pane_is_stale(row, &id) => (Some(id), false),
+                _ => (self.pane_by_name(&row.backend, &row.name), true),
             };
             // The same attempt would fail the same way; a different one is worth
             // making.
@@ -374,7 +383,7 @@ impl Terminals {
             if !self.backend_is_ready(&row.backend) && self.opening(&row.backend) {
                 continue;
             }
-            self.start_attach(row, backend_id, rows, cols);
+            self.start_attach(row, backend_id, via_name, rows, cols);
         }
 
         // Anything no longer in the snapshot has been deleted; dropping the
@@ -467,6 +476,7 @@ impl Terminals {
         &mut self,
         row: &super::snapshot::SessionRow,
         backend_id: String,
+        via_name: bool,
         rows: u16,
         cols: u16,
     ) {
@@ -536,6 +546,7 @@ impl Terminals {
                 pane,
                 backend: backend_name,
                 readied,
+                via_name,
                 session_handle: result,
             });
         });
@@ -550,6 +561,13 @@ impl Terminals {
             }
             match done.session_handle {
                 Ok(session) => {
+                    // A pane that had to be resolved by window name is worth
+                    // persisting: names are not unique, so the row must not
+                    // depend on one past this first adoption. The loop drains
+                    // these and writes the id back (`drain_adopted_panes`).
+                    if done.via_name {
+                        self.adopted.push((done.session.clone(), done.pane));
+                    }
                     self.live.insert(
                         done.session.clone(),
                         Live {
@@ -580,6 +598,14 @@ impl Terminals {
                 self.discovered.insert(done.backend, panes);
             }
         }
+    }
+
+    /// Take the panes adopted by window-name resolution since the last call,
+    /// as `(session id, pane id)` pairs for the loop to persist. Legacy rows
+    /// (spawned before local spawns recorded their pane id) migrate this way:
+    /// one successful adoption, and the row stops depending on its name.
+    pub fn drain_adopted_panes(&mut self) -> Vec<(String, String)> {
+        std::mem::take(&mut self.adopted)
     }
 
     /// Let go of a session's terminal, so the next sync attaches afresh.

--- a/src/session_ops/delete.rs
+++ b/src/session_ops/delete.rs
@@ -144,9 +144,9 @@ pub fn reap_soft_deleted(db: &Database, id: SessionId) -> Result<bool, String> {
         return Ok(false);
     }
 
-    // A remote session's window lives on its host and its pane id is not carried
-    // on a deleted row, so there is nothing here that could kill it correctly.
-    // Left running and reported rather than half-killed.
+    // A remote session's window lives on its host, and a best-effort reap is
+    // not the place to be resolving hosts and dialing ssh. Left running and
+    // reported rather than half-killed.
     if crate::session::is_remote_backend(&row.backend_type) {
         tracing::warn!(
             "'{}' was soft-deleted on {}; its remote window is left running",
@@ -156,7 +156,7 @@ pub fn reap_soft_deleted(db: &Database, id: SessionId) -> Result<bool, String> {
         return Ok(false);
     }
 
-    if let Err(e) = crate::agent::tmux::kill_window(&row.name) {
+    if let Err(e) = crate::agent::tmux::kill_window(&row.name, &row.backend_id) {
         // The window may already be gone — the agent exited, or a previous reap
         // got there first. Not worth failing a cleanup over.
         tracing::debug!("kill_window({}) during reap: {e}", row.name);
@@ -182,11 +182,11 @@ fn kill_local_window(session: &crate::sync::SharedSession, report: &mut ForceDel
     // process's cwd, and a session's agent runs with cwd = its worktree /
     // extension home; Unix has no such restriction, so this is Windows-only.
     #[cfg(windows)]
-    let pane_pid = crate::agent::tmux::window_pane_pid(&session.name)
+    let pane_pid = crate::agent::tmux::window_pane_pid(&session.name, &session.backend_id)
         .ok()
         .flatten();
 
-    match crate::agent::tmux::kill_window(&session.name) {
+    match crate::agent::tmux::kill_window(&session.name, &session.backend_id) {
         Ok(()) => report.killed_window = true,
         Err(e) => tracing::warn!("kill_window({}) failed: {e}", session.name),
     }

--- a/src/session_ops/restart.rs
+++ b/src/session_ops/restart.rs
@@ -125,10 +125,14 @@ pub fn restart_session_headless(db: &Database, session_id: SessionId) -> Result<
             // path: a session whose tmux server died is restarted by asking for
             // exactly this, and refusing because there was nothing to kill would
             // make the one case that needs it the one case that fails.
-            if let Err(e) = crate::agent::tmux::kill_window(&plan.window_name) {
+            // Killed by the persisted pane id when one is usable: the window
+            // *name* is not unique, and killing by name with a duplicate around
+            // tears down an arbitrary one of them.
+            if let Err(e) = crate::agent::tmux::kill_window(&plan.window_name, &session.backend_id)
+            {
                 tracing::debug!("no window to kill for '{}': {e:#}", plan.window_name);
             }
-            crate::agent::tmux::spawn_window(
+            let pane = crate::agent::tmux::spawn_window(
                 &plan.window_name,
                 &plan.command,
                 &plan.args,
@@ -137,16 +141,15 @@ pub fn restart_session_headless(db: &Database, session_id: SessionId) -> Result<
             )
             .map_err(|e| format!("Failed to re-spawn tmux window: {e}"))?;
 
-            // Forget the pane that was just killed. The local one-shot spawn
-            // does not report the new pane's id — a local spawn never has, which
-            // is why the interface resolves one by window name — so the row must
-            // not keep pointing at the dead one. Left as the old id, the
-            // interface stays attached to a pane that no longer exists and the
-            // restarted session shows a frozen last frame that takes no keys.
+            // The new pane is a different one, and the id is how every later
+            // read finds it — leaving the old one persisted would point the
+            // interface at a pane that no longer exists. (Empty on psmux, where
+            // the spawn can't report an id; the interface then resolves by
+            // window name as before.)
             let mut session = session.clone();
-            session.backend_id = String::new();
+            session.backend_id = pane;
             db.upsert_session(&session)
-                .map_err(|e| format!("Failed to clear the old pane: {e}"))?;
+                .map_err(|e| format!("Failed to record the new pane: {e}"))?;
         }
         Some(host) => {
             // By pane id, not window name: the host's tmux server is shared with

--- a/src/session_ops/restore.rs
+++ b/src/session_ops/restore.rs
@@ -128,14 +128,19 @@ fn respawn(db: &Database, id: SessionId) -> Result<(), String> {
     // above, since its worktrees cannot be recreated from here.
     let hooks_enabled = super::hooks_enabled(db);
     let plan = super::restart::build_restart_plan(&session, None, hooks_enabled)?;
-    crate::agent::tmux::spawn_window(
+    let pane = crate::agent::tmux::spawn_window(
         &plan.window_name,
         &plan.command,
         &plan.args,
         plan.cwd.as_deref(),
         &plan.env,
     )
-    .map_err(|e| format!("re-spawn: {e}"))
+    .map_err(|e| format!("re-spawn: {e}"))?;
+    // The row still carries the pane the delete killed; the fresh one is what
+    // every later read must target (empty on psmux — the name fallback stands).
+    db.set_backend_id(session.id, &pane)
+        .map_err(|e| format!("record the new pane: {e}"))?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/session_ops/spawn.rs
+++ b/src/session_ops/spawn.rs
@@ -75,6 +75,10 @@ pub struct SpawnResult {
     pub name: String,
     pub agent: String,
     pub agent_session_id: String,
+    /// The spawned pane's id (`%N`), empty only where the platform can't
+    /// report one (psmux). Callers that act on the fresh session (prompt
+    /// delivery, teardown) target this rather than the non-unique window name.
+    pub backend_id: String,
     pub cwd: PathBuf,
     pub worktrees: Vec<SharedWorktree>,
     pub parent_session_id: Option<SessionId>,
@@ -205,8 +209,11 @@ pub fn spawn_session_headless_with_progress(
     let (command, args) = super::build_agent_invocation(&agent_def, &config);
 
     report(SpawnPhase::Launching);
-    // Remote spawns drive the SSH backend's control mode to learn the real pane
-    // id; local spawns leave `backend_id` empty for the TUI to resolve by name.
+    // Both paths learn the real pane id up front — the remote one over the SSH
+    // backend's control mode, the local one from `new-window -P`. The id is
+    // what the row is targeted by thereafter: a window *name* is not unique
+    // (two sessions can share one), and resolving by name is only the legacy
+    // fallback for rows persisted before the id was recorded.
     let backend_id = match host.as_ref() {
         Some(h) => crate::agent::tmux::spawn_window_remote(
             h,
@@ -217,17 +224,14 @@ pub fn spawn_session_headless_with_progress(
             &config.env,
         )
         .map_err(|e| format!("Failed to spawn remote tmux window: {e:#}"))?,
-        None => {
-            crate::agent::tmux::spawn_window(
-                &req.name,
-                &command,
-                &args,
-                Some(&launch_cwd),
-                &config.env,
-            )
-            .map_err(|e| format!("Failed to spawn tmux window: {e}"))?;
-            String::new()
-        }
+        None => crate::agent::tmux::spawn_window(
+            &req.name,
+            &command,
+            &args,
+            Some(&launch_cwd),
+            &config.env,
+        )
+        .map_err(|e| format!("Failed to spawn tmux window: {e}"))?,
     };
 
     report(SpawnPhase::Persisting);
@@ -261,7 +265,7 @@ pub fn spawn_session_headless_with_progress(
         );
         let cleanup = match host.as_ref() {
             Some(h) => crate::agent::tmux::kill_pane_remote(h, &backend_id),
-            None => crate::agent::tmux::kill_window(&req.name),
+            None => crate::agent::tmux::kill_window(&req.name, &backend_id),
         };
         if let Err(kill_err) = cleanup {
             tracing::error!(
@@ -292,6 +296,7 @@ pub fn spawn_session_headless_with_progress(
         name: req.name,
         agent: agent_name,
         agent_session_id,
+        backend_id,
         cwd: primary_cwd,
         worktrees,
         parent_session_id: req.parent_session_id,

--- a/src/storage/sessions.rs
+++ b/src/storage/sessions.rs
@@ -34,6 +34,10 @@ pub struct DeletedSessionInfo {
     /// Persisted backend (`local-tmux` or `ssh:<host>`). Preserved on restore so
     /// a remote session re-spawns against its own host, not the local default.
     pub backend_type: String,
+    /// The pane id (`%N`) the session held when it was deleted — what the reap
+    /// kills, so a live session sharing the name is never the one torn down.
+    /// Empty for rows persisted before local spawns recorded an id.
+    pub backend_id: String,
     pub deleted_at: u64,
     /// Whether this row was hard-deleted (tmux window + worktrees torn down). A
     /// force-deleted session is shown in the restore list but cannot be restored
@@ -327,7 +331,7 @@ impl Database {
         let sql = format!(
             "SELECT s.id, s.name, s.agent, s.agent_session_id, \
              s.cwd, s.parent_session_id, s.deleted_at, s.backend_type, \
-             s.force_deleted, \
+             s.force_deleted, s.backend_id, \
              w.repo_path, w.worktree_path, w.branch \
              FROM sessions s \
              LEFT JOIN worktrees w ON s.id = w.session_id \
@@ -345,9 +349,10 @@ impl Database {
             let deleted_at: i64 = row.get(6)?;
             let backend_type: String = row.get(7)?;
             let force_deleted: i64 = row.get(8)?;
-            let wt_repo: Option<String> = row.get(9)?;
-            let wt_path: Option<String> = row.get(10)?;
-            let wt_branch: Option<String> = row.get(11)?;
+            let backend_id: String = row.get(9)?;
+            let wt_repo: Option<String> = row.get(10)?;
+            let wt_path: Option<String> = row.get(11)?;
+            let wt_branch: Option<String> = row.get(12)?;
 
             let worktree = worktree_from_cols(wt_repo, wt_path, wt_branch);
 
@@ -360,6 +365,7 @@ impl Database {
                     cwd: cwd.map(PathBuf::from),
                     parent_session_id: parent_str.and_then(|s| s.parse().ok()),
                     backend_type,
+                    backend_id,
                     deleted_at: deleted_at as u64,
                     force_deleted: force_deleted != 0,
                     worktrees: Vec::new(),
@@ -446,6 +452,21 @@ impl Database {
             )
             .optional()
             .map(Option::flatten)
+    }
+
+    /// Record the pane id (`%N`) of a session's agent window. A targeted UPDATE
+    /// like [`set_session_shell`](Self::set_session_shell) — one column, no
+    /// worktree churn. Used to refresh a stale or missing id (a legacy row the
+    /// interface just resolved by window name, a restore's fresh spawn);
+    /// ordinary spawns persist theirs through
+    /// [`upsert_session`](Self::upsert_session). Returns whether a row matched.
+    pub fn set_backend_id(&self, id: SessionId, pane: &str) -> rusqlite::Result<bool> {
+        let mut stmt = self.conn.prepare_cached(
+            "UPDATE sessions SET backend_id = ?1 \
+             WHERE id = ?2 AND deleted_at IS NULL",
+        )?;
+        let updated = stmt.execute(params![pane, id.to_string()])?;
+        Ok(updated > 0)
     }
 
     /// Record — or clear — the pane id of a session's companion shell. A

--- a/tests/create_e2e.rs
+++ b/tests/create_e2e.rs
@@ -55,6 +55,19 @@ fn repo() -> tempfile::TempDir {
     dir
 }
 
+/// Point the spawn at a private socket in a private directory, so it can never
+/// see — or race — the shared dev server (`thurbox-dev`). Without this the
+/// pipeline lands on the real socket: the "throwaway socket" was aspirational,
+/// `cleanup` killed a server nothing used, and the spawned windows leaked into
+/// (and interfered with) whatever else ran there. nextest runs one process per
+/// test, so env mutation is safe. Returns the tempdir so it outlives the test.
+fn isolate_tmux() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::env::set_var("TMUX_TMPDIR", dir.path());
+    std::env::set_var(thurbox::agent::tmux::SOCKET_OVERRIDE_ENV, SOCKET);
+    dir
+}
+
 fn cleanup() {
     let _ = Command::new("tmux")
         .args(["-L", SOCKET, "kill-server"])
@@ -70,6 +83,7 @@ fn creating_a_session_produces_a_worktree_a_row_and_a_window() {
 
     let repo = repo();
     let db = thurbox::storage::Database::open_in_memory().expect("db");
+    let _tmux_dir = isolate_tmux();
 
     // Isolate config and data, so this uses neither the real agents.toml nor
     // the real database. nextest runs each test in its own process, so a
@@ -130,6 +144,18 @@ fn creating_a_session_produces_a_worktree_a_row_and_a_window() {
     assert_eq!(row.name, "e2e-probe");
     assert_eq!(row.agent, "shell");
 
+    // The local spawn learned its pane id up front (`new-window -P`), so the
+    // row never depends on its window name — which is not unique.
+    #[cfg(not(windows))]
+    {
+        assert!(
+            spawned.backend_id.starts_with('%'),
+            "expected a pane id, got {:?}",
+            spawned.backend_id
+        );
+        assert_eq!(row.backend_id, spawned.backend_id);
+    }
+
     // The worktree exists on disk, on the branch that was asked for.
     let worktree = row
         .worktrees
@@ -157,4 +183,69 @@ fn creating_a_session_produces_a_worktree_a_row_and_a_window() {
     assert_eq!(published.branch.as_deref(), Some("feat/e2e"));
 
     cleanup();
+}
+
+/// Two sessions sharing a name — the state accepting the creation flow's
+/// proposed default twice produces. Each spawn must learn its *own* pane id,
+/// or the second one can never attach (their windows share the `tb-` name,
+/// which the interface refuses to guess between).
+#[test]
+#[cfg(not(windows))]
+fn two_sessions_sharing_a_name_get_distinct_pane_ids() {
+    if !have_tmux() {
+        eprintln!("skipping: tmux is not installed");
+        return;
+    }
+
+    let repo = repo();
+    let db = thurbox::storage::Database::open_in_memory().expect("db");
+    let _tmux_dir = isolate_tmux();
+    let home = tempfile::tempdir().expect("tempdir");
+    thurbox::paths::set_test_dir(home.path());
+    let config = thurbox::paths::config_file()
+        .expect("config path")
+        .parent()
+        .expect("config dir")
+        .to_path_buf();
+    std::fs::create_dir_all(&config).expect("mkdir");
+    std::fs::write(
+        config.join("agents.toml"),
+        "default = \"shell\"\n\n[[agents]]\nname = \"shell\"\ncommand = \"sh\"\nargs = []\n",
+    )
+    .expect("write agents.toml");
+
+    // No worktree: the duplicate-default repro is the plain-directory path (a
+    // repeated branch would fail loudly long before the window spawns).
+    let request = || thurbox::session_ops::spawn::SpawnRequest {
+        name: "twin".into(),
+        repo_path: repo.path().to_path_buf(),
+        agent: Some("shell".into()),
+        ..Default::default()
+    };
+
+    let first = match thurbox::session_ops::spawn::spawn_session_headless(&db, request()) {
+        Ok(spawned) => spawned,
+        Err(e) => {
+            cleanup();
+            if e.contains("tmux") {
+                eprintln!("skipping: tmux would not spawn a window: {e}");
+                return;
+            }
+            panic!("first creation failed: {e}");
+        }
+    };
+    let second = thurbox::session_ops::spawn::spawn_session_headless(&db, request())
+        .expect("second creation");
+    cleanup();
+
+    assert!(first.backend_id.starts_with('%'), "{:?}", first.backend_id);
+    assert!(
+        second.backend_id.starts_with('%'),
+        "{:?}",
+        second.backend_id
+    );
+    assert_ne!(
+        first.backend_id, second.backend_id,
+        "each session must be addressable by its own pane"
+    );
 }

--- a/tests/v2_attach_by_name.rs
+++ b/tests/v2_attach_by_name.rs
@@ -1,10 +1,11 @@
 //! Attaching to a session whose pane id the database does not carry.
 //!
-//! This is the gap that made the creation flow useless: a **local** spawn leaves
-//! `backend_id` empty on purpose — "for the TUI to resolve by name", which is
-//! what v1 does when it adopts windows at restore — so a session created by v2
-//! had a running agent, a real tmux window, and an interface insisting it had
-//! "no pane yet".
+//! This is the gap that made the creation flow useless: a **local** spawn used
+//! to leave `backend_id` empty — "for the TUI to resolve by name" — so a
+//! session created by v2 had a running agent, a real tmux window, and an
+//! interface insisting it had "no pane yet". Local spawns record their pane id
+//! now, but the name path remains the legacy ramp for rows persisted before
+//! that (and for psmux, which cannot report one), so it stays under test.
 //!
 //! Driven against a real tmux server on a private socket, because the thing under
 //! test is precisely the round trip: a window exists, its name is derivable from
@@ -115,12 +116,18 @@ async fn a_session_with_no_pane_id_is_found_by_its_window_name() {
         .failure("11111111-1111-1111-1111-111111111111")
         .unwrap_or_default()
         .to_string();
+    // A name-resolved adoption is queued for the loop to persist, so this row
+    // stops depending on its (non-unique) name after this first attach.
+    let adopted = terminals.drain_adopted_panes();
     tmux(&["kill-server"]);
 
     assert!(
         attached,
         "a session whose window exists must be attached, not reported as paneless: {failure}"
     );
+    assert_eq!(adopted.len(), 1, "the resolved pane must be migrated");
+    assert_eq!(adopted[0].0, "11111111-1111-1111-1111-111111111111");
+    assert!(adopted[0].1.starts_with('%'), "{:?}", adopted[0].1);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -192,6 +199,73 @@ fn a_remote_row_is_not_resolved_by_name() {
         terminals.failure("11111111-1111-1111-1111-111111111111"),
         Some("session has no pane yet")
     );
+}
+
+/// Two sessions sharing a name, each carrying its own pane id — what accepting
+/// the creation flow's proposed default twice now produces. Both must attach:
+/// the id is precise where the shared `tb-` window name is ambiguous.
+#[tokio::test(flavor = "multi_thread")]
+async fn two_sessions_sharing_a_name_both_attach_by_their_pane_ids() {
+    if !have_tmux() {
+        eprintln!("skipping: tmux is not installed");
+        return;
+    }
+    let home = tempfile::tempdir().expect("tempdir");
+    std::env::set_var("TMUX_TMPDIR", home.path());
+    std::env::set_var(thurbox::agent::tmux::SOCKET_OVERRIDE_ENV, SOCKET);
+
+    tmux(&["new-session", "-d", "-s", SESSION, "-n", "bash", "sh"]);
+    let pane_of =
+        |out: std::process::Output| String::from_utf8_lossy(&out.stdout).trim().to_string();
+    let first_pane = pane_of(tmux(&[
+        "new-window",
+        "-P",
+        "-F",
+        "#{pane_id}",
+        "-t",
+        SESSION,
+        "-n",
+        "tb-demo",
+        "sh -c 'while :; do sleep 1; done'",
+    ]));
+    let second_pane = pane_of(tmux(&[
+        "new-window",
+        "-P",
+        "-F",
+        "#{pane_id}",
+        "-t",
+        SESSION,
+        "-n",
+        "tb-demo",
+        "sh -c 'while :; do sleep 1; done'",
+    ]));
+    assert!(first_pane.starts_with('%') && second_pane.starts_with('%'));
+
+    let mut first = row("demo");
+    first.backend_id = Some(first_pane);
+    let mut second = row("demo");
+    second.id = "22222222-2222-2222-2222-222222222222".into();
+    second.backend_id = Some(second_pane);
+    let rows = snapshot(vec![first, second]);
+
+    let mut terminals = Terminals::new();
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    let mut both = false;
+    while std::time::Instant::now() < deadline && !both {
+        terminals.sync(&rows, 24, 80);
+        both = terminals.is_attached("11111111-1111-1111-1111-111111111111")
+            && terminals.is_attached("22222222-2222-2222-2222-222222222222");
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    // Neither pane was resolved by name, so there is nothing to migrate.
+    let adopted = terminals.drain_adopted_panes();
+    tmux(&["kill-server"]);
+
+    assert!(
+        both,
+        "both sessions carry their own pane id and must attach"
+    );
+    assert!(adopted.is_empty(), "nothing was name-resolved: {adopted:?}");
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Summary
- A local spawn stored no pane id and the TUI resolved its pane by tmux window name (`tb-<name>`), which is not unique: creating two sessions with the same name (accepting the creation flow's proposed default twice) left the second stuck at "no live terminal" — the resolver deliberately refuses an ambiguous window name — and name-targeted lifecycle ops (restart/delete kill, capture, prompt-send) could hit the wrong duplicate's window.
- Local spawns now learn their pane id up front (`new-window -P`, matching what remote spawns already did) and persist it; the one-shot tmux helpers target the pane id first, verifying it still sits in the session's own `tb-` window (tmux reuses pane numbers across server restarts), with the window name kept as fallback for legacy rows.
- Legacy rows migrate themselves: a pane the interface still resolved by name has its id written back after the first successful adoption (`Database::set_backend_id`, drained by the loop). Windows/psmux keeps today's empty-id behavior until `-P` is probed there.
- Also actually applies `tests/create_e2e.rs`'s throwaway tmux socket — it was aspirational, so its spawned windows landed on (and raced) the real `thurbox-dev` server.

## Test plan
- [x] `cargo nextest run --all` — 1944 pass (plus clippy `-D warnings`, `cargo doc -D warnings`, fmt, architecture rules)
- [x] New test: two same-named sessions with distinct pane ids both attach (`tests/v2_attach_by_name.rs`)
- [x] New test: two same-named spawns get distinct pane ids (`tests/create_e2e.rs`)
- [x] Sandbox repro: `session create --name thurbox` twice on one repo → rows persisted with `%1`/`%2`
- [ ] Manual TUI check: Ctrl+N twice on the same repo accepting the default name → both panes live; Ctrl+D one → the other survives

🤖 Generated with [Claude Code](https://claude.com/claude-code)