### PR TITLE
feat(core): session lifecycle hooks (hooks.toml)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -968,6 +968,55 @@ since recovery is committed-state-only, and only then issues `restore` with
 `best_effort`. The flag never changes
 `thurbox-cli session delete`, which stays soft unless `--force`.
 
+### Session lifecycle hooks (`hooks.toml`)
+
+The user's own commands, run **by thurbox** before and after it creates,
+deletes, restarts or restores a session — eight events, `session.{pre,post}_
+{create,delete,restart,restore}`, declared as `[[hooks]] { event, command,
+timeout_secs }` in `~/.config/thurbox/hooks.toml` (seeded commented-out; read
+at fire time, no cache, no restart). **Not** the `hooks` extension: that
+installs status hooks *into* the agent CLIs (`<config>/hooks/`,
+`session_ops::builtin_hooks`) — the code says `lifecycle_hooks`/`HookEvent`
+for this one so the two never blur.
+
+They fire once per operation for every caller because every caller already
+ends in the same four pipelines: `session_ops::spawn_session_headless`
+(the TUI's create *and* fork, the CLI, `spawn` automations, extension
+self-heal), `delete_session_headless` (`Ctrl+D` soft and hard, the CLI,
+extension uninstall), `restart_session_headless`, `restore_session_headless`
+(the TUI's undo and — since this change — the CLI's `session restore`, which
+used to clear the flag alone). `fire_pre` runs before the pipeline's first
+side effect and a failure (non-zero exit, timeout, cannot start) is its
+`Err`; `fire_post` runs after its last and returns the failures, carried as
+`hook_failures` on `SpawnResult`/`ForceDeleteReport`/`RestartReport`/
+`RestoreReport` and in the CLI JSON. `SpawnPhase::Hooks` is reported while
+the pre-create hooks run, so the placeholder row says so.
+
+- **Data**: `session::hook_def` — `HookEvent` (closed enum, serde-spelled
+  as the dotted names), `LifecycleHook`, `HooksFile`, and `HookContext` with
+  `env()` (the `THURBOX_*` set — unset, never empty, for an unknown fact),
+  `json()` (the stdin document) and `workdir()`.
+- **File**: `agent::hooks_config` mirrors `host_config` — seed, strict
+  parse through `parse_toml_reporting_unknown`, empty-with-warning on
+  failure; `hooks_for(event)` in file order. `config validate`/`show` cover
+  it.
+- **Runner**: `session_ops::lifecycle_hooks::run_hook` — `platform_shell`
+  (shared with `Exec` automations), `ctx.env()` + `thurbox_dir_overrides()`
+  (shared with `inject_thurbox_env`, so a `thurbox-cli` inside hits the same
+  DB), JSON on a piped stdin, both output pipes drained on threads, a
+  `try_wait` poll against the timeout, `kill()` at the deadline. Synchronous
+  by design — it runs on whichever thread runs the operation (a worker in
+  the TUI, rule 5), and `session_ops` has no runtime to lean on.
+- **Cwd rule**: the primary repository when it is a local directory, else
+  thurbox's own — the one path that exists at `pre_create` (no worktree yet)
+  and at `post_delete` (worktree gone). A remote session's hook runs
+  locally with `THURBOX_HOST` set.
+- Proof: `tests/create_e2e.rs` (the pairs fire once each with the facts, a
+  hook's `thurbox-cli` finds the row, a veto leaves nothing behind and
+  surfaces through the command bus, a post failure leaves the session
+  running); unit tests beside each module. User docs: `docs/CONFIG.md` →
+  hooks.toml.
+
 ### Parent sessions (lead/worker)
 
 Sessions carry an optional **`parent_session_id`** so orchestration scripts can
@@ -1725,7 +1774,8 @@ cargo crate — `scripts/install-dev-tools.sh` prints a reminder).
 - Session state in SQLite:
   `~/.local/share/thurbox/thurbox.db` (XDG_DATA_HOME respected);
   agent definitions in `~/.config/thurbox/agents.toml`;
-  remote SSH hosts in `~/.config/thurbox/hosts.toml`
+  remote SSH hosts in `~/.config/thurbox/hosts.toml`;
+  session lifecycle hooks in `~/.config/thurbox/hooks.toml`
 - Requires tmux >= 3.2
 
 ## Keybindings
@@ -1949,7 +1999,7 @@ and startup reports the directory whenever there is a question about it — an o
 is in force, the fallback was used, or this is a dev build. The user-copy path is
 derived
 from `paths::config_file()` like every other config path — `agents.toml`,
-`hosts.toml`, `settings.toml`, `themes.toml`, `extensions/`, `ui.json` — so a **dev
+`hosts.toml`, `hooks.toml`, `settings.toml`, `themes.toml`, `extensions/`, `ui.json` — so a **dev
 build reads `~/.config/thurbox-dev/ui`** and cannot touch the release copy.
 `THURBOX_CONFIG_DIR` overrides that anchor and thurbox injects it into every
 session it spawns, which is why a `thurbox-cli` run *inside* a session resolves

--- a/README.md
+++ b/README.md
@@ -573,6 +573,10 @@ colours, so a pane you write looks right under all thirty-six.
   over SSH while the TUI stays local; declare hosts in `hosts.toml` and they
   become `ssh:<name>` backends with the same persistence and restore as
   local ones.
+- **[Session lifecycle hooks](docs/CONFIG.md#hookstoml)** — your own commands,
+  run before and after a session is created, deleted, restarted or restored
+  (`hooks.toml`); a pre-hook can refuse the operation, a post-hook reacts to
+  it, and both fire once whichever interface asked.
 - **[OS notifications](docs/CONFIG.md)** — desktop alerts when a session
   needs you, with click-to-focus on Linux.
 - **Mouse navigation** — the whole TUI is clickable: select rows, confirm
@@ -604,6 +608,7 @@ you can open in an editor.
 | Panes somebody else wrote | `ui/plugins.toml` → `thurbox-cli plugin sync` |
 | Which agent CLIs you can launch | `agents.toml` |
 | Remote SSH machines and WSL distros | `hosts.toml` |
+| Commands to run around a session's creation, deletion, restart, restore | `hooks.toml` |
 | Colours | `Ctrl+Y`, or `themes.toml` |
 | Chords | the `F1` editor, or `ui.json` |
 | Core and plugin settings | `Ctrl+,`, or `settings.toml` |
@@ -766,6 +771,9 @@ a different name — possible on equal terms.
 - **Hosts** — `hosts.toml` declares SSH machines and WSL distros; each becomes
   an `ssh:<name>` / `wsl:<name>` backend a session can spawn on, with the same
   persistence and restore as a local one.
+- **Lifecycle hooks** — `hooks.toml` runs your commands before and after
+  thurbox creates, deletes, restarts or restores a session; a `pre_*` hook can
+  refuse, and every interface fires the same hook once.
 - **Themes** — thirty-six presets, plus your own as a `base` and per-colour
   overrides in `themes.toml`. Panes ask for roles, not colours.
 - **Keybindings** — one registry, so `F1` renders what is actually bound and

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -24,6 +24,7 @@ development checkout never touches your real setup.
 | `~/.config/thurbox/hosts.toml` | TOML | you | startup | remote SSH hosts + local WSL distros |
 | `~/.config/thurbox/settings.toml` | TOML | you + `Ctrl+,` panel | **live** (feature flags) / startup (rest) | tuning knobs + feature flags |
 | `~/.config/thurbox/themes.toml` | TOML | you | startup | custom theme palettes |
+| `~/.config/thurbox/hooks.toml` | TOML | you | on each session operation | **session lifecycle hooks** — your commands, run before/after a session is created, deleted, restarted or restored |
 | `~/.config/thurbox/ui/` | Lua | you | **live** (watched, 120 ms debounce; `F10` forces) | **the interface itself** — one file per pane, plus `layout.lua`, `lib/`, `AGENTS.md`/`README.md` for whoever edits it, and a directory per plugin installed from a repository (its own working copy, `.git` included) |
 | `~/.config/thurbox/ui/plugins.toml` | TOML | you (or `thurbox-cli plugin`) | on each `plugin` command | **what the interface is composed of**: a source, a destination file and an optional pin, per installed pane |
 | `~/.config/thurbox/ui/plugins.lock` | TOML | `thurbox-cli plugin` | on each `plugin` command | what each entry resolved to, and the digest of every file delivered. Machine-written — commit it beside the spec and the same interface reproduces elsewhere |
@@ -71,6 +72,7 @@ the right knob:
 | Tune scrollback, panel breakpoints, audit retention | `settings.toml` | [settings.toml](#settingstoml) |
 | Change when/how OS notifications fire | `settings.toml` `[notifications]` | [`[notifications]`](#notifications--os-notification-settings) |
 | Add or recolour a TUI theme | `themes.toml` | [themes.toml](#themestoml) |
+| Run my own command when a session is created/deleted/restarted/restored, or refuse one | `hooks.toml` | [hooks.toml](#hookstoml) |
 | Rebind a key | `keybindings.json` (or the F1 editor) | [keybindings.json](#keybindingsjson) |
 | Set the `Ctrl+O` editor, pick a theme | (runtime — SQLite) | [SQLite-backed settings](#sqlite-backed-settings) |
 
@@ -206,6 +208,97 @@ paths (a WSL distro's worktrees live in its own Linux filesystem, not on
 `/mnt/c`); the distro needs `tmux` >= 3.2 and `git`. Host changes
 require a restart (the registry is read once and each host's `$HOME` is
 cached for the process lifetime).
+
+## hooks.toml
+
+Declares **session lifecycle hooks**: your own shell commands, run by
+thurbox before and after it creates, deletes, restarts or restores a
+session. Seeded fully commented-out (a fresh install runs nothing); read
+**each time an event fires**, so an edit is in force at the next
+operation with no restart. Malformed file → no hooks run, warning in the
+log, and `config validate` fails.
+
+> Not the `hooks/` **directory** beside it. That is the home of the
+> built-in `hooks` *extension*, which installs status-hook files **into**
+> the agent CLIs so they can tell thurbox what they are doing
+> (see [Session status](#session-status)). `hooks.toml` is the other
+> direction: thurbox telling *your* scripts what *it* is doing.
+
+```toml
+[[hooks]]
+event = "session.pre_create"
+command = 'case "$THURBOX_BRANCH" in main|master) echo "refusing: protected branch" >&2; exit 1;; esac'
+
+[[hooks]]
+event = "session.post_create"
+command = '[ -n "$THURBOX_CWD" ] && cp -n .env.local "$THURBOX_CWD/.env"; true'
+timeout_secs = 120
+```
+
+| Field | Required | Default | Purpose |
+|-------|----------|---------|---------|
+| `event` | yes | — | one of the eight events below |
+| `command` | yes | — | run through `sh -c` (`cmd /C` on Windows) |
+| `timeout_secs` | no | `30` | the hook is killed after this long |
+
+**Events** — a `pre_*` fires before the operation has any side effect, a
+`post_*` after it has fully succeeded (never after a failure):
+
+| Operation | Events | Fired by |
+|-----------|--------|----------|
+| create (incl. fork) | `session.pre_create` / `session.post_create` | the creation flow, `Ctrl+F`, `thurbox-cli session create`, a `spawn` automation, an extension's sessions |
+| delete (soft or force) | `session.pre_delete` / `session.post_delete` | `Ctrl+D`, `thurbox-cli session delete [--force]`, extension uninstall |
+| restart | `session.pre_restart` / `session.post_restart` | `Ctrl+R`, `thurbox-cli session restart` |
+| restore (incl. undo) | `session.pre_restore` / `session.post_restore` | `Ctrl+Z`/`Ctrl+U`, `thurbox-cli session restore` |
+
+Hooks fire **once per operation whichever interface asked**, because
+every interface ends in the same pipeline (`session_ops`). Hooks for one
+event run one at a time, in file order.
+
+**A `pre_*` hook can refuse.** Exit non-zero (or exceed the timeout) and
+the operation is aborted before it has done anything — no worktree, no
+process, no row changed — with the hook's command, exit status and the
+tail of its stderr as the reported reason (the in-flight error in the
+TUI, the error and exit status of `thurbox-cli`). Later hooks for that
+event do not run. **A `post_*` hook is informational**: every one runs,
+a failure is logged to `thurbox.log` and carried in the CLI's JSON
+(`hook_failures`), and never fails the operation.
+
+**What a hook receives.** Environment variables — **unset** (never
+empty) when the fact is not known at that moment:
+
+| Variable | Meaning |
+|----------|---------|
+| `THURBOX_HOOK_EVENT` | the event name, e.g. `session.post_create` |
+| `THURBOX_SESSION` | the thurbox session id (at `pre_create`: the id it will have if creation succeeds) |
+| `THURBOX_SESSION_ID` | the agent's own conversation id |
+| `THURBOX_SESSION_NAME` | the session name |
+| `THURBOX_AGENT` | the agent name |
+| `THURBOX_REPO` | the primary repository path |
+| `THURBOX_CWD` | the directory the agent runs in (the worktree, or the symlink workspace of a multi-repo session); unset at `pre_create` |
+| `THURBOX_BRANCH` / `THURBOX_BASE_BRANCH` | the worktree branch and what it was created from (base: create events only) |
+| `THURBOX_HOST` | the remote host name; unset for a local session |
+| `THURBOX_PARENT_SESSION` | the parent session id (a fork, or `--parent`) |
+| `THURBOX_TASK` | the originating task id, for a task-spawned session |
+| `THURBOX_CONFIG_DIR` / `THURBOX_DATA_DIR` | so a `thurbox-cli` run inside the hook hits the database of the thurbox that fired it |
+
+The same facts — plus `worktrees` (`repo_path`, `worktree_path`,
+`branch`), `additional_dirs`, `force` (delete) and `force_deleted`
+(restore) — arrive as **one JSON object on stdin** (`jq -r .cwd`).
+
+**Where and how it runs.** In the primary repository when that is a
+directory on this machine, otherwise in thurbox's own working directory
+— the repository is the one path that exists at every event (at
+`pre_create` the worktree is not made; at `post_delete` it is gone).
+With **no terminal**: stdin is the JSON, stdout/stderr are captured and
+only their tail (500 chars) is reported, so a hook can neither draw on
+nor read from the TUI's screen. A hook for a **remote** (SSH/WSL)
+session still runs **locally**; `THURBOX_HOST` names the host and the
+paths are the host's — `ssh "$THURBOX_HOST" …` from the hook is your
+call.
+
+`thurbox-cli config validate` strict-parses the file; `config show`
+lists the hooks in force.
 
 ## settings.toml
 
@@ -730,6 +823,19 @@ these to prove its own identity without scraping panes or names:
 | `THURBOX_TASK` | the originating task id; task-spawned sessions only (headless `task run`) |
 | `THURBOX_METRICS_DIR` | metrics output dir |
 | `THURBOX_CONFIG_DIR` / `THURBOX_DATA_DIR` | the resolved config/data dirs, so the agent's `thurbox-cli` (its status hook) targets the same DB the TUI reads — independent of XDG, which `thurbox-cli` is on PATH, or a stale tmux-server env. Also honored if you set them yourself to relocate thurbox's state. |
+
+Set **by** thurbox into every [lifecycle hook](#hookstoml) it runs
+(`session_ops::lifecycle_hooks`), beside `THURBOX_SESSION`,
+`THURBOX_SESSION_ID`, `THURBOX_TASK` and the two dir overrides above:
+
+| Variable | Set into hook process |
+|----------|-----------------------|
+| `THURBOX_HOOK_EVENT` | the event, e.g. `session.pre_delete` |
+| `THURBOX_SESSION_NAME`, `THURBOX_AGENT` | the session's name and agent |
+| `THURBOX_REPO`, `THURBOX_CWD` | the primary repository, and the directory the agent runs in |
+| `THURBOX_BRANCH`, `THURBOX_BASE_BRANCH` | the worktree branch and its base |
+| `THURBOX_HOST` | the remote host name (local: unset) |
+| `THURBOX_PARENT_SESSION` | the parent session id |
 
 Set **at build time** (not runtime):
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -620,6 +620,40 @@ reusing the session's stored agent. Agents that define no
 - The session's `SessionInfo` (ID, name, agent, repos)
   stays intact — only the backend pane and I/O are replaced.
 
+### Session lifecycle hooks (`hooks.toml`)
+
+The user's own commands, run around the four session operations: before
+and after a session is created, deleted, restarted or restored. Declared
+as data (`~/.config/thurbox/hooks.toml`, one `[[hooks]]` entry per
+event + command), seeded commented-out, read each time an event fires.
+
+The mechanism is where they fire, not what they are. Every interface —
+the TUI's flow and chords, `thurbox-cli`, a `spawn` automation, an
+extension's self-healed sessions — ends in the same four functions in
+`session_ops` (`spawn`, `delete`, `restart`, `restore`), so a hook placed
+inside those fires **once per operation for every caller**, and nothing
+in the kernel or the Lua interface knows hooks exist. They run on the
+thread that runs the operation — a worker in the TUI — never the render
+loop.
+
+**Pre hooks veto, post hooks inform** — git's `pre-commit` model. A
+`pre_*` that exits non-zero (or hangs past its timeout, default 30 s) aborts
+the operation before its first side effect, with its stderr tail as the
+reported reason; a `post_*` fires only after full success, every one
+runs, and a failure is logged and reported (`hook_failures` in the CLI
+JSON) but cannot undo what happened.
+
+A hook receives the session's facts as `THURBOX_*` environment variables
+and as one JSON object on stdin, inherits the config/data-dir overrides
+so a `thurbox-cli` it runs hits the right database, runs in the primary
+repository (the one path that exists at every event) with no terminal,
+and — for a remote session — runs *locally*, told the host by
+`THURBOX_HOST`. Full reference: `docs/CONFIG.md` → hooks.toml.
+
+Deliberately not the same thing as the built-in `hooks` *extension*
+(`<config>/hooks/`), which is the reverse direction: files thurbox
+installs into the agent CLIs so they can report status.
+
 ### Why UUID v4?
 
 Sessions need unique identifiers for the lifetime of the process.

--- a/openspec/changes/archive/2026-08-26-session-lifecycle-hooks/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-26-session-lifecycle-hooks/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-26

--- a/openspec/changes/archive/2026-08-26-session-lifecycle-hooks/design.md
+++ b/openspec/changes/archive/2026-08-26-session-lifecycle-hooks/design.md
@@ -1,0 +1,253 @@
+## Context
+
+See `proposal.md` — Why. The requirements are in `specs/session-hooks/spec.md`.
+
+What makes this small is a property the codebase already has: each session
+operation has exactly one pipeline, and every interface goes through it.
+Creation is `session_ops::spawn::spawn_session_headless_with_progress` (the
+TUI's `kernel::command::execute::create`, the fork path, `thurbox-cli session
+create`, `cli::action`'s automation spawn and an extension's session self-heal
+all end there); deletion is `session_ops::delete_session_headless` (the TUI's
+`Command::Delete` for both the soft and the hard path, the CLI, extension
+uninstall); restart is `restart_session_headless`; restore is
+`restore_session_headless`, which the TUI's undo also dispatches. So a hook
+placed inside those four functions fires once per operation for every caller,
+and there is nothing to add in the kernel or the interface.
+
+Constraints that shape the rest:
+
+- **Rule 5** — anything touching the world runs on a worker. The four functions
+  already do (the command worker and the spawn worker in the TUI; the main
+  thread in the CLI), so a hook that runs synchronously *inside* them inherits
+  that for free and adds no thread.
+- **Architecture rules** (`tests/architecture_rules.rs`) — `session` is pure
+  data, `agent` loads config and may not touch `git`, `session_ops` may reach
+  both. Rules are per top-level module, so new submodules need no new entries.
+- **The TUI owns the terminal.** A child process that inherits stdout paints
+  over the interface; one that inherits stdin steals keystrokes. `Exec`
+  automations already solve this in `session_ops::run_exec_command` by
+  capturing both and tail-truncating.
+- **`hooks` is a taken word.** `session_ops::builtin_hooks`, `hooks_enabled`
+  and the `<config>/hooks/` directory are the *agent status hook* extension —
+  files thurbox installs into the agent CLIs. This change is the reverse
+  direction and must not be confused with it in code or docs.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Declarative, agent-neutral, zero-cost when unused.
+- Veto semantics for `pre_*`, informational for `post_*` — git's model, which
+  is what anyone who has written a `pre-commit` expects.
+- One runner, one context builder, one place the environment convention lives.
+
+**Non-Goals:**
+
+- **Failure events** (`session.create_failed`). A `post_*` hook fires only on
+  success; a user who needs cleanup after a vetoed or failed creation has no
+  event for it yet. Deliberately left out: it doubles the event set for the
+  rarest case, and the shape here (one runner, one context) makes it a later
+  addition of one variant and one call.
+- **Events for the reaper, sync, reorder, send, rename.** The reaper is the
+  tail of a soft delete, not an operation of its own; the rest are not
+  lifecycle.
+- **Hooks in extension manifests** (`[[hooks]]` in `extension.toml`). The
+  manifest machinery could carry them the way it carries `[[automations]]`;
+  that is a second change once the file format has been used.
+- **Running a hook on the session's remote host.** Hooks run where thurbox
+  runs. `THURBOX_HOST` tells a hook the session is elsewhere; `ssh $HOST …`
+  from the hook is the user's call.
+- **A TUI surface for hook failures beyond the log.** A post-hook failure is
+  in `thurbox.log` and in the CLI's JSON; toasting it in the interface is a
+  follow-up on the command bus's result channel, not part of this.
+- **A Lua-side hook API.** Plugins already have `command`; a plugin that wants
+  to react to session creation reads the snapshot. This is for the user's
+  scripts, not for panes.
+
+## Decisions
+
+### D1 — A dedicated `hooks.toml`, read at fire time, not a `settings.toml` section
+
+`agents.toml`, `hosts.toml`, `themes.toml` and `plugins.toml` are each a
+registry of `[[entries]]` in their own file, loaded by an `agent::*_config`
+module with a commented-out seed and a `load_or_seed_with_warnings` that
+degrades to empty on a parse error. Hooks are the same shape, so they get the
+same treatment: `agent::hooks_config` mirrors `host_config` line for line
+(path via `paths::config_file().with_file_name("hooks.toml")`, seed, strict
+parse through `parse_toml_reporting_unknown`, empty-with-warning on failure).
+
+The file is read **each time an event fires**, on the worker that fires it.
+That is a small disk read per session operation — a rate measured in
+operations per minute at most — and it buys: no cache to give an age to
+(ADR-P13/P18 both bit this codebase before), no live-reload plumbing, an edit
+in force the next time a hook fires, and nothing held in `App`.
+
+*Alternative considered.* A `[[hooks]]` array in `settings.toml`. Rejected:
+`settings.toml` is round-tripped by the settings panel through `toml_edit`
+and live-reloaded through `Config::adopt`/`restart_only_differs`, and hooks
+would be the one section neither the panel offers nor the adopt logic cares
+about — present in that file only to be stepped around.
+
+*The name.* `hooks.toml` will sit beside the `hooks/` directory that is the
+status-hook extension's home. The two are the two directions of the same
+word — what thurbox runs, what thurbox installs — and the alternative names
+(`events.toml`, `lifecycle.toml`) are less discoverable to someone who arrives
+asking "does thurbox have hooks?". The docs draw the line in one sentence at
+the top of the `hooks.toml` section; the code never says bare "hooks" for
+this feature (`lifecycle_hooks`, `HookEvent`, `LifecycleHook`).
+
+### D2 — Data in `session`, loading in `agent`, running in `session_ops`
+
+- `session::hook_def` — `HookEvent` (a closed enum with a serde rename to the
+  `session.pre_create` spelling, so an unknown event is a parse error rather
+  than a silently-never-fired hook), `LifecycleHook { event, command,
+  timeout_secs: Option<u64> }`, `HooksFile { hooks: Vec<LifecycleHook> }`
+  with `deny_unknown_fields`, and `HookContext` — the facts handed to a hook,
+  with `fn env(&self) -> Vec<(String, String)>` and `fn json(&self) ->
+  String`. Pure data plus formatting, which is what `session` is for, and
+  what lets the env convention be unit-tested without a process.
+- `agent::hooks_config` — the file: path, seed, `load_or_seed_with_warnings`,
+  `hooks_for(event) -> Vec<LifecycleHook>` preserving file order.
+- `session_ops::lifecycle_hooks` — the runner. `fire_pre(event, &ctx) ->
+  Result<(), String>` (stops at the first failure, returns its message);
+  `fire_post(event, &ctx) -> Vec<String>` (runs all, returns every failure's
+  message). Both log; `fire_post` logs at `warn`.
+
+### D3 — The runner: `sh -c`, captured output, a piped stdin, a real timeout
+
+`run_exec_command` already has the right platform split and the tail helper
+(`exec_tail`). It cannot be reused as is: it has no env, no stdin and no
+timeout. The runner extracts the shared parts (`platform shell + args`,
+`exec_tail`) so `Exec` automations and hooks build the command the same way,
+then adds:
+
+- `envs(ctx.env())` on top of the inherited environment — plus the two
+  override vars `inject_thurbox_env` already computes for agents
+  (`THURBOX_CONFIG_DIR`, `THURBOX_DATA_DIR`), lifted into a helper the two
+  share so the "a `thurbox-cli` inside hits the right DB" property has one
+  definition.
+- `stdin(Stdio::piped())`, the JSON written and the handle dropped before
+  waiting; `stdout`/`stderr` piped. Never inherited.
+- A timeout, default 30 s. `std::process::Child` has no timed wait, so the
+  runner polls `try_wait` at a short interval while draining the pipes on
+  two reader threads (draining is what stops a chatty hook from blocking on
+  a full pipe — the reason `output()` could not simply be given a deadline),
+  and on the deadline `kill()`s the child and reports `timed out after Ns`.
+  Nothing async: the callers are synchronous functions on a worker, and
+  `session_ops` has no runtime to lean on.
+
+*Alternative considered.* `tokio::process` with `timeout`. Rejected: `session_ops`
+is synchronous throughout and is called from the CLI's main thread as well as
+the TUI's workers; entering a runtime from a worker that may itself be inside
+one is the trap `kernel::terminal` documents.
+
+### D4 — Where each event fires, and what the context knows
+
+| Event | Fires at | Context notes |
+|---|---|---|
+| `pre_create` | after `validate_safe_name`/`validate_parent_session` and host resolution, before `resolve_dirs` | the `SessionId` is minted **before** this point (it is a fresh UUID, minting it earlier changes nothing) so the hook can correlate with `post_create`; `THURBOX_CWD` is unset — the worktree path is not known until it is made |
+| `post_create` | after the row is persisted and the base branch recorded, before returning | full context: id, cwd, worktrees, backend id |
+| `pre_delete` | after the row is loaded, before `teardown_runtime_resources` | `force` in the payload |
+| `post_delete` | after `soft_delete_session` (+ `mark_session_force_deleted`) | the worktrees list is what *was* there |
+| `pre_restart` | after the plan is built, before the kill | — |
+| `post_restart` | after the new pane id is persisted | `backend_id` is the new pane |
+| `pre_restore` | after the best-effort and remote refusals, before `db.restore_session` | `force_deleted` in the payload |
+| `post_restore` | after `respawn`, whatever it returned | a restore whose agent did not come up is still a restore (the report says so) |
+
+`SpawnPhase` gains `Hooks` ("hooks"), reported before `fire_pre`, so the
+placeholder row says `running hooks` rather than `resolving` while a slow one
+runs. `tests/kernel_mvp.rs` pins the phase sequence and
+`ui/plugins/10_sessions.lua`'s `PHASE_LABEL` maps names to labels — both grow
+one entry.
+
+The working directory rule ("the primary repository if it is a local
+directory, else thurbox's own") is chosen because the primary repository is
+the one path that exists at every event: at `pre_create` the worktree is not
+made, at `post_delete` it is gone. `HookContext::workdir()` owns the rule.
+
+### D5 — Reporting a post-hook failure
+
+`SpawnResult`, `ForceDeleteReport` and `RestoreReport` gain
+`hook_failures: Vec<String>`; `restart_session_headless` returns `()` today
+and gains a small `RestartReport { hook_failures }` rather than a bool. The
+CLI JSON emits the field; the TUI's command worker logs each entry (its
+result channel carries only success/error today, and widening it is the
+non-goal above). A `pre_*` veto is an `Err(String)` from the operation, which
+already reaches the in-flight command's error and the CLI's exit status.
+
+### D6 — Environment variable names extend the existing convention
+
+`THURBOX_SESSION`, `THURBOX_TASK`, `THURBOX_CONFIG_DIR`, `THURBOX_DATA_DIR`
+already mean what they will mean inside a hook — the injected identity an
+agent gets. The new names (`THURBOX_HOOK_EVENT`, `THURBOX_SESSION_NAME`,
+`THURBOX_AGENT`, `THURBOX_REPO`, `THURBOX_CWD`, `THURBOX_BRANCH`,
+`THURBOX_BASE_BRANCH`, `THURBOX_HOST`, `THURBOX_PARENT_SESSION`) follow the
+prefix and are documented in `docs/CONFIG.md`'s environment-variables table
+beside the existing ones. `THURBOX_SESSION_ID` (the *agent* session id the
+metrics statusline reads) is set too, for symmetry with the agent's
+environment. A variable is **unset**, not empty, when the fact is unknown, so
+`${THURBOX_HOST:+…}` idioms work.
+
+## Risks / Trade-offs
+
+- **A pre-hook makes every creation slower, and a hung one makes it fail.** →
+  The timeout is per hook (default 30 s) and always enforced; the phase is
+  named so the user sees *hooks* and not a mysterious stall. Nothing else in
+  the pipeline waits on a hook.
+- **A hook runs with the user's authority and thurbox spawns it unasked.** →
+  Same position as `run` capabilities and `Exec` automations: the user wrote
+  the file; thurbox can only refuse to run things it was not asked to run. The
+  file lives in the config dir, not in a repository, so a cloned repo cannot
+  bring a hook with it.
+- **Two hooks vocabularies in one project.** → Code never says bare "hooks"
+  for this; docs draw the line once, where the reader will look
+  (`docs/CONFIG.md`, the seed file's header comment).
+- **Reading the file per fire hides a broken file until the next operation.** →
+  `thurbox-cli config validate` catches it on demand, and the fire-time warning
+  is logged with the parse error; a malformed file never blocks an operation,
+  it only means no hooks ran — the same degrade `hosts.toml` chose.
+- **The reader-thread timeout is more code than `output()`.** → It is the only
+  correct shape: a deadline without draining deadlocks on a full pipe; draining
+  without a deadline hangs on a hook that never exits. Unit-tested with `sleep`
+  and `yes`.
+- **`post_*` failures in the TUI are log-only.** → Accepted for this change;
+  the report field exists so the interface can show it once the command bus
+  carries warnings.
+
+## Migration Plan
+
+Nothing to migrate: the file is seeded commented-out, the reports' new fields
+are additive (`Vec` defaults to empty in JSON), and no schema or setting
+changes. Rollback is deleting the file's entries.
+
+## Findings from implementing
+
+**`deny_unknown_fields` was dropped (D2, task 1.1).** Every other config file
+tolerates an unknown key with a named warning at load and fails only
+`config validate` on it (`parse_toml_reporting_unknown`), and the seed files
+promise exactly that. A hooks file that refused to load over a misspelt
+`timeout_sec` would be the one file that broke the convention, and the
+scenario it protects — "a misspelt field fails `validate`" — holds either
+way. `HooksFile` follows the convention; an unknown *event* is still a parse
+error, because that is a variant of a closed enum, not a field.
+
+**The CLI's `session restore` did not run the restore pipeline.** It cleared
+the row's flags and stopped — no worktrees, no agent — even though
+`restore_session_headless` exists "so the interface and the command line
+cannot disagree about what restoring means". The spec needs the restore hooks
+to fire from the CLI, so `cli::sessions::restore_deleted` now calls the
+pipeline; its JSON gains `worktrees_wanted`/`worktrees_recovered`/
+`respawn_error` beside `hook_failures`. A behaviour fix in its own right,
+recorded here because it is wider than the change's title.
+
+**The overrides stayed out of `Exec` automations.** `platform_shell` is shared
+with `run_exec_command`, and the first cut put the `THURBOX_CONFIG_DIR`/
+`THURBOX_DATA_DIR` overrides inside it — which would have changed every `Exec`
+automation's environment as a side effect of a hooks change. They live in the
+hook runner instead; `run_exec_command` is byte-for-byte what it was.
+
+**The stdin write is a thread too (D3).** A hook that exits without reading
+its stdin closes the pipe, and a synchronous `write_all` of the payload then
+fails with `EPIPE` before the runner has even started waiting. Writing on a
+thread and ignoring its result is what makes "a hook need not read stdin"
+true.

--- a/openspec/changes/archive/2026-08-26-session-lifecycle-hooks/proposal.md
+++ b/openspec/changes/archive/2026-08-26-session-lifecycle-hooks/proposal.md
@@ -1,0 +1,78 @@
+## Why
+
+thurbox knows when a session is created, deleted, restarted and restored, but
+the user cannot: there is no way to run their own command at those moments — copy
+an `.env` into a fresh worktree, install dependencies before the agent boots,
+post to a chat channel when a session lands, refuse a session on a branch that
+must not be touched, clean a scratch directory when one is deleted. Today that
+needs a wrapper around `thurbox-cli` (which the TUI never calls) or a fork.
+
+The only "hooks" thurbox has run in the *opposite* direction — the built-in
+`hooks` extension installs status hooks into the agent CLIs so they can tell
+thurbox what they are doing. Nothing lets thurbox tell the user's own scripts
+what *it* is doing.
+
+## What Changes
+
+- A new config file, `~/.config/thurbox/hooks.toml`, declares **session
+  lifecycle hooks** as data: `[[hooks]]` entries pairing an event name with a
+  shell command (and an optional timeout). Seeded commented-out on first run,
+  like `hosts.toml`; absent or empty means no hooks, exactly today's behaviour.
+- Eight events, pre and post for each of the four session operations:
+  `session.pre_create` / `session.post_create`, `session.pre_delete` /
+  `session.post_delete`, `session.pre_restart` / `session.post_restart`,
+  `session.pre_restore` / `session.post_restore`.
+- **`pre_*` hooks can veto**: a non-zero exit or a timeout aborts the operation
+  before it has any side effect, and the hook's stderr is the reported reason.
+  **`post_*` hooks are informational**: every one runs, a failure is logged and
+  reported but never fails the operation.
+- Hooks receive the session's facts as **`THURBOX_*` environment variables**
+  (event, session id, name, agent, repository, working directory, branch, base,
+  host, parent) and, for anything structured, the same facts plus the worktree
+  list as **one JSON document on stdin**. A `thurbox-cli` call inside a hook hits
+  the same database as the thurbox that fired it, the way an agent's status hook
+  already does.
+- Hooks fire **once per operation, for every caller**: the TUI, `thurbox-cli`,
+  a `spawn` automation, an extension's self-heal — because they fire inside the
+  one pipeline each operation already has, not in each interface.
+- `thurbox-cli config validate` / `config show` learn the new file, and the
+  creation progress a plugin renders gains a phase for the pre-hooks, so a slow
+  hook is named rather than mistaken for a slow fetch.
+
+No existing behaviour changes for a user with no `hooks.toml` entries.
+
+## Capabilities
+
+### New Capabilities
+
+- `session-hooks`: which session lifecycle events exist, how a user declares a
+  command for one, what the command receives, when it runs relative to the
+  operation, and what its exit status means (veto vs. informational).
+
+### Modified Capabilities
+
+None. `session-creation`'s requirements hold as written — a vetoed creation is
+"a failure reported through the in-flight channel, leaving no half-created
+session", which it already requires — and `core-settings` covers
+`settings.toml`, which this does not touch.
+
+## Impact
+
+- **New**: `session::hook_def` (pure data: events, entries, the context handed
+  to a hook), `agent::hooks_config` (load-or-seed of `hooks.toml`, mirroring
+  `host_config`), `session_ops::lifecycle_hooks` (the runner: env + stdin +
+  timeout + output capture).
+- **Touched**: `session_ops::{spawn,delete,restart,restore}` gain a pre and a
+  post call each; `SpawnPhase` gains a `hooks` phase; `SpawnResult`,
+  `ForceDeleteReport` and `RestoreReport` carry post-hook failures;
+  `cli::config` validates and shows the file; the CLI's JSON surfaces the
+  failures.
+- **Not touched**: the kernel, the Lua interface, `settings.toml`, the
+  database schema, the agent status-hook extension. `tests/architecture_rules.rs`
+  needs entries for the new modules.
+- **Docs**: `docs/CONFIG.md` (a `hooks.toml` section, and a sentence drawing the
+  line between it and the `hooks/` extension home beside it), `docs/FEATURES.md`,
+  `CLAUDE.md`.
+- **Performance**: a pre-hook adds its own runtime to an operation, bounded by
+  its timeout (default 30 s); it runs on the thread that already runs the
+  operation — a worker in the TUI — so the render loop is never on the path.

--- a/openspec/changes/archive/2026-08-26-session-lifecycle-hooks/specs/session-hooks/spec.md
+++ b/openspec/changes/archive/2026-08-26-session-lifecycle-hooks/specs/session-hooks/spec.md
@@ -1,0 +1,228 @@
+## Purpose
+
+Lets a user run their own commands at the moments thurbox creates, deletes,
+restarts or restores a session — before the operation, where they can refuse
+it, and after, where they can react to it — declared as data and fired the same
+way whichever interface asked for the operation.
+
+## ADDED Requirements
+
+### Requirement: Hooks are declared as data in a config file
+
+The system SHALL read session lifecycle hooks from a `hooks.toml` file beside
+the other config files, as a list of entries each naming one **event** and one
+**shell command**, with an optional per-entry timeout in seconds. The file
+SHALL be seeded with commented-out examples on first run. A missing, empty or
+example-only file SHALL mean no hooks, and the system SHALL behave exactly as it
+did before hooks existed.
+
+#### Scenario: No hooks file
+
+- **WHEN** no `hooks.toml` exists in the config directory
+- **THEN** the system writes one containing only comments
+- **AND** every session operation behaves as it did without hooks
+
+#### Scenario: A hook is declared
+
+- **WHEN** `hooks.toml` contains an entry for `session.post_create` with a command
+- **THEN** that command runs after every session creation
+
+#### Scenario: The file is malformed
+
+- **WHEN** `hooks.toml` cannot be parsed, or names an event that does not exist
+- **THEN** no hooks run
+- **AND** a warning naming the file and the problem is reported, the same way a
+  malformed `hosts.toml` is
+- **AND** `thurbox-cli config validate` reports the file as failing
+
+### Requirement: Eight events cover the four session operations
+
+The system SHALL fire `session.pre_create`, `session.post_create`,
+`session.pre_delete`, `session.post_delete`, `session.pre_restart`,
+`session.post_restart`, `session.pre_restore` and `session.post_restore`. A
+`pre_*` event fires before the operation has any side effect; a `post_*` event
+fires after the operation has fully succeeded, and not otherwise.
+
+#### Scenario: A creation that fails part-way
+
+- **WHEN** `session.pre_create` hooks have run and creation then fails (a bad
+  branch, an unreachable host)
+- **THEN** `session.post_create` does not fire
+
+#### Scenario: A fork is a creation
+
+- **WHEN** a session is forked
+- **THEN** the `session.pre_create` and `session.post_create` hooks fire for the
+  new session, with the parent's id in the context
+
+#### Scenario: A soft delete and a force delete are both deletes
+
+- **WHEN** a session is soft-deleted from the TUI, or force-deleted from the CLI
+- **THEN** the `session.pre_delete` and `session.post_delete` hooks fire, and the
+  context says whether it was forced
+
+#### Scenario: An undo is a restore
+
+- **WHEN** a soft-deleted session is brought back, by undo in the TUI or by
+  `session restore`
+- **THEN** the restore hooks fire
+
+### Requirement: Hooks fire once per operation regardless of the caller
+
+Every way of performing a session operation — the TUI, `thurbox-cli`, an
+automation, an extension — SHALL fire the same hooks exactly once for that
+operation.
+
+#### Scenario: Creation from three entry points
+
+- **WHEN** a session is created from the TUI's creation flow, from
+  `thurbox-cli session create`, and from a `spawn` automation
+- **THEN** each creation fires `session.pre_create` and `session.post_create`
+  once
+
+### Requirement: Hooks run in declaration order and never on the render path
+
+Hooks for one event SHALL run one at a time in the order they appear in the
+file. They SHALL run on the thread performing the operation, which in the TUI
+is never the thread that draws the screen.
+
+#### Scenario: Two hooks for one event
+
+- **WHEN** two entries name `session.post_create`
+- **THEN** the first has exited before the second starts
+
+#### Scenario: A slow hook in the TUI
+
+- **WHEN** a `session.pre_create` hook takes ten seconds
+- **THEN** the interface keeps painting and reports the creation as running its
+  hooks, and the creation proceeds when the hook exits
+
+### Requirement: A pre-hook can veto the operation
+
+If any `pre_*` hook exits non-zero, cannot be started, or exceeds its timeout,
+the system SHALL abort the operation before it has any side effect — no
+worktree, no process, no row changed — and SHALL report the failure with the
+hook's command, its exit status (or that it timed out) and the tail of its
+stderr. Hooks declared after the failing one for that event SHALL not run.
+
+#### Scenario: A pre-create hook refuses
+
+- **WHEN** a `session.pre_create` hook exits `1` with `refusing: protected
+  branch` on stderr
+- **THEN** no session is created, no worktree exists, no process was launched
+- **AND** the reported error contains `refusing: protected branch`
+
+#### Scenario: A pre-delete hook refuses
+
+- **WHEN** a `session.pre_delete` hook exits non-zero
+- **THEN** the session is not deleted and is unchanged in the list
+- **AND** the interface reports why
+
+#### Scenario: A pre-hook hangs
+
+- **WHEN** a `session.pre_restart` hook does not exit within its timeout
+- **THEN** it is killed, the restart does not happen, and the report says the
+  hook timed out
+
+### Requirement: A post-hook cannot fail the operation
+
+A `post_*` hook's exit status SHALL never change the outcome of the operation.
+Every `post_*` hook for the event SHALL run even if an earlier one failed. A
+failure SHALL be logged and SHALL be carried in the operation's report where
+the caller exposes one.
+
+#### Scenario: A post-create hook fails
+
+- **WHEN** a `session.post_create` hook exits `2`
+- **THEN** the session exists and is running
+- **AND** the CLI's JSON for the create names the failed hook
+- **AND** the failure is in the log
+
+#### Scenario: A post-hook hangs
+
+- **WHEN** a `session.post_delete` hook exceeds its timeout
+- **THEN** it is killed, the delete stands, and the timeout is reported as a
+  hook failure
+
+### Requirement: A hook receives the session's facts as environment and as JSON
+
+Each hook SHALL receive `THURBOX_HOOK_EVENT` (the event name) and, as far as
+they are known at that point, `THURBOX_SESSION` (the session id),
+`THURBOX_SESSION_NAME`, `THURBOX_AGENT`, `THURBOX_REPO` (the primary
+repository path), `THURBOX_CWD` (the directory the agent runs in),
+`THURBOX_BRANCH`, `THURBOX_BASE_BRANCH`, `THURBOX_HOST` (the remote host name,
+unset for a local session), `THURBOX_PARENT_SESSION` and `THURBOX_TASK`. The
+same facts, plus the list of worktrees and additional directories, SHALL be
+written to the hook's stdin as one JSON object, after which stdin is closed. A
+hook SHALL inherit the same config- and data-directory overrides the agent
+inside a session receives, so a `thurbox-cli` it runs addresses the database of
+the thurbox that fired it.
+
+#### Scenario: A post-create hook reads its environment
+
+- **WHEN** `session.post_create` fires for a worktree session on branch `feat/x`
+- **THEN** `THURBOX_BRANCH` is `feat/x`, `THURBOX_CWD` is the worktree path,
+  `THURBOX_REPO` is the repository it was made from, and `THURBOX_SESSION` is
+  the id `thurbox-cli session get` accepts
+
+#### Scenario: A pre-create hook sees what will be created
+
+- **WHEN** `session.pre_create` fires
+- **THEN** `THURBOX_SESSION_NAME`, `THURBOX_AGENT`, `THURBOX_REPO` and the
+  requested branch are set
+- **AND** `THURBOX_SESSION` is the id the session will have if creation succeeds
+
+#### Scenario: A hook calls thurbox-cli
+
+- **WHEN** a hook fired by a dev build runs `thurbox-cli session list`
+- **THEN** it lists that dev build's sessions, not the release build's
+
+#### Scenario: The JSON payload
+
+- **WHEN** a hook reads its stdin
+- **THEN** it gets one JSON object whose `event` matches `THURBOX_HOOK_EVENT` and
+  whose `worktrees` lists each worktree's repository, path and branch
+
+### Requirement: A hook runs in the session's repository with no terminal
+
+A hook SHALL run through the platform shell (`sh -c`, or `cmd /C` on Windows)
+with its working directory set to the session's primary repository when that is
+a directory on the local machine, and otherwise to the working directory of the
+thurbox process. It SHALL not inherit thurbox's stdin, stdout or stderr: its
+output is captured and tail-truncated for reporting, and it can neither draw on
+nor read from the terminal the TUI owns.
+
+#### Scenario: A hook for a local worktree session
+
+- **WHEN** `session.post_delete` fires for a local session whose worktree was
+  removed
+- **THEN** the hook's working directory is the repository the worktree was made
+  from, which still exists
+
+#### Scenario: A hook for a remote session
+
+- **WHEN** any hook fires for a session on an SSH or WSL host
+- **THEN** the hook runs on the local machine, `THURBOX_HOST` names the host,
+  and `THURBOX_CWD` is the path on that host
+
+#### Scenario: A chatty hook
+
+- **WHEN** a hook prints a megabyte and exits non-zero
+- **THEN** the TUI's screen is undisturbed and the report carries only the tail
+  of the output
+
+### Requirement: The config surface knows the file
+
+`thurbox-cli config validate` SHALL strict-parse `hooks.toml` alongside the
+other config files, and `thurbox-cli config show` SHALL print its path and the
+hooks in force.
+
+#### Scenario: Validate on an unknown field
+
+- **WHEN** an entry in `hooks.toml` has a misspelt field
+- **THEN** `config validate` exits non-zero and names `hooks.toml`
+
+#### Scenario: Show the hooks in force
+
+- **WHEN** `config show` runs with two hooks declared
+- **THEN** its output lists both, each with its event and command

--- a/openspec/changes/archive/2026-08-26-session-lifecycle-hooks/tasks.md
+++ b/openspec/changes/archive/2026-08-26-session-lifecycle-hooks/tasks.md
@@ -1,0 +1,48 @@
+## 1. Data (`session`)
+
+- [x] 1.1 Add `session::hook_def` with `HookEvent` (closed enum, serde-renamed to the `session.pre_create` … `session.post_restore` spellings), `LifecycleHook { event, command, timeout_secs }` and `HooksFile { hooks }` with `deny_unknown_fields`
+- [x] 1.2 Add `HookContext` (event, session id, name, agent, repo, cwd, branch, base branch, host, parent session, task, agent session id, force / force_deleted, backend id, worktrees, additional dirs) with `env()` (unset-not-empty for unknown facts), `json()` and `workdir()` (primary repo if a local directory, else none)
+- [x] 1.3 Unit tests: every event round-trips through serde by its dotted name, an unknown event and an unknown field fail to parse, `env()` sets exactly the documented `THURBOX_*` names, `json()` carries `event` and `worktrees`, `workdir()` falls back for a remote path
+
+## 2. Config (`agent`)
+
+- [x] 2.1 Add `agent::hooks_config` mirroring `host_config`: `hooks_config_path()`, a commented-out seed whose header states the difference from the `hooks/` extension home and shows one entry per pre/post pair, `load_or_seed_with_warnings()`, `load_or_seed()`, `hooks_for(event)` in file order
+- [x] 2.2 Unit tests: the seed parses to zero hooks and documents every field and every event name, a missing file is seeded, a malformed file degrades to no hooks with a warning naming `hooks.toml`, a two-entry file yields them in order
+
+## 3. Runner (`session_ops`)
+
+- [x] 3.1 Extract from `run_exec_command` a platform-shell command builder and make `exec_tail` shared; `run_exec_command` keeps its signature and behaviour
+- [x] 3.2 Lift the `THURBOX_CONFIG_DIR`/`THURBOX_DATA_DIR` override computation out of `inject_thurbox_env` into a helper both it and the hook runner use
+- [x] 3.3 Add `session_ops::lifecycle_hooks` with `run_hook(hook, ctx) -> Result<(), String>`: env from `ctx.env()` plus the overrides, cwd from `ctx.workdir()`, JSON on a piped stdin closed before waiting, stdout/stderr drained on reader threads, `try_wait` polling against the hook's timeout (default 30 s), `kill()` and a `timed out after Ns` message on the deadline, `exit N: <stderr tail>` on a non-zero exit
+- [x] 3.4 Add `fire_pre(event, &ctx) -> Result<(), String>` (first failure aborts, later hooks do not run, failure logged) and `fire_post(event, &ctx) -> Vec<String>` (all run, every failure collected and logged at warn); both read `hooks.toml` at call time
+- [x] 3.5 Unit tests (unix): a hook that echoes `$THURBOX_HOOK_EVENT` and its stdin to a file sees the right values, exit 3 with stderr surfaces as `exit 3: …`, `sleep 5` with `timeout_secs = 1` is killed and reported as timed out, `yes` with a timeout does not deadlock, two pre-hooks stop at the first failure, two post-hooks both run past a failure
+
+## 4. Firing (`session_ops` pipelines)
+
+- [x] 4.1 `spawn`: mint the `SessionId` before validation, add `SpawnPhase::Hooks` reported before `fire_pre(PreCreate)` (after name/parent/host validation, before `resolve_dirs`), `fire_post(PostCreate)` after the row and base branch are persisted, `hook_failures` on `SpawnResult`
+- [x] 4.2 `delete`: `fire_pre(PreDelete)` after the row is loaded and before any teardown, `fire_post(PostDelete)` after the soft delete (+ force mark), `hook_failures` on `ForceDeleteReport`; a veto returns `Err` with nothing changed
+- [x] 4.3 `restart`: `fire_pre(PreRestart)` after the plan is built and before the kill, `fire_post(PostRestart)` after the new pane id is persisted; return a `RestartReport { hook_failures }` and update its callers (`cli::sessions`, `kernel::command::execute`)
+- [x] 4.4 `restore`: `fire_pre(PreRestore)` after the best-effort and remote refusals and before `db.restore_session`, `fire_post(PostRestore)` after `respawn`, `hook_failures` on `RestoreReport`
+- [x] 4.5 Add `"hooks"` to the pinned phase sequence in `tests/kernel_mvp.rs` and a `running hooks` label to `PHASE_LABEL` in `ui/plugins/10_sessions.lua`; run `selene`/`stylua`/`lua-language-server` on the Lua
+
+## 5. CLI surface
+
+- [x] 5.1 `cli::config validate`: strict-parse `hooks.toml` through the same `validate_toml` path as `hosts.toml`, add it to the per-file pass/fail list and the JSON
+- [x] 5.2 `cli::config show`: print `hooks_toml` path and the hooks in force (event + command + timeout)
+- [x] 5.3 `cli::sessions`: emit `hook_failures` in the JSON of `create`, `delete`, `restart`, `restore`; `cli::action`'s automation spawn logs them
+- [x] 5.4 Tests in `cli::config`: validate fails and names `hooks.toml` on an unknown field; show lists two declared hooks
+
+## 6. End-to-end proof
+
+- [x] 6.1 In `tests/create_e2e.rs` (tmux, unix): with `THURBOX_CONFIG_DIR` pointing at a tempdir holding a `hooks.toml`, a headless create fires `pre_create` then `post_create` once each, in that order, with `THURBOX_CWD` = the worktree and `THURBOX_REPO` = the repository, and the hook's `thurbox-cli session get $THURBOX_SESSION` (dev binary on PATH) finds the row
+- [x] 6.2 A `pre_create` hook exiting 1 leaves no worktree, no tmux window and no row, and the error carries its stderr
+- [x] 6.3 A `post_create` hook exiting 2 leaves the session running and the failure in `SpawnResult.hook_failures`
+- [x] 6.4 A TUI creation through the command bus (`tests/kernel_mvp.rs` style) reports the `hooks` phase and a veto as the in-flight error
+- [x] 6.5 Delete (soft and force), restart and restore each fire their pair once; a `pre_delete` veto leaves the row undeleted
+
+## 7. Docs
+
+- [x] 7.1 `docs/CONFIG.md`: a `hooks.toml` section (file layout, the eight events, veto vs. informational, the env table, the stdin JSON, cwd rule, timeout, remote sessions), one sentence distinguishing it from the `hooks/` extension home, the new `THURBOX_*` names in the environment-variables table, `config validate`/`show` coverage
+- [x] 7.2 `docs/FEATURES.md`: a Session lifecycle hooks entry
+- [x] 7.3 `CLAUDE.md`: a short Session lifecycle hooks section under the session sections, naming the modules and the single-pipeline reason hooks fire once per caller; list `hooks.toml` where the config files are enumerated
+- [x] 7.4 `just lint` clean (rumdl on the docs, clippy, fmt, the three Lua gates) and `cargo nextest run --all` green

--- a/openspec/specs/session-hooks/spec.md
+++ b/openspec/specs/session-hooks/spec.md
@@ -1,0 +1,227 @@
+# session-hooks Specification
+
+## Purpose
+Lets a user run their own commands at the moments thurbox creates, deletes,
+restarts or restores a session — before the operation, where they can refuse
+it, and after, where they can react to it — declared as data and fired the same
+way whichever interface asked for the operation.
+## Requirements
+### Requirement: Hooks are declared as data in a config file
+
+The system SHALL read session lifecycle hooks from a `hooks.toml` file beside
+the other config files, as a list of entries each naming one **event** and one
+**shell command**, with an optional per-entry timeout in seconds. The file
+SHALL be seeded with commented-out examples on first run. A missing, empty or
+example-only file SHALL mean no hooks, and the system SHALL behave exactly as it
+did before hooks existed.
+
+#### Scenario: No hooks file
+
+- **WHEN** no `hooks.toml` exists in the config directory
+- **THEN** the system writes one containing only comments
+- **AND** every session operation behaves as it did without hooks
+
+#### Scenario: A hook is declared
+
+- **WHEN** `hooks.toml` contains an entry for `session.post_create` with a command
+- **THEN** that command runs after every session creation
+
+#### Scenario: The file is malformed
+
+- **WHEN** `hooks.toml` cannot be parsed, or names an event that does not exist
+- **THEN** no hooks run
+- **AND** a warning naming the file and the problem is reported, the same way a
+  malformed `hosts.toml` is
+- **AND** `thurbox-cli config validate` reports the file as failing
+
+### Requirement: Eight events cover the four session operations
+
+The system SHALL fire `session.pre_create`, `session.post_create`,
+`session.pre_delete`, `session.post_delete`, `session.pre_restart`,
+`session.post_restart`, `session.pre_restore` and `session.post_restore`. A
+`pre_*` event fires before the operation has any side effect; a `post_*` event
+fires after the operation has fully succeeded, and not otherwise.
+
+#### Scenario: A creation that fails part-way
+
+- **WHEN** `session.pre_create` hooks have run and creation then fails (a bad
+  branch, an unreachable host)
+- **THEN** `session.post_create` does not fire
+
+#### Scenario: A fork is a creation
+
+- **WHEN** a session is forked
+- **THEN** the `session.pre_create` and `session.post_create` hooks fire for the
+  new session, with the parent's id in the context
+
+#### Scenario: A soft delete and a force delete are both deletes
+
+- **WHEN** a session is soft-deleted from the TUI, or force-deleted from the CLI
+- **THEN** the `session.pre_delete` and `session.post_delete` hooks fire, and the
+  context says whether it was forced
+
+#### Scenario: An undo is a restore
+
+- **WHEN** a soft-deleted session is brought back, by undo in the TUI or by
+  `session restore`
+- **THEN** the restore hooks fire
+
+### Requirement: Hooks fire once per operation regardless of the caller
+
+Every way of performing a session operation — the TUI, `thurbox-cli`, an
+automation, an extension — SHALL fire the same hooks exactly once for that
+operation.
+
+#### Scenario: Creation from three entry points
+
+- **WHEN** a session is created from the TUI's creation flow, from
+  `thurbox-cli session create`, and from a `spawn` automation
+- **THEN** each creation fires `session.pre_create` and `session.post_create`
+  once
+
+### Requirement: Hooks run in declaration order and never on the render path
+
+Hooks for one event SHALL run one at a time in the order they appear in the
+file. They SHALL run on the thread performing the operation, which in the TUI
+is never the thread that draws the screen.
+
+#### Scenario: Two hooks for one event
+
+- **WHEN** two entries name `session.post_create`
+- **THEN** the first has exited before the second starts
+
+#### Scenario: A slow hook in the TUI
+
+- **WHEN** a `session.pre_create` hook takes ten seconds
+- **THEN** the interface keeps painting and reports the creation as running its
+  hooks, and the creation proceeds when the hook exits
+
+### Requirement: A pre-hook can veto the operation
+
+If any `pre_*` hook exits non-zero, cannot be started, or exceeds its timeout,
+the system SHALL abort the operation before it has any side effect — no
+worktree, no process, no row changed — and SHALL report the failure with the
+hook's command, its exit status (or that it timed out) and the tail of its
+stderr. Hooks declared after the failing one for that event SHALL not run.
+
+#### Scenario: A pre-create hook refuses
+
+- **WHEN** a `session.pre_create` hook exits `1` with `refusing: protected
+  branch` on stderr
+- **THEN** no session is created, no worktree exists, no process was launched
+- **AND** the reported error contains `refusing: protected branch`
+
+#### Scenario: A pre-delete hook refuses
+
+- **WHEN** a `session.pre_delete` hook exits non-zero
+- **THEN** the session is not deleted and is unchanged in the list
+- **AND** the interface reports why
+
+#### Scenario: A pre-hook hangs
+
+- **WHEN** a `session.pre_restart` hook does not exit within its timeout
+- **THEN** it is killed, the restart does not happen, and the report says the
+  hook timed out
+
+### Requirement: A post-hook cannot fail the operation
+
+A `post_*` hook's exit status SHALL never change the outcome of the operation.
+Every `post_*` hook for the event SHALL run even if an earlier one failed. A
+failure SHALL be logged and SHALL be carried in the operation's report where
+the caller exposes one.
+
+#### Scenario: A post-create hook fails
+
+- **WHEN** a `session.post_create` hook exits `2`
+- **THEN** the session exists and is running
+- **AND** the CLI's JSON for the create names the failed hook
+- **AND** the failure is in the log
+
+#### Scenario: A post-hook hangs
+
+- **WHEN** a `session.post_delete` hook exceeds its timeout
+- **THEN** it is killed, the delete stands, and the timeout is reported as a
+  hook failure
+
+### Requirement: A hook receives the session's facts as environment and as JSON
+
+Each hook SHALL receive `THURBOX_HOOK_EVENT` (the event name) and, as far as
+they are known at that point, `THURBOX_SESSION` (the session id),
+`THURBOX_SESSION_NAME`, `THURBOX_AGENT`, `THURBOX_REPO` (the primary
+repository path), `THURBOX_CWD` (the directory the agent runs in),
+`THURBOX_BRANCH`, `THURBOX_BASE_BRANCH`, `THURBOX_HOST` (the remote host name,
+unset for a local session), `THURBOX_PARENT_SESSION` and `THURBOX_TASK`. The
+same facts, plus the list of worktrees and additional directories, SHALL be
+written to the hook's stdin as one JSON object, after which stdin is closed. A
+hook SHALL inherit the same config- and data-directory overrides the agent
+inside a session receives, so a `thurbox-cli` it runs addresses the database of
+the thurbox that fired it.
+
+#### Scenario: A post-create hook reads its environment
+
+- **WHEN** `session.post_create` fires for a worktree session on branch `feat/x`
+- **THEN** `THURBOX_BRANCH` is `feat/x`, `THURBOX_CWD` is the worktree path,
+  `THURBOX_REPO` is the repository it was made from, and `THURBOX_SESSION` is
+  the id `thurbox-cli session get` accepts
+
+#### Scenario: A pre-create hook sees what will be created
+
+- **WHEN** `session.pre_create` fires
+- **THEN** `THURBOX_SESSION_NAME`, `THURBOX_AGENT`, `THURBOX_REPO` and the
+  requested branch are set
+- **AND** `THURBOX_SESSION` is the id the session will have if creation succeeds
+
+#### Scenario: A hook calls thurbox-cli
+
+- **WHEN** a hook fired by a dev build runs `thurbox-cli session list`
+- **THEN** it lists that dev build's sessions, not the release build's
+
+#### Scenario: The JSON payload
+
+- **WHEN** a hook reads its stdin
+- **THEN** it gets one JSON object whose `event` matches `THURBOX_HOOK_EVENT` and
+  whose `worktrees` lists each worktree's repository, path and branch
+
+### Requirement: A hook runs in the session's repository with no terminal
+
+A hook SHALL run through the platform shell (`sh -c`, or `cmd /C` on Windows)
+with its working directory set to the session's primary repository when that is
+a directory on the local machine, and otherwise to the working directory of the
+thurbox process. It SHALL not inherit thurbox's stdin, stdout or stderr: its
+output is captured and tail-truncated for reporting, and it can neither draw on
+nor read from the terminal the TUI owns.
+
+#### Scenario: A hook for a local worktree session
+
+- **WHEN** `session.post_delete` fires for a local session whose worktree was
+  removed
+- **THEN** the hook's working directory is the repository the worktree was made
+  from, which still exists
+
+#### Scenario: A hook for a remote session
+
+- **WHEN** any hook fires for a session on an SSH or WSL host
+- **THEN** the hook runs on the local machine, `THURBOX_HOST` names the host,
+  and `THURBOX_CWD` is the path on that host
+
+#### Scenario: A chatty hook
+
+- **WHEN** a hook prints a megabyte and exits non-zero
+- **THEN** the TUI's screen is undisturbed and the report carries only the tail
+  of the output
+
+### Requirement: The config surface knows the file
+
+`thurbox-cli config validate` SHALL strict-parse `hooks.toml` alongside the
+other config files, and `thurbox-cli config show` SHALL print its path and the
+hooks in force.
+
+#### Scenario: Validate on an unknown field
+
+- **WHEN** an entry in `hooks.toml` has a misspelt field
+- **THEN** `config validate` exits non-zero and names `hooks.toml`
+
+#### Scenario: Show the hooks in force
+
+- **WHEN** `config show` runs with two hooks declared
+- **THEN** its output lists both, each with its event and command

--- a/src/agent/hooks_config.rs
+++ b/src/agent/hooks_config.rs
@@ -1,0 +1,337 @@
+//! Loading and seeding of the session lifecycle hooks file.
+//!
+//! `~/.config/thurbox/hooks.toml` declares the user's own commands to run
+//! before and after thurbox creates, deletes, restarts or restores a session.
+//! It is the reverse of the `hooks/` directory beside it, which is where the
+//! built-in `hooks` *extension* keeps the status-hook files it installs into
+//! the agent CLIs. On first run the file is seeded fully commented-out, so a
+//! fresh install runs nothing. If it exists but cannot be read or parsed, no
+//! hooks run and a warning says why — the same degrade `hosts.toml` chose,
+//! since a broken config file must never block a session operation.
+//!
+//! The file is read each time an event fires, on the worker firing it: one
+//! small read per session operation buys an edit that is in force at once and
+//! no cache to give an age to.
+
+use std::path::PathBuf;
+
+use crate::session::{HookEvent, HooksFile, LifecycleHook};
+
+/// Seed contents for `hooks.toml` on first run: full documentation plus one
+/// commented-out example per event, but no active hooks.
+pub const SEED_HOOKS_TOML: &str = r#"# Thurbox session lifecycle hooks  —  ~/.config/thurbox/hooks.toml
+#
+# Each [[hooks]] entry runs a shell command of yours at one moment in a
+# session's life: before or after thurbox creates, deletes, restarts or
+# restores it. Hooks run on the machine thurbox runs on, whichever interface
+# asked for the operation — the TUI, `thurbox-cli`, an automation, an
+# extension — once per operation.
+#
+# NOT the same thing as the `hooks/` directory next to this file: that is
+# where the built-in `hooks` extension keeps the status-hook files it installs
+# INTO the agent CLIs (so an agent can tell thurbox it is working/blocked/
+# done). This file is the other direction — thurbox telling your scripts what
+# it is doing.
+#
+# Events (pre = before the operation has any effect; post = after it fully
+# succeeded, and never after a failure):
+#
+#   session.pre_create    session.post_create
+#   session.pre_delete    session.post_delete
+#   session.pre_restart   session.post_restart
+#   session.pre_restore   session.post_restore
+#
+# A `pre_*` hook can REFUSE the operation: exit non-zero (or exceed the
+# timeout) and nothing happens — no worktree, no process, no row changed —
+# and its stderr is the reported reason. Later hooks for that event do not
+# run. A `post_*` hook is informational: every one runs, a failure is logged
+# and reported but never fails the operation.
+#
+# What a hook receives, as environment variables (unset — not empty — when
+# the fact is not known at that moment):
+#
+#   THURBOX_HOOK_EVENT       the event name, e.g. "session.post_create"
+#   THURBOX_SESSION          the thurbox session id (at pre_create: the id it
+#                            will have if creation succeeds)
+#   THURBOX_SESSION_ID       the agent's own conversation id
+#   THURBOX_SESSION_NAME     the session name
+#   THURBOX_AGENT            the agent, e.g. "claude"
+#   THURBOX_REPO             the primary repository path
+#   THURBOX_CWD              the directory the agent runs in (the worktree, or
+#                            the symlink workspace of a multi-repo session);
+#                            unset at pre_create, before the worktree exists
+#   THURBOX_BRANCH           the worktree branch, when there is one
+#   THURBOX_BASE_BRANCH      the branch it was created from (create events)
+#   THURBOX_HOST             the remote host name; unset for a local session.
+#                            When set, THURBOX_REPO/THURBOX_CWD are paths on
+#                            that host — the hook itself still runs locally
+#   THURBOX_PARENT_SESSION   the parent session id (a fork, or --parent)
+#   THURBOX_TASK             the originating task id, for a task-spawned session
+#   THURBOX_CONFIG_DIR / THURBOX_DATA_DIR
+#                            so a `thurbox-cli` you run inside the hook hits the
+#                            same database as the thurbox that fired it
+#
+# The same facts — plus `worktrees` (repo_path, worktree_path, branch), the
+# additional directories, and `force`/`force_deleted` for delete/restore —
+# arrive as ONE JSON object on stdin, for anything structured:
+#   jq -r .cwd
+#
+# The hook runs through `sh -c` (`cmd /C` on Windows), in the primary
+# repository when that is a directory on this machine (otherwise in thurbox's
+# own working directory), with no terminal: stdout/stderr are captured and only
+# their tail is reported. It is killed after `timeout_secs` (default 30).
+#
+# Unknown keys are reported on startup (and fail `thurbox-cli config
+# validate`) but don't break the load. A file that fails to parse means NO
+# hooks run, with a warning — never a blocked session.
+#
+# Fields per [[hooks]] entry:
+#
+#   event          (string, required)   one of the eight event names above
+#   command        (string, required)   the shell command
+#   timeout_secs   (integer, optional, default: 30)
+#
+config_version = 1
+
+# ──────────────────────────────────────────────────────────────────────────
+# Examples — every entry below is commented out. Uncomment and edit to use.
+# ──────────────────────────────────────────────────────────────────────────
+
+# Refuse a session on a branch nobody should work on directly.
+# [[hooks]]
+# event = "session.pre_create"
+# command = 'case "$THURBOX_BRANCH" in main|master) echo "refusing: protected branch" >&2; exit 1;; esac'
+
+# Copy a local env file and warm the dependencies in a fresh worktree.
+# [[hooks]]
+# event = "session.post_create"
+# command = '[ -n "$THURBOX_CWD" ] && cp -n .env.local "$THURBOX_CWD/.env" 2>/dev/null; true'
+# timeout_secs = 120
+
+# Ask before deleting a session that still has a running build.
+# [[hooks]]
+# event = "session.pre_delete"
+# command = 'test ! -f "$THURBOX_CWD/.build-lock"'
+
+# Tell a channel a session is gone.
+# [[hooks]]
+# event = "session.post_delete"
+# command = 'notify-send "thurbox" "deleted $THURBOX_SESSION_NAME"'
+
+# [[hooks]]
+# event = "session.pre_restart"
+# command = 'echo "restarting $THURBOX_SESSION_NAME" >> ~/thurbox-hooks.log'
+
+# [[hooks]]
+# event = "session.post_restart"
+# command = 'echo "restarted $THURBOX_SESSION_NAME" >> ~/thurbox-hooks.log'
+
+# [[hooks]]
+# event = "session.pre_restore"
+# command = 'jq -e ".force_deleted | not"'   # refuse a lossy restore
+
+# [[hooks]]
+# event = "session.post_restore"
+# command = 'notify-send "thurbox" "restored $THURBOX_SESSION_NAME"'
+"#;
+
+/// Path to the lifecycle hooks file: `~/.config/thurbox/hooks.toml` (sibling
+/// of `config.toml`; `~/.config/thurbox-dev/hooks.toml` on a dev build).
+pub fn hooks_config_path() -> Option<PathBuf> {
+    crate::paths::config_file().map(|p| p.with_file_name("hooks.toml"))
+}
+
+/// Load the hooks file, seeding it commented-out when absent. Any read/parse
+/// error degrades to no hooks; the warnings are logged here (headless callers)
+/// — [`load_or_seed_with_warnings`] returns them for a caller that surfaces
+/// them itself.
+pub fn load_or_seed() -> HooksFile {
+    let (file, warnings) = load_or_seed_with_warnings();
+    for w in &warnings {
+        tracing::warn!("{w}");
+    }
+    file
+}
+
+/// [`load_or_seed`], also returning user-facing warnings for anything that
+/// silently degraded (parse error → no hooks, seed failure, unknown keys).
+pub fn load_or_seed_with_warnings() -> (HooksFile, Vec<String>) {
+    let Some(path) = hooks_config_path() else {
+        return (
+            HooksFile::default(),
+            vec!["Could not resolve hooks.toml path; no lifecycle hooks".into()],
+        );
+    };
+
+    if !path.exists() {
+        if let Some(parent) = path.parent() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                return (
+                    HooksFile::default(),
+                    vec![format!("Failed to create config dir for hooks.toml: {e}")],
+                );
+            }
+        }
+        if let Err(e) = std::fs::write(&path, SEED_HOOKS_TOML) {
+            return (
+                HooksFile::default(),
+                vec![format!("Failed to seed hooks.toml: {e}")],
+            );
+        }
+        tracing::info!(path = %path.display(), "Seeded hooks.toml (no active hooks)");
+        return (HooksFile::default(), Vec::new());
+    }
+
+    match std::fs::read_to_string(&path) {
+        Ok(contents) => {
+            match super::agent_config::parse_toml_reporting_unknown::<HooksFile>(
+                &contents,
+                "hooks.toml",
+            ) {
+                Ok((file, warnings)) => (file, warnings),
+                Err(e) => (
+                    HooksFile::default(),
+                    vec![format!(
+                        "hooks.toml: {}; no lifecycle hooks",
+                        super::agent_config::compact_toml_error(&e.to_string())
+                    )],
+                ),
+            }
+        }
+        Err(e) => (
+            HooksFile::default(),
+            vec![format!("Failed to read hooks.toml: {e}")],
+        ),
+    }
+}
+
+/// The hooks declared for `event`, in file order, read from disk now.
+pub fn hooks_for(event: HookEvent) -> Vec<LifecycleHook> {
+    load_or_seed().for_event(event)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seed_toml_parses_to_no_hooks() {
+        let file: HooksFile = toml::from_str(SEED_HOOKS_TOML).unwrap();
+        assert!(file.hooks.is_empty());
+        assert_eq!(file.config_version, Some(1));
+    }
+
+    /// The seeded file is the documentation users see, so it names every
+    /// field, every event, every variable a hook can read, and the line
+    /// between it and the extension's `hooks/` directory.
+    #[test]
+    fn seed_toml_documents_every_field_event_and_variable() {
+        for field in ["event", "command", "timeout_secs"] {
+            assert!(
+                SEED_HOOKS_TOML.contains(field),
+                "seed must document '{field}'"
+            );
+        }
+        for event in HookEvent::ALL {
+            assert!(
+                SEED_HOOKS_TOML.contains(&format!("event = \"{}\"", event.name())),
+                "seed must show an example for {event}"
+            );
+        }
+        let ctx = crate::session::HookContext {
+            session_id: Some(crate::session::SessionId::default()),
+            name: "n".into(),
+            agent: "a".into(),
+            agent_session_id: Some("c".into()),
+            repo: Some("/r".into()),
+            cwd: Some("/c".into()),
+            branch: Some("b".into()),
+            base_branch: Some("m".into()),
+            host: Some("h".into()),
+            parent_session_id: Some(crate::session::SessionId::default()),
+            task_id: Some(1),
+            ..Default::default()
+        };
+        for (name, _) in ctx.env(HookEvent::PostCreate) {
+            assert!(SEED_HOOKS_TOML.contains(&name), "seed must document {name}");
+        }
+        assert!(
+            SEED_HOOKS_TOML.contains("hooks/"),
+            "seed must draw the line to the extension dir"
+        );
+    }
+
+    #[test]
+    fn load_or_seed_writes_file_when_absent_and_stays_empty() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+
+        let path = hooks_config_path().unwrap();
+        assert!(!path.exists());
+
+        let (file, warnings) = load_or_seed_with_warnings();
+        assert!(file.hooks.is_empty());
+        assert!(warnings.is_empty(), "{warnings:?}");
+        assert!(path.exists(), "hooks.toml should have been seeded");
+        assert!(load_or_seed().hooks.is_empty());
+    }
+
+    #[test]
+    fn load_or_seed_falls_back_on_malformed_file_naming_it() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+
+        let path = hooks_config_path().unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "this is not = valid toml {{{").unwrap();
+
+        let (file, warnings) = load_or_seed_with_warnings();
+        assert!(file.hooks.is_empty());
+        assert!(
+            warnings.iter().any(|w| w.contains("hooks.toml")),
+            "{warnings:?}"
+        );
+        assert!(hooks_for(HookEvent::PreCreate).is_empty());
+    }
+
+    #[test]
+    fn an_unknown_event_means_no_hooks_and_a_warning() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+
+        let path = hooks_config_path().unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            "[[hooks]]\nevent = \"session.on_create\"\ncommand = \"true\"\n",
+        )
+        .unwrap();
+
+        let (file, warnings) = load_or_seed_with_warnings();
+        assert!(file.hooks.is_empty());
+        assert!(!warnings.is_empty());
+    }
+
+    #[test]
+    fn hooks_for_returns_the_events_entries_in_file_order() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+
+        let path = hooks_config_path().unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            "[[hooks]]\nevent = \"session.post_create\"\ncommand = \"one\"\n\
+             [[hooks]]\nevent = \"session.pre_create\"\ncommand = \"other\"\n\
+             [[hooks]]\nevent = \"session.post_create\"\ncommand = \"two\"\n",
+        )
+        .unwrap();
+
+        let commands: Vec<String> = hooks_for(HookEvent::PostCreate)
+            .into_iter()
+            .map(|h| h.command)
+            .collect();
+        assert_eq!(commands, ["one", "two"]);
+        assert_eq!(hooks_for(HookEvent::PreDelete).len(), 0);
+    }
+}

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -3,6 +3,7 @@ pub mod backend;
 pub mod control_mode;
 pub mod extension_config;
 pub mod generic;
+pub mod hooks_config;
 pub mod host_config;
 pub mod input;
 pub mod json_merge;

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -148,6 +148,10 @@ fn validate() -> (Value, Vec<String>) {
         crate::agent::themes_config::themes_config_path(),
         "themes.toml",
     );
+    let (hooks, hooks_ok) = validate_toml::<crate::session::HooksFile>(
+        crate::agent::hooks_config::hooks_config_path(),
+        "hooks.toml",
+    );
     let (ui_json, ui_ok) = validate_ui_json();
     // Parsed only to report where it is and whether it is well-formed; its
     // verdict is not in the failure list, because nothing reads it.
@@ -158,6 +162,7 @@ fn validate() -> (Value, Vec<String>) {
         ("hosts.toml", hosts_ok),
         ("settings.toml", settings_ok),
         ("themes.toml", themes_ok),
+        ("hooks.toml", hooks_ok),
         ("ui.json", ui_ok),
         // Deliberately NOT in the failure list: nothing reads it, so a malformed
         // one cannot break anything and calling it invalid would send an upgrader
@@ -175,6 +180,7 @@ fn validate() -> (Value, Vec<String>) {
         "hosts_toml": hosts,
         "settings_toml": settings,
         "themes_toml": themes,
+        "hooks_toml": hooks,
         "ui_json": ui_json,
         "keybindings_json_legacy": keybindings,
     });
@@ -188,6 +194,7 @@ fn render_validate(report: &Value, failed: &[String]) -> String {
         ("hosts.toml", "hosts_toml"),
         ("settings.toml", "settings_toml"),
         ("themes.toml", "themes_toml"),
+        ("hooks.toml", "hooks_toml"),
         ("ui.json", "ui_json"),
         ("keybindings.json (v1, ignored)", "keybindings_json_legacy"),
     ];
@@ -267,6 +274,30 @@ fn render_show(report: &Value) -> String {
         output::kv(&[("active", output::dash(report["theme"].as_str()))])
     ));
 
+    // The lifecycle hooks in force, one line each: event, then the command.
+    let hooks: Vec<(&str, String)> = report["hooks"]
+        .as_array()
+        .map(|list| {
+            list.iter()
+                .map(|h| {
+                    let command = h["command"].as_str().unwrap_or_default();
+                    let timeout = h["timeout_secs"]
+                        .as_u64()
+                        .map(|t| format!("  (timeout {t}s)"))
+                        .unwrap_or_default();
+                    (
+                        h["event"].as_str().unwrap_or_default(),
+                        format!("{command}{timeout}"),
+                    )
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    sections.push(match hooks.is_empty() {
+        true => "Lifecycle hooks\n  (none)".to_string(),
+        false => format!("Lifecycle hooks\n{}", output::kv(&hooks)),
+    });
+
     sections.join("\n\n")
 }
 
@@ -278,6 +309,7 @@ fn show(db: &Database) -> Result<Value, String> {
     let hosts = crate::agent::host_config::load_all();
     let settings = crate::session::settings::global();
     let (custom_themes, _) = crate::agent::themes_config::load_or_seed_with_warnings();
+    let (hooks, _) = crate::agent::hooks_config::load_or_seed_with_warnings();
 
     // Editor resolution mirrors the TUI's Ctrl+O chain: DB → $VISUAL → $EDITOR.
     let (editor, editor_source) = resolve_editor(db);
@@ -293,6 +325,8 @@ fn show(db: &Database) -> Result<Value, String> {
             "settings_toml": crate::agent::settings_config::settings_config_path()
                 .map(|p| p.display().to_string()),
             "themes_toml": crate::agent::themes_config::themes_config_path()
+                .map(|p| p.display().to_string()),
+            "hooks_toml": crate::agent::hooks_config::hooks_config_path()
                 .map(|p| p.display().to_string()),
             // The interface is config like the rest of it, and it was the one
             // thing this command could not tell you the location of — which is
@@ -317,6 +351,7 @@ fn show(db: &Database) -> Result<Value, String> {
         "editor": { "command": editor, "source": editor_source, "mode": editor_mode.as_db_value() },
         "theme": db.get_active_theme().ok().flatten(),
         "custom_themes": custom_themes.iter().map(|t| t.name.as_str()).collect::<Vec<_>>(),
+        "hooks": hooks.hooks,
     }))
 }
 
@@ -447,6 +482,53 @@ mod tests {
             failed.iter().any(|f| f == "settings.toml"),
             "got: {failed:?}"
         );
+    }
+
+    #[test]
+    fn validate_fails_on_a_misspelt_hook_field_naming_the_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _g = TestPathGuard::new(tmp.path());
+        let path = crate::agent::hooks_config::hooks_config_path().unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            "[[hooks]]\nevent = \"session.post_create\"\ncommand = \"true\"\ntimeout_sec = 5\n",
+        )
+        .unwrap();
+
+        let (report, failed) = validate();
+        assert!(failed.iter().any(|f| f == "hooks.toml"), "got: {failed:?}");
+        assert!(
+            report["hooks_toml"]["problems"]
+                .as_array()
+                .is_some_and(|p| !p.is_empty()),
+            "{report}"
+        );
+        assert!(render_validate(&report, &failed).contains("✗ hooks.toml"));
+    }
+
+    #[test]
+    fn show_lists_the_lifecycle_hooks_in_force() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _g = TestPathGuard::new(tmp.path());
+        let db = Database::open_in_memory().unwrap();
+        let path = crate::agent::hooks_config::hooks_config_path().unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            "[[hooks]]\nevent = \"session.pre_create\"\ncommand = \"check\"\n\
+             [[hooks]]\nevent = \"session.post_delete\"\ncommand = \"clean\"\ntimeout_secs = 5\n",
+        )
+        .unwrap();
+
+        let v = show(&db).unwrap();
+        assert_eq!(v["hooks"][0]["event"], json!("session.pre_create"));
+        assert_eq!(v["hooks"][0]["command"], json!("check"));
+        assert_eq!(v["hooks"][1]["timeout_secs"], json!(5));
+        assert!(v["paths"]["hooks_toml"].is_string());
+        let text = render_show(&v);
+        assert!(text.contains("session.post_delete"), "{text}");
+        assert!(text.contains("clean  (timeout 5s)"), "{text}");
     }
 
     #[test]

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -186,13 +186,14 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
                 ..Default::default()
             };
             let res = crate::session_ops::spawn_session_headless(db, req)?;
-            let human = format!(
+            let mut human = format!(
                 "Created session '{}' ({}) — {}\ncwd: {}",
                 res.name,
                 res.agent,
                 res.session_id,
                 res.cwd.display()
             );
+            push_hook_failures(&mut human, &res.hook_failures);
             Ok(CommandOutput::new(
                 json!({
                     "id": res.session_id.to_string(),
@@ -201,6 +202,7 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
                     "agent_session_id": res.agent_session_id,
                     "cwd": res.cwd.display().to_string(),
                     "parent_session_id": res.parent_session_id.map(|id| id.to_string()),
+                    "hook_failures": res.hook_failures,
                 }),
                 human,
             ))
@@ -209,14 +211,17 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
         Action::Restore { uuid, best_effort } => restore_deleted(db, &uuid, best_effort),
         Action::Restart { uuid } => {
             let session = resolve(db, &uuid)?;
-            crate::session_ops::restart_session_headless(db, session.id)?;
+            let report = crate::session_ops::restart_session_headless(db, session.id)?;
+            let mut human = format!("Restarted session '{}' ({})", session.name, session.id);
+            push_hook_failures(&mut human, &report.hook_failures);
             Ok(CommandOutput::new(
                 json!({
                     "restarted": true,
                     "session_id": session.id.to_string(),
                     "session_name": session.name,
+                    "hook_failures": report.hook_failures,
                 }),
-                format!("Restarted session '{}' ({})", session.name, session.id),
+                human,
             ))
         }
         Action::Send { uuid, text } => {
@@ -291,6 +296,7 @@ fn delete_session(db: &Database, uuid: &str, force: bool) -> Result<CommandOutpu
             human.push_str(&format!("\n  {line}"));
         }
     }
+    push_hook_failures(&mut human, &report.hook_failures);
     Ok(CommandOutput::new(
         json!({
             "deleted": true,
@@ -302,6 +308,7 @@ fn delete_session(db: &Database, uuid: &str, force: bool) -> Result<CommandOutpu
             "worktree_errors": report.worktree_errors,
             "disabled_automations": report.disabled_automations,
             "remote_teardown_error": report.remote_teardown_error,
+            "hook_failures": report.hook_failures,
         }),
         human,
     ))
@@ -332,43 +339,66 @@ fn force_delete_detail(
     detail
 }
 
-/// Revive a soft-deleted session. A running TUI re-creates its worktrees and
-/// tmux window on the next sync.
+/// Restore a deleted session: the row, its worktrees and its agent — the same
+/// pipeline the interface's undo runs, so the two cannot disagree about what
+/// restoring means (it used to clear the flag alone, handing back a session
+/// with no worktree and no window). A force-deleted row is refused without
+/// `--best-effort`, since only committed work can return.
 fn restore_deleted(db: &Database, uuid: &str, best_effort: bool) -> Result<CommandOutput, String> {
     let id: SessionId = uuid
         .parse()
         .map_err(|_| format!("Invalid session UUID: {uuid}"))?;
+    // The pipeline refuses this too, but its message is interface-neutral; the
+    // command line is where `--best-effort` is the way to say yes.
     let deleted = db
         .get_deleted_session_by_id(id)
         .map_err(|e| format!("get_deleted_session_by_id: {e}"))?
         .ok_or_else(|| format!("Deleted session not found: {uuid}"))?;
-    // A force-deleted session lost its uncommitted work; restoring it only
-    // recovers committed branch state, so require an explicit opt-in.
     if deleted.force_deleted && !best_effort {
         return Err(format!(
             "Session '{}' was force-deleted; pass --best-effort to recover committed work (uncommitted/untracked changes are gone)",
             deleted.name
         ));
     }
-    // `Database::restore_session` clears `deleted_at` and `force_deleted`.
-    db.restore_session(deleted.id)
-        .map_err(|e| format!("restore_session: {e}"))?;
-    let human = match deleted.force_deleted {
+    let report = crate::session_ops::restore_session_headless(db, id, best_effort)?;
+    let mut human = match report.best_effort {
         true => format!(
-            "Restored session '{}' ({}) — best-effort: uncommitted work was not recovered",
-            deleted.name, deleted.id
+            "Restored session '{}' ({id}) — best-effort: uncommitted work was not recovered",
+            report.name
         ),
-        false => format!("Restored session '{}' ({})", deleted.name, deleted.id),
+        false => format!("Restored session '{}' ({id})", report.name),
     };
+    if report.worktrees_recovered < report.worktrees_wanted {
+        human.push_str(&format!(
+            "\n  worktrees recovered: {}/{}",
+            report.worktrees_recovered, report.worktrees_wanted
+        ));
+    }
+    if let Some(err) = &report.respawn_error {
+        human.push_str(&format!("\n  agent not relaunched: {err}"));
+    }
+    push_hook_failures(&mut human, &report.hook_failures);
     Ok(CommandOutput::new(
         json!({
             "restored": true,
-            "id": deleted.id.to_string(),
-            "name": deleted.name,
-            "best_effort": deleted.force_deleted,
+            "id": id.to_string(),
+            "name": report.name,
+            "best_effort": report.best_effort,
+            "worktrees_wanted": report.worktrees_wanted,
+            "worktrees_recovered": report.worktrees_recovered,
+            "respawn_error": report.respawn_error,
+            "hook_failures": report.hook_failures,
         }),
         human,
     ))
+}
+
+/// The human half of a post-hook failure list: one indented line each. The
+/// operation succeeded; these are what the user's own hooks had to say.
+fn push_hook_failures(human: &mut String, failures: &[String]) {
+    for failure in failures {
+        human.push_str(&format!("\n  hook failed: {failure}"));
+    }
 }
 
 /// Resolve the session a `signal` targets: an explicit `--session` UUID, else

--- a/src/kernel/command/execute.rs
+++ b/src/kernel/command/execute.rs
@@ -118,7 +118,10 @@ pub(super) fn execute(
                 }
             })
         }
-        Command::Restart { .. } => crate::session_ops::restart_session_headless(&db, id),
+        // A failed post-restart hook is already in the log; the restart stands.
+        Command::Restart { .. } => {
+            crate::session_ops::restart_session_headless(&db, id).map(|_| ())
+        }
         Command::Reap { .. } => crate::session_ops::reap_soft_deleted(&db, id).map(|_| ()),
         Command::Send { text, .. } => {
             let session = db

--- a/src/session/hook_def.rs
+++ b/src/session/hook_def.rs
@@ -1,0 +1,450 @@
+//! Session lifecycle hooks — the user's own commands, run by thurbox at the
+//! moments it creates, deletes, restarts or restores a session.
+//!
+//! This is the *reverse* of the built-in `hooks` extension, which installs
+//! status hooks **into** the agent CLIs so they can report to thurbox. Here
+//! thurbox reports to the user's scripts. The two share a word and nothing
+//! else; this module and its consumers say "lifecycle hook" for the same
+//! reason.
+//!
+//! Pure data: the events, an entry of `hooks.toml`, and the facts handed to a
+//! hook — as an environment and as one JSON document — so the convention a
+//! hook script relies on is unit-testable without a process.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use super::SessionId;
+
+/// How long a hook may run before it is killed, when its entry sets no
+/// `timeout_secs`.
+pub const DEFAULT_HOOK_TIMEOUT_SECS: u64 = 30;
+
+/// The moments a hook can be attached to: a `pre_*` before the operation has
+/// any side effect (and able to refuse it), a `post_*` after it has fully
+/// succeeded.
+///
+/// Closed and spelled in serde exactly as `hooks.toml` spells it, so an
+/// unknown event is a parse error rather than a hook that silently never fires.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum HookEvent {
+    #[serde(rename = "session.pre_create")]
+    PreCreate,
+    #[serde(rename = "session.post_create")]
+    PostCreate,
+    #[serde(rename = "session.pre_delete")]
+    PreDelete,
+    #[serde(rename = "session.post_delete")]
+    PostDelete,
+    #[serde(rename = "session.pre_restart")]
+    PreRestart,
+    #[serde(rename = "session.post_restart")]
+    PostRestart,
+    #[serde(rename = "session.pre_restore")]
+    PreRestore,
+    #[serde(rename = "session.post_restore")]
+    PostRestore,
+}
+
+impl HookEvent {
+    /// Every event, pre before post, in the order the operations are documented.
+    pub const ALL: [HookEvent; 8] = [
+        HookEvent::PreCreate,
+        HookEvent::PostCreate,
+        HookEvent::PreDelete,
+        HookEvent::PostDelete,
+        HookEvent::PreRestart,
+        HookEvent::PostRestart,
+        HookEvent::PreRestore,
+        HookEvent::PostRestore,
+    ];
+
+    /// The dotted name — the `event` value in `hooks.toml` and the
+    /// `THURBOX_HOOK_EVENT` a hook reads.
+    pub fn name(self) -> &'static str {
+        match self {
+            HookEvent::PreCreate => "session.pre_create",
+            HookEvent::PostCreate => "session.post_create",
+            HookEvent::PreDelete => "session.pre_delete",
+            HookEvent::PostDelete => "session.post_delete",
+            HookEvent::PreRestart => "session.pre_restart",
+            HookEvent::PostRestart => "session.post_restart",
+            HookEvent::PreRestore => "session.pre_restore",
+            HookEvent::PostRestore => "session.post_restore",
+        }
+    }
+
+    /// Whether a failing hook for this event aborts the operation.
+    pub fn is_pre(self) -> bool {
+        matches!(
+            self,
+            HookEvent::PreCreate
+                | HookEvent::PreDelete
+                | HookEvent::PreRestart
+                | HookEvent::PreRestore
+        )
+    }
+}
+
+impl std::fmt::Display for HookEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.name())
+    }
+}
+
+/// One `[[hooks]]` entry of `hooks.toml`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LifecycleHook {
+    pub event: HookEvent,
+    /// Run through the platform shell (`sh -c`, `cmd /C` on Windows).
+    pub command: String,
+    /// Seconds before the hook is killed; [`DEFAULT_HOOK_TIMEOUT_SECS`] when
+    /// unset.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_secs: Option<u64>,
+}
+
+impl LifecycleHook {
+    pub fn timeout(&self) -> Duration {
+        Duration::from_secs(self.timeout_secs.unwrap_or(DEFAULT_HOOK_TIMEOUT_SECS))
+    }
+}
+
+/// The whole of `hooks.toml`, in declaration order.
+///
+/// Unknown fields are tolerated but reported, like every other config file:
+/// the loader names each one in a warning and `config validate` fails on it.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HooksFile {
+    /// Config-format version, for future migrations. Currently `1`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub config_version: Option<u32>,
+    #[serde(default)]
+    pub hooks: Vec<LifecycleHook>,
+}
+
+impl HooksFile {
+    /// The hooks declared for `event`, in file order.
+    pub fn for_event(&self, event: HookEvent) -> Vec<LifecycleHook> {
+        self.hooks
+            .iter()
+            .filter(|h| h.event == event)
+            .cloned()
+            .collect()
+    }
+}
+
+/// One worktree as a hook sees it.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HookWorktree {
+    pub repo_path: PathBuf,
+    pub worktree_path: PathBuf,
+    pub branch: String,
+}
+
+/// What a hook is told about the session — everything known at the moment
+/// the event fires. A field that is not known at that moment is `None`, and
+/// [`HookContext::env`] leaves its variable **unset** (never empty), so
+/// `${THURBOX_HOST:+…}` idioms work.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct HookContext {
+    /// The thurbox session id. At `pre_create` it is the id the session will
+    /// have if creation succeeds — minted early precisely so a pre and its post
+    /// can be correlated.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<SessionId>,
+    pub name: String,
+    pub agent: String,
+    /// The agent's own conversation id — `THURBOX_SESSION_ID`, as the agent
+    /// receives it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_session_id: Option<String>,
+    /// The primary repository — the one path that exists at every event: at
+    /// `pre_create` the worktree is not made, at `post_delete` it is gone.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repo: Option<PathBuf>,
+    /// The directory the agent runs in (the worktree, or the symlink workspace
+    /// of a multi-repo session). Unknown before the worktree exists.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<PathBuf>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_branch: Option<String>,
+    /// The remote host's name; `None` for a local session. When set, `repo`
+    /// and `cwd` are paths **on that host**.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub host: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_session_id: Option<SessionId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<i64>,
+    /// The agent conversation a fork resumes from.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fork_session_id: Option<String>,
+    /// Delete events: whether the runtime resources are torn down too.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub force: Option<bool>,
+    /// Restore events: whether the session had been force-deleted, so only
+    /// committed work returns.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub force_deleted: Option<bool>,
+    /// The multiplexer pane (`%N`) once one exists.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub backend_id: Option<String>,
+    pub worktrees: Vec<HookWorktree>,
+    pub additional_dirs: Vec<PathBuf>,
+}
+
+/// The stdin document: the context with the event folded in.
+#[derive(Serialize)]
+struct Payload<'a> {
+    event: &'a str,
+    #[serde(flatten)]
+    context: &'a HookContext,
+}
+
+impl HookContext {
+    /// The `THURBOX_*` variables a hook for `event` receives — only the ones
+    /// whose value is known.
+    pub fn env(&self, event: HookEvent) -> Vec<(String, String)> {
+        let mut vars: Vec<(String, String)> =
+            vec![("THURBOX_HOOK_EVENT".into(), event.name().into())];
+        let mut set = |key: &str, value: Option<String>| {
+            if let Some(value) = value.filter(|v| !v.is_empty()) {
+                vars.push((key.to_string(), value));
+            }
+        };
+        set("THURBOX_SESSION", self.session_id.map(|id| id.to_string()));
+        set("THURBOX_SESSION_ID", self.agent_session_id.clone());
+        set("THURBOX_SESSION_NAME", Some(self.name.clone()));
+        set("THURBOX_AGENT", Some(self.agent.clone()));
+        set("THURBOX_REPO", self.repo.as_deref().map(display));
+        set("THURBOX_CWD", self.cwd.as_deref().map(display));
+        set("THURBOX_BRANCH", self.branch.clone());
+        set("THURBOX_BASE_BRANCH", self.base_branch.clone());
+        set("THURBOX_HOST", self.host.clone());
+        set(
+            "THURBOX_PARENT_SESSION",
+            self.parent_session_id.map(|id| id.to_string()),
+        );
+        set("THURBOX_TASK", self.task_id.map(|id| id.to_string()));
+        vars
+    }
+
+    /// The JSON document written to the hook's stdin.
+    pub fn json(&self, event: HookEvent) -> String {
+        serde_json::to_string(&Payload {
+            event: event.name(),
+            context: self,
+        })
+        .expect("a HookContext serializes: every field is a string, a number, a bool or a list")
+    }
+
+    /// Where the hook runs: the primary repository when it is a directory on
+    /// this machine. A remote session's paths are the host's, so a same-named
+    /// local directory is a coincidence, not a match. `None` means the hook
+    /// inherits thurbox's own working directory.
+    pub fn workdir(&self) -> Option<&Path> {
+        if self.host.is_some() {
+            return None;
+        }
+        self.repo.as_deref().filter(|p| p.is_dir())
+    }
+}
+
+fn display(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_event_round_trips_by_its_dotted_name() {
+        for event in HookEvent::ALL {
+            let toml = format!("event = \"{}\"\ncommand = \"true\"\n", event.name());
+            let hook: LifecycleHook =
+                toml::from_str(&toml).unwrap_or_else(|e| panic!("{event}: {e}"));
+            assert_eq!(hook.event, event);
+            assert_eq!(toml::to_string(&hook).unwrap(), toml);
+            assert!(event.name().starts_with("session."));
+            assert_eq!(event.is_pre(), event.name().contains(".pre_"));
+        }
+    }
+
+    #[test]
+    fn an_unknown_event_is_a_parse_error() {
+        let err =
+            toml::from_str::<LifecycleHook>("event = \"session.on_create\"\ncommand = \"true\"\n")
+                .unwrap_err()
+                .to_string();
+        assert!(
+            err.contains("session.on_create") || err.contains("unknown variant"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn a_missing_command_is_a_parse_error() {
+        assert!(toml::from_str::<LifecycleHook>("event = \"session.pre_create\"\n").is_err());
+    }
+
+    #[test]
+    fn a_file_lists_hooks_in_order_and_filters_by_event() {
+        let file: HooksFile = toml::from_str(
+            r#"
+            [[hooks]]
+            event = "session.post_create"
+            command = "first"
+
+            [[hooks]]
+            event = "session.pre_create"
+            command = "veto"
+            timeout_secs = 5
+
+            [[hooks]]
+            event = "session.post_create"
+            command = "second"
+            "#,
+        )
+        .unwrap();
+        let post: Vec<String> = file
+            .for_event(HookEvent::PostCreate)
+            .into_iter()
+            .map(|h| h.command)
+            .collect();
+        assert_eq!(post, ["first", "second"]);
+        let pre = file.for_event(HookEvent::PreCreate);
+        assert_eq!(pre[0].timeout(), Duration::from_secs(5));
+        assert_eq!(
+            file.for_event(HookEvent::PostCreate)[0].timeout(),
+            Duration::from_secs(DEFAULT_HOOK_TIMEOUT_SECS)
+        );
+        assert!(file.for_event(HookEvent::PreDelete).is_empty());
+    }
+
+    #[test]
+    fn env_sets_exactly_the_documented_names() {
+        let sid = SessionId::default();
+        let parent = SessionId::default();
+        let ctx = HookContext {
+            session_id: Some(sid),
+            name: "demo".into(),
+            agent: "claude".into(),
+            agent_session_id: Some("conv-1".into()),
+            repo: Some(PathBuf::from("/srv/repo")),
+            cwd: Some(PathBuf::from("/srv/repo/worktrees/demo")),
+            branch: Some("feat/x".into()),
+            base_branch: Some("main".into()),
+            host: Some("devbox".into()),
+            parent_session_id: Some(parent),
+            task_id: Some(7),
+            ..HookContext::default()
+        };
+        let env = ctx.env(HookEvent::PostCreate);
+        let mut names: Vec<&str> = env.iter().map(|(k, _)| k.as_str()).collect();
+        names.sort_unstable();
+        assert_eq!(
+            names,
+            [
+                "THURBOX_AGENT",
+                "THURBOX_BASE_BRANCH",
+                "THURBOX_BRANCH",
+                "THURBOX_CWD",
+                "THURBOX_HOOK_EVENT",
+                "THURBOX_HOST",
+                "THURBOX_PARENT_SESSION",
+                "THURBOX_REPO",
+                "THURBOX_SESSION",
+                "THURBOX_SESSION_ID",
+                "THURBOX_SESSION_NAME",
+                "THURBOX_TASK",
+            ]
+        );
+        let get = |k: &str| {
+            env.iter()
+                .find(|(key, _)| key == k)
+                .map(|(_, v)| v.as_str())
+        };
+        assert_eq!(get("THURBOX_HOOK_EVENT"), Some("session.post_create"));
+        assert_eq!(get("THURBOX_SESSION"), Some(sid.to_string().as_str()));
+        assert_eq!(
+            get("THURBOX_PARENT_SESSION"),
+            Some(parent.to_string().as_str())
+        );
+        assert_eq!(get("THURBOX_TASK"), Some("7"));
+        assert_eq!(get("THURBOX_CWD"), Some("/srv/repo/worktrees/demo"));
+    }
+
+    #[test]
+    fn an_unknown_fact_is_unset_not_empty() {
+        let ctx = HookContext {
+            name: "demo".into(),
+            agent: "claude".into(),
+            ..HookContext::default()
+        };
+        let env = ctx.env(HookEvent::PreCreate);
+        let names: Vec<&str> = env.iter().map(|(k, _)| k.as_str()).collect();
+        assert_eq!(
+            names,
+            [
+                "THURBOX_HOOK_EVENT",
+                "THURBOX_SESSION_NAME",
+                "THURBOX_AGENT"
+            ]
+        );
+        assert!(env.iter().all(|(_, v)| !v.is_empty()));
+    }
+
+    #[test]
+    fn json_carries_the_event_and_the_worktrees() {
+        let ctx = HookContext {
+            name: "demo".into(),
+            agent: "codex".into(),
+            worktrees: vec![HookWorktree {
+                repo_path: PathBuf::from("/srv/repo"),
+                worktree_path: PathBuf::from("/srv/repo/worktrees/demo"),
+                branch: "feat/x".into(),
+            }],
+            force: Some(true),
+            ..HookContext::default()
+        };
+        let value: serde_json::Value =
+            serde_json::from_str(&ctx.json(HookEvent::PreDelete)).unwrap();
+        assert_eq!(value["event"], "session.pre_delete");
+        assert_eq!(value["name"], "demo");
+        assert_eq!(value["force"], true);
+        assert_eq!(value["worktrees"][0]["branch"], "feat/x");
+        assert_eq!(value["worktrees"][0]["repo_path"], "/srv/repo");
+        // Unknown facts are absent, not null.
+        assert!(value.get("host").is_none());
+        assert!(value.get("session_id").is_none());
+    }
+
+    #[test]
+    fn workdir_is_the_local_repo_and_nothing_for_a_remote_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let local = HookContext {
+            repo: Some(dir.path().to_path_buf()),
+            ..HookContext::default()
+        };
+        assert_eq!(local.workdir(), Some(dir.path()));
+
+        // The same path, but on a host: not ours to cd into.
+        let remote = HookContext {
+            host: Some("devbox".into()),
+            ..local.clone()
+        };
+        assert_eq!(remote.workdir(), None);
+
+        let gone = HookContext {
+            repo: Some(dir.path().join("missing")),
+            ..HookContext::default()
+        };
+        assert_eq!(gone.workdir(), None);
+    }
+}

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -1,6 +1,7 @@
 pub mod agent_def;
 pub mod automation;
 pub mod extension_def;
+pub mod hook_def;
 pub mod host_def;
 pub mod hyperlink;
 pub mod message;
@@ -18,6 +19,9 @@ pub use automation::{
 pub use extension_def::{
     AgentPatch, ConfigMerge, ExtensionAutomation, ExtensionDef, ExtensionFile, ExtensionSession,
     ExtensionSymlink, ExternalFile,
+};
+pub use hook_def::{
+    HookContext, HookEvent, HookWorktree, HooksFile, LifecycleHook, DEFAULT_HOOK_TIMEOUT_SECS,
 };
 pub use host_def::{
     is_remote_backend, is_ssh_backend, is_wsl_backend, HostDef, HostKind, HostRegistry,

--- a/src/session_ops/delete.rs
+++ b/src/session_ops/delete.rs
@@ -19,6 +19,8 @@ pub struct ForceDeleteReport {
     /// unreachable host is expected (that's often *why* someone force-deletes),
     /// so this is recorded rather than aborting the delete.
     pub remote_teardown_error: Option<String>,
+    /// `session.post_delete` hooks that failed. The delete stands regardless.
+    pub hook_failures: Vec<String>,
 }
 
 /// Soft-delete a session and (when `force`) also tear down its runtime
@@ -39,6 +41,12 @@ pub fn delete_session_headless(
         .map_err(|e| format!("get_session_by_id: {e}"))?
         .ok_or_else(|| format!("Session not found: {session_id}"))?;
 
+    // The user's say, before anything is torn down or marked: a refusal here
+    // leaves the row exactly as it was.
+    let mut hook_ctx = super::lifecycle_hooks::context_for(&session);
+    hook_ctx.force = Some(force);
+    super::fire_pre(crate::session::HookEvent::PreDelete, &hook_ctx)?;
+
     let mut report = ForceDeleteReport::default();
 
     if force {
@@ -57,6 +65,8 @@ pub fn delete_session_headless(
         db.mark_session_force_deleted(session_id)
             .map_err(|e| format!("mark_session_force_deleted: {e}"))?;
     }
+
+    report.hook_failures = super::fire_post(crate::session::HookEvent::PostDelete, &hook_ctx);
 
     Ok(report)
 }

--- a/src/session_ops/lifecycle_hooks.rs
+++ b/src/session_ops/lifecycle_hooks.rs
@@ -1,0 +1,474 @@
+//! Running the user's session lifecycle hooks (`hooks.toml`).
+//!
+//! The data is [`crate::session::hook_def`], the file is
+//! [`crate::agent::hooks_config`]; this is the process. Each of the four
+//! session pipelines in this module (`spawn`, `delete`, `restart`, `restore`)
+//! calls [`fire_pre`] before its first side effect and [`fire_post`] after its
+//! last, so a hook fires once per operation whichever interface asked — the
+//! TUI, `thurbox-cli`, an automation, an extension — because every one of
+//! them ends in those pipelines. That is the whole mechanism; nothing in the
+//! kernel or the interface knows hooks exist.
+//!
+//! Everything here is synchronous and blocks the calling thread, which is a
+//! worker in the TUI and the main thread in the CLI — never the render loop
+//! (rule 5). `session_ops` has no async runtime to lean on, and entering one
+//! from a thread that may already be inside one is the trap `kernel::terminal`
+//! documents, so the timeout is a `try_wait` poll rather than a timed future.
+
+use std::io::{Read, Write};
+use std::process::Stdio;
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+use crate::session::{HookContext, HookEvent, LifecycleHook};
+use crate::sync::SharedSession;
+
+/// How often the runner checks whether the hook has exited. Coarse enough to
+/// cost nothing, fine enough that a timeout lands within a frame of the
+/// deadline.
+const POLL_INTERVAL: Duration = Duration::from_millis(20);
+
+/// Bytes of each stream the reader keeps. Only the tail is reported, but a
+/// hook that prints a megabyte still has to be *drained* or it blocks on a
+/// full pipe — which is why the readers are threads and this is a cap rather
+/// than a limit.
+const STREAM_KEEP: usize = 64 * 1024;
+
+/// How long to wait for the reader threads after the hook has exited. They end
+/// when the pipes close, which is at once unless the hook left a grandchild
+/// holding them (`sleep 100 &`); then the output is simply not reported, rather
+/// than the operation waiting on a process the hook forgot about.
+const READER_GRACE: Duration = Duration::from_millis(500);
+
+/// Run every `pre_*` hook for `event`, in file order, stopping at the first
+/// failure. `Err` is the reason the operation must not proceed: the caller
+/// returns it before its first side effect.
+pub fn fire_pre(event: HookEvent, ctx: &HookContext) -> Result<(), String> {
+    debug_assert!(event.is_pre(), "{event} is not a pre-event");
+    for hook in crate::agent::hooks_config::hooks_for(event) {
+        if let Err(reason) = run_hook(&hook, event, ctx) {
+            tracing::warn!("{reason}; refusing the operation");
+            return Err(reason);
+        }
+    }
+    Ok(())
+}
+
+/// Run every `post_*` hook for `event`, in file order, all of them. Returns
+/// each failure's message; the operation has already succeeded and nothing
+/// here can change that.
+pub fn fire_post(event: HookEvent, ctx: &HookContext) -> Vec<String> {
+    debug_assert!(!event.is_pre(), "{event} is not a post-event");
+    let mut failures = Vec::new();
+    for hook in crate::agent::hooks_config::hooks_for(event) {
+        if let Err(reason) = run_hook(&hook, event, ctx) {
+            tracing::warn!("{reason}");
+            failures.push(reason);
+        }
+    }
+    failures
+}
+
+/// The facts a persisted session yields for its delete/restart/restore hooks.
+///
+/// The primary repository is the first worktree's repository when there is
+/// one — `cwd` is then the worktree — and `cwd` itself otherwise. The base
+/// branch is a database column this row does not carry, so it stays unknown.
+pub fn context_for(session: &SharedSession) -> HookContext {
+    let primary = session.worktrees.first();
+    HookContext {
+        session_id: Some(session.id),
+        name: session.name.clone(),
+        agent: session.agent.clone(),
+        agent_session_id: session.agent_session_id.clone(),
+        repo: primary
+            .map(|w| w.repo_path.clone())
+            .or_else(|| session.cwd.clone()),
+        cwd: session.cwd.clone(),
+        branch: primary.map(|w| w.branch.clone()),
+        host: host_name(&session.backend_type),
+        parent_session_id: session.parent_session_id,
+        backend_id: Some(session.backend_id.clone()).filter(|id| !id.is_empty()),
+        worktrees: session.worktrees.iter().map(worktree).collect(),
+        additional_dirs: session.additional_dirs.clone(),
+        ..HookContext::default()
+    }
+}
+
+/// The pane a session's row points at now — what a post-restart/restore hook
+/// is told, since the pane the operation started with is gone. `None` when the
+/// row is missing or the platform reported no id (psmux).
+pub(crate) fn current_pane(
+    db: &crate::storage::Database,
+    id: crate::session::SessionId,
+) -> Option<String> {
+    db.get_session_by_id(id)
+        .ok()
+        .flatten()
+        .map(|s| s.backend_id)
+        .filter(|pane| !pane.is_empty())
+}
+
+/// The host a backend name denotes (`ssh:devbox` → `devbox`); `None` for local.
+pub(crate) fn host_name(backend_type: &str) -> Option<String> {
+    crate::session::is_remote_backend(backend_type)
+        .then(|| {
+            backend_type
+                .split_once(':')
+                .map(|(_, name)| name.to_string())
+        })
+        .flatten()
+}
+
+pub(crate) fn worktree(w: &crate::sync::SharedWorktree) -> crate::session::HookWorktree {
+    crate::session::HookWorktree {
+        repo_path: w.repo_path.clone(),
+        worktree_path: w.worktree_path.clone(),
+        branch: w.branch.clone(),
+    }
+}
+
+/// Run one hook to completion or to its timeout.
+///
+/// The shell gets the inherited environment plus the `THURBOX_*` facts and the
+/// config/data-dir overrides, the JSON on a piped stdin (written and closed
+/// before waiting, so a hook that never reads it is not blocked by it), and
+/// nothing of thurbox's own stdio — the TUI owns that terminal. Both output
+/// pipes are drained on threads for the whole run; a deadline without draining
+/// deadlocks on a full pipe, and draining without a deadline hangs on a hook
+/// that never exits.
+pub fn run_hook(hook: &LifecycleHook, event: HookEvent, ctx: &HookContext) -> Result<(), String> {
+    let label = format!("hook `{}` for {event}", elide(&hook.command));
+    tracing::debug!("{label}: running");
+
+    let mut cmd = super::platform_shell(&hook.command);
+    cmd.envs(ctx.env(event))
+        .envs(super::thurbox_dir_overrides())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    if let Some(dir) = ctx.workdir() {
+        cmd.current_dir(dir);
+    }
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| format!("{label} could not start: {e}"))?;
+
+    // The payload is small, but a hook that exits without reading would make
+    // a synchronous write fail on a closed pipe — and one that reads slowly
+    // would stall the runner before its deadline was even armed.
+    if let Some(mut stdin) = child.stdin.take() {
+        let payload = ctx.json(event);
+        std::thread::spawn(move || {
+            let _ = stdin.write_all(payload.as_bytes());
+        });
+    }
+    let stdout = child.stdout.take().map(drain);
+    let stderr = child.stderr.take().map(drain);
+
+    let started = Instant::now();
+    let timeout = hook.timeout();
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break Ok(status),
+            Ok(None) if started.elapsed() >= timeout => {
+                let _ = child.kill();
+                let _ = child.wait();
+                break Err(format!("{label} timed out after {}s", timeout.as_secs()));
+            }
+            Ok(None) => std::thread::sleep(POLL_INTERVAL),
+            Err(e) => break Err(format!("{label} could not be waited on: {e}")),
+        }
+    };
+    let out_tail = stdout.map(collect).unwrap_or_default();
+    let err_tail = stderr.map(collect).unwrap_or_default();
+
+    let status = status?;
+    if status.success() {
+        return Ok(());
+    }
+    let code = status
+        .code()
+        .map_or_else(|| "with a signal".to_string(), |c| c.to_string());
+    let detail = if err_tail.is_empty() {
+        out_tail
+    } else {
+        err_tail
+    };
+    Err(match detail.is_empty() {
+        true => format!("{label} exited {code}"),
+        false => format!("{label} exited {code}: {detail}"),
+    })
+}
+
+/// Read a stream to its end on a thread, keeping only the last
+/// [`STREAM_KEEP`] bytes, and hand the tail back over a channel — so the
+/// runner can wait for it *with a deadline* ([`READER_GRACE`]).
+fn drain(mut stream: impl Read + Send + 'static) -> mpsc::Receiver<Vec<u8>> {
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let mut kept: Vec<u8> = Vec::new();
+        let mut chunk = [0u8; 8192];
+        loop {
+            match stream.read(&mut chunk) {
+                Ok(0) | Err(_) => break,
+                Ok(n) => {
+                    kept.extend_from_slice(&chunk[..n]);
+                    if kept.len() > 2 * STREAM_KEEP {
+                        kept.drain(..kept.len() - STREAM_KEEP);
+                    }
+                }
+            }
+        }
+        let _ = tx.send(kept);
+    });
+    rx
+}
+
+fn collect(rx: mpsc::Receiver<Vec<u8>>) -> String {
+    rx.recv_timeout(READER_GRACE)
+        .map(|bytes| super::exec_tail(&bytes))
+        .unwrap_or_default()
+}
+
+/// The command as an error message names it: one line, at most 60 chars.
+fn elide(command: &str) -> String {
+    let one_line = command.lines().next().unwrap_or_default();
+    let mut out: String = one_line.chars().take(60).collect();
+    if out.len() < command.len() {
+        out.push('…');
+    }
+    out
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use crate::session::SessionId;
+
+    fn hook(event: HookEvent, command: &str, timeout_secs: Option<u64>) -> LifecycleHook {
+        LifecycleHook {
+            event,
+            command: command.to_string(),
+            timeout_secs,
+        }
+    }
+
+    fn write_hooks_file(dir: &std::path::Path, body: &str) {
+        let path = crate::agent::hooks_config::hooks_config_path().unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, body.replace("{dir}", &dir.display().to_string())).unwrap();
+    }
+
+    #[test]
+    fn a_hook_sees_the_environment_the_json_and_the_workdir() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let repo = temp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let out = temp.path().join("seen");
+        let sid = SessionId::default();
+        let ctx = HookContext {
+            session_id: Some(sid),
+            name: "demo".into(),
+            agent: "claude".into(),
+            repo: Some(repo.clone()),
+            branch: Some("feat/x".into()),
+            ..HookContext::default()
+        };
+        let h = hook(
+            HookEvent::PostCreate,
+            &format!(
+                "printf '%s\\n%s\\n%s\\n%s\\n' \"$THURBOX_HOOK_EVENT\" \"$THURBOX_SESSION\" \"$PWD\" \"$THURBOX_CONFIG_DIR\" > {out}; cat >> {out}",
+                out = out.display()
+            ),
+            None,
+        );
+        run_hook(&h, HookEvent::PostCreate, &ctx).unwrap();
+
+        let seen = std::fs::read_to_string(&out).unwrap();
+        let mut lines = seen.lines();
+        assert_eq!(lines.next(), Some("session.post_create"));
+        assert_eq!(lines.next(), Some(sid.to_string().as_str()));
+        assert_eq!(
+            lines.next().map(std::path::PathBuf::from),
+            Some(repo.canonicalize().unwrap())
+        );
+        let config_dir = lines.next().unwrap();
+        assert_eq!(
+            std::path::Path::new(config_dir),
+            crate::paths::config_file().unwrap().parent().unwrap()
+        );
+        let json: serde_json::Value = serde_json::from_str(lines.next().unwrap()).unwrap();
+        assert_eq!(json["event"], "session.post_create");
+        assert_eq!(json["branch"], "feat/x");
+    }
+
+    #[test]
+    fn a_non_zero_exit_reports_the_code_and_the_stderr_tail() {
+        let h = hook(
+            HookEvent::PreCreate,
+            "echo 'refusing: protected branch' >&2; exit 3",
+            None,
+        );
+        let err = run_hook(&h, HookEvent::PreCreate, &HookContext::default()).unwrap_err();
+        assert!(
+            err.contains("exited 3: refusing: protected branch"),
+            "{err}"
+        );
+        assert!(err.contains("session.pre_create"), "{err}");
+    }
+
+    #[test]
+    fn stdout_stands_in_when_stderr_is_silent() {
+        let h = hook(HookEvent::PreCreate, "echo why; exit 1", None);
+        let err = run_hook(&h, HookEvent::PreCreate, &HookContext::default()).unwrap_err();
+        assert!(err.ends_with("exited 1: why"), "{err}");
+    }
+
+    #[test]
+    fn a_hanging_hook_is_killed_at_its_timeout() {
+        let h = hook(HookEvent::PreRestart, "sleep 5", Some(1));
+        let started = Instant::now();
+        let err = run_hook(&h, HookEvent::PreRestart, &HookContext::default()).unwrap_err();
+        assert!(err.contains("timed out after 1s"), "{err}");
+        assert!(
+            started.elapsed() < Duration::from_secs(4),
+            "{:?}",
+            started.elapsed()
+        );
+    }
+
+    #[test]
+    fn a_chatty_hook_neither_deadlocks_nor_bloats_the_report() {
+        // `yes` fills the pipe far faster than a 500-char tail could ever want;
+        // without the reader threads the child would block on write and the
+        // timeout would be the only way out.
+        let h = hook(
+            HookEvent::PostCreate,
+            "yes | head -c 5000000; exit 2",
+            Some(10),
+        );
+        let started = Instant::now();
+        let err = run_hook(&h, HookEvent::PostCreate, &HookContext::default()).unwrap_err();
+        assert!(
+            started.elapsed() < Duration::from_secs(8),
+            "{:?}",
+            started.elapsed()
+        );
+        assert!(err.contains("exited 2"), "{err}");
+        assert!(
+            err.len() < 700,
+            "the report is a tail, not the stream: {}",
+            err.len()
+        );
+    }
+
+    #[test]
+    fn a_backgrounded_grandchild_does_not_hold_the_operation() {
+        let h = hook(HookEvent::PostCreate, "sleep 30 & exit 0", Some(5));
+        let started = Instant::now();
+        run_hook(&h, HookEvent::PostCreate, &HookContext::default()).unwrap();
+        assert!(
+            started.elapsed() < Duration::from_secs(3),
+            "{:?}",
+            started.elapsed()
+        );
+    }
+
+    #[test]
+    fn pre_hooks_stop_at_the_first_failure() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        write_hooks_file(
+            temp.path(),
+            r#"
+            [[hooks]]
+            event = "session.pre_create"
+            command = "touch {dir}/first; exit 1"
+            [[hooks]]
+            event = "session.pre_create"
+            command = "touch {dir}/second"
+            "#,
+        );
+        let err = fire_pre(HookEvent::PreCreate, &HookContext::default()).unwrap_err();
+        assert!(err.contains("exited 1"), "{err}");
+        assert!(temp.path().join("first").exists());
+        assert!(
+            !temp.path().join("second").exists(),
+            "the second hook must not run"
+        );
+    }
+
+    #[test]
+    fn post_hooks_all_run_past_a_failure() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        write_hooks_file(
+            temp.path(),
+            r#"
+            [[hooks]]
+            event = "session.post_create"
+            command = "touch {dir}/first; exit 1"
+            [[hooks]]
+            event = "session.post_create"
+            command = "touch {dir}/second"
+            [[hooks]]
+            event = "session.post_delete"
+            command = "touch {dir}/other-event"
+            "#,
+        );
+        let failures = fire_post(HookEvent::PostCreate, &HookContext::default());
+        assert_eq!(failures.len(), 1, "{failures:?}");
+        assert!(temp.path().join("first").exists());
+        assert!(temp.path().join("second").exists());
+        assert!(!temp.path().join("other-event").exists());
+    }
+
+    #[test]
+    fn no_hooks_file_means_nothing_runs_and_nothing_fails() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        assert_eq!(
+            fire_pre(HookEvent::PreDelete, &HookContext::default()),
+            Ok(())
+        );
+        assert!(fire_post(HookEvent::PostDelete, &HookContext::default()).is_empty());
+    }
+
+    #[test]
+    fn a_persisted_session_yields_its_facts() {
+        let sid = SessionId::default();
+        let session = SharedSession {
+            id: sid,
+            name: "demo".into(),
+            agent: "codex".into(),
+            backend_id: "%7".into(),
+            backend_type: "ssh:devbox".into(),
+            agent_session_id: Some("conv".into()),
+            cwd: Some("/srv/wt".into()),
+            additional_dirs: vec!["/srv/other".into()],
+            worktrees: vec![crate::sync::SharedWorktree {
+                repo_path: "/srv/repo".into(),
+                worktree_path: "/srv/wt".into(),
+                branch: "feat/x".into(),
+            }],
+            shell_backend_id: None,
+            parent_session_id: None,
+            display_order: None,
+            tombstone: false,
+            tombstone_at: None,
+        };
+        let ctx = context_for(&session);
+        assert_eq!(ctx.session_id, Some(sid));
+        assert_eq!(ctx.repo.as_deref(), Some(std::path::Path::new("/srv/repo")));
+        assert_eq!(ctx.cwd.as_deref(), Some(std::path::Path::new("/srv/wt")));
+        assert_eq!(ctx.branch.as_deref(), Some("feat/x"));
+        assert_eq!(ctx.host.as_deref(), Some("devbox"));
+        assert_eq!(ctx.backend_id.as_deref(), Some("%7"));
+        assert_eq!(ctx.worktrees.len(), 1);
+        assert_eq!(ctx.additional_dirs.len(), 1);
+        assert_eq!(host_name("local-tmux"), None);
+        assert_eq!(host_name("wsl:Ubuntu").as_deref(), Some("Ubuntu"));
+    }
+}

--- a/src/session_ops/mod.rs
+++ b/src/session_ops/mod.rs
@@ -10,6 +10,7 @@ pub mod builtin_hooks;
 pub mod builtin_ui_skill;
 pub mod delete;
 pub mod extensions;
+pub mod lifecycle_hooks;
 pub mod remote_hooks;
 pub mod restart;
 pub mod restore;
@@ -24,7 +25,8 @@ pub use extensions::{
     update_all_extensions, update_extension, DeactivateReport, EnsureReport, ExtensionHealth,
     InstallReport, ReinstallReport, UninstallReport, UpdateReport,
 };
-pub use restart::restart_session_headless;
+pub use lifecycle_hooks::{fire_post, fire_pre};
+pub use restart::{restart_session_headless, RestartReport};
 pub use restore::{restore_session_headless, RestoreReport};
 pub use spawn::{spawn_session_headless, SpawnRequest, SpawnResult};
 
@@ -39,13 +41,7 @@ use crate::session::{AutomationRunStatus, SessionConfig};
 /// the headless `automation tick`. stdout+stderr are tail-truncated so a chatty
 /// command can't bloat the history.
 pub fn run_exec_command(command: &str) -> (AutomationRunStatus, String) {
-    use std::process::Command;
-    let result = if cfg!(windows) {
-        Command::new("cmd").args(["/C", command]).output()
-    } else {
-        Command::new("sh").args(["-c", command]).output()
-    };
-    let out = match result {
+    let out = match platform_shell(command).output() {
         Ok(out) => out,
         Err(e) => return (AutomationRunStatus::Error, format!("spawn failed: {e}")),
     };
@@ -72,10 +68,25 @@ pub fn run_exec_command(command: &str) -> (AutomationRunStatus, String) {
     (AutomationRunStatus::Error, msg)
 }
 
+/// `command` as the platform shell runs it: `sh -c` or, on Windows, `cmd /C`.
+/// Shared by `Exec` automations and lifecycle hooks so the two spell a
+/// command line the same way.
+pub(crate) fn platform_shell(command: &str) -> std::process::Command {
+    if cfg!(windows) {
+        let mut cmd = std::process::Command::new("cmd");
+        cmd.args(["/C", command]);
+        cmd
+    } else {
+        let mut cmd = std::process::Command::new("sh");
+        cmd.args(["-c", command]);
+        cmd
+    }
+}
+
 /// The trailing 500 chars of one captured stream, trimmed. Single pass via a
 /// capped ring so a huge stream isn't walked twice (count + skip) or
 /// materialized in full.
-fn exec_tail(stream: &[u8]) -> String {
+pub(crate) fn exec_tail(stream: &[u8]) -> String {
     const TAIL_CHARS: usize = 500;
     let text = String::from_utf8_lossy(stream);
     let mut ring: std::collections::VecDeque<char> =
@@ -87,6 +98,32 @@ fn exec_tail(stream: &[u8]) -> String {
         ring.push_back(c);
     }
     ring.into_iter().collect()
+}
+
+/// The config/data-dir overrides this process resolved, as the two env vars
+/// `thurbox-cli` honours (`THURBOX_CONFIG_DIR` / `THURBOX_DATA_DIR`). Derived
+/// from the resolved file paths' parents, so a dev build, a sandbox and a
+/// `THURBOX_*_DIR` override all hand the same answer on. One definition, shared
+/// by the agent's environment and a lifecycle hook — "a `thurbox-cli` inside
+/// hits the right DB" is one property, not two.
+pub(crate) fn thurbox_dir_overrides() -> Vec<(String, String)> {
+    let mut vars = Vec::with_capacity(2);
+    if let Some(dir) = crate::paths::config_file().and_then(|p| p.parent().map(|d| d.to_path_buf()))
+    {
+        vars.push((
+            crate::paths::CONFIG_DIR_OVERRIDE_ENV.into(),
+            dir.to_string_lossy().into(),
+        ));
+    }
+    if let Some(dir) =
+        crate::paths::database_file().and_then(|p| p.parent().map(|d| d.to_path_buf()))
+    {
+        vars.push((
+            crate::paths::DATA_DIR_OVERRIDE_ENV.into(),
+            dir.to_string_lossy().into(),
+        ));
+    }
+    vars
 }
 
 /// Decide whether to pass the agent's resume group vs starting fresh when
@@ -323,21 +360,7 @@ pub(crate) fn inject_thurbox_env(
     // dirs this thurbox resolved, so a status `signal` always lands in the DB
     // the TUI reads — independent of XDG, which `thurbox-cli` is on PATH, or a
     // stale tmux-server env. Derived from the resolved file paths' parents.
-    if let Some(dir) = crate::paths::config_file().and_then(|p| p.parent().map(|d| d.to_path_buf()))
-    {
-        config.env.insert(
-            crate::paths::CONFIG_DIR_OVERRIDE_ENV.into(),
-            dir.to_string_lossy().into(),
-        );
-    }
-    if let Some(dir) =
-        crate::paths::database_file().and_then(|p| p.parent().map(|d| d.to_path_buf()))
-    {
-        config.env.insert(
-            crate::paths::DATA_DIR_OVERRIDE_ENV.into(),
-            dir.to_string_lossy().into(),
-        );
-    }
+    config.env.extend(thurbox_dir_overrides());
 }
 
 #[cfg(test)]

--- a/src/session_ops/restart.rs
+++ b/src/session_ops/restart.rs
@@ -88,6 +88,13 @@ pub(crate) fn build_restart_plan(
     })
 }
 
+/// What a restart has to say beyond having happened.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RestartReport {
+    /// `session.post_restart` hooks that failed. The restart stands regardless.
+    pub hook_failures: Vec<String>,
+}
+
 /// Restart an existing session in-place — kills its tmux window and
 /// re-spawns the agent CLI.
 ///
@@ -97,7 +104,10 @@ pub(crate) fn build_restart_plan(
 /// resumes the latest session in the (unchanged) launch directory. Other agents
 /// degrade to "start fresh" (the live tmux process is what carries state across
 /// restarts).
-pub fn restart_session_headless(db: &Database, session_id: SessionId) -> Result<(), String> {
+pub fn restart_session_headless(
+    db: &Database,
+    session_id: SessionId,
+) -> Result<RestartReport, String> {
     let session = db
         .get_session_by_id(session_id)
         .map_err(|e| format!("Failed to load session: {e}"))?
@@ -117,6 +127,11 @@ pub fn restart_session_headless(db: &Database, session_id: SessionId) -> Result<
 
     let hooks_enabled = super::hooks_enabled(db);
     let plan = build_restart_plan(&session, host.as_ref(), hooks_enabled)?;
+
+    // The user's say, with the plan built and nothing yet killed: a refusal
+    // leaves the running window running.
+    let mut hook_ctx = super::lifecycle_hooks::context_for(&session);
+    super::fire_pre(crate::session::HookEvent::PreRestart, &hook_ctx)?;
 
     match host.as_ref() {
         None => {
@@ -186,7 +201,12 @@ pub fn restart_session_headless(db: &Database, session_id: SessionId) -> Result<
     // (a resumed agent may not re-fire its boot hook). Best-effort.
     let _ = db.clear_hook_state(session_id);
 
-    Ok(())
+    // The new pane is what the row now points at, so that is what the
+    // post-restart hooks are told.
+    hook_ctx.backend_id = super::lifecycle_hooks::current_pane(db, session_id);
+    let hook_failures = super::fire_post(crate::session::HookEvent::PostRestart, &hook_ctx);
+
+    Ok(RestartReport { hook_failures })
 }
 
 #[cfg(test)]

--- a/src/session_ops/restore.rs
+++ b/src/session_ops/restore.rs
@@ -30,6 +30,8 @@ pub struct RestoreReport {
     pub worktrees_recovered: usize,
     /// Set when the row and its worktrees returned but the agent did not.
     pub respawn_error: Option<String>,
+    /// `session.post_restore` hooks that failed. The restore stands regardless.
+    pub hook_failures: Vec<String>,
 }
 
 /// Restore a deleted session: the row, then its worktrees, then its agent.
@@ -70,6 +72,31 @@ pub fn restore_session_headless(
         ));
     }
 
+    // The user's say, with both refusals above already made and the row still
+    // deleted: a refusal here changes nothing.
+    let primary = deleted.worktrees.first();
+    let mut hook_ctx = crate::session::HookContext {
+        session_id: Some(deleted.id),
+        name: deleted.name.clone(),
+        agent: deleted.agent.clone(),
+        agent_session_id: deleted.agent_session_id.clone(),
+        repo: primary
+            .map(|w| w.repo_path.clone())
+            .or_else(|| deleted.cwd.clone()),
+        cwd: deleted.cwd.clone(),
+        branch: primary.map(|w| w.branch.clone()),
+        host: super::lifecycle_hooks::host_name(&deleted.backend_type),
+        parent_session_id: deleted.parent_session_id,
+        force_deleted: Some(deleted.force_deleted),
+        worktrees: deleted
+            .worktrees
+            .iter()
+            .map(super::lifecycle_hooks::worktree)
+            .collect(),
+        ..crate::session::HookContext::default()
+    };
+    super::fire_pre(crate::session::HookEvent::PreRestore, &hook_ctx)?;
+
     db.restore_session(deleted.id)
         .map_err(|e| format!("restore session: {e}"))?;
 
@@ -78,12 +105,18 @@ pub fn restore_session_headless(
 
     let respawn_error = respawn(db, deleted.id).err();
 
+    // A restore whose agent did not come up is still a restore — the report
+    // says so, and the hooks fire either way.
+    hook_ctx.backend_id = super::lifecycle_hooks::current_pane(db, deleted.id);
+    let hook_failures = super::fire_post(crate::session::HookEvent::PostRestore, &hook_ctx);
+
     Ok(RestoreReport {
         name: deleted.name,
         best_effort: deleted.force_deleted,
         worktrees_wanted: wanted,
         worktrees_recovered: recovered.len(),
         respawn_error,
+        hook_failures,
     })
 }
 

--- a/src/session_ops/spawn.rs
+++ b/src/session_ops/spawn.rs
@@ -82,6 +82,9 @@ pub struct SpawnResult {
     pub cwd: PathBuf,
     pub worktrees: Vec<SharedWorktree>,
     pub parent_session_id: Option<SessionId>,
+    /// `session.post_create` hooks that failed. The session exists and is
+    /// running regardless; these are for the caller's report.
+    pub hook_failures: Vec<String>,
 }
 
 /// Spawn a new session inside `tmux -L thurbox`, persisting its state to the
@@ -96,6 +99,8 @@ pub struct SpawnResult {
 pub enum SpawnPhase {
     /// Resolving the agent definition and the host.
     Resolving,
+    /// Running the user's `session.pre_create` hooks, which may refuse.
+    Hooks,
     /// Creating or attaching worktrees — the `git fetch` and checkout.
     Worktrees,
     /// Readying the backend: for a remote host, the ssh connect.
@@ -110,6 +115,7 @@ impl SpawnPhase {
     pub fn as_str(self) -> &'static str {
         match self {
             SpawnPhase::Resolving => "resolving",
+            SpawnPhase::Hooks => "hooks",
             SpawnPhase::Worktrees => "worktrees",
             SpawnPhase::Backend => "backend",
             SpawnPhase::Launching => "launching",
@@ -152,6 +158,54 @@ pub fn spawn_session_headless_with_progress(
     // `ssh:<host>`; `host` is the matching HostDef for remote git/tmux ops.
     let (backend_type, host) = resolve_host(req.host.as_deref())?;
 
+    // Both ids are minted before anything happens, so the pre-create hook can
+    // name the session it is being asked about — and correlate with the
+    // post-create one — and so `THURBOX_SESSION` is in the process env before
+    // the agent launches.
+    let session_id = SessionId::default();
+    let agent_session_id = req
+        .agent_session_id
+        .clone()
+        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+
+    // The user's say, before the first side effect: nothing below this line has
+    // touched a repository, a host or the database. A refusal is the reported
+    // error, and the pipeline reports which phase it is in so a slow hook is
+    // named rather than mistaken for a slow fetch.
+    report(SpawnPhase::Hooks);
+    let base_branch = req.worktree_branch.as_ref().map(|_| {
+        req.base_branch
+            .as_deref()
+            .unwrap_or(DEFAULT_BASE_BRANCH)
+            .to_string()
+    });
+    let mut hook_ctx = crate::session::HookContext {
+        session_id: Some(session_id),
+        name: req.name.clone(),
+        agent: agent_name.clone(),
+        agent_session_id: Some(agent_session_id.clone()),
+        repo: Some(req.repo_path.clone()),
+        branch: req.worktree_branch.clone(),
+        base_branch,
+        host: host.as_ref().map(|h| h.name.clone()),
+        parent_session_id: req.parent_session_id,
+        task_id: req.task_id,
+        fork_session_id: req.fork_session_id.clone(),
+        worktrees: req
+            .inherit_worktrees
+            .iter()
+            .map(super::lifecycle_hooks::worktree)
+            .collect(),
+        additional_dirs: req
+            .extra_repos
+            .iter()
+            .filter(|extra| !extra.worktree)
+            .map(|extra| extra.repo_path.clone())
+            .collect(),
+        ..crate::session::HookContext::default()
+    };
+    super::fire_pre(crate::session::HookEvent::PreCreate, &hook_ctx)?;
+
     // The def's `args` may reference thurbox-managed config files by their
     // *local* absolute path (e.g. claude's hooks `--settings <config>/hooks/
     // claude.json`), which the agent errors on when the path doesn't exist on
@@ -170,11 +224,6 @@ pub fn spawn_session_headless_with_progress(
     report(SpawnPhase::Worktrees);
     let (primary_cwd, worktrees, additional_dirs) = resolve_dirs(&req, host.as_ref())?;
 
-    let agent_session_id = req
-        .agent_session_id
-        .clone()
-        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
-
     // For a multi-repo session, launch the agent in a per-session symlink
     // workspace gathering every member dir (so each repo is a visible subdir,
     // agent-neutral). `info.cwd` keeps the *primary* repo. Single-repo sessions
@@ -187,10 +236,6 @@ pub fn spawn_session_headless_with_progress(
         &additional_dirs,
         host.as_ref(),
     );
-
-    // Mint the thurbox SessionId up front so it can be injected into the
-    // process env (`THURBOX_SESSION`) before the agent launches.
-    let session_id = SessionId::default();
 
     let mut config = SessionConfig {
         session_id: Some(session_id),
@@ -291,6 +336,17 @@ pub fn spawn_session_headless_with_progress(
     // SessionStart → idle on boot, then working/blocked/done through the turn.
     // Seeding `working` here made an idle, just-booted agent look stuck working.
 
+    // The session exists, is running and is persisted: the post-create hooks
+    // are told everything, and nothing they do can undo it.
+    hook_ctx.cwd = Some(launch_cwd);
+    hook_ctx.backend_id = Some(backend_id.clone()).filter(|id| !id.is_empty());
+    hook_ctx.worktrees = worktrees
+        .iter()
+        .map(super::lifecycle_hooks::worktree)
+        .collect();
+    hook_ctx.additional_dirs = additional_dirs;
+    let hook_failures = super::fire_post(crate::session::HookEvent::PostCreate, &hook_ctx);
+
     Ok(SpawnResult {
         session_id,
         name: req.name,
@@ -300,6 +356,7 @@ pub fn spawn_session_headless_with_progress(
         cwd: primary_cwd,
         worktrees,
         parent_session_id: req.parent_session_id,
+        hook_failures,
     })
 }
 

--- a/tests/create_e2e.rs
+++ b/tests/create_e2e.rs
@@ -249,3 +249,402 @@ fn two_sessions_sharing_a_name_get_distinct_pane_ids() {
         "each session must be addressable by its own pane"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Session lifecycle hooks (`hooks.toml`), fired around the same pipeline.
+// ---------------------------------------------------------------------------
+
+/// Isolate config + data under a fresh home, install a `sh` agent, and return
+/// the config directory. Every hooks test below starts here; the process-wide
+/// override is safe because nextest runs one process per test.
+fn isolated_config() -> (tempfile::TempDir, std::path::PathBuf) {
+    let home = tempfile::tempdir().expect("tempdir");
+    // Both forms: the thread-local override for this thread, and the
+    // process-wide env overrides for any thread the pipeline spawns — the
+    // command bus runs each command on its own, and a worker resolving the
+    // real XDG paths would create a real session in the real database.
+    thurbox::paths::set_test_dir(home.path());
+    std::env::set_var(thurbox::paths::CONFIG_DIR_OVERRIDE_ENV, home.path());
+    std::env::set_var(thurbox::paths::DATA_DIR_OVERRIDE_ENV, home.path());
+    let config = thurbox::paths::config_file()
+        .expect("config path")
+        .parent()
+        .expect("config dir")
+        .to_path_buf();
+    std::fs::create_dir_all(&config).expect("mkdir");
+    std::fs::write(
+        config.join("agents.toml"),
+        "default = \"shell\"\n\n[[agents]]\nname = \"shell\"\ncommand = \"sh\"\nargs = []\n",
+    )
+    .expect("write agents.toml");
+    (home, config)
+}
+
+/// The database at the path a `thurbox-cli` run *inside* a hook resolves —
+/// the same file, so what the hook reads is what the pipeline wrote.
+fn on_disk_db() -> thurbox::storage::Database {
+    let path = thurbox::paths::database_file().expect("db path");
+    std::fs::create_dir_all(path.parent().expect("data dir")).expect("mkdir");
+    thurbox::storage::Database::open(&path).expect("open db")
+}
+
+fn write_hooks(config: &Path, body: &str) {
+    std::fs::write(config.join("hooks.toml"), body).expect("write hooks.toml");
+}
+
+/// A hook entry that appends `$THURBOX_HOOK_EVENT` (and, for the create pair,
+/// the paths) to `log`.
+fn logging_hook(event: &str, log: &Path) -> String {
+    format!(
+        "[[hooks]]\nevent = \"{event}\"\ncommand = 'echo \"$THURBOX_HOOK_EVENT ${{THURBOX_CWD:-unset}} ${{THURBOX_REPO:-unset}} ${{THURBOX_SESSION:-unset}}\" >> {}'\n\n",
+        log.display()
+    )
+}
+
+fn shell_request(repo: &Path, branch: Option<&str>) -> thurbox::session_ops::spawn::SpawnRequest {
+    thurbox::session_ops::spawn::SpawnRequest {
+        name: "hooked".into(),
+        repo_path: repo.to_path_buf(),
+        worktree_branch: branch.map(String::from),
+        base_branch: branch.map(|_| "main".to_string()),
+        agent: Some("shell".into()),
+        ..Default::default()
+    }
+}
+
+#[test]
+#[cfg(unix)]
+fn create_hooks_fire_once_each_with_the_facts_and_can_reach_the_database() {
+    if !have_tmux() {
+        eprintln!("skipping: tmux is not installed");
+        return;
+    }
+    let repo = repo();
+    let _tmux_dir = isolate_tmux();
+    let (home, config) = isolated_config();
+    let db = on_disk_db();
+    let log = home.path().join("hooks.log");
+    let seen_by_cli = home.path().join("session.json");
+    // The post hook asks thurbox-cli about the session it was told of — the
+    // dev binary, by absolute path, so PATH plays no part.
+    let mut hooks = logging_hook("session.pre_create", &log);
+    hooks.push_str(&logging_hook("session.post_create", &log));
+    hooks.push_str(&format!(
+        "[[hooks]]\nevent = \"session.post_create\"\ncommand = '{} session get \"$THURBOX_SESSION\" --json > {}'\n",
+        env!("CARGO_BIN_EXE_thurbox-cli"),
+        seen_by_cli.display()
+    ));
+    write_hooks(&config, &hooks);
+
+    let spawned = match thurbox::session_ops::spawn::spawn_session_headless(
+        &db,
+        shell_request(repo.path(), Some("feat/hooked")),
+    ) {
+        Ok(spawned) => spawned,
+        Err(e) => {
+            cleanup();
+            if e.contains("tmux") {
+                eprintln!("skipping: tmux would not spawn a window: {e}");
+                return;
+            }
+            panic!("creation failed: {e}");
+        }
+    };
+    cleanup();
+
+    assert!(
+        spawned.hook_failures.is_empty(),
+        "{:?}",
+        spawned.hook_failures
+    );
+    let seen = std::fs::read_to_string(&log).expect("the hooks ran");
+    let lines: Vec<Vec<&str>> = seen
+        .lines()
+        .map(|l| l.split_whitespace().collect())
+        .collect();
+    assert_eq!(lines.len(), 2, "one pre, one post:\n{seen}");
+    let sid = spawned.session_id.to_string();
+    let worktree = spawned.worktrees[0].worktree_path.display().to_string();
+    let repo_path = repo.path().display().to_string();
+    assert_eq!(lines[0], ["session.pre_create", "unset", &repo_path, &sid]);
+    assert_eq!(
+        lines[1],
+        ["session.post_create", &worktree, &repo_path, &sid]
+    );
+
+    let cli = std::fs::read_to_string(&seen_by_cli).expect("thurbox-cli ran inside the hook");
+    assert!(
+        cli.contains(&sid),
+        "the hook's thurbox-cli must see the row the pipeline wrote: {cli}"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn a_pre_create_veto_leaves_nothing_behind() {
+    // No tmux needed: the veto lands before anything is spawned, and that is
+    // the point — so this runs everywhere.
+    use std::sync::{Arc, Mutex};
+    let repo = repo();
+    let _tmux_dir = isolate_tmux();
+    let (_home, config) = isolated_config();
+    let db = on_disk_db();
+    write_hooks(
+        &config,
+        "[[hooks]]\nevent = \"session.pre_create\"\ncommand = 'echo \"refusing: protected branch\" >&2; exit 1'\n\
+         [[hooks]]\nevent = \"session.post_create\"\ncommand = 'touch post-ran'\n",
+    );
+
+    let phases: Arc<Mutex<Vec<&'static str>>> = Arc::new(Mutex::new(Vec::new()));
+    let recorder = {
+        let phases = phases.clone();
+        move |phase: thurbox::session_ops::spawn::SpawnPhase| {
+            phases.lock().unwrap().push(phase.as_str());
+        }
+    };
+    let err = thurbox::session_ops::spawn::spawn_session_headless_with_progress(
+        &db,
+        shell_request(repo.path(), Some("feat/vetoed")),
+        Some(&recorder),
+    )
+    .expect_err("a vetoed creation fails");
+
+    assert!(err.contains("refusing: protected branch"), "{err}");
+    assert!(err.contains("session.pre_create"), "{err}");
+    assert_eq!(*phases.lock().unwrap(), ["resolving", "hooks"]);
+
+    // Nothing happened: no row, no worktree, no window, no post hook.
+    let store = thurbox::kernel::snapshot::SnapshotStore::with_database(db);
+    assert!(store.current().sessions.is_empty());
+    let worktrees = Command::new("git")
+        .args(["worktree", "list", "--porcelain"])
+        .current_dir(repo.path())
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .output()
+        .expect("git");
+    let listed = String::from_utf8_lossy(&worktrees.stdout);
+    assert_eq!(
+        listed.matches("worktree ").count(),
+        1,
+        "only the main checkout:\n{listed}"
+    );
+    assert!(!repo.path().join("post-ran").exists());
+    let server = Command::new("tmux")
+        .args(["-L", SOCKET, "list-windows"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    assert!(
+        !server,
+        "no window was ever spawned, so no server should be up"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn a_vetoed_creation_reports_through_the_command_bus() {
+    // The TUI's path: the creation flow dispatches, the worker runs the same
+    // pipeline, and the refusal is the in-flight error the placeholder shows.
+    use thurbox::kernel::command::{Command, CommandBus, Phase};
+    let repo = repo();
+    let _tmux_dir = isolate_tmux();
+    let (_home, config) = isolated_config();
+    drop(on_disk_db());
+    write_hooks(
+        &config,
+        "[[hooks]]\nevent = \"session.pre_create\"\ncommand = 'echo \"not on my watch\" >&2; exit 7'\n",
+    );
+
+    let mut bus = CommandBus::new();
+    bus.dispatch(Command::Create {
+        name: "vetoed".into(),
+        repo: repo.path().display().to_string(),
+        branch: None,
+        base: None,
+        agent: Some("shell".into()),
+        host: None,
+        extras: Vec::new(),
+    });
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    while std::time::Instant::now() < deadline {
+        bus.poll();
+        if let Some(failed) = bus
+            .inflight()
+            .into_iter()
+            .find(|entry| entry.phase == Phase::Failed)
+        {
+            let error = failed.error.unwrap_or_default();
+            assert!(error.contains("not on my watch"), "{error}");
+            assert!(error.contains("exited 7"), "{error}");
+            return;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+    panic!("the veto never surfaced through the bus");
+}
+
+#[test]
+#[cfg(unix)]
+fn a_post_create_failure_leaves_the_session_running() {
+    if !have_tmux() {
+        eprintln!("skipping: tmux is not installed");
+        return;
+    }
+    let repo = repo();
+    let _tmux_dir = isolate_tmux();
+    let (_home, config) = isolated_config();
+    let db = on_disk_db();
+    write_hooks(
+        &config,
+        "[[hooks]]\nevent = \"session.post_create\"\ncommand = 'echo \"could not warm the cache\" >&2; exit 2'\n",
+    );
+
+    let spawned = match thurbox::session_ops::spawn::spawn_session_headless(
+        &db,
+        shell_request(repo.path(), None),
+    ) {
+        Ok(spawned) => spawned,
+        Err(e) => {
+            cleanup();
+            if e.contains("tmux") {
+                eprintln!("skipping: tmux would not spawn a window: {e}");
+                return;
+            }
+            panic!("creation failed: {e}");
+        }
+    };
+    cleanup();
+
+    assert_eq!(
+        spawned.hook_failures.len(),
+        1,
+        "{:?}",
+        spawned.hook_failures
+    );
+    assert!(
+        spawned.hook_failures[0].contains("exited 2: could not warm the cache"),
+        "{:?}",
+        spawned.hook_failures
+    );
+    assert!(
+        db.get_session_by_id(spawned.session_id)
+            .expect("query")
+            .is_some(),
+        "the session stands"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn delete_restart_and_restore_fire_their_pairs_once_and_pre_delete_can_refuse() {
+    if !have_tmux() {
+        eprintln!("skipping: tmux is not installed");
+        return;
+    }
+    let repo = repo();
+    let _tmux_dir = isolate_tmux();
+    let (home, config) = isolated_config();
+    let db = on_disk_db();
+    let log = home.path().join("hooks.log");
+    let mut hooks = String::new();
+    for event in [
+        "session.pre_delete",
+        "session.post_delete",
+        "session.pre_restart",
+        "session.post_restart",
+        "session.pre_restore",
+        "session.post_restore",
+    ] {
+        hooks.push_str(&logging_hook(event, &log));
+    }
+    write_hooks(&config, &hooks);
+
+    let spawned = match thurbox::session_ops::spawn::spawn_session_headless(
+        &db,
+        shell_request(repo.path(), None),
+    ) {
+        Ok(spawned) => spawned,
+        Err(e) => {
+            cleanup();
+            if e.contains("tmux") {
+                eprintln!("skipping: tmux would not spawn a window: {e}");
+                return;
+            }
+            panic!("creation failed: {e}");
+        }
+    };
+    let id = spawned.session_id;
+    let events = |log: &Path| -> Vec<String> {
+        std::fs::read_to_string(log)
+            .unwrap_or_default()
+            .lines()
+            .map(|l| l.split_whitespace().next().unwrap_or_default().to_string())
+            .collect()
+    };
+
+    let restart = thurbox::session_ops::restart_session_headless(&db, id).expect("restart");
+    assert!(
+        restart.hook_failures.is_empty(),
+        "{:?}",
+        restart.hook_failures
+    );
+    assert_eq!(
+        events(&log),
+        ["session.pre_restart", "session.post_restart"]
+    );
+
+    let soft = thurbox::session_ops::delete_session_headless(&db, id, false).expect("soft delete");
+    assert!(soft.hook_failures.is_empty());
+    let restore = thurbox::session_ops::restore_session_headless(&db, id, false).expect("restore");
+    assert!(
+        restore.hook_failures.is_empty(),
+        "{:?}",
+        restore.hook_failures
+    );
+    let forced =
+        thurbox::session_ops::delete_session_headless(&db, id, true).expect("force delete");
+    assert!(forced.hook_failures.is_empty());
+    cleanup();
+    assert_eq!(
+        events(&log),
+        [
+            "session.pre_restart",
+            "session.post_restart",
+            "session.pre_delete",
+            "session.post_delete",
+            "session.pre_restore",
+            "session.post_restore",
+            "session.pre_delete",
+            "session.post_delete",
+        ]
+    );
+    // The delete hooks were told which kind each was.
+    let seen = std::fs::read_to_string(&log).unwrap();
+    assert!(seen.contains(&id.to_string()));
+
+    // A second session, and a pre-delete that refuses: the row is untouched.
+    write_hooks(
+        &config,
+        "[[hooks]]\nevent = \"session.pre_delete\"\ncommand = 'echo \"build still running\" >&2; exit 1'\n",
+    );
+    let kept = match thurbox::session_ops::spawn::spawn_session_headless(
+        &db,
+        shell_request(repo.path(), None),
+    ) {
+        Ok(spawned) => spawned,
+        Err(e) => {
+            cleanup();
+            panic!("second creation failed: {e}");
+        }
+    };
+    let err = thurbox::session_ops::delete_session_headless(&db, kept.session_id, true)
+        .expect_err("the veto refuses the delete");
+    cleanup();
+    assert!(err.contains("build still running"), "{err}");
+    let row = db
+        .get_session_by_id(kept.session_id)
+        .expect("query")
+        .expect("still an active row");
+    assert_eq!(row.name, "hooked");
+}

--- a/tests/create_e2e.rs
+++ b/tests/create_e2e.rs
@@ -257,6 +257,7 @@ fn two_sessions_sharing_a_name_get_distinct_pane_ids() {
 /// Isolate config + data under a fresh home, install a `sh` agent, and return
 /// the config directory. Every hooks test below starts here; the process-wide
 /// override is safe because nextest runs one process per test.
+#[cfg(unix)]
 fn isolated_config() -> (tempfile::TempDir, std::path::PathBuf) {
     let home = tempfile::tempdir().expect("tempdir");
     // Both forms: the thread-local override for this thread, and the
@@ -282,18 +283,21 @@ fn isolated_config() -> (tempfile::TempDir, std::path::PathBuf) {
 
 /// The database at the path a `thurbox-cli` run *inside* a hook resolves —
 /// the same file, so what the hook reads is what the pipeline wrote.
+#[cfg(unix)]
 fn on_disk_db() -> thurbox::storage::Database {
     let path = thurbox::paths::database_file().expect("db path");
     std::fs::create_dir_all(path.parent().expect("data dir")).expect("mkdir");
     thurbox::storage::Database::open(&path).expect("open db")
 }
 
+#[cfg(unix)]
 fn write_hooks(config: &Path, body: &str) {
     std::fs::write(config.join("hooks.toml"), body).expect("write hooks.toml");
 }
 
 /// A hook entry that appends `$THURBOX_HOOK_EVENT` (and, for the create pair,
 /// the paths) to `log`.
+#[cfg(unix)]
 fn logging_hook(event: &str, log: &Path) -> String {
     format!(
         "[[hooks]]\nevent = \"{event}\"\ncommand = 'echo \"$THURBOX_HOOK_EVENT ${{THURBOX_CWD:-unset}} ${{THURBOX_REPO:-unset}} ${{THURBOX_SESSION:-unset}}\" >> {}'\n\n",
@@ -301,6 +305,7 @@ fn logging_hook(event: &str, log: &Path) -> String {
     )
 }
 
+#[cfg(unix)]
 fn shell_request(repo: &Path, branch: Option<&str>) -> thurbox::session_ops::spawn::SpawnRequest {
     thurbox::session_ops::spawn::SpawnRequest {
         name: "hooked".into(),

--- a/tests/kernel_mvp.rs
+++ b/tests/kernel_mvp.rs
@@ -2069,6 +2069,7 @@ fn the_spawn_pipeline_reports_the_stage_it_reached() {
         assert!(
             [
                 "resolving",
+                "hooks",
                 "worktrees",
                 "backend",
                 "launching",

--- a/ui/plugins/10_sessions.lua
+++ b/ui/plugins/10_sessions.lua
@@ -300,6 +300,7 @@ local PHASE_LABEL = {
   queued = "creating…",
   running = "creating…",
   resolving = "setting up…",
+  hooks = "running hooks…",
   worktrees = "creating…",
   backend = "setting up…",
   launching = "spawning…",

--- a/website/_includes/sidebar.njk
+++ b/website/_includes/sidebar.njk
@@ -17,6 +17,7 @@
     { href: "features.html#worktree-sync", label: "Worktree Sync" },
     { href: "features.html#session-forking", label: "Session Forking" },
     { href: "features.html#parent-sessions", label: "Parent Sessions" },
+    { href: "features.html#session-hooks", label: "Session Hooks" },
     { href: "features.html#inter-session-messages", label: "Inter-Session Messages" },
     { href: "features.html#global-search", label: "Global Search" },
     { href: "features.html#themes", label: "Themes" },

--- a/website/docs/agent-hooks.html
+++ b/website/docs/agent-hooks.html
@@ -56,6 +56,20 @@ breadcrumb: 'Agent hooks'
             ), so a hook firing headlessly is honored too.
           </p>
 
+          <div class="callout">
+            <p>
+              These are the hooks thurbox installs
+              <em>into</em>
+              the agents. The other direction &mdash; your own commands that thurbox runs when it
+              creates, deletes, restarts or restores a session &mdash; is
+              <a href="configuration.html#hooks-toml"><code>hooks.toml</code></a>
+              (<a href="features.html#session-hooks">session lifecycle hooks</a>), a file that
+              sits beside this extension's
+              <code>hooks/</code>
+              directory and shares nothing with it but the word.
+            </p>
+          </div>
+
           <h2 id="states">
             The five states
             <a href="#states" class="heading-anchor">#</a>

--- a/website/docs/configuration.html
+++ b/website/docs/configuration.html
@@ -1,7 +1,7 @@
 ---
 layout: docs.njk
 title: 'Configuration — Thurbox Docs'
-description: 'Every config file and knob Thurbox reads: agents.toml, hosts.toml, settings.toml feature flags, themes.toml, the editable ui/ interface and ui.json, extension manifests, SQLite-backed state, and environment variables.'
+description: 'Every config file and knob Thurbox reads: agents.toml, hosts.toml, hooks.toml session lifecycle hooks, settings.toml feature flags, themes.toml, the editable ui/ interface and ui.json, extension manifests, SQLite-backed state, and environment variables.'
 currentPage: 'configuration'
 breadcrumb: 'Configuration'
 ---
@@ -74,6 +74,17 @@ breadcrumb: 'Configuration'
                 <td>you</td>
                 <td>startup</td>
                 <td>custom theme palettes</td>
+              </tr>
+              <tr>
+                <td><code>~/.config/thurbox/hooks.toml</code></td>
+                <td>TOML</td>
+                <td>you</td>
+                <td>on each session operation</td>
+                <td>
+                  <strong>session lifecycle hooks</strong>
+                  &mdash; your commands, run before/after a session is created, deleted,
+                  restarted or restored
+                </td>
               </tr>
               <tr>
                 <td><code>~/.config/thurbox/ui/</code></td>
@@ -227,6 +238,13 @@ thurbox-cli config show       # effective config + where each value came from</c
                 <td><a href="#themes-toml"><code>themes.toml</code></a></td>
               </tr>
               <tr>
+                <td>
+                  Run my own command when a session is created, deleted, restarted or restored
+                  &mdash; or refuse one
+                </td>
+                <td><a href="#hooks-toml"><code>hooks.toml</code></a></td>
+              </tr>
+              <tr>
                 <td>Rebind a key</td>
                 <td><a href="#keybindings-json"><code>keybindings.json</code> (or the F1 editor)</a></td>
               </tr>
@@ -351,6 +369,254 @@ resume_latest = false       # true = id-less "resume last session in cwd"</code>
             Auth comes entirely from your
             <code>~/.ssh/config</code>
             ; thurbox never handles credentials. Host changes require a restart.
+          </p>
+
+          <h2 id="hooks-toml">
+            hooks.toml
+            <a href="#hooks-toml" class="heading-anchor">#</a>
+          </h2>
+          <p>
+            Declares
+            <strong>session lifecycle hooks</strong>
+            : your own shell commands, run by thurbox before and after it creates, deletes,
+            restarts or restores a session. Seeded fully commented-out (a fresh install runs
+            nothing) and read
+            <strong>each time an event fires</strong>
+            , so an edit is in force at the next operation with no restart. A malformed file
+            means no hooks run, a warning in the log, and a failing
+            <code>config validate</code>
+            .
+          </p>
+          <div class="callout">
+            <p>
+              Not the
+              <code>hooks/</code>
+              <strong>directory</strong>
+              beside it. That is the home of the built-in
+              <a href="agent-hooks.html">agent hooks extension</a>
+              , which installs status-hook files
+              <em>into</em>
+              the agent CLIs so they can tell thurbox what they are doing.
+              <code>hooks.toml</code>
+              is the other direction: thurbox telling
+              <em>your</em>
+              scripts what
+              <em>it</em>
+              is doing.
+            </p>
+          </div>
+          <pre data-title="hooks.toml"><code class="language-toml">[[hooks]]
+event = "session.pre_create"
+command = 'case "$THURBOX_BRANCH" in main|master) echo "refusing: protected branch" &gt;&amp;2; exit 1;; esac'
+
+[[hooks]]
+event = "session.post_create"
+command = '[ -n "$THURBOX_CWD" ] &amp;&amp; cp -n .env.local "$THURBOX_CWD/.env"; true'
+timeout_secs = 120</code></pre>
+          <table>
+            <thead>
+              <tr>
+                <th>Field</th>
+                <th>Required</th>
+                <th>Default</th>
+                <th>Purpose</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>event</code></td>
+                <td>yes</td>
+                <td>&mdash;</td>
+                <td>one of the eight events below</td>
+              </tr>
+              <tr>
+                <td><code>command</code></td>
+                <td>yes</td>
+                <td>&mdash;</td>
+                <td>run through <code>sh -c</code> (<code>cmd /C</code> on Windows)</td>
+              </tr>
+              <tr>
+                <td><code>timeout_secs</code></td>
+                <td>no</td>
+                <td><code>30</code></td>
+                <td>the hook is killed after this long</td>
+              </tr>
+            </tbody>
+          </table>
+          <p>
+            A
+            <code>pre_*</code>
+            event fires before the operation has any side effect; a
+            <code>post_*</code>
+            event fires after it has fully succeeded, and never after a failure. Hooks fire
+            <strong>once per operation whichever interface asked</strong>
+            &mdash; the TUI,
+            <code>thurbox-cli</code>
+            , an automation, an extension &mdash; because every interface ends in the same
+            pipeline. Hooks for one event run one at a time, in file order.
+          </p>
+          <table>
+            <thead>
+              <tr>
+                <th>Operation</th>
+                <th>Events</th>
+                <th>Fired by</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>create (incl. fork)</td>
+                <td><code>session.pre_create</code> / <code>session.post_create</code></td>
+                <td>
+                  the creation flow, <code>Ctrl+F</code>, <code>thurbox-cli session create</code>,
+                  a <code>spawn</code> automation, an extension's sessions
+                </td>
+              </tr>
+              <tr>
+                <td>delete (soft or force)</td>
+                <td><code>session.pre_delete</code> / <code>session.post_delete</code></td>
+                <td>
+                  <code>Ctrl+D</code>, <code>thurbox-cli session delete [--force]</code>,
+                  extension uninstall
+                </td>
+              </tr>
+              <tr>
+                <td>restart</td>
+                <td><code>session.pre_restart</code> / <code>session.post_restart</code></td>
+                <td><code>Ctrl+R</code>, <code>thurbox-cli session restart</code></td>
+              </tr>
+              <tr>
+                <td>restore (incl. undo)</td>
+                <td><code>session.pre_restore</code> / <code>session.post_restore</code></td>
+                <td>
+                  <code>Ctrl+Z</code>/<code>Ctrl+U</code>, <code>thurbox-cli session restore</code>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <p>
+            <strong>A <code>pre_*</code> hook can refuse.</strong>
+            Exit non-zero (or exceed the timeout) and the operation is aborted before it has done
+            anything &mdash; no worktree, no process, no row changed &mdash; with the hook's
+            command, exit status and the tail of its stderr as the reported reason (the in-flight
+            error in the TUI; the error and exit status of
+            <code>thurbox-cli</code>
+            ). Later hooks for that event do not run.
+            <strong>A <code>post_*</code> hook is informational</strong>
+            : every one runs, a failure is logged to
+            <code>thurbox.log</code>
+            and carried in the CLI's JSON as
+            <code>hook_failures</code>
+            , and never fails the operation.
+          </p>
+          <p>
+            <strong>What a hook receives.</strong>
+            Environment variables &mdash;
+            <strong>unset</strong>
+            (never empty) when the fact is not known at that moment:
+          </p>
+          <table>
+            <thead>
+              <tr>
+                <th>Variable</th>
+                <th>Meaning</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>THURBOX_HOOK_EVENT</code></td>
+                <td>the event name, e.g. <code>session.post_create</code></td>
+              </tr>
+              <tr>
+                <td><code>THURBOX_SESSION</code></td>
+                <td>
+                  the thurbox session id (at <code>pre_create</code>: the id it will have if
+                  creation succeeds)
+                </td>
+              </tr>
+              <tr>
+                <td><code>THURBOX_SESSION_ID</code></td>
+                <td>the agent's own conversation id</td>
+              </tr>
+              <tr>
+                <td><code>THURBOX_SESSION_NAME</code>, <code>THURBOX_AGENT</code></td>
+                <td>the session name and its agent</td>
+              </tr>
+              <tr>
+                <td><code>THURBOX_REPO</code></td>
+                <td>the primary repository path</td>
+              </tr>
+              <tr>
+                <td><code>THURBOX_CWD</code></td>
+                <td>
+                  the directory the agent runs in (the worktree, or the symlink workspace of a
+                  multi-repo session); unset at <code>pre_create</code>
+                </td>
+              </tr>
+              <tr>
+                <td><code>THURBOX_BRANCH</code> / <code>THURBOX_BASE_BRANCH</code></td>
+                <td>the worktree branch and what it was created from (base: create events only)</td>
+              </tr>
+              <tr>
+                <td><code>THURBOX_HOST</code></td>
+                <td>the remote host name; unset for a local session</td>
+              </tr>
+              <tr>
+                <td><code>THURBOX_PARENT_SESSION</code></td>
+                <td>the parent session id (a fork, or <code>--parent</code>)</td>
+              </tr>
+              <tr>
+                <td><code>THURBOX_TASK</code></td>
+                <td>the originating task id, for a task-spawned session</td>
+              </tr>
+              <tr>
+                <td><code>THURBOX_CONFIG_DIR</code> / <code>THURBOX_DATA_DIR</code></td>
+                <td>
+                  so a <code>thurbox-cli</code> run inside the hook hits the database of the
+                  thurbox that fired it
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <p>
+            The same facts &mdash; plus
+            <code>worktrees</code>
+            (<code>repo_path</code>, <code>worktree_path</code>, <code>branch</code>),
+            <code>additional_dirs</code>
+            ,
+            <code>force</code>
+            (delete) and
+            <code>force_deleted</code>
+            (restore) &mdash; arrive as
+            <strong>one JSON object on stdin</strong>
+            (<code>jq -r .cwd</code>).
+          </p>
+          <p>
+            <strong>Where and how it runs.</strong>
+            In the primary repository when that is a directory on this machine, otherwise in
+            thurbox's own working directory &mdash; the repository is the one path that exists at
+            every event (at
+            <code>pre_create</code>
+            the worktree is not made; at
+            <code>post_delete</code>
+            it is gone). With
+            <strong>no terminal</strong>
+            : stdin is the JSON, stdout/stderr are captured and only their tail (500 chars) is
+            reported, so a hook can neither draw on nor read from the TUI's screen. A hook for a
+            <strong>remote</strong>
+            (SSH/WSL) session still runs
+            <strong>locally</strong>
+            ;
+            <code>THURBOX_HOST</code>
+            names the host and the paths are the host's &mdash;
+            <code>ssh "$THURBOX_HOST" &hellip;</code>
+            from the hook is your call.
+          </p>
+          <p>
+            <code>thurbox-cli config validate</code>
+            strict-parses the file;
+            <code>config show</code>
+            lists the hooks in force.
           </p>
 
           <h2 id="settings-toml">
@@ -891,6 +1157,17 @@ thurbox-cli extension status [&lt;name&gt;]      # per-resource presence + versi
               </tr>
             </tbody>
           </table>
+          <p>
+            Every
+            <a href="#hooks-toml">lifecycle hook</a>
+            additionally receives the
+            <code>THURBOX_*</code>
+            facts of the session it concerns (event, id, name, agent, repository, working
+            directory, branch, host, parent) and the config/data-dir overrides; the full list is
+            in the
+            <code>hooks.toml</code>
+            section above.
+          </p>
           <p>
             Editor resolution order: DB
             <code>editor_command</code>

--- a/website/docs/features.html
+++ b/website/docs/features.html
@@ -1,7 +1,7 @@
 ---
 layout: docs.njk
 title: 'Features — Thurbox Docs'
-description: 'Thurbox features: a fully customizable Lua-plugin interface (with a v1-to-v2 surface map), persistent coding-agent sessions, agent definitions, git worktrees, remote SSH sessions, automations, and a headless CLI.'
+description: 'Thurbox features: a fully customizable Lua-plugin interface (with a v1-to-v2 surface map), persistent coding-agent sessions, agent definitions, git worktrees, remote SSH sessions, session lifecycle hooks, automations, and a headless CLI.'
 currentPage: 'features'
 breadcrumb: 'Features'
 ---
@@ -611,6 +611,118 @@ ssh_opts = ["-o", "ControlMaster=auto", "-o", "ControlPersist=10m"]
               the lead). A dangling parent just renders the child as a top-level session again.
             </li>
           </ul>
+
+          <h2 id="session-hooks">
+            Session Lifecycle Hooks
+            <a href="#session-hooks" class="heading-anchor">#</a>
+          </h2>
+          <p>
+            Run your own command at the moments thurbox creates, deletes, restarts or restores a
+            session &mdash; copy an
+            <code>.env</code>
+            into a fresh worktree, warm the dependencies before the agent boots, post to a
+            channel when a session lands, refuse a session on a branch nobody should touch, clean
+            a scratch directory when one is deleted. Hooks are declared as data in
+            <a href="configuration.html#hooks-toml"><code>~/.config/thurbox/hooks.toml</code></a>
+            , one
+            <code>[[hooks]]</code>
+            entry per event and command, seeded commented-out.
+          </p>
+          <pre data-title="hooks.toml"><code class="language-toml">[[hooks]]
+event = "session.post_create"
+command = 'npm ci --prefer-offline'   # runs in the new worktree's repository; $THURBOX_CWD is the worktree
+timeout_secs = 300</code></pre>
+          <ul>
+            <li>
+              <strong>Eight events</strong>
+              , pre and post for each operation:
+              <code>session.pre_create</code>
+              /
+              <code>post_create</code>
+              ,
+              <code>pre_delete</code>
+              /
+              <code>post_delete</code>
+              ,
+              <code>pre_restart</code>
+              /
+              <code>post_restart</code>
+              ,
+              <code>pre_restore</code>
+              /
+              <code>post_restore</code>
+              . A fork is a create; an undo is a restore.
+            </li>
+            <li>
+              <strong>Pre hooks veto, post hooks inform</strong>
+              &mdash; git's
+              <code>pre-commit</code>
+              model. A
+              <code>pre_*</code>
+              hook that exits non-zero (or hangs past its timeout, default 30&nbsp;s) aborts the
+              operation before its first side effect, with its stderr as the reason shown in the
+              TUI or returned by the CLI. A
+              <code>post_*</code>
+              hook fires only after full success; every one runs, and a failure is logged and
+              reported but cannot undo what happened.
+            </li>
+            <li>
+              <strong>Once per operation, whichever interface asked.</strong>
+              The creation flow,
+              <code>Ctrl+F</code>
+              ,
+              <code>Ctrl+D</code>
+              ,
+              <code>Ctrl+R</code>
+              , undo,
+              <code>thurbox-cli</code>
+              , a
+              <code>spawn</code>
+              automation and an extension's sessions all end in the same four pipelines, so a
+              hook fires exactly once for each of them and never on the render thread.
+            </li>
+            <li>
+              <strong>The session's facts, two ways.</strong>
+              <code>THURBOX_*</code>
+              environment variables for a one-liner (
+              <code>THURBOX_HOOK_EVENT</code>
+              ,
+              <code>THURBOX_SESSION</code>
+              ,
+              <code>THURBOX_SESSION_NAME</code>
+              ,
+              <code>THURBOX_AGENT</code>
+              ,
+              <code>THURBOX_REPO</code>
+              ,
+              <code>THURBOX_CWD</code>
+              ,
+              <code>THURBOX_BRANCH</code>
+              ,
+              <code>THURBOX_HOST</code>
+              , &hellip;) and one JSON object on stdin for anything structured. A
+              <code>thurbox-cli</code>
+              call inside a hook hits the same database as the thurbox that fired it.
+            </li>
+            <li>
+              Runs in the session's primary repository with
+              <strong>no terminal</strong>
+              (output is captured, only its tail reported), and
+              <strong>locally</strong>
+              even for a remote session &mdash;
+              <code>THURBOX_HOST</code>
+              says where the session actually is.
+            </li>
+          </ul>
+          <p>
+            This is the reverse of the built-in
+            <a href="agent-hooks.html">agent hooks</a>
+            extension, which installs status hooks
+            <em>into</em>
+            the agent CLIs so they can report to thurbox. Full reference:
+            <a href="configuration.html#hooks-toml">configuration &rarr; hooks.toml</a>
+            .
+          </p>
 
           <h2 id="inter-session-messages">
             Inter-Session Messages

--- a/website/llms.txt
+++ b/website/llms.txt
@@ -35,7 +35,9 @@
 > session list included — is a file the user can move, turn off, delete,
 > rewrite, or install from someone else, with no recompile and no restart. The
 > arrangement (`ui/layout.lua`), agents (`agents.toml`), hosts (`hosts.toml`),
-> themes, keybindings and settings are all data files. Because the interface is
+> session lifecycle hooks (`hooks.toml` — your commands run before/after a
+> session is created, deleted, restarted or restored), themes, keybindings and
+> settings are all data files. Because the interface is
 > plain text in a directory, the usual way to change it is to ask a coding
 > session for the change in English — thurbox ships a built-in `ui-skill`
 > extension that teaches whichever CLI is running how the interface is put
@@ -51,12 +53,12 @@
 - [Documentation hub](https://thurbox.thurbeen.eu/docs/index.html): entry point to all Thurbox documentation.
 - [Tutorial](https://thurbox.thurbeen.eu/docs/tutorial.html): onboarding walkthrough with screenshots — adding a repository to the picker, creating a first session on its own git worktree, the everyday keybindings, and the equivalent thurbox-cli commands.
 - [FAQ](https://thurbox.thurbeen.eu/docs/faq.html): short answers to the most common questions (what it is, how it differs, install, platforms, license).
-- [Features](https://thurbox.thurbeen.eu/docs/features.html): the customizable interface and a full v1-to-v2 surface map, plus sessions, agent definitions, git worktrees, remote SSH and WSL hosts, automations, tasks, global search, headless CLI.
+- [Features](https://thurbox.thurbeen.eu/docs/features.html): the customizable interface and a full v1-to-v2 surface map, plus sessions, agent definitions, git worktrees, remote SSH and WSL hosts, session lifecycle hooks, automations, tasks, global search, headless CLI.
 - [Built-in agents](https://thurbox.thurbeen.eu/docs/agents.html): every built-in coding agent (claude, codex, antigravity, opencode, aider, copilot, vibe, pi, omp) with its recommended agents.toml config, resume/fork behavior, and status support.
 - [Comparison](https://thurbox.thurbeen.eu/docs/comparison.html): how Thurbox compares to Conductor, Claude Squad, Cursor, and other parallel coding-agent tools.
 - [Installation](https://thurbox.thurbeen.eu/docs/installation.html): install via curl, Homebrew, AUR, winget, Chocolatey, or from source; prerequisites; running it; how to pin a specific version.
 - [Orchestration](https://thurbox.thurbeen.eu/docs/orchestration.html): asking an agent to spin up a fleet with thurbox-cli, and the control-plane pattern for running agents across many repos.
-- [Configuration](https://thurbox.thurbeen.eu/docs/configuration.html): every config file and knob — agents.toml, hosts.toml, settings.toml, themes, keybindings.
+- [Configuration](https://thurbox.thurbeen.eu/docs/configuration.html): every config file and knob — agents.toml, hosts.toml, hooks.toml (session lifecycle hooks), settings.toml, themes, keybindings.
 - [Deprecated surfaces](https://thurbox.thurbeen.eu/docs/deprecated.html): the six panes 1.x had that the current interface does not — code review and the info panel, now the installable thurbox-code-review and thurbox-info-panel plugins; the file viewer, with no replacement; and the tasks/automations/restore panes that moved to thurbox-cli.
 - [Using v1](https://thurbox.thurbeen.eu/docs/v1.html): thurbox 1.x is still maintained — what it has that the current interface does not, how to stay on it or go back, and what it will receive.
 - [The Interface](https://thurbox.thurbeen.eu/docs/v2-interface.html): every pane is an editable Lua plugin — how to move, disable, replace or write one, how to have a coding agent do it for you, what the kernel refuses a plugin, and the two v1 panes (thurbox-code-review, thurbox-info-panel) you install as plugins.


### PR DESCRIPTION
## Summary
- New `~/.config/thurbox/hooks.toml` (seeded commented-out): `[[hooks]] { event, command, timeout_secs }` for eight events — `session.{pre,post}_{create,delete,restart,restore}`.
- `pre_*` hooks can veto (non-zero exit / timeout aborts the operation before its first side effect, stderr tail is the reason); `post_*` hooks are informational (all run, failures logged and returned as `hook_failures`).
- Hooks fire once per operation for every caller (TUI, `thurbox-cli`, automations, extensions) because they sit inside the four `session_ops` pipelines everything already goes through; nothing in the kernel or Lua knows hooks exist.
- A hook gets the session's facts as `THURBOX_*` env vars and as one JSON object on stdin, inherits the config/data-dir overrides (an inner `thurbox-cli` hits the same DB), runs in the primary repo with no terminal, killed at its timeout (default 30 s).
- `SpawnPhase::Hooks` names the phase in the placeholder row; `config validate`/`show` cover the file; CLI JSON carries `hook_failures`.
- Fix along the way: `thurbox-cli session restore` now runs the shared restore pipeline (worktrees + agent) instead of clearing the row's flag alone.
- OpenSpec change `session-lifecycle-hooks` archived; new main spec `openspec/specs/session-hooks`.

## Test plan
- [x] Unit tests: `session::hook_def`, `agent::hooks_config`, `session_ops::lifecycle_hooks` (env/JSON convention, seed, malformed file degrade, exit-code/stderr reporting, timeout kill, chatty-hook drain, grandchild not holding the run, pre stops at first failure, post runs all)
- [x] `tests/create_e2e.rs`: pre→post pair with the real facts, hook's `thurbox-cli` finds the row, veto leaves no worktree/window/row and surfaces through the command bus, post failure leaves the session running, delete/restart/restore pairs fire once, pre-delete veto refused
- [x] `cargo nextest run --all` — 2016 passed; clippy `-D warnings`, rustdoc, fmt, selene, stylua, rumdl clean

https://claude.ai/code/session_016PdYx2ZQ3cPDAt5ReBaxcQ