### PR TITLE
fix: Windows paste, mouse selection, and SSH clipboard copy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2636,6 +2636,7 @@ dependencies = [
  "clap",
  "cron",
  "crossterm",
+ "crossterm_winapi",
  "libc",
  "mlua",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,12 @@ serde_ignored = "0.1.14"
 [target.'cfg(target_os = "linux")'.dependencies]
 notify-rust = "4"
 
+# The console input mode, for the mouse. Already in the tree (crossterm's own
+# Windows backend is built on it), so this costs no new dependency -- see
+# `coordinator::chrome`'s `windows_console` for what it is needed for.
+[target.'cfg(windows)'.dependencies]
+crossterm_winapi = "0.9"
+
 [[bin]]
 name = "thurbox-cli"
 path = "src/bin/thurbox-cli.rs"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -124,6 +124,60 @@ are handled in one place.
   crossterm's internal byte representation doesn't match xterm
   sequences. Modifier keys, in particular, would break.
 
+### A paste on Windows arrives as keys, not as a paste
+
+`Event::Paste` is unix-only. crossterm's Windows source reads console
+INPUT_RECORDs, and `EnableBracketedPaste` there is documented as unsupported
+(`execute_winapi` returns `Unsupported`), so a paste into the TUI arrives as a
+stream of key presses — every line break an `Enter` that thurbox forwarded to
+the agent, which submitted the prompt one line at a time.
+
+`coordinator::paste` turns that stream back into a paste before anything is
+dispatched. Its shape is dictated by what the console actually delivers,
+measured against the `ssh` → ConPTY path with a key dumper rather than assumed:
+
+- **The bracketed-paste markers are gone.** The ConPTY strips `ESC[200~` /
+  `ESC[201~` before the app sees them; a paste is plain `Char`/`Enter` events
+  with no framing at all. There is nothing to match on, so there is no marker
+  machinery.
+- **Editing keys arrive whole.** An arrow key, `Delete`, `Ctrl+Delete`, a
+  function key each arrive as their own `KeyEvent` (`KeyCode::Left`, …), not as
+  a run of `ESC` `[` `…` character events.
+
+So the only thing separating a paste from typing is **timing**, and two small
+rules follow:
+
+1. **Grouping is by the inter-key gap.** A plain character joins a run when it
+   lands within 10 ms of the previous one; a person's fastest two keys stay
+   well above that and a pasted stream runs far under it. **Everything that is
+   not a plain character passes straight through the instant it arrives** — an
+   arrow, `Delete`, `Esc`, any `Ctrl`/`Alt` chord is never buffered, so it can
+   never be swallowed. (Earlier attempts carried a marker/`Esc`/VT-sequence
+   state machine that matched none of these inputs yet sat between every one of
+   them and the agent; each rev fixed one input and broke another until it was
+   removed.)
+2. **A run is a paste only if it carries an interior newline.** Delivering
+   newlines to the agent one keystroke at a time is the sole thing this path
+   exists to prevent — it is what submits a prompt mid-paste — so it is the only
+   thing acted on. A newline-free run is emitted as the keys it was, because the
+   clock times when a key is *read*, not when it was pressed: under load two
+   keys a person typed 100 ms apart can be read together, and coalescing on
+   length alone announced a phantom "pasted 2 characters" mid-type. A run that
+   merely *ends* at a newline is a typed line submitted with `Enter`, so it too
+   stays keys and still submits.
+
+The result is that a multi-line paste reaches the agent as one bracketed paste
+— which it renders as a paste (Claude Code collapses it to `[Pasted text #1 +N
+lines]`) rather than as typing — while every editing key and every keystroke of
+ordinary typing is untouched. The loop waits at most 10 ms for the next key
+while a run is open and not at all otherwise, so an idle interface polls exactly
+as before. The coalescer is inert where `Event::Paste` arrives on its own, and
+its decisions are unit-tested on every platform against a driven clock.
+
+This is the *inbound* half of a journey whose outbound half is ADR-13's
+`PsmuxPaste`: the reassembled paste is carried to a psmux pane in one piece by
+psmux's own paste command.
+
 ---
 
 ## ADR-5: Responsive layout breakpoints

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -2168,6 +2168,18 @@ for one can stall for seconds. When no local clipboard is reachable,
 (usually **`Ctrl+Shift+V`**), which delivers the text as an ordinary
 bracketed paste that thurbox routes exactly like `Ctrl+V`.
 
+### Pasting on Windows
+
+A Windows terminal reports no paste at all — crossterm delivers one there as
+ordinary key presses, so a multi-line prompt used to submit itself a line at a
+time. thurbox rebuilds the paste from that key stream before it is dispatched,
+by timing: characters arriving faster than anyone can type are gathered, and a
+gathered run that carries a line break is handed over as one paste (so an agent
+shows it as a paste, not as typing). Everything else is left exactly as it was
+— every editing key passes straight through, ordinary typing is untouched, and
+a line you type and submit with `Enter` still submits. Rationale: ADR-4 in
+`docs/ARCHITECTURE.md`.
+
 ---
 
 ## Mouse Navigation

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -2137,18 +2137,29 @@ provider` in settings.toml (`auto` | `native` | `osc52` | `none`):
    to `/dev/tty` rather than stdout, because a multiplexer intercepts
    OSC 52 arriving on a child's stdout.
 
-`auto` tries native first (it is the only one that can confirm it
-worked) and falls back to OSC 52. There is deliberately **no**
-`$SSH_TTY` check: the SSH env vars are only a proxy for "no local
-clipboard", trying the local clipboard answers that directly, and
-under tmux those vars are frequently stale (the server daemonizes with
-its first client's environment). Neovim shipped SSH detection here and
-removed it in 0.11 for the same reason.
+`auto` writes to **both**: native for the local case, OSC 52 for
+whoever is actually looking at the screen. There is deliberately **no**
+`$SSH_TTY` check — those vars are frequently stale under tmux (the
+server daemonizes with its first client's environment), and Neovim
+shipped SSH detection here and removed it in 0.11.
 
-The toast names the transport (`Copied to clipboard (OSC 52)`) so a
-terminal that silently ignores the sequence is diagnosable. Text over
-~74 KB is refused with an explicit error rather than written, because
-tmux discards an oversized OSC 52 sequence **entirely**.
+It used to *stop* at a successful native write, on the reasoning that
+trying the local clipboard answers "is there one?" directly. That
+holds only where a native clipboard is absent when nobody is at the
+machine — X11 and Wayland, where a headless SSH session has no display
+and `arboard` fails. Windows has no such property: the clipboard of a
+session nobody is looking at accepts writes and reports success, so a
+copy from a Windows host over SSH landed there, said `copied 15
+line(s)`, and never reached the person who pressed the key. Writing
+both costs one escape sequence a terminal either uses or ignores, and
+removes the platform difference rather than adding a branch.
+
+The toast names the transport only when OSC 52 was the *only* path that
+ran (`copied 8 line(s) (OSC 52)`), so a terminal that silently ignores
+the sequence is diagnosable while an ordinary copy stays quiet. Text
+over ~74 KB skips OSC 52 — tmux discards an oversized sequence
+**entirely** — and is an error only when the native write did not
+carry it either.
 
 thurbox sets `set-clipboard on` and `terminal-features ,*:clipboard`
 on its own tmux server (`TmuxBackend::apply_clipboard_config`). Both

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,7 +1,7 @@
 //! Clipboard writes that survive SSH.
 //!
-//! Two transports, tried in order (see [`ClipboardProvider`] for the config
-//! knob that overrides the order):
+//! Two transports, and by default both are used (see [`ClipboardProvider`] for
+//! the config knob that forces one):
 //!
 //! 1. **Native** ([`arboard`]) — talks to the local display server. Verifiable:
 //!    it reports real success or a real error. Unavailable the moment thurbox
@@ -11,19 +11,31 @@
 //!    many SSH hops are in between. Fire-and-forget: a terminal that doesn't
 //!    implement it discards the sequence, and we can never tell.
 //!
-//! ## Why the order is "native, then OSC 52" and not a check for SSH
+//! ## Why `auto` writes BOTH, and still does not check for SSH
 //!
-//! The obvious design — sniff `$SSH_TTY` and pick a transport — is a trap, and
-//! the ecosystem has already walked out of it. Neovim shipped exactly that in
-//! 0.10 and **removed it as a breaking change** in 0.11 (PR #31730): the SSH
-//! check is only ever a proxy for "no local clipboard here", and *trying* the
-//! local clipboard answers that question directly and correctly. Helix and
-//! gitui order their providers the same way; nothing modern branches on SSH for
-//! a clipboard *write*.
+//! Sniffing `$SSH_TTY` to pick a transport is a trap, and the ecosystem has
+//! already walked out of it. Neovim shipped exactly that in 0.10 and **removed
+//! it as a breaking change** in 0.11 (PR #31730); nothing modern branches on
+//! SSH for a clipboard *write*. thurbox has an extra reason to distrust the
+//! env: the tmux server daemonizes with the environment of its **first**
+//! client, so panes routinely carry stale or missing `SSH_*`.
 //!
-//! thurbox has an extra reason to distrust the env: the tmux server daemonizes
-//! with the environment of its **first** client, so panes routinely carry stale
-//! or missing `SSH_*` from whenever the server happened to start.
+//! What that reasoning got wrong here was the next step: "*trying* the local
+//! clipboard answers the question directly". It answers it only where a native
+//! clipboard is **absent when nobody is at the machine** — X11 and Wayland,
+//! where a headless SSH session has no display and `arboard` fails, so the
+//! fallback to OSC 52 ran and copy worked. Windows has no such property: the
+//! clipboard of a session nobody is looking at accepts writes and reports
+//! success. So a copy from a Windows host over SSH landed in that host's
+//! clipboard, reported success, and never reached the person who pressed the
+//! key.
+//!
+//! Hence `auto` writes to **both**: native for the local case (verifiable, and
+//! what a clipboard manager sees), OSC 52 for whoever is actually looking at
+//! the screen. No SSH check, no platform branch, no way for one transport's
+//! success to hide the other's necessity — and either one succeeding is a
+//! successful copy. `native` and `osc52` still force a single transport for
+//! anyone who wants one.
 //!
 //! ## Why we don't probe for OSC 52 support either
 //!
@@ -62,6 +74,10 @@ pub enum CopyRoute {
     Native,
     /// An OSC 52 sequence was written to the terminal (unverifiable).
     Osc52,
+    /// Both: the local clipboard took it AND the sequence went out, which is
+    /// what `auto` does so that neither the person at the machine nor the
+    /// person at the far end of an SSH hop is the one who misses out.
+    Both,
 }
 
 impl CopyRoute {
@@ -70,7 +86,10 @@ impl CopyRoute {
     /// drops it can tell which path ran.
     pub fn toast_suffix(self) -> &'static str {
         match self {
-            CopyRoute::Native => "",
+            // The unremarkable cases: something verifiable took it.
+            CopyRoute::Native | CopyRoute::Both => "",
+            // Named, so a user whose terminal drops OSC 52 can tell that this
+            // was the only path that ran.
             CopyRoute::Osc52 => " (OSC 52)",
         }
     }
@@ -156,29 +175,43 @@ pub fn copy(
 
     let mut detail = String::new();
 
-    // Native first when permitted: it is the only transport that can confirm it
-    // worked, so preferring it keeps the common local case verifiable.
+    // Native when permitted: the only transport that can confirm it worked, and
+    // the one a local clipboard manager sees. Its success is no longer the end
+    // of the story under `auto` — see the module docs for why a Windows host
+    // says yes to a clipboard nobody is looking at.
+    let mut native_ok = false;
     if provider != ClipboardProvider::Osc52 {
         match native {
             Some(cb) => match cb.set_text(text) {
-                Ok(()) => return Ok(CopyRoute::Native),
+                Ok(()) => native_ok = true,
                 Err(e) => detail = format!("native: {e}"),
             },
             None => detail = "native: unavailable".into(),
         }
         if provider == ClipboardProvider::Native {
-            return Err(CopyError::NoTransport { detail });
+            return native_ok
+                .then_some(CopyRoute::Native)
+                .ok_or(CopyError::NoTransport { detail });
         }
     }
 
     // OSC 52 carries the payload whole or not at all, so refuse oversized text
-    // rather than let tmux discard it silently.
+    // rather than let tmux discard it silently. Text that big is still a
+    // successful copy when the local clipboard took it — only the far end
+    // misses out, and saying so beats reporting a failure that did not happen.
     if text.len() > OSC52_MAX_BYTES {
-        return Err(CopyError::TooLarge { bytes: text.len() });
+        return native_ok
+            .then_some(CopyRoute::Native)
+            .ok_or(CopyError::TooLarge { bytes: text.len() });
     }
 
     match write_osc52(text) {
+        Ok(()) if native_ok => Ok(CopyRoute::Both),
         Ok(()) => Ok(CopyRoute::Osc52),
+        Err(e) if native_ok => {
+            tracing::warn!("copied natively, but the OSC 52 write failed: {e}");
+            Ok(CopyRoute::Native)
+        }
         Err(e) => {
             if !detail.is_empty() {
                 detail.push_str("; ");
@@ -259,5 +292,18 @@ mod tests {
     fn toast_suffix_names_only_the_unverifiable_route() {
         assert_eq!(CopyRoute::Native.toast_suffix(), "");
         assert!(CopyRoute::Osc52.toast_suffix().contains("OSC 52"));
+        // Both is the ordinary `auto` outcome, and something verifiable took
+        // it: naming a transport there would be noise on every copy.
+        assert_eq!(CopyRoute::Both.toast_suffix(), "");
+    }
+
+    /// Oversized text is only a failure when nothing else carried it. The
+    /// far end misses out; the local clipboard still has it, and reporting a
+    /// failure that did not happen is worse than saying so.
+    #[test]
+    fn oversized_text_without_a_native_clipboard_is_still_an_error() {
+        let huge = "x".repeat(OSC52_MAX_BYTES + 1);
+        let err = copy(&huge, None, ClipboardProvider::Auto).unwrap_err();
+        assert!(matches!(err, CopyError::TooLarge { .. }));
     }
 }

--- a/src/coordinator/boot.rs
+++ b/src/coordinator/boot.rs
@@ -190,6 +190,7 @@ pub(crate) async fn run() -> Result<(), Box<dyn Error>> {
         selected_text: None,
         hovered: None,
         mouse: config.features().mouse,
+        paste_burst: crate::coordinator::paste::PasteBurst::for_platform(),
         config,
         registry: Registry::load(),
         modals: Modals::default(),

--- a/src/coordinator/chrome.rs
+++ b/src/coordinator/chrome.rs
@@ -256,6 +256,9 @@ pub(crate) fn restore_terminal() {
         crossterm::event::DisableMouseCapture,
         crossterm::event::DisableBracketedPaste
     );
+    // The console's own mouse handling is a mode, not an escape, so the line
+    // above does not give it back. Idempotent, and a no-op if we never took it.
+    windows_console::release_mouse();
     ratatui::restore();
 }
 
@@ -314,8 +317,73 @@ pub(crate) fn pop_keyboard_enhancement() {
 /// `DisableMouseCapture` still turns everything off, so teardown is unchanged.
 pub(crate) fn enable_mouse_clicks() -> bool {
     use std::io::Write;
+    // The escape asks the TERMINAL to report. On Windows something else has to
+    // be asked as well, or the console keeps every drag for itself.
+    windows_console::capture_mouse();
     let mut out = std::io::stdout();
     out.write_all(b"\x1b[?1000h\x1b[?1003h\x1b[?1006h").is_ok() && out.flush().is_ok()
+}
+
+/// The Windows console's own mouse handling, which that escape does not reach.
+///
+/// A console with `ENABLE_QUICK_EDIT_MODE` set -- the Windows default -- takes
+/// every drag for **its** selection: it highlights a rectangle of the whole
+/// screen buffer, copies through conhost, and never tells the application. So a
+/// drag selected across panes instead of within one, and the copy that followed
+/// raised no toast, because thurbox was not involved in either. crossterm does
+/// not touch these bits (its raw mode clears only the line, echo and processed
+/// flags), so this does.
+///
+/// Three bits, and all three are load-bearing: `ENABLE_MOUSE_INPUT` to be told
+/// about the mouse at all, `ENABLE_EXTENDED_FLAGS` because without it a write
+/// of the quick-edit bit is ignored, and quick edit **off** so the drag is
+/// ours. The mode that was there is put back by [`restore_terminal`].
+#[cfg(windows)]
+mod windows_console {
+    use crossterm_winapi::{ConsoleMode, Handle};
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    const ENABLE_MOUSE_INPUT: u32 = 0x0010;
+    const ENABLE_QUICK_EDIT_MODE: u32 = 0x0040;
+    const ENABLE_EXTENDED_FLAGS: u32 = 0x0080;
+    /// Not a mode any console reports, so it cannot be one we saved.
+    const NOT_SAVED: u32 = u32::MAX;
+
+    static SAVED_MODE: AtomicU32 = AtomicU32::new(NOT_SAVED);
+
+    pub(super) fn capture_mouse() {
+        let Ok(handle) = Handle::current_in_handle() else {
+            return;
+        };
+        let console = ConsoleMode::from(handle);
+        let Ok(current) = console.mode() else {
+            return;
+        };
+        let wanted =
+            (current | ENABLE_MOUSE_INPUT | ENABLE_EXTENDED_FLAGS) & !ENABLE_QUICK_EDIT_MODE;
+        match console.set_mode(wanted) {
+            // Saved only once it is really ours, so a failed take restores
+            // nothing on the way out.
+            Ok(()) => SAVED_MODE.store(current, Ordering::SeqCst),
+            Err(e) => tracing::warn!("could not take the console's mouse input: {e}"),
+        }
+    }
+
+    pub(super) fn release_mouse() {
+        let saved = SAVED_MODE.swap(NOT_SAVED, Ordering::SeqCst);
+        if saved == NOT_SAVED {
+            return;
+        }
+        if let Ok(handle) = Handle::current_in_handle() {
+            let _ = ConsoleMode::from(handle).set_mode(saved);
+        }
+    }
+}
+
+#[cfg(not(windows))]
+mod windows_console {
+    pub(super) fn capture_mouse() {}
+    pub(super) fn release_mouse() {}
 }
 
 /// The next terminal event, or `None` if none arrived within `timeout`.

--- a/src/coordinator/input.rs
+++ b/src/coordinator/input.rs
@@ -8,6 +8,7 @@
 //! outranks a global one — which is why search cannot take `Ctrl+N` from
 //! new-session.
 
+use super::paste::Input;
 use super::*;
 
 impl App {
@@ -30,9 +31,11 @@ impl App {
         let mut published = false;
         let mut waited = false;
         loop {
-            // Only the first read waits; the rest take what is already queued.
+            // Only the first read waits; the rest take what is already queued —
+            // except while the paste coalescer holds a key it cannot yet
+            // decide about, which is worth a few milliseconds of the batch.
             let timeout = if waited {
-                Duration::ZERO
+                self.paste_burst.drain_timeout()
             } else {
                 self.poll_timeout()
             };
@@ -64,10 +67,13 @@ impl App {
                 }
             };
             match event {
+                // Where the terminal reports no paste of its own, one arrives
+                // here as keys and has to be recognised as one — the coalescer
+                // hands back whichever of the two this turned out to be.
                 Event::Key(key) if key.kind == KeyEventKind::Press => {
-                    self.publish_for_batch(&mut published);
-                    self.time_op("input_dispatch", |app| app.on_key(&key));
-                    self.note_input();
+                    for input in self.paste_burst.push(key, Instant::now()) {
+                        self.apply_input(input, &mut published);
+                    }
                 }
                 // Dropped rather than merely uncaptured when the feature is
                 // off, so the flag stays authoritative even if a terminal
@@ -93,7 +99,22 @@ impl App {
                 _ => {}
             }
         }
+        // Nothing is queued behind the batch, so a run being watched has to go
+        // somewhere: a paste, or the keys it was made of.
+        for input in self.paste_burst.flush() {
+            self.apply_input(input, &mut published);
+        }
         Ok(())
+    }
+
+    /// Dispatch one resolved input, publishing `thurbox.*` once per batch.
+    fn apply_input(&mut self, input: Input, published: &mut bool) {
+        self.publish_for_batch(published);
+        match input {
+            Input::Key(key) => self.time_op("input_dispatch", |app| app.on_key(&key)),
+            Input::Paste(text) => self.on_paste(text),
+        }
+        self.note_input();
     }
 
     pub(crate) fn on_key(&mut self, key: &KeyEvent) {
@@ -116,7 +137,6 @@ impl App {
         if self.dispatch_session_input(key) {
             return;
         }
-
         // An `Esc` no pane claimed means "leave this one" — the v2 spelling of
         // v1 closing a modal, since a centre-slot pane is dismissed by focusing
         // whatever you came from.

--- a/src/coordinator/mod.rs
+++ b/src/coordinator/mod.rs
@@ -4,7 +4,8 @@
 //! is the one type here. Its methods are split across this directory by *what
 //! they are for*, because a hundred of them in one `impl` block was not a
 //! surface anybody reviews: the loop and its workers here, then `commands`, `publish`,
-//! `draw`, `input`, `mouse`, `focus` and `interface` — plus `boot` (the startup
+//! `draw`, `input`, `mouse`, `focus` and `interface` — plus `paste` (turning a
+//! Windows key stream back into a paste), `boot` (the startup
 //! sequence `main` delegates to) and `chrome` (the free helpers for the
 //! terminal, the error panel and the perf HUD).
 //!
@@ -23,6 +24,7 @@ mod focus;
 mod input;
 mod interface;
 mod mouse;
+pub(crate) mod paste;
 mod publish;
 
 use super::*;

--- a/src/coordinator/paste.rs
+++ b/src/coordinator/paste.rs
@@ -1,0 +1,408 @@
+//! Rebuilding a paste on Windows, where the console delivers no `Event::Paste`.
+//!
+//! crossterm's Windows backend never emits `Event::Paste` — its
+//! `EnableBracketedPaste` is documented as unsupported — so a paste arrives as a
+//! stream of ordinary key events, and a multi-line one submitted the prompt a
+//! line at a time. This turns that stream back into one paste before it is
+//! dispatched.
+//!
+//! The design rests on what the console actually delivers, measured against this
+//! environment's `ssh` → ConPTY path with a key dumper rather than assumed:
+//!
+//! * **The bracketed-paste markers are gone.** The ConPTY strips `ESC[200~` /
+//!   `ESC[201~` before the app sees them; a paste is plain `Char`/`Enter`
+//!   events with no framing at all. There is nothing to match on.
+//! * **Editing keys arrive whole.** An arrow key, `Delete`, `Ctrl+Delete`, a
+//!   function key each arrive as their own `KeyEvent` (`KeyCode::Left`, …), not
+//!   as a run of `ESC` `[` `…` character events.
+//!
+//! Two rules, both deliberately small:
+//!
+//! * **Grouping is by timing.** A plain character joins a run when it arrives
+//!   within [`MACHINE_GAP`] of the last one; **everything else passes straight
+//!   through the instant it arrives** — an arrow key, `Delete`, `Esc`, any
+//!   `Ctrl`/`Alt` chord is never held, never matched against a marker, never at
+//!   risk of being swallowed. The earlier attempts carried a marker/`Esc`/
+//!   VT-sequence state machine that fired on none of these inputs yet stood
+//!   between every one of them and the agent; it is gone.
+//! * **A run is a paste only if it carries an interior newline.** Sending
+//!   newlines to the agent one keystroke at a time is the sole thing this path
+//!   exists to prevent, so it is the sole thing it acts on. A newline-free run
+//!   — fast typing, quick `j`/`k`, two keys a slow frame batched — is emitted
+//!   as the keys it was, because the clock times when a key is *read*, not when
+//!   it was pressed, and under load ordinary input bunches up. Coalescing that
+//!   on length alone is what announced a phantom "pasted 2 characters" mid-type.
+//!
+//! The outbound half of the journey is `agent::control_mode`'s `PsmuxPaste`,
+//! which carries the reassembled paste to a psmux pane in one piece (ADR-13);
+//! the rationale for both halves is ADR-4.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use std::time::{Duration, Instant};
+
+/// What the key stream resolved to, in the order it must be dispatched.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Input {
+    Key(KeyEvent),
+    Paste(String),
+}
+
+/// Two keys closer together than this were machine-fed, not typed. A pasted
+/// stream runs orders of magnitude under it; a person's fastest two keys stay
+/// well above it. It is also the most the first key of any run is delayed —
+/// under one frame, so typing does not feel it.
+const MACHINE_GAP: Duration = Duration::from_millis(10);
+
+/// Reassembles a paste from a Windows key stream. Inert everywhere else, where
+/// crossterm delivers `Event::Paste` on its own.
+pub(crate) struct PasteBurst {
+    active: bool,
+    /// Plain-character keys gathered so far as a possible paste.
+    run: Vec<KeyEvent>,
+    /// When the last key arrived, for the gap that tells paste from typing.
+    last: Option<Instant>,
+}
+
+impl PasteBurst {
+    /// The coalescer this platform needs: real on Windows, inert elsewhere.
+    pub(crate) fn for_platform() -> Self {
+        Self::new(cfg!(windows))
+    }
+
+    fn new(active: bool) -> Self {
+        Self {
+            active,
+            run: Vec::new(),
+            last: None,
+        }
+    }
+
+    /// How long the loop should wait for the next key before flushing the
+    /// batch: [`MACHINE_GAP`] while a run is open (its next key may still be on
+    /// the way), nothing otherwise — so an idle interface polls exactly as it
+    /// did.
+    pub(crate) fn drain_timeout(&self) -> Duration {
+        if self.active && !self.run.is_empty() {
+            MACHINE_GAP
+        } else {
+            Duration::ZERO
+        }
+    }
+
+    /// Feed one key press, with the instant it arrived.
+    pub(crate) fn push(&mut self, key: KeyEvent, at: Instant) -> Vec<Input> {
+        if !self.active {
+            return vec![Input::Key(key)];
+        }
+        let gap = self.last.map(|last| at.saturating_duration_since(last));
+        self.last = Some(at);
+
+        // Anything that is not a plain character cannot be part of a paste:
+        // end the run and pass the key on immediately, in order. This is the
+        // line that keeps arrows, Delete, Esc and every chord working —
+        // nothing here can hold one back.
+        if paste_char(key).is_none() {
+            let mut out = self.flush();
+            out.push(Input::Key(key));
+            return out;
+        }
+
+        // A character that arrived slowly ends the previous run before starting
+        // its own; one that arrived fast continues the burst.
+        let mut out = Vec::new();
+        if gap.map_or(true, |gap| gap >= MACHINE_GAP) {
+            out = self.flush();
+        }
+        self.run.push(key);
+        out
+    }
+
+    /// Nothing more is coming within the window, so decide what the run was.
+    ///
+    /// The signal is a **line break with content after it**, and only that.
+    /// Delivering newlines to the agent one keystroke at a time is the sole
+    /// thing this path exists to prevent — it is what submits a prompt
+    /// mid-paste — so a run carrying an interior newline is the paste, handed
+    /// over whole.
+    ///
+    /// Everything else is emitted as the keys it was: fast typing, quick
+    /// `j`/`k` navigation, or two keys an event queue batched during a slow
+    /// frame all read as one rapid run, and calling any of them a paste is what
+    /// produced a phantom "pasted 2 characters" while someone was only typing.
+    /// A run that merely *ends* at a newline is a typed line submitted with
+    /// `Enter`; it must still submit, so it too stays keys. A newline-free
+    /// paste loses nothing by arriving as keystrokes — the text lands in the
+    /// prompt identically.
+    pub(crate) fn flush(&mut self) -> Vec<Input> {
+        if self.run.len() >= 2 {
+            let text: String = self.run.iter().filter_map(|key| paste_char(*key)).collect();
+            if text.trim_end_matches(['\r', '\n']).contains(['\r', '\n']) {
+                self.run.clear();
+                return vec![Input::Paste(text)];
+            }
+        }
+        self.run.drain(..).map(Input::Key).collect()
+    }
+}
+
+/// The character a key contributes to pasted text, or `None` for a key that is
+/// not text — which ends a run and passes straight through.
+///
+/// `Enter` becomes CR because that is what a terminal's own bracketed paste puts
+/// between two pasted lines, so an agent sees the same bytes on either platform.
+/// A modifier other than SHIFT means a chord, which is never paste text.
+fn paste_char(key: KeyEvent) -> Option<char> {
+    let plain = (key.modifiers - KeyModifiers::SHIFT).is_empty();
+    match key.code {
+        KeyCode::Char(ch) if plain => Some(ch),
+        KeyCode::Enter if plain => Some('\r'),
+        KeyCode::Tab if plain => Some('\t'),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn ch(c: char) -> KeyEvent {
+        key(KeyCode::Char(c))
+    }
+
+    fn events(text: &str) -> Vec<KeyEvent> {
+        text.chars()
+            .map(|c| match c {
+                '\r' => key(KeyCode::Enter),
+                '\t' => key(KeyCode::Tab),
+                c => ch(c),
+            })
+            .collect()
+    }
+
+    fn as_keys(text: &str) -> Vec<Input> {
+        events(text).into_iter().map(Input::Key).collect()
+    }
+
+    /// Drives a clock: every key lands `gap` after the one before it, which is
+    /// the whole of what separates a paste from typing.
+    struct Feed {
+        burst: PasteBurst,
+        now: Instant,
+    }
+
+    impl Feed {
+        fn new(active: bool) -> Self {
+            Self {
+                burst: PasteBurst::new(active),
+                now: Instant::now(),
+            }
+        }
+
+        fn typed(&mut self, text: &str) -> Vec<Input> {
+            self.feed(events(text), Duration::from_millis(80))
+        }
+
+        fn pasted(&mut self, text: &str) -> Vec<Input> {
+            self.feed(events(text), Duration::from_millis(1))
+        }
+
+        fn feed(&mut self, keys: Vec<KeyEvent>, gap: Duration) -> Vec<Input> {
+            let mut out = Vec::new();
+            for key in keys {
+                self.now += gap;
+                out.extend(self.burst.push(key, self.now));
+            }
+            out
+        }
+
+        fn settle(&mut self) -> Vec<Input> {
+            self.burst.flush()
+        }
+    }
+
+    #[test]
+    fn inert_off_windows_passes_every_key_through() {
+        let mut feed = Feed::new(false);
+        let mut out = feed.pasted("a\rb");
+        out.extend(feed.settle());
+        assert_eq!(out, as_keys("a\rb"));
+    }
+
+    /// The bug, and the shape it has to arrive in: a pasted block is ONE paste,
+    /// so an agent renders it as a paste rather than as typing.
+    #[test]
+    fn a_pasted_block_is_one_paste() {
+        let mut feed = Feed::new(true);
+        let mut out = feed.pasted("Bonjour\r\rIl y a plusieurs lignes\rdans ce texte");
+        out.extend(feed.settle());
+        assert_eq!(
+            out,
+            vec![Input::Paste(
+                "Bonjour\r\rIl y a plusieurs lignes\rdans ce texte".to_string()
+            )]
+        );
+    }
+
+    /// No line may submit while a paste is still arriving — the "Bonjour went
+    /// alone" failure. Delivered one key at a time, nothing queued behind.
+    #[test]
+    fn no_line_submits_mid_paste() {
+        let mut feed = Feed::new(true);
+        let mut out = feed.pasted("Bonjour\r\rIl y a\rdans ce texte\rpour un exemple");
+        out.extend(feed.settle());
+        assert!(
+            !out.contains(&Input::Key(key(KeyCode::Enter))),
+            "an Enter reached the agent mid-paste: {out:?}"
+        );
+        assert_eq!(out.len(), 1, "should be exactly one paste: {out:?}");
+    }
+
+    #[test]
+    fn typing_stays_keys_and_still_submits() {
+        let mut feed = Feed::new(true);
+        let mut out = feed.typed("yes\r");
+        out.extend(feed.settle());
+        assert_eq!(out, as_keys("yes\r"));
+    }
+
+    /// A slow frame can batch a whole typed line; the trailing newline is what
+    /// keeps it submitting rather than becoming a paste.
+    #[test]
+    fn a_batched_typed_line_still_submits() {
+        let mut feed = Feed::new(true);
+        let mut out = feed.pasted("yes\r");
+        out.extend(feed.settle());
+        assert_eq!(out, as_keys("yes\r"));
+    }
+
+    /// A pasted single command is let through so it runs — what pasting one is
+    /// for.
+    #[test]
+    fn a_pasted_single_line_submits() {
+        let mut feed = Feed::new(true);
+        let mut out = feed.pasted("ls -la\r");
+        out.extend(feed.settle());
+        assert_eq!(out, as_keys("ls -la\r"));
+    }
+
+    /// A newline-free burst is not a paste, however fast it arrived — this is
+    /// the reported bug, where two quick keys raised a phantom "pasted 2
+    /// characters" while someone was only typing or navigating. It goes out as
+    /// the keys it was; the text lands in the prompt just the same.
+    #[test]
+    fn a_newline_free_burst_stays_keys() {
+        let mut feed = Feed::new(true);
+        let mut out = feed.pasted("jk");
+        out.extend(feed.settle());
+        assert_eq!(out, as_keys("jk"));
+
+        let mut feed = Feed::new(true);
+        let mut out = feed.pasted("some pasted words");
+        out.extend(feed.settle());
+        assert_eq!(out, as_keys("some pasted words"));
+    }
+
+    /// The regression this rewrite is meant to make impossible: an arrow key,
+    /// `Delete`, `Ctrl+Delete`, `Esc` all pass straight through, in order, with
+    /// nothing held and no wait left behind.
+    #[test]
+    fn editing_keys_pass_straight_through() {
+        for code in [
+            KeyCode::Left,
+            KeyCode::Right,
+            KeyCode::Delete,
+            KeyCode::Home,
+            KeyCode::Esc,
+            KeyCode::Backspace,
+        ] {
+            let mut feed = Feed::new(true);
+            let out = feed.feed(vec![key(code)], Duration::from_millis(1));
+            assert_eq!(
+                out,
+                vec![Input::Key(key(code))],
+                "{code:?} was not passed on"
+            );
+            assert_eq!(feed.burst.drain_timeout(), Duration::ZERO);
+        }
+    }
+
+    /// `Ctrl+Delete` is a chord: the modifier makes it non-text, so it passes
+    /// through even though `Delete` alone already does.
+    #[test]
+    fn a_chord_is_never_paste_text() {
+        let mut feed = Feed::new(true);
+        let chord = KeyEvent::new(KeyCode::Delete, KeyModifiers::CONTROL);
+        let out = feed.feed(vec![chord], Duration::from_millis(1));
+        assert_eq!(out, vec![Input::Key(chord)]);
+    }
+
+    /// An editing key in the MIDDLE of a fast burst ends whatever preceded it
+    /// and goes out in order — a run is never silently extended across a cursor
+    /// move. With no newlines here, the surrounding text is keys, not a paste.
+    #[test]
+    fn an_editing_key_ends_a_run_in_place() {
+        let mut feed = Feed::new(true);
+        let mut out = feed.pasted("ab");
+        out.extend(feed.feed(vec![key(KeyCode::Left)], Duration::from_millis(1)));
+        out.extend(feed.pasted("cd"));
+        out.extend(feed.settle());
+        assert_eq!(
+            out,
+            vec![
+                Input::Key(ch('a')),
+                Input::Key(ch('b')),
+                Input::Key(key(KeyCode::Left)),
+                Input::Key(ch('c')),
+                Input::Key(ch('d')),
+            ]
+        );
+    }
+
+    /// A multi-line paste interrupted by a cursor move still yields a paste for
+    /// the part that carries the newline.
+    #[test]
+    fn a_multiline_run_before_an_editing_key_is_a_paste() {
+        let mut feed = Feed::new(true);
+        let mut out = feed.pasted("one\rtwo");
+        out.extend(feed.feed(vec![key(KeyCode::Left)], Duration::from_millis(1)));
+        out.extend(feed.settle());
+        assert_eq!(
+            out,
+            vec![
+                Input::Paste("one\rtwo".to_string()),
+                Input::Key(key(KeyCode::Left)),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_lone_character_is_not_held_past_its_window() {
+        let mut feed = Feed::new(true);
+        let out = feed.feed(vec![ch('a')], Duration::from_millis(1));
+        assert!(out.is_empty(), "held to see if a burst follows");
+        assert_eq!(feed.burst.drain_timeout(), MACHINE_GAP);
+        assert_eq!(feed.settle(), as_keys("a"));
+    }
+
+    /// Two pastes far enough apart in time are two pastes, not one.
+    #[test]
+    fn a_gap_separates_two_pastes() {
+        let mut feed = Feed::new(true);
+        let mut out = feed.pasted("first line\rsecond");
+        // A human pause, then another paste.
+        feed.now += Duration::from_millis(500);
+        out.extend(feed.pasted("third line\rfourth"));
+        out.extend(feed.settle());
+        assert_eq!(
+            out,
+            vec![
+                Input::Paste("first line\rsecond".to_string()),
+                Input::Paste("third line\rfourth".to_string()),
+            ]
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -303,6 +303,11 @@ struct App {
     /// `[features] mouse`. Off means no capture escape was ever sent, so the
     /// terminal keeps its native selection and scrolling.
     mouse: bool,
+    /// Turns a key stream back into a paste where the terminal reports none
+    /// (see `coordinator::paste`). Held across input batches so a run's timing
+    /// is judged against the previous key even when the drain boundary falls
+    /// between them. Inert where `Event::Paste` arrives on its own.
+    paste_burst: coordinator::paste::PasteBurst,
     /// The session shown by the focused plugin's surface, as of the last frame.
     /// Read off the tree that was just painted, so the kernel never needs to
     /// know which plugin is "the terminal".


### PR DESCRIPTION
## Summary

Three Windows-specific fixes, each verified end-to-end on a Windows VM over SSH:

- **Paste reconstruction** — crossterm emits no `Event::Paste` on Windows, so a paste arrived as a key stream and a multi-line prompt submitted itself a line at a time. A key dumper against the `ssh` → ConPTY path showed the ConPTY strips the bracketed-paste markers and delivers editing keys as their own `KeyEvent`, so the only signal is timing: characters within 10 ms of each other are gathered, and a run becomes one paste only when it carries an interior newline. Everything else — arrows, `Delete`, chords, ordinary typing, quick `j`/`k` — passes straight through untouched.
- **Mouse selection** — a Windows console starts with `ENABLE_QUICK_EDIT_MODE`, which claimed every drag for its own whole-screen selection and never told the app (drag selected across panes, copy raised no toast). thurbox now sets the console input mode itself when it enables mouse reporting, and restores it on teardown.
- **SSH clipboard copy** — `auto` stopped at a successful native write, which on Windows silently succeeds against a clipboard nobody is looking at, so a copy over SSH never reached the user. `auto` now writes both native and OSC 52, with no SSH check or platform branch.

## Test plan

- `cargo nextest run --all` — 1954 tests pass (13 new in `coordinator::paste`, plus clipboard cases)
- `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --all --check`, `cargo doc` clean
- Verified live on a Windows VM over SSH: multi-line paste lands as one `[Pasted text]` chip; arrows/`Delete`/`Ctrl+Delete` work; typed line + `Enter` submits; fast typing raises no phantom paste; drag-select is pane-scoped; copy reaches the local clipboard.

https://claude.ai/code/session_01WB19RqUmLDBTJFvuwitrS4