### PR TITLE
fix(core): keep the agent activity line across a restart

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -421,6 +421,23 @@ to repaint its visible screen through the normal `%output` stream
 of the seeded history. Seeding is best-effort: a failed capture
 logs a warning and adoption proceeds with an empty seed.
 
+The seed also carries the pane's **window title**, replayed ahead
+of the history as an OSC 2 (`title_seed_bytes`). Agents use the
+title as their activity line — Claude Code writes the task it is
+on, and the session list renders it beside the name — and thurbox
+reads it off the PTY, so an adopt that joins the stream mid-flight
+showed nothing there until the agent next repainted it. tmux kept
+the value (`#{pane_title}` *is* the last OSC the pane emitted), so
+adopt reads it back and replays it through the same callback a
+live title takes; nothing downstream learns a second way of being
+told. A pane that never had one reads back as `#{host_short}` —
+tmux's default, not an agent's line — and is suppressed. The query
+is its own best-effort round trip rather than a chain onto the
+capture: a mux that answers it differently (psmux is unverified
+here) must lose the activity line, never the scrollback. The
+attention notification (OSC 9/777) is deliberately **not**
+restored — it is an event, not state.
+
 **Rejected**:
 
 - *`pipe-pane` + FIFO (previous)* — intermittent data loss from

--- a/src/agent/backend.rs
+++ b/src/agent/backend.rs
@@ -242,8 +242,8 @@ pub trait SessionBackend: Send + Sync {
         cols: u16,
     ) -> Result<SpawnedSession>;
 
-    /// Reconnect to an existing session. `seed` is pre-captured scrollback
-    /// history to prepend to the live stream (see [`Self::capture_history`]);
+    /// Reconnect to an existing session. `seed` is the pre-captured pane state
+    /// to prepend to the live stream (see [`Self::capture_history`]);
     /// `None` makes the backend capture it itself — the two paths produce the
     /// same bytes, `Some` just lets restore overlap the captures (ADR-P9).
     fn adopt(
@@ -254,12 +254,14 @@ pub trait SessionBackend: Send + Sync {
         seed: Option<Vec<u8>>,
     ) -> Result<AdoptedSession>;
 
-    /// Capture a session's scrollback history as terminal bytes suitable for
-    /// seeding a fresh parser, to pass into [`Self::adopt`]. An independent
-    /// subprocess per pane, safe to run concurrently across sessions — unlike
-    /// `adopt`'s control-mode connect, which is serialized. Default: no
-    /// history (backends without a capture facility adopt with an empty
-    /// scrollback, exactly as if the capture had failed).
+    /// Capture the pane state the live stream cannot replay — its scrollback
+    /// history, and any terminal state the backend can read back, such as the
+    /// window title an agent uses as its activity line — as terminal bytes
+    /// suitable for seeding a fresh parser, to pass into [`Self::adopt`]. An
+    /// independent subprocess per pane, safe to run concurrently across
+    /// sessions — unlike `adopt`'s control-mode connect, which is serialized.
+    /// Default: nothing (backends without a capture facility adopt with an
+    /// empty scrollback, exactly as if the capture had failed).
     fn capture_history(&self, _backend_id: &str) -> Result<Vec<u8>> {
         Ok(Vec::new())
     }
@@ -730,8 +732,8 @@ impl Session {
         ))
     }
 
-    /// Reconnect to an existing backend session. `seed` is optional
-    /// pre-captured scrollback (see [`SessionBackend::capture_history`]);
+    /// Reconnect to an existing backend session. `seed` is the optional
+    /// pre-captured pane state (see [`SessionBackend::capture_history`]);
     /// `None` = the backend captures it during the adopt.
     #[allow(clippy::too_many_arguments)]
     pub fn adopt(
@@ -1583,6 +1585,15 @@ mod tests {
         // OSC 0 (set icon name + title) updates it too.
         parser.process(b"\x1b]0;done\x07");
         assert_eq!(title.lock().unwrap().as_deref(), Some("done"));
+
+        // ST-terminated, which is what the adopt-time replay of a pane title
+        // emits (`title_seed_bytes`) — the restored activity line depends on
+        // this arriving through the same callback a live title does.
+        parser.process(b"\x1b]2;restored from the pane title\x1b\\");
+        assert_eq!(
+            title.lock().unwrap().as_deref(),
+            Some("restored from the pane title")
+        );
 
         // An empty title clears the cell rather than storing "".
         parser.process(b"\x1b]2;\x07");

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -239,6 +239,13 @@ const SEND_KEYS_ENTER_DELAY: std::time::Duration = std::time::Duration::from_mil
 /// Hard cap on the number of scrollback lines `capture_pane_text` will return.
 const MAX_CAPTURE_LINES: u32 = 10_000;
 
+/// Longest agent activity line replayed from a pane title at adopt time.
+///
+/// A title is one line in the session list, and the value comes back from a
+/// host: bounding it here means a pane whose title is a megabyte cannot make
+/// the seed one.
+const MAX_TITLE_SEED_BYTES: usize = 512;
+
 /// A tmux backend — sessions persist in `tmux -L <socket>` on either the local
 /// machine or a remote host reached over SSH.
 ///
@@ -803,15 +810,16 @@ impl TmuxBackend {
         })
     }
 
-    /// Capture a pane's scrollback history + visible screen as terminal bytes
-    /// suitable for seeding a fresh vt100 parser.
+    /// Capture a pane's window title, scrollback history and visible screen as
+    /// terminal bytes suitable for seeding a fresh vt100 parser.
     ///
     /// The control-mode `%output` stream only carries bytes emitted after the
     /// pane is connected, so an adopted session would otherwise start with an
     /// empty scrollback — the forced repaint restores the visible screen but
     /// not the history above it. `-e` keeps colors, `-J` rejoins wrapped lines
     /// so they re-wrap at the adopting panel's width, `-S -<n>` extends the
-    /// capture into history (tmux clamps to what exists).
+    /// capture into history (tmux clamps to what exists). The title rides
+    /// along because the capture cannot carry it — see [`Self::pane_title_seed`].
     fn capture_history_seed(&self, pane_id: &str) -> Result<Vec<u8>> {
         let lines = crate::session::settings::global()
             .scrollback_lines
@@ -827,7 +835,50 @@ impl TmuxBackend {
             "-t",
             pane_id,
         ])?;
-        Ok(history_seed_bytes(output.stdout))
+        // Ahead of the history, not after it: the capture ends wherever the
+        // pane's last line ended, and appending to a run that stopped mid
+        // escape sequence would feed the parser a spliced one.
+        let mut seed = self.pane_title_seed(pane_id);
+        seed.extend(history_seed_bytes(output.stdout));
+        Ok(seed)
+    }
+
+    /// The pane's window title replayed as an OSC 2, or empty when the pane
+    /// has none worth restoring.
+    ///
+    /// Agents use the window title as their activity line — Claude Code writes
+    /// the task it is on — and thurbox reads it off the PTY, so a restart that
+    /// joins the stream mid-flight shows nothing until the agent next repaints
+    /// it. tmux kept the value: `#{pane_title}` *is* the last OSC the pane
+    /// emitted. Replaying it puts it back through the same callback a live
+    /// title takes (`TermSignals`'s title callback), so nothing downstream
+    /// learns a second way of being told.
+    ///
+    /// Best-effort by construction: a pane title is a nicety and the history
+    /// beside it is not, so a mux that answers this differently (psmux is
+    /// unverified here) loses the line rather than the scrollback.
+    fn pane_title_seed(&self, pane_id: &str) -> Vec<u8> {
+        // One query for both halves: a pane that never had a title set reads
+        // back as the host's own short name, which is tmux's default rather
+        // than anything an agent said.
+        let out = match self.run_tmux(&[
+            "display-message",
+            "-p",
+            "-t",
+            pane_id,
+            "#{host_short}|#{pane_title}",
+        ]) {
+            Ok(out) => out,
+            Err(e) => {
+                debug!(pane = %pane_id, "could not read pane title: {e:#}");
+                return Vec::new();
+            }
+        };
+        let line = String::from_utf8_lossy(&out.stdout);
+        let Some((host, title)) = line.lines().next().and_then(|l| l.split_once('|')) else {
+            return Vec::new();
+        };
+        title_seed_bytes(host, title)
     }
 
     /// Resize a pane, forcing a SIGWINCH even if dimensions haven't changed.
@@ -1516,6 +1567,33 @@ pub fn capture_pane_text(session_name: &str, pane_id: &str, lines: u32) -> Resul
         );
     }
     Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// The OSC 2 that restores `title` as a pane's window title, or empty when
+/// there is nothing to restore.
+///
+/// Suppressed for a title equal to `host_short`, which is what tmux seeds a
+/// pane with and therefore means "no agent ever set one" — replaying it would
+/// put a hostname in the session list where the activity line goes. Control
+/// characters are dropped because the value is remote-controlled text and the
+/// sequence is terminated by one.
+fn title_seed_bytes(host_short: &str, title: &str) -> Vec<u8> {
+    let title = title.trim();
+    if title.is_empty() || title == host_short.trim() {
+        return Vec::new();
+    }
+    let mut text = String::new();
+    for c in title.chars().filter(|c| !c.is_control()) {
+        if text.len() + c.len_utf8() > MAX_TITLE_SEED_BYTES {
+            break;
+        }
+        text.push(c);
+    }
+    let text = text.trim_end();
+    if text.is_empty() {
+        return Vec::new();
+    }
+    format!("\x1b]2;{text}\x1b\\").into_bytes()
 }
 
 /// Convert raw `capture-pane -p` output into vt100 parser input: drop the
@@ -2224,6 +2302,41 @@ mod tests {
         // Never infer deadness from anything but the flag itself.
         assert!(!parse_pane_dead("10"));
         assert!(!parse_pane_dead("dead"));
+    }
+
+    // --- title_seed_bytes tests (adopt-time activity-line restore) ---
+
+    #[test]
+    fn title_seed_replays_an_agent_title_as_osc_2() {
+        assert_eq!(
+            title_seed_bytes("devbox", "\u{2733} Terminal name lost on restart"),
+            "\x1b]2;\u{2733} Terminal name lost on restart\x1b\\".as_bytes()
+        );
+    }
+
+    #[test]
+    fn title_seed_suppresses_tmuxs_default_title() {
+        // A pane nothing ever titled reads back as the host's own short name.
+        assert!(title_seed_bytes("devbox", "devbox").is_empty());
+        assert!(title_seed_bytes("devbox", "  devbox  ").is_empty());
+        assert!(title_seed_bytes("devbox", "   ").is_empty());
+    }
+
+    #[test]
+    fn title_seed_drops_control_characters() {
+        // The title is remote-controlled text and the sequence it goes into is
+        // terminated by an escape, so a title carrying one must not close it.
+        let seed = title_seed_bytes("h", "done\x1b\\ + rm -rf\x07\nnext");
+        assert_eq!(seed, "\x1b]2;done\\ + rm -rfnext\x1b\\".as_bytes());
+    }
+
+    #[test]
+    fn title_seed_bounds_a_huge_title() {
+        let seed = title_seed_bytes("h", &"\u{00e9}".repeat(4_000));
+        // The budget is the payload's; the introducer and terminator sit
+        // outside it. Multi-byte chars must not be split to reach it either.
+        assert!(seed.len() <= MAX_TITLE_SEED_BYTES + 6, "{}", seed.len());
+        assert!(std::str::from_utf8(&seed).is_ok());
     }
 
     // --- history_seed_bytes tests (adopt-time scrollback seeding) ---


### PR DESCRIPTION
## Summary

- The session list's activity text is the agent's **OSC window title** — Claude Code writes the task it is on — captured off the live PTY by `TermSignals::set_window_title`. An adopt seeds the parser from `capture-pane -e -p -J`, which carries text and SGR colours but no OSC, so **restarting thurbox blanked that line** until the agent next repainted its title.
- tmux kept the value all along: `#{pane_title}` *is* the last OSC the pane emitted. `TmuxBackend::pane_title_seed` reads it back and `title_seed_bytes` replays it as an OSC 2 **ahead of** the history, so it arrives through the same callback a live title takes — nothing downstream learns a second way of being told. Both the inline adopt and restore's parallel prefetch (ADR-P9) go through `capture_history_seed`, so both paths get it.
- A pane that never had a title reads back as `#{host_short}` (tmux's default), and is **suppressed** — otherwise the list would show a hostname where the activity line goes.
- Title text is control-char-stripped and bounded at 512 bytes: it is remote-controlled text going into an escape-terminated sequence.
- The query is its **own** best-effort round trip rather than a chain onto the capture. A mux that answers it differently (psmux is unverified here) loses the activity line, never the scrollback.
- The OSC 9/777 **notification** is deliberately not restored — it is an event, not state, and tmux keeps no equivalent.
- `SessionBackend::capture_history` / `adopt` docs widened from "scrollback" to the pane state the live stream cannot replay, so the trait contract matches what the seed now carries. `docs/ARCHITECTURE.md` records the decision under ADR-13's "Session restore".

## Test plan

- `cargo nextest run --all` — 1948 passed.
- New unit tests (`src/agent/tmux.rs`): OSC 2 shape, default-title suppression, control-character stripping, and the byte bound on a huge multi-byte title.
- `title_capture_extracts_osc_title` (`src/agent/backend.rs`) extended with the **ST-terminated** form the replay emits — the previous coverage was BEL-only, and the restore depends on ST reaching the same callback.
- Verified against a real tmux on a throwaway socket: a fresh pane reports `linux-host|linux-host` (suppressed); a pane that set a title reports `linux-host|✳ Restoring the activity line`, while its `capture-pane` output carries no title at all — which is exactly why the line was lost.
- `cargo clippy --all-targets --all-features -- -D warnings` and `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` clean.

https://claude.ai/code/session_01Crc3NQMHYnjQkFBMNUtZt2