### PR TITLE
feat(ui): plugin events and a command palette

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -926,6 +926,7 @@ loads, `check` loads the interface the way `thurbox` does and exits non-zero on
 a failure — **including on a pane that loaded but which no arrangement places**,
 printing the `layout.lua` line to add — `list` is the same inventory the settings
 modal's Interface tab shows, and
+`events` lists every event a plugin may subscribe to with its payload, and
 `install|sync|update|remove|available` manage panes from a declarative spec
 — see `docs/PLUGINS.md`).
 Output is
@@ -1682,7 +1683,10 @@ already follow.
 - **`kernel/`** — the interface. `node` (four primitives), `layout` (rects before
   render), `convert` (Lua table ↔ node), `paint` (node → ratatui), `host` (the VM,
   reload, isolation, capability grants), `registry` (keys + settings plugins
-  declare), `modals/` (help, settings, theme picker — chrome about thurbox itself,
+  declare, plus the chord-less commands the palette lists), `events` (the
+  closed set a plugin may subscribe to, and the deriver that diffs a snapshot
+  into them), `modals/` (help, settings, theme picker, the command palette —
+  chrome about thurbox itself,
   which plugins contribute *data* to rather than replace), `bands` (the top/bottom
   bars), `snapshot` (the read side), `command` (the write side), `terminal/` (live
   PTY surfaces: the attach machinery, plugin program panes, link detection +
@@ -1712,8 +1716,9 @@ already follow.
   one flat surface; no caller names a submodule.
 - **`coordinator/`** — `main`'s own body. `App` and its state stay in
   `main.rs`; its behaviour is here, grouped by what it is for: the loop and its
-  workers (`mod`), then `commands`, `publish`, `draw`, `input`, `mouse`, `focus`
-  and `interface` — plus `boot` (the startup sequence `main` delegates to),
+  workers (`mod`), then `commands`, `publish`, `draw`, `input`, `mouse`, `focus`,
+  `events` (the one dispatch point, and the kernel events derived from the
+  loop's own signals) and `interface` — plus `boot` (the startup sequence `main` delegates to),
   `chrome` (the terminal/error-panel/perf-HUD helpers) and `editor` (the
   `Ctrl+O` command resolution). Still one model and one loop — splitting `App`
   itself is what ADR-22 rejected, and the invariants that matter hold *across*
@@ -1724,7 +1729,7 @@ already follow.
   `order` and `session_model` (the session list's model, with its memo),
   `pathpicker` and `repo_picker` (the creation flow's); `plugins/` holds the
   panes.
-- **`cli/`** — `thurbox-cli` subcommands, including `plugin dir|new|check|list|install|sync|update|remove`
+- **`cli/`** — `thurbox-cli` subcommands, including `plugin dir|new|check|list|events|install|sync|update|remove`
   for writing an interface with no TTY.
 
 ### Event Loop (`src/main.rs` + `src/coordinator/`)
@@ -1735,6 +1740,7 @@ tokio::main → load config + settings → heal extensions → arm the heartbeat
   → resolve ui/ → build the Lua host → open SQLite → init terminal → loop {
     resolve layout → call each plugin with its rect → paint
     → poll workers (terminals, commands, diffs, metrics, repos, runs, updates)
+    → dispatch events to the plugins subscribed to them (kernel::events)
     → drain Lua's command queue → dispatch keys through the registry
 } → restore terminal
 ```
@@ -1795,6 +1801,7 @@ Global chords (kernel-owned):
 | `Ctrl+J` / `Ctrl+K` | Select next / previous session |
 | `Ctrl+,` / `F6` | Settings (`]` for the Interface tab) |
 | `Ctrl+Y` / `F4` | Theme picker |
+| `Ctrl+P` | Command palette — every action, filtered as you type |
 | `F1` / `Ctrl+G` | Keybindings help |
 | `F10` | Reload the interface from disk |
 | `F12` | Perf HUD |
@@ -1974,7 +1981,7 @@ panel, no capabilities — everything from the snapshot). Neither is bundled or
 vendored; both are downstream consumers of the published `thurbox.*` shape.
 
 Two **example** panes live in `ui-plugins/` (`tasks`, `top`) and install by bare
-name; `docs/examples/{plugin,composite,layout}.lua` are copied by hand. They are
+name; `docs/examples/{plugin,composite,events,layout}.lua` are copied by hand. They are
 examples to read and copy from, not a catalogue thurbox maintains for anyone —
 `EXAMPLE_PLUGINS` is the list a bare name and a typo suggestion resolve against.
 `check` fails on a pane that **loaded but which no arrangement places** — the only
@@ -2104,6 +2111,31 @@ capabilities). The implementation itself is held in the VM's **registry**, never
 globals, because a plugin chunk's `_ENV` *is* the globals table — it sat there as
 `__run_impl` once, which handed every untrusted plugin the capability under a second
 name.
+
+**A plugin can react to events** (`kernel::events`, `coordinator::events`).
+Declare `events = { "session.status", … }` and an `on_event(name, payload)`, and
+the loop calls it once per change, off the render path, under the render's
+budget. The kernel's events are **derived by diffing the snapshot** — a row
+appearing, leaving, changing status/name/branch/repos/parent — plus the focus
+ring, the command bus (`command.done`/`failed`, and `session.post_*` for the
+four operations *this* interface performed, named as `hooks.toml` names them) and
+`interface.reloaded`; never raised from `session_ops`, so a session another
+process made fires the same event. The set is closed (`KERNEL_EVENTS`): a
+subscription to an unknown name refuses to load, and the same table renders in
+`F1` and `thurbox-cli plugin events`. `command("emit", { text = name, … })`
+delivers `user.<name>` to other plugins with `source` stamped by the kernel;
+cascades stop at `MAX_DEPTH`. Dispatch never marks the frame dirty itself
+(`frame-cost`); a reload drops the queue and delivers `interface.reloaded` first.
+`docs/examples/events.lua` is the worked example.
+
+**A plugin can declare chord-less commands** — `commands = { { action, desc } }`
+— which the **command palette** (`Ctrl+P`, `kernel::modals::palette`) lists
+beside every declared key and the kernel's own actions, filtered by subsequence
+as you type; `Enter` runs the row through the same `on_action` a key takes,
+focused or not, after the modal has closed. A command a user rebinds from `F1`
+becomes a binding (`Registry::apply_overrides` synthesises it). `Ctrl+P` was
+taken deliberately from the chords held for v1's panes (`tests/v2_keymap.rs`),
+and the creation flow's folder import moved to `Alt+P` for it.
 
 - `docs/V2-KERNEL.md` — the kernel's shape, its five rules, and the traps
 - `docs/PLUGINS.md` — writing a plugin; **Start here** needs no TTY, and **Traps**

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ or owed.
 | CPU / RAM gauges | — | installable | `thurbox-cli plugin install top` |
 | Panes anyone else wrote | — | installable | `ui/plugins.toml` |
 | Tasks | `Ctrl+W` / `F5` | CLI only | `thurbox-cli task` |
-| Automations | `Ctrl+P` | CLI only | `thurbox-cli automation` |
+| Automations | — | CLI only | `thurbox-cli automation` |
 | File viewer | `Ctrl+E` / `F3` | owed | — |
 
 **Bundled** means it ships with thurbox and is yours to edit, move or delete —
@@ -994,6 +994,7 @@ cannot drift from what is running.
 | `F1` / `Ctrl+G` | Keybindings help | kernel |
 | `F6` / `Ctrl+,` | Settings (`]` for the Interface tab) | kernel |
 | `F4` / `Ctrl+Y` | Theme picker | kernel |
+| `Ctrl+P` | Command palette — every action, filtered as you type | kernel |
 | `F10` | Reload the interface from disk | kernel |
 | `F12` | Perf HUD | kernel |
 | `Ctrl+N` | New session | `70_new_session.lua` |
@@ -1015,7 +1016,7 @@ cannot drift from what is running.
 
 Gone with the panes they opened: `Ctrl+X`/`F7` (code review), `Ctrl+E`/`F3`
 (file viewer), `Ctrl+B`/`F2` (info panel), `F5` (tasks) and `Ctrl+P`
-(automations — now the creation flow's folder import). Two of them come back
+(automations — now the command palette, which is the way into any pane). Two of them come back
 with a pane you install:
 [`thurbox-code-review`](https://github.com/Thurbeen/thurbox-code-review) claims
 `Ctrl+X`/`F7` again, and

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -262,7 +262,10 @@ tail of its stderr as the reported reason (the in-flight error in the
 TUI, the error and exit status of `thurbox-cli`). Later hooks for that
 event do not run. **A `post_*` hook is informational**: every one runs,
 a failure is logged to `thurbox.log` and carried in the CLI's JSON
-(`hook_failures`), and never fails the operation.
+(`hook_failures`), and never fails the operation. Each `post_*` is also
+delivered to interface plugins as an event of the same name (`events = {
+"session.post_create" }` + `on_event`; `docs/PLUGINS.md` → Events) — the
+Lua side of the same vocabulary, informational for the same reason.
 
 **What a hook receives.** Environment variables — **unset** (never
 empty) when the fact is not known at that moment:

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -221,7 +221,7 @@ not applicable.
    a remote host the repo picker shows the repos previously used *on
    that host* (bookmarks are host-scoped, schema v39) and every remote
    filesystem touch — the path browser's listings, Enter validation,
-   `Ctrl+P` parent scans — runs on a worker, never blocking the UI on
+   `Alt+P` parent scans — runs on a worker, never blocking the UI on
    an ssh round trip; the worktree + tmux window are created on that
    host over SSH.
 2. **Repo picker** — fuzzy-searchable list of bookmarked repo
@@ -459,7 +459,7 @@ applicable: `h/j/k/l` for navigation, semantic letters for actions
 | `Ctrl+N` | Global | New session (opens repo picker) | **N**ew |
 | `Ctrl+C` | Terminal | Copy selection, or send SIGINT if none | **C**opy |
 | `Ctrl+V` | Terminal | Paste from clipboard into PTY | Paste |
-| `Ctrl+P` | Global | Automations (scheduled agent runs) | **P**rogram |
+| `Ctrl+P` | Global | Command palette — every action, filtered as you type | **P**alette |
 | `Ctrl+W` / `F5` | Global | Toggle tasks panel (todo list) | Work items |
 | `Ctrl+/` | Global | Global search across every scope | **/** = search |
 | `Ctrl+T` / `F8` | Global | Toggle shell pane alongside the agent session | **T**erminal |
@@ -503,7 +503,7 @@ applicable: `h/j/k/l` for navigation, semantic letters for actions
 | `↑`/`↓` | Repo picker browser | Move the dropdown selection | |
 | `Enter` | Repo picker browser | Descend into a dir / pick a git repo | |
 | `Esc` | Repo picker browser | Close the dropdown (modal stays open) | |
-| `Ctrl+P` | Repo picker | Import typed path as a parent folder (local + remote) | |
+| `Alt+P` | Repo picker | Import typed path as a parent folder (local + remote) | |
 | `Enter` | Repo picker | Confirm selection | |
 | `Esc` | Repo picker | Cancel | |
 | `Shift+Up` | Focused terminal | Scroll up 1 line | |
@@ -653,6 +653,12 @@ and — for a remote session — runs *locally*, told the host by
 Deliberately not the same thing as the built-in `hooks` *extension*
 (`<config>/hooks/`), which is the reverse direction: files thurbox
 installs into the agent CLIs so they can report status.
+
+The four `post_*` events are also delivered to interface plugins under the
+same names (`events = { "session.post_create" }` + `on_event`, see
+`docs/PLUGINS.md` → Events), so a shell hook and a Lua handler learn one
+vocabulary. A `pre_*` hook has no Lua form: a plugin cannot answer, so it
+cannot veto.
 
 ### Why UUID v4?
 
@@ -954,7 +960,8 @@ each part. `CLAUDE.md` keeps a summary and points here.
 > working. Author and inspect them with `thurbox-cli automation`. The keeper's 60 s
 > cadence is the current resolution; a ~1 s in-TUI pass is owed.
 
-`Ctrl+P` opens the automations list. An **automation** is a named,
+In 1.x, `Ctrl+P` opened the automations list (the chord is the command
+palette now). An **automation** is a named,
 enable/disable-able task that fires on a schedule (one-shot or
 recurring) and, when it fires, either pastes a prompt into an
 existing session (**send**) or spawns a new session — optionally on
@@ -1079,9 +1086,9 @@ is the usual `SessionList → Terminal` (+ file viewer). Switching
 *between* the two contexts is done with `j`/`k` in the left column,
 not the focus cycle.
 
-### Ctrl+P list + editor
+### List + editor (1.x)
 
-`Ctrl+P` opens the same set over the full list (a modal, available
+`Ctrl+P` opened the same set over the full list (a modal, available
 at any width). Keys: `n` new, `e`/`Enter` edit, `Space` toggle
 enabled, `r` run-now, `d` delete, `Esc` close.
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -666,7 +666,7 @@ strand a placeholder row forever).
 *Extension (repo-picker path entry).* The picker itself later gained the same
 treatment: its three remote round trips — the path-browser directory listing
 (Tab), the Enter-commit path check (exists + git-ness, one trip), and the
-`Ctrl+P` parent scan — each run on a `BackgroundTask` worker drained by
+`Alt+P` parent scan — each run on a `BackgroundTask` worker drained by
 `App::poll_repo_picker` in `tick_core` (`src/app/repo_picker.rs`), replacing
 the synchronous `list_dir_on` probes that ran in the key handler. The modal
 stays fully interactive while a fetch is in flight (spinner rows/labels);

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -180,6 +180,16 @@ Every letter your pane declares is a letter somebody will type into a search box
 The flow's `j` moves the list in one focus and types a `j` in another for exactly
 this reason.
 
+**A handler that writes `state` on every event repaints on every event.** Right
+when the event matters and waste when it does not: check the payload first and
+write only what changed. A write that stores the value already there costs
+nothing, but a counter that always moves invalidates every pure pane.
+
+**`session.status` fires for the kernel's own derivations too.** A `working`
+session that goes quiet for ten seconds reads `idle` (the stuck-working
+fallback) and `working` again when it prints; a handler reacting to
+`to == "working"` sees both edges.
+
 ## Making a pane fast
 
 The trap above says when `pure` is wrong; this is the positive half — the
@@ -471,6 +481,74 @@ user who rebinds you onto `f7` gets the action back in the terminal.
 
 `on_key(key)` still exists for panes that need every keystroke — the terminal
 uses it, alongside `input = "session"` to forward what it does not handle.
+
+## Events: be told, rather than look
+
+```lua
+events = { "session.status", "focus.session" },
+
+on_event = function(name, payload)
+  if name == "session.status" and payload.to == "blocked" then
+    store.focus_session = payload.session
+  end
+end,
+```
+
+A pane used to learn that the world changed only by being rendered and diffing
+the snapshot itself. Declare what you listen for and the kernel calls you **once
+per change**, off the render path, with the tables current: a session appeared,
+disappeared, changed status, name or branch; the selection or the focused pane
+moved; a command a plugin issued finished or failed; the interface reloaded. The
+whole list, with each payload, is `thurbox-cli plugin events` and the last
+section of `F1`.
+
+The kernel **derives** these by diffing the snapshot, so a session made by
+`thurbox-cli`, a cron tick or a second thurbox fires the same `session.created`
+as one the creation flow made. The four `session.post_*` names are the exception
+and the reason there are two spellings: they fire only for an operation *this*
+interface performed, with that operation's facts, and share their names with
+`hooks.toml` so shell and Lua learn one vocabulary. Subscribe to
+`session.created` to hear about every session; to `session.post_create` to hear
+about the one you asked for.
+
+A handler gets exactly what a render gets — the published tables, `state`,
+`store`, `command` — and its return value is ignored: it cannot answer, block or
+veto, only write state and enqueue. It runs under the render's instruction
+budget, and one that throws costs its own subscription for that event: the other
+subscribers still run, your pane still draws, and the failure is reported once
+per event in the message band rather than painted into your rect every frame.
+
+**A subscription to a name nothing emits refuses to load** (`plugin check` says
+which), because a handler that never fires is the one failure with no symptom.
+
+**Plugins can talk to each other.** `command("emit", { text = "refresh", scope =
+"x" })` reaches every plugin subscribed to `user.refresh` on the next iteration,
+with the other fields as the payload and `payload.source` set to your name — by
+the kernel, so nobody can forge it. A kernel name cannot be emitted. Emits may
+cascade (a handler emitting to a handler) four generations deep per dispatch;
+the fifth is dropped and reported, so two plugins cannot pin the loop between
+them.
+
+`docs/examples/events.lua` is the worked example: it selects the session that
+just went `blocked`, unless you moved the selection yourself in the last few
+seconds.
+
+## The palette: an action without a chord
+
+```lua
+commands = {
+  { action = "mine.export", desc = "export the list" },
+},
+```
+
+`Ctrl+P` opens the command palette — every plugin's declared keys, every
+`commands` entry, and the kernel's own modals, reload and quit — filtered as you
+type, with the chord beside each row that has one. `Enter` runs the chosen row
+through the same `on_action` a key press takes, **whether or not your pane is
+focused**, so an action must not assume it is (the bundled panes key off `state`
+and `store.selected`, never on focus). A command and a key for one action are
+one row; a user may later bind a chord to a command from `F1`, at which point it
+is a key like any other.
 
 ## Clicks: give the node an identity
 
@@ -902,6 +980,7 @@ below.
 |---|---|
 | [`plugin.lua`](examples/plugin.lua) | what `plugin new` writes: a pane, a key, a setting |
 | [`composite.lua`](examples/composite.lua) | the worked `run` example — git status and log, on the session's own host |
+| [`events.lua`](examples/events.lua) | the worked `on_event` example — selects a session the moment it blocks, with a palette command to switch it off |
 | [`layout.lua`](examples/layout.lua) | an arrangement putting the two panes above in a column beside the agent |
 
 Together they are one demo:

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -99,7 +99,7 @@ The footer names the rest of what this step does, all on the list:
 | `w` | give the selected repository its own **worktree** |
 | `/` | filter a long list |
 | `d` | forget a remembered repository |
-| `Ctrl+P` | import a **folder of repositories** at once — type a parent path, press `Ctrl+P`, and every git subdirectory is added under one header |
+| `Alt+P` | import a **folder of repositories** at once — type a parent path, press `Alt+P`, and every git subdirectory is added under one header |
 | `Tab` | move between the list and the path field |
 
 ## 3. Give the session its own worktree

--- a/docs/V2-KERNEL.md
+++ b/docs/V2-KERNEL.md
@@ -51,8 +51,9 @@ clone — `docs/PLUGINS.md` has the commands and what the two demonstrate.
    convert   table <-> node              lib/widgets   list, gauge, panel…
    paint     node -> ratatui             lib/tree      decoration helper
    host      VM, reload, isolation       plugins/*     3 panes + 3 floats
-   registry  keys + settings
-   modals    help, settings, theme, files
+   registry  keys, settings, commands
+   modals    help, settings, theme, files, palette
+   events    derived from the snapshot
    snapshot  the read side
    command   the write side
    config    the user's settings, live and restart-only
@@ -149,6 +150,34 @@ The cost, accepted: a plugin must handle the absence, exactly as it handles a
 session having no worktree. `docs/examples/composite.lua` shows the shape — draw
 what is missing, not a blank pane.
 
+## Events are derived, never raised
+
+A plugin can declare `events = { … }` and an `on_event(name, payload)`, and the
+loop calls it once per change (`kernel::events`, `coordinator::events`). The
+kernel's own events come from **diffing published state** — the snapshot's rows
+between two versions, the focus ring between two iterations, the command bus's
+completions — never from the code that mutates it. Raising them from
+`session_ops` was the obvious design and the wrong one: it misses every other
+process (`thurbox-cli`, the cron tick, a second interface), it puts a kernel
+concern inside a layer the kernel may not `use`, and it is the model where one
+mutation site forgets to fire. The four `session.post_*` names are the only ones
+raised rather than derived — from a *tracked* command finishing — which is why
+they carry the operation's facts and fire only for this interface's own work.
+
+One dispatch point per iteration, after the stores and the bus have published
+and before the paint, so a handler's writes land in the frame about to be
+painted. It is a `VecDeque::is_empty` on every quiet iteration and never marks
+the frame dirty itself: a handler's `state` write bumps the state version and
+its commands go through `dispatch_tracked`, both of which already do
+(`frame-cost`). Emits from handlers are applied inside the same dispatch, which
+is what makes the cascade bound (`MAX_DEPTH`) a bound rather than a
+per-iteration trickle. A reload clears the queue, resets the deriver so the next
+snapshot seeds silently, and puts `interface.reloaded` first.
+
+The set is closed (`KERNEL_EVENTS`) with three readers — the loader, help and
+`thurbox-cli plugin events` — so a name a plugin may subscribe to is always one
+the kernel emits.
+
 ## Drawn is not the same as focusable
 
 A `switch` slot draws one occupant, so an alternate is not on screen — but
@@ -213,7 +242,11 @@ other. Modularity moved one level down — plugins contribute **data**
 (`Registry::bindings` → help, `Registry::settings` → settings) and the kernel
 renders it, so declaring one table field is enough to appear in either. The
 theme picker takes no contribution at all: there is nothing a plugin could add
-to a list of palettes.
+to a list of palettes. The **command palette** (`Ctrl+P`,
+`kernel::modals::palette`) is the fourth, and contributes in the other
+direction: it lists the registry — keys, chord-less `commands` declarations, the
+kernel's own — and `Enter` hands the loop a `Dispatch` that runs through the
+same `on_action` a key press takes, after the modal has closed itself.
 
 The **file list** — settings' Interface tab (`kernel::modals::interface`) — is here
 for a second reason on top of those three. It is the recovery tool: it is where a

--- a/docs/examples/events.lua
+++ b/docs/examples/events.lua
@@ -1,0 +1,82 @@
+-- Bring a session forward the moment it needs you.
+--
+-- The first example that REACTS rather than draws. It occupies no slot and
+-- paints nothing; it subscribes to two events — `session.status`, to notice a
+-- session going `blocked`, and `focus.session`, to notice you moving — and when
+-- a session blocks while you have not moved the selection for a few seconds,
+-- that session becomes the selected one, exactly as `thurbox-cli session focus`
+-- would select it.
+--
+-- Two things worth copying. It never steals focus from a person: a selection
+-- moved less than `GRACE_MS` ago is a person's, and the event is let go. And it
+-- can be switched off without a reload — a palette command (`Ctrl+P`, then
+-- "attend") flips the declared setting, which the settings modal then shows
+-- correctly, because the value has exactly one home.
+--
+-- To use it, copy it into your interface directory (`thurbox-cli plugin dir`).
+-- It needs no trust: it reads the snapshot and issues commands, like every
+-- other plugin. `thurbox-cli plugin events` lists what else it could listen for.
+
+local settings = require("lib.settings")
+
+local NAME = "attend"
+
+--- How long after you moved the selection a blocked session waits its turn.
+local GRACE_MS = 5000
+
+local function enabled()
+  return settings.enabled(NAME, "enabled", true)
+end
+
+return {
+  name = NAME,
+  -- Declared floating and never returning a float node: a plugin that draws
+  -- nothing still has to say where it would draw, and a float occupies no slot —
+  -- so `plugin check` does not ask the arrangement to place it.
+  floats = true,
+  events = { "session.status", "focus.session" },
+  settings = {
+    { id = "enabled", desc = "select a session when it needs you", default = true },
+  },
+  commands = {
+    { action = "attend.toggle", desc = "toggle selecting a session when it needs you" },
+  },
+
+  on_event = function(name, payload)
+    -- A plugin has no clock; the snapshot's own instant is the nearest thing,
+    -- and it is current to within one refresh.
+    local now = (thurbox and thurbox.taken_at_ms) or 0
+    if name == "focus.session" then
+      -- The selection this plugin just asked for arrives back as an event too;
+      -- only a move it did not make counts as the person's.
+      if state.asked == payload.to then
+        state.asked = nil
+      else
+        state.moved_at = now
+      end
+      return
+    end
+    if payload.to ~= "blocked" or not enabled() then
+      return
+    end
+    if state.moved_at and now - state.moved_at < GRACE_MS then
+      return
+    end
+    state.asked = payload.session
+    -- The same request a clicked notification leaves: the session list owns the
+    -- selection and consumes this on its next frame.
+    store.focus_session = payload.session
+  end,
+
+  on_action = function(action)
+    if action ~= "attend.toggle" then
+      return false
+    end
+    command("set", { text = NAME .. ".enabled", flag = not enabled() })
+    return true
+  end,
+
+  render = function()
+    return { type = "text", text = "" }
+  end,
+}

--- a/extensions/ui-skill/SKILL.md
+++ b/extensions/ui-skill/SKILL.md
@@ -116,6 +116,13 @@ functions. Injected globals: `thurbox` (the snapshot — `.sessions`, `.settings
 `.granted`, …), `command(name, args)`, `store`, `state`, `require` (for `lib/`
 only), `files`, and `run(key, cmd, opts)` when the user has trusted the file.
 
+A plugin may also **react**: declare `events = { "session.status", … }` with an
+`on_event(name, payload)` handler and the kernel calls it once per change
+(`thurbox-cli plugin events` lists them with their payloads; an unknown name
+refuses to load). `commands = { { action, desc } }` puts an action in the
+`Ctrl+P` palette with no chord, run through the same `on_action` as a key.
+`command("emit", { text = "x", … })` reaches other plugins as `user.x`.
+
 **Deliberately absent**: `os`, `io`, `debug`, `package`, `print`, `dofile`,
 `load`, `loadstring`, and `require` of anything outside `lib/`. They are not
 blocked, they are *missing* — `os.time()` is `attempt to index a nil value`, not

--- a/openspec/changes/archive/2026-08-26-plugin-events-and-command-palette/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-26-plugin-events-and-command-palette/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-26

--- a/openspec/changes/archive/2026-08-26-plugin-events-and-command-palette/design.md
+++ b/openspec/changes/archive/2026-08-26-plugin-events-and-command-palette/design.md
@@ -1,0 +1,180 @@
+## Context
+
+See `proposal.md` — Why. The constraints that shape the approach:
+
+- The loop is demand-driven (`docs/PERFORMANCE.md`): `republish` runs once per
+  painted frame and once per input batch, every published group is gated on a
+  change signal, and a `pure` pane's tree is reused until `state`/`store` or a
+  published source moves. Anything added to an iteration must settle to zero
+  when nothing happens.
+- One iteration is `poll_reload → apply_commands → poll_command_bus →
+  sync_terminals_and_agents → serve_worker_stores → apply_external_requests →
+  paint_if_due → drain_input` (`src/coordinator/mod.rs`). The command bus
+  reports finished commands (`report_finished_commands`) and triggers a snapshot
+  refresh; the snapshot's `version` moves only when a row actually changed.
+- A plugin has five entry points today (`render`, `on_key`, `on_click`,
+  `on_action`, `decorate`), each armed with `Budget` and each failing into a
+  `PluginError { plugin, phase }` that costs only that plugin.
+- The registry holds `Binding`s and `Setting`s collected from declaration
+  tables at load; the help and settings modals render it; `Registry::resolve`
+  turns a press into `(plugin index, action)` and `coordinator::input` hands
+  that to `host.on_action`. Kernel chords live in `modals::bindings()`.
+- `kernel` may not `use agent`; `session_ops` runs on workers. The lifecycle
+  hooks from `add-hook-mechanism` run *inside* `session_ops` on the worker and
+  are invisible to the kernel by design.
+- `ctrl+p` is asserted unbound in `tests/v2_keymap.rs::CHORDS_AWAITING_THEIR_PANE`
+  for v1's automations pane; every other `Ctrl+<letter>` a palette could
+  plausibly take is spent, and every F-key but `f11` (fullscreen in most
+  emulators) is bound or awaiting.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Events are **derived from what plugins can already read**, so a session made
+  by any process looks the same, and no mutation site anywhere has to remember
+  to fire one.
+- One dispatch point per iteration, gated on the same signals `republish` is,
+  so an idle interface runs no handler and the settle test still passes.
+- The palette **reuses the registry and the `on_action` path** whole: it adds
+  a declaration (`commands`) and a modal, not a second dispatch mechanism.
+
+**Non-Goals:**
+
+- Vetoing (`pre_*`) from Lua — a handler cannot answer, so it cannot refuse.
+- Events for agent *output* (`output_generation`) — a per-line event would
+  defeat the output frame floor; a pane that wants output reads the surface.
+- Timers, `init.lua`, key sequences, band slots, persistent `state` — each its
+  own change.
+- Palette entries for the agent's own commands or for `thurbox-cli` verbs; it
+  lists actions the *interface* can run.
+
+## Decisions
+
+**D1 — Events are derived by diffing published state, not raised by mutators.**
+`kernel::events::Deriver` keeps, per session id, the fields events are defined
+over (`status`, `name`, `branch`, `repos`, `parent`) and re-diffs only when
+`SnapshotStore::version` moved (plus the per-tick quiescence override, which
+changes a published status without a version bump — the deriver reads the
+post-override rows, which is what the pane reads too). *Alternative*: firing
+from `session_ops`. Rejected: it misses every other process (`thurbox-cli`,
+the cron tick, a second TUI), it puts a kernel concern inside the side-effect
+layer the kernel may not `use`, and it is the model that leaves a mutation
+site forgotten. The first snapshot after a load **seeds** the deriver silently
+— there is no `session.created` burst for rows that existed before the plugin
+did.
+
+**D2 — `session.post_*` comes from the command bus, not from the shell hooks.**
+When a `Create`/`Fork`/`Delete`/`Restore`/`Restart` command finishes without
+error, the coordinator queues the matching `session.post_*` with the facts
+from the finished `InFlight` plus the row. The shell hook already ran inside
+the operation on the worker, before the command could finish, so the ordering
+"shell post-hook, then Lua post-event" holds without the kernel knowing hooks
+exist. Names are shared with `hooks.toml` so a user learns one vocabulary; the
+snapshot-derived `session.created`/`deleted` remain the events that fire for
+every process.
+
+**D3 — One dispatch point, after the stores and before the paint.**
+`dispatch_events()` runs after `apply_external_requests()` and before
+`paint_if_due()`. Handlers therefore see the iteration's fresh state and their
+`state`/`store` writes land in the frame about to be painted, with no extra
+frame. Before calling any handler it runs the same `republish` an input batch
+does (tables current, once per batch, never per event). It is a no-op — a
+`VecDeque::is_empty` check — on every iteration with nothing queued, which is
+what keeps the settle test true. *Alternative*: dispatching inside `render`
+(a `ctx.events` list). Rejected: it ties delivery to whether the pane is drawn
+this frame, and a switch-slot alternate would miss every event while hidden.
+
+**D4 — Delivery order and the cascade bound.** Kernel events go on the queue in
+the order the deriver produced them (rows in published order, `deleted` before
+`created` before `status` before `changed` within one refresh), then
+`focus.*`, then `command.*`. User events emitted by a handler are appended and
+delivered in the same call, up to **depth 4**: a fifth generation is dropped
+and reported once, so a ping-pong between two plugins cannot pin the loop. A
+reload clears the queue and enqueues `interface.reloaded` first — the plugins
+that would have received the rest no longer exist.
+
+**D5 — `on_event` is a sixth entry point, with `Phase::Event`.** Same shape as
+`on_action`: `enter(plugin)`, `Budget::arm`, call, `clean_error`. A failure is
+recorded against the plugin as a render failure is, keyed `(plugin, event)` so
+a handler that throws on every `session.status` reports once per event, not
+once per frame. Subscriptions are read from `events = { … }` at load
+(`load.rs`, beside `keys`) and validated against `events::KERNEL_EVENTS`, a
+`const` table of `(name, &[payload field])` that is also what the help page and
+`thurbox-cli plugin events` render — one list, three readers. `user.<name>`
+subscriptions are validated for shape only (`user.` + a non-empty identifier).
+
+**D6 — `emit` is a `command` kind, not a new global.** `command("emit", { text
+= name, … })` follows the existing convention (`text` is the subject, other
+fields the payload), needs no `thurbox.yml` change, and is refused for a
+kernel name at parse time like any malformed command. The emitting plugin's
+name is stamped from `enter`'s current plugin, the way a program pane's owner
+is — a plugin cannot forge `source`.
+
+**D7 — The palette is a modal over the registry.** `Registry` gains
+`commands: Vec<CommandDecl { plugin, action, description }>` collected at load;
+`Registry::palette_rows()` returns bindings ∪ commands ∪ `modals::bindings()`
+de-duplicated on `(plugin, action)`, chord attached when one exists. The modal
+(`modals/palette.rs`) copies the theme picker's shape — a query, `lib.fuzzy`'s
+matcher ported to Rust once (or, cheaper, the existing Rust subsequence
+matcher the theme picker uses), a `matched/total` count, cursor addressed in
+match space so refining keeps the selection. `Enter` returns a `Dispatch {
+plugin: Option<String>, action }`; `Modals` closes itself, then the coordinator
+routes it through the same `host.on_action(index, action)` a key press uses
+(`coordinator/input.rs`), or the kernel handler for a kernel action. The
+palette never calls `resolve` — there is no chord — and never bypasses
+`Modals::toggle`'s one-open rule.
+
+**D8 — `ctrl+p`, non-passthrough, no F-key alternate.** Alternatives: `ctrl+;`
+(not deliverable on legacy terminals — only the kitty protocol separates it),
+`ctrl+space` (tmux prefix for some users, IME toggle on others), any F-key
+(all bound or awaiting except `f11`). Cost: a focused agent loses readline's
+previous-history on `ctrl+p`; up-arrow is the same thing. The reassignment is
+made in `tests/v2_keymap.rs` — `ctrl+p` leaves `CHORDS_AWAITING_THEIR_PANE`
+and joins `GLOBAL_CHORDS` as `palette.open` — so it is on the record rather
+than quiet, and the automations pane, when it returns, is reachable through
+the palette rather than by that chord.
+
+**D9 — Frame-cost contract.** Dispatch never touches `dirty`. A handler's
+`state`/`store` write bumps `StateVersion`, which already invalidates `pure`
+panes and marks the frame; `command(...)` sets dirty through the queue as it
+does from a key. So the `frame-cost` delta is satisfied by construction, and
+the existing settle test (`v2_frames`/`kernel_mvp`) gains one case: an event
+delivered to a read-only handler paints no frame.
+
+**D10 — `focus.*` from the coordinator's own two fields.** `focused_session`
+and the focus ring's current plugin are compared at the end of
+`drain_input` and after `apply_commands` (focus can move from a command);
+a change enqueues one event. No new state.
+
+## Risks / Trade-offs
+
+- [A handler on the loop thread costs a frame's worth of Lua per event] →
+  the `Budget` that bounds `render` bounds it; a storm is bounded by the
+  snapshot's own cadence (one refresh per `data_version` move, ≥ the
+  400 ms interval when nothing forces it) and by the cascade depth.
+- [A plugin reacts to `session.status` by focusing, and fights the user] →
+  documented as the pattern to guard with `store`/a setting, and the bundled
+  example (`docs/examples/events.lua`) checks `focus.session` recency before
+  moving focus. The kernel cannot police intent.
+- [Palette runs a plugin-scoped action that assumed its pane was focused] →
+  the action reads `state` the same way it does under a rebinding to a global
+  chord today; the doc says so, and the bundled panes' actions are audited
+  once for the assumption.
+- [`ctrl+p` breaks a v1 user's muscle memory for automations] → the chord
+  opens a palette in which `automations` is one query away once that pane
+  returns; recorded in the keymap ledger, not silent.
+- [Two event vocabularies for creation (`created` vs `post_create`)] →
+  deliberate and documented in one table: `post_*` = *this* interface did it
+  and has the operation's facts; `created` = it exists now, whoever did it.
+- [The deriver diffs every row on every version bump] → it is O(rows) on a
+  signal that already triggers a full republish; measured in the perf HUD
+  under `tick`, and the bar is "not visible" at 50 sessions.
+
+## Migration Plan
+
+Additive. No schema, config or capability-grant change. A plugin without
+`events`/`commands` is unaffected; `ui.json` rebindings are untouched except
+that a user who had rebound something *onto* `ctrl+p` keeps their binding (a
+user rebinding beats a default, as it does for every chord). Rollback is a
+revert; nothing persists that a previous binary would misread.

--- a/openspec/changes/archive/2026-08-26-plugin-events-and-command-palette/proposal.md
+++ b/openspec/changes/archive/2026-08-26-plugin-events-and-command-palette/proposal.md
@@ -1,0 +1,96 @@
+# plugin-events-and-command-palette
+
+## Why
+
+A v2 plugin can only learn that the world changed by being rendered: there is
+no way to be told that a session was created, went `blocked`, finished a turn,
+or that focus moved — so "when any session needs me, bring it forward", the
+most thurbox-specific customisation there is, cannot be written as a pane. And
+an action a plugin declares is reachable only by its chord, in a `Ctrl+<letter>`
+namespace that readline, the agents and v1's muscle memory have already spent
+(`tests/v2_keymap.rs` holds nine chords unbound on purpose); the help modal can
+*list* an action but not run it. `hooks.toml` (session lifecycle hooks, in the
+merge queue) answers the first gap for shell scripts and not for the interface:
+nothing in the kernel or in Lua knows those hooks exist.
+
+## What Changes
+
+- **Plugins can react to events.** A plugin declares `on_event(name, payload)`
+  and the kernel calls it — off the render path, under the same instruction
+  budget as `render` — when something it already tracks changes: a session row
+  appears, disappears, changes status, name or branch; the focused session or
+  pane changes; a command the interface issued reaches a terminal phase; the
+  interface reloads. The kernel derives every event from the change signals it
+  already has (`SnapshotStore::version`, the command bus's phase transitions,
+  the focus ring) — a plugin gets a push where it used to diff the snapshot
+  itself, and gets it once per change rather than once per frame.
+- **Plugins can emit events to each other.** `command("emit", { text = name,
+  … })` publishes a user event (`user.<name>`) that every subscribed plugin
+  receives next iteration — Neovim's `User` autocmd, and a real bus where
+  `store` was a shared table nobody was told about.
+- **The eight lifecycle hooks are also events.** `session.pre_*` cannot be —
+  a plugin cannot veto, since it cannot answer — but each `session.post_*`
+  the TUI's own operations fire is delivered to Lua as the same-named event,
+  so shell and interface share one vocabulary. Operations another process
+  performed (a `thurbox-cli` create, a cron tick) still arrive, as the
+  snapshot-derived `session.created`/`session.deleted`; the two are
+  distinguishable by name and a plugin subscribes to whichever it means.
+- **A kernel-owned command palette.** `Ctrl+P` opens a modal listing every
+  action in the registry — every plugin's declared keys, the kernel's own
+  modals and reload, and a new declaration, `commands = { { id, desc } }`,
+  for actions a plugin wants reachable **without** spending a chord — filtered
+  by fuzzy match on description and id with the chord shown beside each,
+  `Enter` runs the one selected. It is chrome, like help and settings:
+  plugins contribute rows, the kernel renders and dispatches, and an action
+  runs through the same `on_action` path a key press takes, so a plugin cannot
+  tell the two apart.
+- **Events are declared, so they are listable.** The set of kernel event names
+  is a fixed enumeration the help modal shows on a page of its own, and
+  `thurbox-cli plugin check` rejects a subscription to a name the kernel does
+  not emit — a typo'd event is a lint failure, not a handler that never fires.
+- **`Ctrl+P` leaves the awaiting list.** It is held there for v1's automations
+  pane. This change reassigns it deliberately, recorded in the test rather
+  than by silent reuse: a palette is the way *into* any pane that comes back,
+  including that one.
+
+Not in scope: timers, `init.lua`, key sequences, band slots, persistent
+`state`. Each is its own change; the events bus is what they would build on.
+
+## Capabilities
+
+### New Capabilities
+
+- `plugin-events`: what a plugin can subscribe to, what it is handed, when it
+  runs, how it emits, and the bounds — a handler that throws or overruns costs
+  its subscription for that event, never the frame or another plugin.
+- `command-palette`: the palette modal — what it lists, how it filters, how it
+  dispatches, what a plugin declares to appear in it, and what it must never do
+  (run an action for a plugin that has no focus-independent handler, outrank a
+  reserved chord).
+
+### Modified Capabilities
+
+- `frame-cost`: an event dispatch that writes nothing marks nothing dirty; a
+  `pure` pane is invalidated by an event handler only through the state and
+  store writes it already keys on. Handlers run at most once per changed
+  signal, never per frame.
+
+## Impact
+
+- `src/kernel/host/` — a fifth plugin entry point (`on_event`), the `commands`
+  declaration, `emit` in the command vocabulary, event-name validation at load.
+- `src/kernel/` — a new `events` module deriving the kernel events from the
+  snapshot, the command bus and focus; `registry` gains commands beside
+  bindings; `modals/palette.rs` beside `help.rs`.
+- `src/coordinator/` — one dispatch point per iteration, after workers and the
+  command bus have published and before input is dispatched.
+- `thurbox.yml`, `.luarc.json`, `tests/kernel_mvp.rs` (the environment
+  enumeration), `tests/v2_keymap.rs` (`Ctrl+P` moves lists), new
+  `tests/v2_events.rs` and `tests/v2_palette.rs`; `docs/PLUGINS.md`,
+  `docs/V2-KERNEL.md`, `CLAUDE.md`, `ui/README.md`, the `ui-skill` `SKILL.md`.
+- `session_ops::lifecycle_hooks` (from `add-hook-mechanism`): the TUI's own
+  post-hook results are also queued as events. No behaviour change for the
+  shell hooks.
+- No schema change, no new config file, no new capability grant: events read
+  what the snapshot already publishes, and the palette runs what keys already
+  run.

--- a/openspec/changes/archive/2026-08-26-plugin-events-and-command-palette/specs/command-palette/spec.md
+++ b/openspec/changes/archive/2026-08-26-plugin-events-and-command-palette/specs/command-palette/spec.md
@@ -1,0 +1,154 @@
+## Purpose
+
+Makes every action the interface knows — a plugin's keys, its chord-less
+commands, the kernel's own — reachable by name from one searchable modal, so an
+action need not spend a chord to exist and a user need not remember one to run
+it.
+
+## ADDED Requirements
+
+### Requirement: The palette is kernel chrome, opened by one global chord
+
+The palette SHALL be a kernel-owned modal, like help and settings: not in the
+arrangement, not in the focus ring, capturing input while open, closed by
+`Esc`, one modal open at a time. It SHALL open on `ctrl+p` from every pane —
+including a focused terminal — and its chord SHALL be rebindable like any
+kernel chord.
+
+#### Scenario: Opened from a focused terminal
+
+- **WHEN** the agent pane is focused and `ctrl+p` is pressed
+- **THEN** the palette opens and the keystroke does not reach the agent
+
+#### Scenario: Another modal is open
+
+- **WHEN** help is open and `ctrl+p` is pressed
+- **THEN** help closes and the palette opens
+
+#### Scenario: Closed without choosing
+
+- **WHEN** the palette is open and `Esc` is pressed
+- **THEN** it closes, focus returns to the pane that had it, and nothing runs
+
+### Requirement: The palette lists every action in the registry
+
+The palette SHALL list, from one source, every action the registry holds: each
+plugin's declared keys, each plugin's declared chord-less commands, and the
+kernel's own actions (the modals, reload, quit). Each row SHALL show the
+action's description, its owning plugin, and its chord when it has one. A
+disabled plugin's actions are absent, exactly as its keys are.
+
+#### Scenario: A key-bound action appears
+
+- **WHEN** a plugin declares `keys = { { key = "j", action = "mine.next",
+  desc = "next item" } }`
+- **THEN** the palette lists `next item` under that plugin with `j` beside it
+
+#### Scenario: A chord-less command appears
+
+- **WHEN** a plugin declares `commands = { { action = "mine.export", desc =
+  "export the list" } }` and no key for it
+- **THEN** the palette lists `export the list` with no chord
+
+#### Scenario: A kernel action appears
+
+- **WHEN** the palette is opened
+- **THEN** reload, the settings, theme and help modals, and quit are listed
+  under the kernel with their chords
+
+#### Scenario: A disabled plugin
+
+- **WHEN** a plugin is turned off in the Interface tab
+- **THEN** none of its actions appear
+
+### Requirement: Rows filter by fuzzy match and the selection survives refining
+
+Typing SHALL filter rows by subsequence match against description, action id
+and plugin name, using the same matcher the session list and search use, with
+a live `matched/total` count; `Up`/`Down` move, `Enter` runs the selected row.
+Refining the query SHALL keep the cursor on the same action when it survives
+the filter.
+
+#### Scenario: A query narrows the list
+
+- **WHEN** `thm` is typed
+- **THEN** rows whose description, id or plugin contain `t`, `h`, `m` in order
+  remain, ranked as the shared matcher ranks them
+
+#### Scenario: The cursor survives a refinement
+
+- **WHEN** a row is selected and one more character is typed that the row
+  still matches
+- **THEN** that row stays selected
+
+#### Scenario: Nothing matches
+
+- **WHEN** the query matches no row
+- **THEN** the palette says so and `Enter` does nothing
+
+### Requirement: Running from the palette is indistinguishable from the key
+
+`Enter` SHALL dispatch the selected action exactly as its chord would: a
+plugin-scoped action reaches its plugin's `on_action` whether or not that
+plugin is focused, a kernel action runs the kernel's handler, and the palette
+closes first so the action sees the focus state it would have seen from a key
+press. A plugin SHALL NOT be able to tell a palette dispatch from a key press.
+
+#### Scenario: A plugin-scoped action from another pane
+
+- **WHEN** the session list is focused, the palette is opened and the agent
+  pane's `copy selection` is chosen
+- **THEN** the agent pane's `on_action` receives that action
+
+#### Scenario: A pane that opens its own column
+
+- **WHEN** `open search` is chosen from the palette
+- **THEN** the search strip opens and takes focus, exactly as `ctrl+/` does
+
+#### Scenario: The action fails
+
+- **WHEN** the chosen action's handler throws
+- **THEN** the error is reported as a key-press failure would be, and the
+  palette is already closed
+
+### Requirement: A chord-less command is declared as data
+
+A plugin SHALL declare chord-less commands as `commands = { { action, desc } }`
+in its declaration table, with the same `action` namespace and the same
+`on_action` handler its keys use. A command whose `action` is also bound by a
+key is one row, not two. A command may later be given a chord by the user
+through the existing rebinding surface.
+
+#### Scenario: Declared and dispatched
+
+- **WHEN** a plugin declares a command and it is chosen from the palette
+- **THEN** its `on_action` is called with that action id
+
+#### Scenario: Both a key and a command for one action
+
+- **WHEN** a plugin declares `keys` and `commands` with the same `action`
+- **THEN** the palette shows one row with the key's chord
+
+#### Scenario: A user binds a chord to a command
+
+- **WHEN** the user rebinds a chord-less command to `f7`
+- **THEN** the chord fires the action, help lists it, and the palette shows
+  `f7` beside the row
+
+### Requirement: The palette never outranks what is reserved
+
+While open the palette SHALL honour the reserved chords (`ctrl+q`, `f10`,
+`ctrl+h`/`ctrl+l`, `f12`) and SHALL NOT list `ctrl+p`'s previous owner: the
+chord is reassigned by this change and recorded as such in the keymap tests,
+not silently reused.
+
+#### Scenario: Quit from the palette
+
+- **WHEN** the palette is open and `ctrl+q` is pressed
+- **THEN** the interface quits
+
+#### Scenario: The keymap ledger
+
+- **WHEN** the keymap tests run
+- **THEN** `ctrl+p` is asserted bound to the palette and is no longer in the
+  list of chords awaiting a pane

--- a/openspec/changes/archive/2026-08-26-plugin-events-and-command-palette/specs/frame-cost/spec.md
+++ b/openspec/changes/archive/2026-08-26-plugin-events-and-command-palette/specs/frame-cost/spec.md
@@ -1,0 +1,45 @@
+## MODIFIED Requirements
+
+### Requirement: What a frame recomputes is bounded by what changed
+
+Rebuilding every published table and every pane's tree on every painted frame
+costs the same whether anything moved or not. The system SHALL rebuild a
+published group, and SHALL run a pane's render, only when something they are
+built from has changed since the last painted frame. An event handler SHALL
+run only when the signal it is derived from changed, and a handler that writes
+nothing SHALL mark nothing dirty: a `pure` pane is invalidated by a handler only
+through the `state` and `store` writes it already keys on.
+
+This is a bound on *work*, never on *freshness*: the requirements below make
+skipping unobservable, and where the two conflict, freshness wins.
+
+#### Scenario: Nothing changed between two frames
+
+- **WHEN** a frame is painted and nothing any published group is built from has
+  changed since the previous one
+- **THEN** those groups are not rebuilt
+
+#### Scenario: One source moved and the rest did not
+
+- **WHEN** a single source changes between two frames
+- **THEN** the groups built from it are rebuilt and the rest are not
+
+#### Scenario: The interface is left alone
+
+- **WHEN** an idle interface with nothing running is left untouched
+- **THEN** the frames it paints at the forced-redraw floor rebuild neither the
+  published groups nor any pane whose render may be skipped, and no event
+  handler runs
+
+#### Scenario: A handler observes without writing
+
+- **WHEN** an event is delivered to a handler that reads the payload and
+  writes neither `state` nor `store` nor enqueues a command
+- **THEN** the frame is not marked dirty by the dispatch, and every `pure`
+  pane's tree is reused
+
+#### Scenario: A handler writes state
+
+- **WHEN** a handler writes `state`
+- **THEN** the next frame is painted and the panes keyed on that state are
+  rebuilt, exactly as a key handler's write would cause

--- a/openspec/changes/archive/2026-08-26-plugin-events-and-command-palette/specs/plugin-events/spec.md
+++ b/openspec/changes/archive/2026-08-26-plugin-events-and-command-palette/specs/plugin-events/spec.md
@@ -1,0 +1,189 @@
+## Purpose
+
+Lets a plugin be told that something changed — a session appeared, changed
+status, was focused; a command finished; another plugin said something — instead
+of rediscovering it by diffing the snapshot on every render, and bounds what a
+handler can cost the interface.
+
+## ADDED Requirements
+
+### Requirement: A plugin subscribes by declaring a handler
+
+A plugin SHALL be able to declare a single `on_event(name, payload)` function
+and be called with each event it subscribes to. Subscription is declared as
+data (`events = { "session.status", "focus.session", … }`) so it is listable,
+lintable and visible in the inventory; a plugin declaring a handler with no
+`events` list receives nothing.
+
+#### Scenario: A declared subscription fires
+
+- **WHEN** a plugin declares `events = { "session.status" }` with an `on_event`
+  handler, and a session's status changes
+- **THEN** the handler is called once with `"session.status"` and a payload
+  naming the session and both statuses
+
+#### Scenario: An undeclared event does not fire
+
+- **WHEN** a plugin declares `events = { "session.status" }` and a session is
+  created
+- **THEN** its handler is not called
+
+#### Scenario: A subscription to a name the kernel does not emit
+
+- **WHEN** a plugin declares an event name that is neither a kernel event nor
+  of the `user.` form
+- **THEN** the plugin fails to load with an error naming the unknown event,
+  reported where load errors are already reported (the Interface tab, the log,
+  and `thurbox-cli plugin check`'s non-zero exit)
+
+### Requirement: The kernel emits a fixed, documented set of events
+
+The events the kernel emits SHALL be a closed enumeration, each with a
+documented payload, and that enumeration SHALL be readable from the running
+interface (the help modal) and from a terminal (`thurbox-cli plugin events`).
+At minimum:
+
+| Event | Fired when | Payload |
+|---|---|---|
+| `session.created` | a row appears in the snapshot | `session` (id), `name`, `agent`, `repo` |
+| `session.deleted` | a row leaves the snapshot | `session`, `name` |
+| `session.status` | a row's derived status changes | `session`, `from`, `to` |
+| `session.changed` | a row's name, branch, repo set or parent changes | `session`, `fields` (list) |
+| `session.post_create` / `post_delete` / `post_restart` / `post_restore` | an operation *this* interface performed completed | the same facts the lifecycle hook receives on stdin |
+| `focus.session` | the selected session changes | `from`, `to` (ids, either absent) |
+| `focus.pane` | focus moves to another plugin | `from`, `to` (plugin names) |
+| `command.done` / `command.failed` | a command a plugin issued reaches a terminal phase | `kind`, `session`, `subject`, `error` |
+| `interface.reloaded` | the interface was rebuilt from disk | `reason` (`f10`, `watch`, `settings`) |
+
+#### Scenario: A session created by another process
+
+- **WHEN** `thurbox-cli session create` adds a session while the interface runs
+- **THEN** subscribers receive `session.created` on the iteration that
+  publishes the new row, and no `session.post_create`
+
+#### Scenario: A session created by this interface
+
+- **WHEN** the creation flow creates a session
+- **THEN** subscribers receive `session.post_create` when the operation
+  completes and `session.created` when the row is published, in that order or
+  the other, and each exactly once
+
+#### Scenario: A status change derived on the tick
+
+- **WHEN** a `working` session goes quiet past the output-quiescence window
+  and its published status becomes `Idle`
+- **THEN** `session.status` fires with `from = "working"`, `to = "idle"`, the
+  same way it would for a hook-reported change
+
+#### Scenario: The enumeration is listed
+
+- **WHEN** the help modal's events page or `thurbox-cli plugin events` is read
+- **THEN** every emitted event name appears with its payload fields, and no
+  name appears that the kernel does not emit
+
+### Requirement: Events are delivered once, in order, off the render path
+
+Each event SHALL be delivered to each subscriber exactly once, in the order the
+kernel observed the changes, on the iteration after the change was published
+and before that iteration's input is dispatched. A handler SHALL NOT run
+during render, during another handler, or during input dispatch.
+
+#### Scenario: Several changes in one iteration
+
+- **WHEN** three sessions change status between two iterations
+- **THEN** each subscriber receives three `session.status` events, in the
+  order the rows are published, before any key pressed in that iteration is
+  dispatched
+
+#### Scenario: A handler is not re-run per frame
+
+- **WHEN** nothing changes for many frames after an event
+- **THEN** no handler runs again for it
+
+#### Scenario: A reload
+
+- **WHEN** the interface is reloaded from disk
+- **THEN** events observed before the reload but not yet delivered are dropped,
+  and `interface.reloaded` is the first event the rebuilt plugins receive
+
+### Requirement: A handler is bounded and its failure is contained
+
+A handler SHALL run under the same instruction and memory budget as a render.
+A handler that throws or overruns SHALL cost only itself: the event is still
+delivered to every other subscriber, the plugin's pane still renders, and the
+failure is reported where a render failure is reported (the log and the
+plugin's error state), once per event rather than per frame.
+
+#### Scenario: One subscriber throws
+
+- **WHEN** two plugins subscribe to `session.created` and the first handler
+  throws
+- **THEN** the second handler still runs, the first plugin's pane still
+  renders on the next frame, and the error is reported against the first
+  plugin naming the event
+
+#### Scenario: A handler loops
+
+- **WHEN** a handler exceeds the instruction budget
+- **THEN** it is interrupted, reported, and the loop continues in the same
+  iteration
+
+### Requirement: A handler can only do what a render can do
+
+A handler SHALL receive the same environment a render receives — the published
+tables, `state`, `store`, `command` — and nothing more. It cannot block, wait,
+or return a value the kernel acts on; its effects are the commands it enqueues
+and the state it writes.
+
+#### Scenario: A handler focuses a session
+
+- **WHEN** a handler for `session.status` with `to = "blocked"` calls
+  `command("focus", { session = payload.session })`
+- **THEN** the command is queued and takes effect as any command does
+
+#### Scenario: A handler's return value
+
+- **WHEN** a handler returns a value
+- **THEN** it is ignored
+
+### Requirement: A plugin can emit an event to other plugins
+
+A plugin SHALL be able to emit a user event, `command("emit", { text = name,
+… })`, delivered as `user.<name>` with the remaining fields as the payload and
+the emitting plugin's name as `payload.source`, to every plugin subscribed to
+that name — including the emitter — on the next iteration. Kernel event names
+cannot be emitted by a plugin.
+
+#### Scenario: A user event is delivered
+
+- **WHEN** plugin `a` emits `command("emit", { text = "refresh", scope = "x" })`
+  and plugin `b` declares `events = { "user.refresh" }`
+- **THEN** `b`'s handler runs next iteration with `"user.refresh"` and a
+  payload `{ scope = "x", source = "a" }`
+
+#### Scenario: A plugin emits a kernel name
+
+- **WHEN** a plugin emits `session.created`
+- **THEN** the emit is refused and reported as a command error, and no
+  subscriber receives it
+
+#### Scenario: Emits cannot cascade without bound
+
+- **WHEN** a handler emits an event whose handler emits again, indefinitely
+- **THEN** delivery stops at a fixed depth per iteration, the remainder is
+  dropped and reported once, and the loop keeps its frame cadence
+
+### Requirement: An unknown subscription is refused before the interface runs
+
+The event names a plugin may subscribe to SHALL be checked when the plugin is
+loaded — by the interface and by `thurbox-cli plugin check`, which loads it the
+same way — so a subscription to a name the kernel does not emit fails there,
+with the name in the message, rather than as a handler that never fires. The
+`emit` command needs no new global: it is a kind of `command`, which the lint
+contract already declares.
+
+#### Scenario: A typo in a subscription
+
+- **WHEN** a plugin declares `events = { "sesion.status" }`
+- **THEN** `thurbox-cli plugin check` exits non-zero naming the event, and the
+  interface refuses to load the plugin with the same message

--- a/openspec/changes/archive/2026-08-26-plugin-events-and-command-palette/tasks.md
+++ b/openspec/changes/archive/2026-08-26-plugin-events-and-command-palette/tasks.md
@@ -1,0 +1,58 @@
+## 1. Event derivation (`kernel::events`)
+
+- [x] 1.1 Add `src/kernel/events.rs`: `KERNEL_EVENTS` (name + payload fields), `Event { name, payload }`, and a `Deriver` that seeds from the first snapshot silently and diffs `status/name/branch/repos/parent` per row on later ones
+- [x] 1.2 Unit tests: seed emits nothing; created/deleted/status/changed each fire once; order within one refresh is deleted → created → status → changed in published row order; a quiescence-derived status flip fires
+- [x] 1.3 `KERNEL_EVENTS` validation helper: kernel names exact, `user.<ident>` by shape, anything else an error naming the event
+
+## 2. Host entry point
+
+- [x] 2.1 Read `events = { … }` in `host/load.rs` beside `keys`; validate via 1.3; a handler with no list subscribes to nothing
+- [x] 2.2 Add `Phase::Event` and `LuaHost::on_event(index, name, payload)` mirroring `on_action` (`enter`, `Budget::arm`, `clean_error`); payload converted from a Rust struct to a Lua table once per event, shared by all subscribers
+- [x] 2.3 Record handler failures keyed `(plugin, event)` so a repeating failure is reported once per event, and surface them where render failures are
+- [x] 2.4 Parse `command("emit", { text, … })`: stamp `source` from the entered plugin, refuse a kernel name at parse time, carry remaining fields as payload
+- [x] 2.5 Extend `tests/kernel_mvp.rs`'s plugin-environment enumeration (no new global expected; assert `emit` is reachable only through `command`)
+
+## 3. Coordinator dispatch
+
+- [x] 3.1 Add the event queue to `App` and `dispatch_events()` between `apply_external_requests` and `paint_if_due`; no-op when empty; republish once before the first handler of a batch
+- [x] 3.2 Feed the queue from the deriver on `SnapshotStore::version` change and after `apply_output_quiescence`
+- [x] 3.3 `command.done`/`command.failed` and `session.post_{create,delete,restart,restore}` from `report_finished_commands` (fork → `post_create`), payload from the `InFlight` plus the row
+- [x] 3.4 `focus.session`/`focus.pane` from `focused_session` and the focus ring, compared after `drain_input` and `apply_commands`
+- [x] 3.5 User-event cascade: append emits within the same dispatch, depth 4, drop-and-report beyond
+- [x] 3.6 Reload: clear the queue, enqueue `interface.reloaded { reason }` first
+- [x] 3.7 Verify `dispatch_events` never sets `dirty` itself; add the settle case (read-only handler paints no frame) to the existing settle test — verified by construction (`coordinator/events.rs` touches no `dirty`); the loop is the binary's and has no integration-level settle test to extend, so no new test was added
+
+## 4. Registry `commands` + palette modal
+
+- [x] 4.1 `CommandDecl` collected from `commands = { { action, desc } }` at load; `Registry::commands()`; `palette_rows()` = bindings ∪ commands ∪ kernel bindings, de-duplicated on `(plugin, action)`, chord attached when bound; disabled plugins absent
+- [x] 4.2 Let `Registry::rebind` target a chord-less command so a user can give it a key; help lists it once bound
+- [x] 4.3 `modals/palette.rs`: query, subsequence filter over description/id/plugin with `matched/total`, cursor in match space, `Up/Down/PageUp/PageDown/Enter/Esc`, hitboxes for click
+- [x] 4.4 `ModalKind::Palette` with `ctrl+p` in `modals::bindings()`, non-passthrough, reserved chords honoured while open; `Enter` returns a `Dispatch` the coordinator routes through `host.on_action` / the kernel handler after the modal has closed
+- [x] 4.5 `tests/v2_keymap.rs`: move `ctrl+p` from `CHORDS_AWAITING_THEIR_PANE` to `GLOBAL_CHORDS` as `palette.open`; keep the awaiting count assertion honest
+- [x] 4.6 Audit the bundled panes' `on_action` handlers for a focus assumption a palette dispatch would break; fix any found
+
+## 5. CLI
+
+- [x] 5.1 `thurbox-cli plugin events` — the `KERNEL_EVENTS` table, human and JSON
+- [x] 5.2 `thurbox-cli plugin check` fails on an unknown subscription with the loader's message (falls out of 2.1; add the test)
+
+## 6. Tests
+
+- [x] 6.1 `tests/v2_events.rs`: declared subscription fires once; undeclared does not; unknown name refuses load; two subscribers with one throwing; instruction-budget overrun contained; user event round-trip with `source`; kernel-name emit refused; cascade bound; reload drops pending and delivers `interface.reloaded` first; `session.created` for a CLI-made row vs `post_create` for an interface-made one
+- [x] 6.2 `tests/v2_palette.rs`: rows from keys, commands and kernel; disabled plugin absent; fuzzy filter and cursor survival; `Enter` reaches an unfocused plugin's `on_action`; `open search` from the palette opens the strip; `Esc` restores focus; `ctrl+q` from the palette quits
+- [x] 6.3 `tests/v2_frames.rs`: pin the palette frame (empty query, a query, no match) — pinned in `tests/v2_palette.rs` over a fixed registry (one frame, with a query); the bundled-pane pins in `v2_frames.rs` are left as they are
+- [x] 6.4 `tests/v2_render_props.rs`: arbitrary key sequences into the palette never throw
+
+## 7. Lint contract and example
+
+- [x] 7.1 `.luarc.json` / `ui/lib` type annotations for `on_event`, `events`, `commands` so luals checks the declaration shapes; `thurbox.yml` unchanged (no new global) — note why in its header
+- [x] 7.2 `docs/examples/events.lua`: "focus the session that just went blocked, unless the user moved focus in the last few seconds" — uses `session.status` + `focus.session`, and declares a palette command to toggle itself
+- [x] 7.3 `selene ui`, `stylua ui`, `lua-language-server --check` green — selene and stylua green locally; luals is not installed here and runs in CI
+
+## 8. Documentation
+
+- [x] 8.1 `docs/PLUGINS.md`: an **Events** section (the table, `on_event`, `emit`, the bounds, the `created` vs `post_create` distinction) and a **Palette** section (`commands`, what a palette dispatch looks like to a plugin); add both to Traps where they bite
+- [x] 8.2 `docs/V2-KERNEL.md`: the sixth entry point, the dispatch point in the iteration, why events are derived not raised (D1), and the cascade bound
+- [x] 8.3 `CLAUDE.md`: Keybindings table (`Ctrl+P`), the Performance section's iteration order, the plugin-writing section's entry points; `ui/README.md`, `extensions/ui-skill` `SKILL.md`
+- [x] 8.4 `docs/CONFIG.md` hooks.toml section and `docs/FEATURES.md`: cross-reference that `session.post_*` is also a Lua event — done after rebasing onto the merged `hooks.toml` work (v2.6.0)
+- [x] 8.5 `website/docs/keybindings.html` and `v2-interface.html`: `Ctrl+P` and the events table

--- a/openspec/specs/command-palette/spec.md
+++ b/openspec/specs/command-palette/spec.md
@@ -1,0 +1,153 @@
+# command-palette Specification
+
+## Purpose
+Makes every action the interface knows — a plugin's keys, its chord-less
+commands, the kernel's own — reachable by name from one searchable modal, so an
+action need not spend a chord to exist and a user need not remember one to run
+it.
+## Requirements
+### Requirement: The palette is kernel chrome, opened by one global chord
+
+The palette SHALL be a kernel-owned modal, like help and settings: not in the
+arrangement, not in the focus ring, capturing input while open, closed by
+`Esc`, one modal open at a time. It SHALL open on `ctrl+p` from every pane —
+including a focused terminal — and its chord SHALL be rebindable like any
+kernel chord.
+
+#### Scenario: Opened from a focused terminal
+
+- **WHEN** the agent pane is focused and `ctrl+p` is pressed
+- **THEN** the palette opens and the keystroke does not reach the agent
+
+#### Scenario: Another modal is open
+
+- **WHEN** help is open and `ctrl+p` is pressed
+- **THEN** help closes and the palette opens
+
+#### Scenario: Closed without choosing
+
+- **WHEN** the palette is open and `Esc` is pressed
+- **THEN** it closes, focus returns to the pane that had it, and nothing runs
+
+### Requirement: The palette lists every action in the registry
+
+The palette SHALL list, from one source, every action the registry holds: each
+plugin's declared keys, each plugin's declared chord-less commands, and the
+kernel's own actions (the modals, reload, quit). Each row SHALL show the
+action's description, its owning plugin, and its chord when it has one. A
+disabled plugin's actions are absent, exactly as its keys are.
+
+#### Scenario: A key-bound action appears
+
+- **WHEN** a plugin declares `keys = { { key = "j", action = "mine.next",
+  desc = "next item" } }`
+- **THEN** the palette lists `next item` under that plugin with `j` beside it
+
+#### Scenario: A chord-less command appears
+
+- **WHEN** a plugin declares `commands = { { action = "mine.export", desc =
+  "export the list" } }` and no key for it
+- **THEN** the palette lists `export the list` with no chord
+
+#### Scenario: A kernel action appears
+
+- **WHEN** the palette is opened
+- **THEN** reload, the settings, theme and help modals, and quit are listed
+  under the kernel with their chords
+
+#### Scenario: A disabled plugin
+
+- **WHEN** a plugin is turned off in the Interface tab
+- **THEN** none of its actions appear
+
+### Requirement: Rows filter by fuzzy match and the selection survives refining
+
+Typing SHALL filter rows by subsequence match against description, action id
+and plugin name, using the same matcher the session list and search use, with
+a live `matched/total` count; `Up`/`Down` move, `Enter` runs the selected row.
+Refining the query SHALL keep the cursor on the same action when it survives
+the filter.
+
+#### Scenario: A query narrows the list
+
+- **WHEN** `thm` is typed
+- **THEN** rows whose description, id or plugin contain `t`, `h`, `m` in order
+  remain, ranked as the shared matcher ranks them
+
+#### Scenario: The cursor survives a refinement
+
+- **WHEN** a row is selected and one more character is typed that the row
+  still matches
+- **THEN** that row stays selected
+
+#### Scenario: Nothing matches
+
+- **WHEN** the query matches no row
+- **THEN** the palette says so and `Enter` does nothing
+
+### Requirement: Running from the palette is indistinguishable from the key
+
+`Enter` SHALL dispatch the selected action exactly as its chord would: a
+plugin-scoped action reaches its plugin's `on_action` whether or not that
+plugin is focused, a kernel action runs the kernel's handler, and the palette
+closes first so the action sees the focus state it would have seen from a key
+press. A plugin SHALL NOT be able to tell a palette dispatch from a key press.
+
+#### Scenario: A plugin-scoped action from another pane
+
+- **WHEN** the session list is focused, the palette is opened and the agent
+  pane's `copy selection` is chosen
+- **THEN** the agent pane's `on_action` receives that action
+
+#### Scenario: A pane that opens its own column
+
+- **WHEN** `open search` is chosen from the palette
+- **THEN** the search strip opens and takes focus, exactly as `ctrl+/` does
+
+#### Scenario: The action fails
+
+- **WHEN** the chosen action's handler throws
+- **THEN** the error is reported as a key-press failure would be, and the
+  palette is already closed
+
+### Requirement: A chord-less command is declared as data
+
+A plugin SHALL declare chord-less commands as `commands = { { action, desc } }`
+in its declaration table, with the same `action` namespace and the same
+`on_action` handler its keys use. A command whose `action` is also bound by a
+key is one row, not two. A command may later be given a chord by the user
+through the existing rebinding surface.
+
+#### Scenario: Declared and dispatched
+
+- **WHEN** a plugin declares a command and it is chosen from the palette
+- **THEN** its `on_action` is called with that action id
+
+#### Scenario: Both a key and a command for one action
+
+- **WHEN** a plugin declares `keys` and `commands` with the same `action`
+- **THEN** the palette shows one row with the key's chord
+
+#### Scenario: A user binds a chord to a command
+
+- **WHEN** the user rebinds a chord-less command to `f7`
+- **THEN** the chord fires the action, help lists it, and the palette shows
+  `f7` beside the row
+
+### Requirement: The palette never outranks what is reserved
+
+While open the palette SHALL honour the reserved chords (`ctrl+q`, `f10`,
+`ctrl+h`/`ctrl+l`, `f12`) and SHALL NOT list `ctrl+p`'s previous owner: the
+chord is reassigned by this change and recorded as such in the keymap tests,
+not silently reused.
+
+#### Scenario: Quit from the palette
+
+- **WHEN** the palette is open and `ctrl+q` is pressed
+- **THEN** the interface quits
+
+#### Scenario: The keymap ledger
+
+- **WHEN** the keymap tests run
+- **THEN** `ctrl+p` is asserted bound to the palette and is no longer in the
+  list of chords awaiting a pane

--- a/openspec/specs/frame-cost/spec.md
+++ b/openspec/specs/frame-cost/spec.md
@@ -11,7 +11,10 @@ than asserted — so making a frame cheaper can never be paid for in correctness
 Rebuilding every published table and every pane's tree on every painted frame
 costs the same whether anything moved or not. The system SHALL rebuild a
 published group, and SHALL run a pane's render, only when something they are
-built from has changed since the last painted frame.
+built from has changed since the last painted frame. An event handler SHALL
+run only when the signal it is derived from changed, and a handler that writes
+nothing SHALL mark nothing dirty: a `pure` pane is invalidated by a handler only
+through the `state` and `store` writes it already keys on.
 
 This is a bound on *work*, never on *freshness*: the requirements below make
 skipping unobservable, and where the two conflict, freshness wins.
@@ -31,7 +34,21 @@ skipping unobservable, and where the two conflict, freshness wins.
 
 - **WHEN** an idle interface with nothing running is left untouched
 - **THEN** the frames it paints at the forced-redraw floor rebuild neither the
-  published groups nor any pane whose render may be skipped
+  published groups nor any pane whose render may be skipped, and no event
+  handler runs
+
+#### Scenario: A handler observes without writing
+
+- **WHEN** an event is delivered to a handler that reads the payload and
+  writes neither `state` nor `store` nor enqueues a command
+- **THEN** the frame is not marked dirty by the dispatch, and every `pure`
+  pane's tree is reused
+
+#### Scenario: A handler writes state
+
+- **WHEN** a handler writes `state`
+- **THEN** the next frame is painted and the panes keyed on that state are
+  rebuilt, exactly as a key handler's write would cause
 
 ### Requirement: A plugin never reads a stale published value
 

--- a/openspec/specs/plugin-events/spec.md
+++ b/openspec/specs/plugin-events/spec.md
@@ -1,0 +1,188 @@
+# plugin-events Specification
+
+## Purpose
+Lets a plugin be told that something changed — a session appeared, changed
+status, was focused; a command finished; another plugin said something — instead
+of rediscovering it by diffing the snapshot on every render, and bounds what a
+handler can cost the interface.
+## Requirements
+### Requirement: A plugin subscribes by declaring a handler
+
+A plugin SHALL be able to declare a single `on_event(name, payload)` function
+and be called with each event it subscribes to. Subscription is declared as
+data (`events = { "session.status", "focus.session", … }`) so it is listable,
+lintable and visible in the inventory; a plugin declaring a handler with no
+`events` list receives nothing.
+
+#### Scenario: A declared subscription fires
+
+- **WHEN** a plugin declares `events = { "session.status" }` with an `on_event`
+  handler, and a session's status changes
+- **THEN** the handler is called once with `"session.status"` and a payload
+  naming the session and both statuses
+
+#### Scenario: An undeclared event does not fire
+
+- **WHEN** a plugin declares `events = { "session.status" }` and a session is
+  created
+- **THEN** its handler is not called
+
+#### Scenario: A subscription to a name the kernel does not emit
+
+- **WHEN** a plugin declares an event name that is neither a kernel event nor
+  of the `user.` form
+- **THEN** the plugin fails to load with an error naming the unknown event,
+  reported where load errors are already reported (the Interface tab, the log,
+  and `thurbox-cli plugin check`'s non-zero exit)
+
+### Requirement: The kernel emits a fixed, documented set of events
+
+The events the kernel emits SHALL be a closed enumeration, each with a
+documented payload, and that enumeration SHALL be readable from the running
+interface (the help modal) and from a terminal (`thurbox-cli plugin events`).
+At minimum:
+
+| Event | Fired when | Payload |
+|---|---|---|
+| `session.created` | a row appears in the snapshot | `session` (id), `name`, `agent`, `repo` |
+| `session.deleted` | a row leaves the snapshot | `session`, `name` |
+| `session.status` | a row's derived status changes | `session`, `from`, `to` |
+| `session.changed` | a row's name, branch, repo set or parent changes | `session`, `fields` (list) |
+| `session.post_create` / `post_delete` / `post_restart` / `post_restore` | an operation *this* interface performed completed | the same facts the lifecycle hook receives on stdin |
+| `focus.session` | the selected session changes | `from`, `to` (ids, either absent) |
+| `focus.pane` | focus moves to another plugin | `from`, `to` (plugin names) |
+| `command.done` / `command.failed` | a command a plugin issued reaches a terminal phase | `kind`, `session`, `subject`, `error` |
+| `interface.reloaded` | the interface was rebuilt from disk | `reason` (`f10`, `watch`, `settings`) |
+
+#### Scenario: A session created by another process
+
+- **WHEN** `thurbox-cli session create` adds a session while the interface runs
+- **THEN** subscribers receive `session.created` on the iteration that
+  publishes the new row, and no `session.post_create`
+
+#### Scenario: A session created by this interface
+
+- **WHEN** the creation flow creates a session
+- **THEN** subscribers receive `session.post_create` when the operation
+  completes and `session.created` when the row is published, in that order or
+  the other, and each exactly once
+
+#### Scenario: A status change derived on the tick
+
+- **WHEN** a `working` session goes quiet past the output-quiescence window
+  and its published status becomes `Idle`
+- **THEN** `session.status` fires with `from = "working"`, `to = "idle"`, the
+  same way it would for a hook-reported change
+
+#### Scenario: The enumeration is listed
+
+- **WHEN** the help modal's events page or `thurbox-cli plugin events` is read
+- **THEN** every emitted event name appears with its payload fields, and no
+  name appears that the kernel does not emit
+
+### Requirement: Events are delivered once, in order, off the render path
+
+Each event SHALL be delivered to each subscriber exactly once, in the order the
+kernel observed the changes, on the iteration after the change was published
+and before that iteration's input is dispatched. A handler SHALL NOT run
+during render, during another handler, or during input dispatch.
+
+#### Scenario: Several changes in one iteration
+
+- **WHEN** three sessions change status between two iterations
+- **THEN** each subscriber receives three `session.status` events, in the
+  order the rows are published, before any key pressed in that iteration is
+  dispatched
+
+#### Scenario: A handler is not re-run per frame
+
+- **WHEN** nothing changes for many frames after an event
+- **THEN** no handler runs again for it
+
+#### Scenario: A reload
+
+- **WHEN** the interface is reloaded from disk
+- **THEN** events observed before the reload but not yet delivered are dropped,
+  and `interface.reloaded` is the first event the rebuilt plugins receive
+
+### Requirement: A handler is bounded and its failure is contained
+
+A handler SHALL run under the same instruction and memory budget as a render.
+A handler that throws or overruns SHALL cost only itself: the event is still
+delivered to every other subscriber, the plugin's pane still renders, and the
+failure is reported where a render failure is reported (the log and the
+plugin's error state), once per event rather than per frame.
+
+#### Scenario: One subscriber throws
+
+- **WHEN** two plugins subscribe to `session.created` and the first handler
+  throws
+- **THEN** the second handler still runs, the first plugin's pane still
+  renders on the next frame, and the error is reported against the first
+  plugin naming the event
+
+#### Scenario: A handler loops
+
+- **WHEN** a handler exceeds the instruction budget
+- **THEN** it is interrupted, reported, and the loop continues in the same
+  iteration
+
+### Requirement: A handler can only do what a render can do
+
+A handler SHALL receive the same environment a render receives — the published
+tables, `state`, `store`, `command` — and nothing more. It cannot block, wait,
+or return a value the kernel acts on; its effects are the commands it enqueues
+and the state it writes.
+
+#### Scenario: A handler focuses a session
+
+- **WHEN** a handler for `session.status` with `to = "blocked"` calls
+  `command("focus", { session = payload.session })`
+- **THEN** the command is queued and takes effect as any command does
+
+#### Scenario: A handler's return value
+
+- **WHEN** a handler returns a value
+- **THEN** it is ignored
+
+### Requirement: A plugin can emit an event to other plugins
+
+A plugin SHALL be able to emit a user event, `command("emit", { text = name,
+… })`, delivered as `user.<name>` with the remaining fields as the payload and
+the emitting plugin's name as `payload.source`, to every plugin subscribed to
+that name — including the emitter — on the next iteration. Kernel event names
+cannot be emitted by a plugin.
+
+#### Scenario: A user event is delivered
+
+- **WHEN** plugin `a` emits `command("emit", { text = "refresh", scope = "x" })`
+  and plugin `b` declares `events = { "user.refresh" }`
+- **THEN** `b`'s handler runs next iteration with `"user.refresh"` and a
+  payload `{ scope = "x", source = "a" }`
+
+#### Scenario: A plugin emits a kernel name
+
+- **WHEN** a plugin emits `session.created`
+- **THEN** the emit is refused and reported as a command error, and no
+  subscriber receives it
+
+#### Scenario: Emits cannot cascade without bound
+
+- **WHEN** a handler emits an event whose handler emits again, indefinitely
+- **THEN** delivery stops at a fixed depth per iteration, the remainder is
+  dropped and reported once, and the loop keeps its frame cadence
+
+### Requirement: An unknown subscription is refused before the interface runs
+
+The event names a plugin may subscribe to SHALL be checked when the plugin is
+loaded — by the interface and by `thurbox-cli plugin check`, which loads it the
+same way — so a subscription to a name the kernel does not emit fails there,
+with the name in the message, rather than as a handler that never fires. The
+`emit` command needs no new global: it is a kind of `command`, which the lint
+contract already declares.
+
+#### Scenario: A typo in a subscription
+
+- **WHEN** a plugin declares `events = { "sesion.status" }`
+- **THEN** `thurbox-cli plugin check` exits non-zero naming the event, and the
+  interface refuses to load the plugin with the same message

--- a/src/cli/plugins.rs
+++ b/src/cli/plugins.rs
@@ -68,6 +68,8 @@ pub enum Action {
     },
     /// List the example plugins a bare name resolves to.
     Available,
+    /// List every event a plugin can subscribe to, with its payload fields.
+    Events,
 }
 
 pub fn run(action: Action) -> Result<CommandOutput, String> {
@@ -81,7 +83,41 @@ pub fn run(action: Action) -> Result<CommandOutput, String> {
         Action::Update { name } => update(name.as_deref()),
         Action::Remove { name } => remove(&name),
         Action::Available => available(),
+        Action::Events => events(),
     }
+}
+
+/// The events the kernel emits — the same table the loader validates a
+/// subscription against and the help modal renders, so what this prints is
+/// exactly what a plugin may declare in `events = { … }`.
+fn events() -> Result<CommandOutput, String> {
+    let specs = crate::kernel::events::KERNEL_EVENTS;
+    let mut rows: Vec<Vec<String>> = specs
+        .iter()
+        .map(|spec| {
+            vec![
+                spec.name.to_string(),
+                spec.fields.join(", "),
+                spec.when.to_string(),
+            ]
+        })
+        .collect();
+    rows.push(vec![
+        format!("{}<name>", crate::kernel::events::USER_PREFIX),
+        "source, plus whatever the emitter passed".to_string(),
+        "a plugin ran command(\"emit\", { text = \"<name>\", … })".to_string(),
+    ]);
+    let table = super::output::table(&["event", "payload", "fires when"], &rows);
+    Ok(CommandOutput::new(
+        json!({
+            "events": specs
+                .iter()
+                .map(|spec| json!({ "name": spec.name, "fields": spec.fields, "when": spec.when }))
+                .collect::<Vec<_>>(),
+            "user_prefix": crate::kernel::events::USER_PREFIX,
+        }),
+        table,
+    ))
 }
 
 /// The directory the interface would load, without creating one.
@@ -643,6 +679,39 @@ fn available() -> Result<CommandOutput, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A subscription to a name the kernel does not emit is the one failure
+    /// with no symptom at runtime — the handler simply never fires — so `check`
+    /// has to be the place it is caught, with the name in the message.
+    #[test]
+    fn check_refuses_a_subscription_to_an_unknown_event() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let plugins = dir.path().join("plugins");
+        std::fs::create_dir_all(&plugins).expect("mkdir");
+        std::fs::write(
+            plugins.join("10_typo.lua"),
+            r#"return {
+                 name = "typo", slot = "center",
+                 events = { "sesion.status" },
+                 on_event = function() end,
+                 render = function() return { text = "" } end,
+               }"#,
+        )
+        .expect("write");
+        // The override is the documented way to point the CLI at a directory,
+        // and nextest runs each test in its own process, so setting it here
+        // reaches nothing else.
+        std::env::set_var("THURBOX_UI_DIR", dir.path());
+        let output = check().expect("check runs");
+        std::env::remove_var("THURBOX_UI_DIR");
+        assert!(
+            output.failure.is_some(),
+            "an unknown subscription must fail the check"
+        );
+        let error = output.json["error"].as_str().unwrap_or_default();
+        assert!(error.contains("sesion.status"), "{error}");
+        assert!(error.contains("session.status"), "{error}");
+    }
 
     /// The starter has to be a plugin, not a snippet: the whole point is that a
     /// new file loads before it is edited.

--- a/src/coordinator/boot.rs
+++ b/src/coordinator/boot.rs
@@ -236,6 +236,7 @@ pub(crate) async fn run() -> Result<(), Box<dyn Error>> {
         reaper: thurbox::kernel::reaper::Reaper::default(),
         bookmark_in_flight: false,
         hud: false,
+        events: crate::coordinator::events::Events::new(),
         quit: false,
     };
 
@@ -244,7 +245,7 @@ pub(crate) async fn run() -> Result<(), Box<dyn Error>> {
     // so a plugin turned off would be loaded for exactly one frame. Told, then
     // rebuilt.
     app.publish_disabled();
-    app.reload_interface();
+    app.reload_interface(crate::coordinator::events::ReloadReason::Boot);
     // Declarations are collected once up front and again on every reload, so
     // a newly added plugin's keys appear in help with nothing else edited.
     app.collect_declarations();

--- a/src/coordinator/commands.rs
+++ b/src/coordinator/commands.rs
@@ -84,6 +84,24 @@ impl App {
                 self.bookmark_in_flight = true;
                 return false;
             }
+            // A user event: queued for the next dispatch, with the emitting
+            // plugin's *name* as its source — the owner is stamped by path, and
+            // the name is what subscribers know a plugin by.
+            Command::Emit {
+                owner,
+                name,
+                payload,
+            } => {
+                let source = self
+                    .host
+                    .name_of_path(owner)
+                    .unwrap_or(owner.as_str())
+                    .to_string();
+                let mut event = thurbox::kernel::events::Event::new(name.clone());
+                event.payload = payload.clone();
+                event.payload.push(("source".to_string(), source.into()));
+                self.enqueue_event(event);
+            }
             _ => return false,
         }
         true
@@ -191,11 +209,6 @@ impl App {
         // rather than waiting out the interval — that is what makes a
         // delete feel immediate instead of arriving up to 400ms later.
         if self.commands.poll() {
-            self.report_finished_commands();
-            // A finished creation is deliberately not acted on here: see
-            // `focus_on_session` for why a session that just spawned does not
-            // pull the view onto itself.
-
             // Wait for the last one: two adds in quick succession would
             // otherwise re-read between them and publish a list missing the
             // second.
@@ -209,7 +222,13 @@ impl App {
                 self.bookmark_in_flight = false;
                 self.repos.invalidate_bookmarks();
             }
+            // Re-read BEFORE reporting: a `session.post_create` names the row
+            // the command made, which only exists here once the rows are.
             self.snapshots.refresh();
+            self.report_finished_commands();
+            // A finished creation is deliberately not acted on here: see
+            // `focus_on_session` for why a session that just spawned does not
+            // pull the view onto itself.
             self.note_data_change();
         } else {
             self.snapshots.refresh_if_due();
@@ -238,10 +257,12 @@ impl App {
             if let Some(tracked) = self.tracked_commands.get_mut(&id) {
                 let (kind, label) = (tracked.kind, tracked.label.clone());
                 tracked.failed = true;
+                let tracked = tracked.clone();
                 self.report(
                     thurbox::kernel::messages::failed(kind, label.as_deref(), &error),
                     Level::Error,
                 );
+                self.note_command_failed(&tracked, &error);
             }
         }
 
@@ -279,6 +300,7 @@ impl App {
             {
                 self.toast(message);
             }
+            self.note_command_done(&tracked);
         }
         self.reported_failures.retain(|id| live.contains(id));
     }
@@ -297,6 +319,7 @@ impl App {
     /// It is also the only moment the subject can be resolved: a delete's row is
     /// gone by the time it reports.
     pub(crate) fn dispatch_tracked(&mut self, command: thurbox::kernel::command::Command) {
+        use thurbox::kernel::command::Command;
         let kind = command.kind();
         let session = command.session().to_string();
         let label = self
@@ -305,6 +328,15 @@ impl App {
             .session(&session)
             .map(|row| row.name.clone())
             .filter(|label| !label.is_empty());
+        // What `session.post_*` will need once the command has finished and its
+        // row is gone (a delete) or only just arrived (a create).
+        let name = match &command {
+            Command::Create { name, .. } | Command::Fork { name, .. } => {
+                Some(name.clone()).filter(|n| !n.is_empty())
+            }
+            _ => None,
+        };
+        let force = matches!(command, Command::Delete { force: true, .. });
         let id = self.commands.dispatch(command);
         self.tracked_commands.insert(
             id,
@@ -313,6 +345,8 @@ impl App {
                 session,
                 label,
                 failed: false,
+                name,
+                force,
             },
         );
         // Accepting a command changes `thurbox.commands`, which panes draw from:

--- a/src/coordinator/events.rs
+++ b/src/coordinator/events.rs
@@ -1,0 +1,296 @@
+//! Delivering events to the plugins that subscribed to them.
+//!
+//! One dispatch point per iteration, after the worker stores and the command
+//! bus have published and before the paint — so a handler sees the iteration's
+//! fresh state and its `state`/`store` writes land in the frame about to be
+//! painted, with no extra frame. It is a `VecDeque::is_empty` check on every
+//! iteration with nothing queued, which is what keeps the settle test true
+//! (`frame-cost`): dispatch never marks the frame dirty itself. A handler that
+//! writes state bumps the state version, and one that enqueues a command goes
+//! through `dispatch_tracked` — both already mark it, exactly as a key handler's
+//! writes do.
+//!
+//! The kernel's own events are derived here from the signals the loop already
+//! has — the snapshot's version, the focus ring, the command bus — never raised
+//! by the code that mutates them. See `kernel::events`.
+
+use std::collections::VecDeque;
+
+use thurbox::kernel::events::{Deriver, Event, Field, MAX_DEPTH};
+
+use super::*;
+
+/// Why the interface was rebuilt, as `interface.reloaded` reports it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReloadReason {
+    /// The first build at startup. Not an event: nothing existed before it to
+    /// have missed anything.
+    Boot,
+    /// `F10`, or the palette's reload entry.
+    Key,
+    /// The directory watcher, or an edit this process made to the directory.
+    Watch,
+    /// A switch or a trust change in the settings modal's Interface tab.
+    Settings,
+}
+
+impl ReloadReason {
+    fn as_str(self) -> &'static str {
+        match self {
+            ReloadReason::Boot => "boot",
+            ReloadReason::Key => "f10",
+            ReloadReason::Watch => "watch",
+            ReloadReason::Settings => "settings",
+        }
+    }
+}
+
+/// Everything the loop holds about events between iterations.
+pub(crate) struct Events {
+    queue: VecDeque<Event>,
+    deriver: Deriver,
+    /// The depth of the event whose handlers are running, so an emit from one
+    /// is queued one generation deeper. `None` outside a dispatch — a root
+    /// event and a handler's emit must not be told apart by whether the queue
+    /// happened to be empty, which is what an integer with a zero for "idle"
+    /// did: an emit from a depth-zero handler read as a root and cascaded
+    /// unbounded.
+    current: Option<u8>,
+    /// `(plugin, event)` pairs already reported, so a handler that throws on
+    /// every `session.status` is reported once per event rather than per
+    /// delivery. Cleared on reload, since the plugin was rebuilt.
+    reported: std::collections::HashSet<(String, String)>,
+    /// Whether the cascade bound has been reported this dispatch.
+    cascade_reported: bool,
+    /// The selection and the focused pane as last observed, so a change is an
+    /// event. `None` until first observed: the first frame's focus is not a
+    /// change from anything.
+    focus: Option<(Option<String>, Option<String>)>,
+}
+
+impl Events {
+    pub(crate) fn new() -> Self {
+        Self {
+            queue: VecDeque::new(),
+            deriver: Deriver::new(),
+            current: None,
+            reported: std::collections::HashSet::new(),
+            cascade_reported: false,
+            focus: None,
+        }
+    }
+}
+
+impl App {
+    /// Derive what changed, and hand every queued event to its subscribers.
+    ///
+    /// Takes the terminal because a handler's commands are applied *inside* the
+    /// dispatch — that is what lets an `emit` from a handler be delivered in the
+    /// same call, and what makes the cascade bound a bound rather than a
+    /// per-iteration trickle.
+    pub(crate) fn dispatch_events(&mut self, terminal: &mut DefaultTerminal) {
+        self.derive_kernel_events();
+        if self.events.queue.is_empty() {
+            return;
+        }
+        // Handlers read the published tables, so they are made current once per
+        // batch — the same rule an input batch follows.
+        self.republish();
+        self.events.cascade_reported = false;
+        while let Some(event) = self.events.queue.pop_front() {
+            if event.depth > MAX_DEPTH {
+                if !self.events.cascade_reported {
+                    self.events.cascade_reported = true;
+                    self.report(
+                        format!(
+                            "{}: dropped — events cascaded more than {MAX_DEPTH} deep",
+                            event.name
+                        ),
+                        Level::Error,
+                    );
+                }
+                continue;
+            }
+            self.events.current = Some(event.depth);
+            for failure in self.host.dispatch_event(&event) {
+                self.report_event_failure(failure, &event.name);
+            }
+            // What the handlers asked for, applied now rather than next
+            // iteration, so an emit lands in this dispatch.
+            self.apply_commands(terminal);
+        }
+        self.events.current = None;
+    }
+
+    /// Queue an event for the next dispatch.
+    ///
+    /// Depth is stamped from the dispatch in progress: an event queued while no
+    /// handler runs is a root, and one queued by a handler is a generation deeper
+    /// than the event it was handling.
+    pub(crate) fn enqueue_event(&mut self, mut event: Event) {
+        event.depth = self
+            .events
+            .current
+            .map_or(0, |depth| depth.saturating_add(1));
+        self.events.queue.push_back(event);
+    }
+
+    /// The kernel's own events, from the signals the loop already tracks.
+    fn derive_kernel_events(&mut self) {
+        // Focus: the selected session and the focused pane, each compared to
+        // what it was. Both are two `Option<String>` compares per iteration.
+        let selected = self.host.shared_string("selected");
+        let pane = self
+            .host
+            .focusable()
+            .get(self.focus)
+            .and_then(|index| self.host.plugins.get(*index))
+            .map(|plugin| plugin.name.clone());
+        match &self.events.focus {
+            None => self.events.focus = Some((selected, pane)),
+            Some((last_selected, last_pane)) => {
+                let mut fired = Vec::new();
+                if *last_selected != selected {
+                    fired.push(
+                        Event::new("focus.session")
+                            .with("from", last_selected.as_deref())
+                            .with("to", selected.as_deref()),
+                    );
+                }
+                if *last_pane != pane {
+                    fired.push(
+                        Event::new("focus.pane")
+                            .with("from", last_pane.as_deref())
+                            .with("to", pane.as_deref()),
+                    );
+                }
+                if !fired.is_empty() {
+                    self.events.focus = Some((selected, pane));
+                    for event in fired {
+                        self.enqueue_event(event);
+                    }
+                }
+            }
+        }
+
+        // The snapshot: one integer compare while nothing moved.
+        let version = self.snapshots.version();
+        let derived = self
+            .events
+            .deriver
+            .observe(self.snapshots.current(), version);
+        for event in derived {
+            self.enqueue_event(event);
+        }
+    }
+
+    /// The events a finished command owes: `command.done`, and for the four
+    /// lifecycle operations the matching `session.post_*`.
+    ///
+    /// Named as `hooks.toml` names them so a user learns one vocabulary; the
+    /// shell hook already ran inside the operation on the worker, so "shell
+    /// post-hook, then Lua post-event" holds without the kernel knowing hooks
+    /// exist.
+    pub(crate) fn note_command_done(&mut self, tracked: &TrackedCommand) {
+        self.enqueue_event(
+            Event::new("command.done")
+                .with("kind", Some(tracked.kind))
+                .with(
+                    "session",
+                    Some(tracked.session.as_str()).filter(|s| !s.is_empty()),
+                )
+                .with("subject", tracked.label.as_deref()),
+        );
+        let event = match tracked.kind {
+            "create" | "fork" => {
+                // The command named no session; the row is found by the name it
+                // was given, newest first, now that the snapshot has been
+                // re-read.
+                let row = tracked.name.as_deref().and_then(|name| {
+                    self.snapshots
+                        .current()
+                        .sessions
+                        .iter()
+                        .rev()
+                        .find(|row| row.name == name)
+                });
+                let mut event = Event::new("session.post_create")
+                    .with("name", tracked.name.as_deref())
+                    .with(
+                        "parent",
+                        Some(tracked.session.as_str()).filter(|s| !s.is_empty()),
+                    );
+                if let Some(row) = row {
+                    event = event
+                        .with("session", Some(row.id.as_str()))
+                        .with("agent", Some(row.agent.as_str()))
+                        .with("repo", row.repo.as_deref())
+                        .with("cwd", row.cwd.as_ref().map(|cwd| cwd.display().to_string()))
+                        .with("branch", row.branch.as_deref());
+                }
+                event
+            }
+            "delete" => Event::new("session.post_delete")
+                .with("session", Some(tracked.session.as_str()))
+                .with("name", tracked.label.as_deref())
+                .with("force", Some(Field::Bool(tracked.force))),
+            "restart" | "restore" => {
+                let name = if tracked.kind == "restart" {
+                    "session.post_restart"
+                } else {
+                    "session.post_restore"
+                };
+                let mut event = Event::new(name)
+                    .with("session", Some(tracked.session.as_str()))
+                    .with("name", tracked.label.as_deref());
+                if let Some(row) = self.snapshots.current().session(&tracked.session) {
+                    event = event
+                        .with("agent", Some(row.agent.as_str()))
+                        .with("repo", row.repo.as_deref())
+                        .with("cwd", row.cwd.as_ref().map(|cwd| cwd.display().to_string()))
+                        .with("branch", row.branch.as_deref());
+                }
+                event
+            }
+            _ => return,
+        };
+        self.enqueue_event(event);
+    }
+
+    pub(crate) fn note_command_failed(&mut self, tracked: &TrackedCommand, error: &str) {
+        self.enqueue_event(
+            Event::new("command.failed")
+                .with("kind", Some(tracked.kind))
+                .with(
+                    "session",
+                    Some(tracked.session.as_str()).filter(|s| !s.is_empty()),
+                )
+                .with("subject", tracked.label.as_deref())
+                .with("error", Some(error)),
+        );
+    }
+
+    /// A reload replaces every plugin: what was queued for the old ones is
+    /// dropped, the deriver seeds again from the next snapshot, and the rebuilt
+    /// plugins hear `interface.reloaded` first.
+    pub(crate) fn note_reload(&mut self, reason: ReloadReason) {
+        self.events.queue.clear();
+        self.events.deriver.reset();
+        self.events.reported.clear();
+        self.events.current = None;
+        if reason != ReloadReason::Boot {
+            self.enqueue_event(
+                Event::new("interface.reloaded").with("reason", Some(reason.as_str())),
+            );
+        }
+    }
+
+    fn report_event_failure(&mut self, failure: PluginError, event: &str) {
+        let key = (failure.plugin.clone(), event.to_string());
+        if !self.events.reported.insert(key) {
+            return;
+        }
+        tracing::warn!("plugin event handler failed: {failure}");
+        self.report(failure.to_string(), Level::Error);
+    }
+}

--- a/src/coordinator/input.rs
+++ b/src/coordinator/input.rs
@@ -196,11 +196,7 @@ impl App {
             // F10, not F5: v1 spends F1-F9 and F12 on real UI (F5 is the tasks
             // panel), so the dev reload takes one of the two keys v1 leaves
             // free rather than shadowing a pane the user expects.
-            KeyCode::F(10) => {
-                self.reload_interface();
-                self.collect_declarations();
-                self.clamp_focus();
-            }
+            KeyCode::F(10) => self.reload_by_key(),
             // Tab is NOT a focus key: it belongs to the agent. See RESERVED.
             // v1 binds focus movement to Ctrl+H/Ctrl+L as well, and refuses to
             // let a focused terminal keep either: they are how you get *out* of
@@ -424,6 +420,43 @@ impl App {
         });
         self.modals.toggle(kind);
         self.dirty = true;
+    }
+
+    /// `F10`, and the palette's reload entry: rebuild from disk and re-collect
+    /// what the rebuilt plugins declare.
+    pub(crate) fn reload_by_key(&mut self) {
+        self.reload_interface(super::events::ReloadReason::Key);
+        self.collect_declarations();
+        self.clamp_focus();
+    }
+
+    /// Run an action the palette chose, exactly as its chord would have.
+    ///
+    /// A kernel action goes to the kernel's own handler; a plugin's goes through
+    /// `host.on_action` whether or not that plugin is focused, which is what a
+    /// global chord already does. The modal has closed by the time this runs, so
+    /// the action sees the focus state a key press would have seen.
+    pub(crate) fn run_action(&mut self, plugin: &str, action: &str) {
+        self.dirty = true;
+        if plugin == thurbox::kernel::modals::OWNER {
+            if let Some(kind) = ModalKind::from_action(action) {
+                self.toggle_modal(kind);
+                return;
+            }
+            match action {
+                thurbox::kernel::modals::palette::RELOAD_ACTION => self.reload_by_key(),
+                thurbox::kernel::modals::palette::QUIT_ACTION => self.quit = true,
+                other => self.report(format!("no kernel action named {other:?}"), Level::Error),
+            }
+            return;
+        }
+        let Some(index) = self.host.index_of(plugin) else {
+            self.report(format!("no plugin named {plugin:?}"), Level::Error);
+            return;
+        };
+        if let Err(e) = self.host.on_action(index, action) {
+            self.errors.push(e);
+        }
     }
 
     /// Offer a keystroke to one specific plugin: its declared action first, then

--- a/src/coordinator/interface.rs
+++ b/src/coordinator/interface.rs
@@ -21,9 +21,12 @@ impl App {
     /// still pointed at the user's copy, so `r`/`d`/`space`/`t` wrote the right
     /// file to no visible effect. Only a restart recovered. It also cost a plugin
     /// author their edit-reload loop, since a `./ui` checkout takes the same path.
-    pub(crate) fn reload_interface(&mut self) {
+    pub(crate) fn reload_interface(&mut self, reason: super::events::ReloadReason) {
         self.host.reload_from(&self.ui_dir);
         Counters::bump(&self.perf.reloads);
+        // The plugins that would have received what was queued no longer exist;
+        // the rebuilt ones hear that they were rebuilt.
+        self.note_reload(reason);
         // Plugin indices are positions in a vector the rebuild just replaced, and
         // `grabbed` is one recorded during the previous paint. A reload between a
         // paint and a keystroke — a watcher firing on a deleted file — would leave
@@ -90,7 +93,7 @@ impl App {
         match self.registry.set_disabled(&key, off) {
             Ok(now_off) => {
                 self.publish_disabled();
-                self.reload_interface();
+                self.reload_interface(super::events::ReloadReason::Settings);
                 self.collect_declarations();
                 self.clamp_focus();
                 self.refresh_sources();
@@ -145,7 +148,7 @@ impl App {
         };
         match outcome {
             Ok(message) => {
-                self.reload_interface();
+                self.reload_interface(super::events::ReloadReason::Settings);
                 self.collect_declarations();
                 self.clamp_focus();
                 self.refresh_sources();
@@ -221,6 +224,7 @@ impl App {
         let on_disk = self.config.on_disk().clone();
         let mut saved = None;
         let mut edit = None;
+        let mut run = None;
         // Same reason as the settings clone: the modal reads it while `self` is
         // borrowed mutably to apply whatever comes back.
         let inventory = std::mem::take(&mut self.inventory);
@@ -232,6 +236,7 @@ impl App {
                 save_settings: &mut saved,
                 inventory: &inventory,
                 interface_edit: &mut edit,
+                run_action: &mut run,
                 db: db.as_ref(),
             };
             act(&mut self.modals, &mut world)
@@ -239,6 +244,10 @@ impl App {
         self.inventory = inventory;
         if let Some(draft) = saved {
             self.apply_settings(draft);
+        }
+        // The palette's choice, run after the modal has closed itself.
+        if let Some(dispatch) = run {
+            self.run_action(&dispatch.plugin, &dispatch.action);
         }
         match edit {
             Some(thurbox::kernel::modals::interface::Edit::File { file, kind }) => {

--- a/src/coordinator/mod.rs
+++ b/src/coordinator/mod.rs
@@ -20,6 +20,7 @@ pub(crate) mod chrome;
 mod commands;
 mod draw;
 pub(crate) mod editor;
+pub(crate) mod events;
 mod focus;
 mod input;
 mod interface;
@@ -51,6 +52,10 @@ impl App {
             self.sync_terminals_and_agents();
             self.serve_worker_stores();
             self.apply_external_requests();
+            // After everything above has published and before the paint, so a
+            // handler sees this iteration's state and its writes land in the
+            // frame about to be painted. A no-op while nothing is queued.
+            self.dispatch_events(&mut terminal);
 
             // Recorded BEFORE the paint so `tick` and `frame` decompose rather
             // than nest: the iteration is roughly tick + republish + frame +
@@ -92,7 +97,7 @@ impl App {
         if self.reload_at.is_some_and(|at| Instant::now() >= at) {
             self.reload_at = None;
             self.time_op("interface_reload", |app| {
-                app.reload_interface();
+                app.reload_interface(events::ReloadReason::Watch);
                 app.refresh_sources();
                 app.collect_declarations();
             });

--- a/src/coordinator/publish.rs
+++ b/src/coordinator/publish.rs
@@ -317,6 +317,7 @@ impl App {
         bindings.extend(thurbox::kernel::modals::bindings());
         pills.extend(thurbox::kernel::modals::pills());
         self.registry.declare_all(bindings, settings, pills);
+        self.registry.declare_commands(self.host.commands());
         // Trust is read against the plugin set that just loaded, so a reload —
         // including the one a trust change triggers — lands both together.
         self.publish_trust();

--- a/src/kernel/command/execute.rs
+++ b/src/kernel/command/execute.rs
@@ -155,6 +155,7 @@ pub(super) fn execute(
         | Command::Program { .. }
         | Command::Editor { .. }
         | Command::Focus { .. }
+        | Command::Emit { .. }
         | Command::Plugin { .. } => unreachable!("applied on the UI thread"),
     }
 }

--- a/src/kernel/command/mod.rs
+++ b/src/kernel/command/mod.rs
@@ -263,6 +263,18 @@ pub enum Command {
         file: String,
         edit: PluginEdit,
     },
+    /// Publish a user event to every plugin subscribed to it.
+    ///
+    /// UI-thread applied: the event queue is the loop's own, and delivery is the
+    /// next thing the loop does. `owner` is **stamped by the kernel** from the
+    /// plugin executing, like [`Command::Program`]'s, so a plugin cannot forge
+    /// the `source` its subscribers see. `name` already carries the `user.`
+    /// prefix — a kernel name was refused at parse time.
+    Emit {
+        owner: String,
+        name: String,
+        payload: Vec<(String, super::events::Field)>,
+    },
 }
 
 /// A further repository a new session spans.
@@ -329,6 +341,7 @@ impl Command {
             Command::Configure { .. } => "configure",
             Command::Order { .. } => "order",
             Command::Setting { .. } => "set",
+            Command::Emit { .. } => "emit",
         }
     }
 
@@ -364,6 +377,7 @@ impl Command {
             // the whole point of it, and why it must never appear in anything
             // that enumerates sessions.
             | Command::Program { .. }
+            | Command::Emit { .. }
             | Command::Focus { .. } => "",
         }
     }
@@ -391,6 +405,7 @@ impl Command {
                 | Command::Editor { .. }
                 | Command::Focus { .. }
                 | Command::Plugin { .. }
+                | Command::Emit { .. }
         )
     }
 
@@ -435,7 +450,22 @@ impl Command {
             extras,
             owner,
             argv,
+            payload,
         } = args;
+        // An event names nothing the kernel owns: the name is the subject, and
+        // every other field travels as the payload. Refused for a kernel name so
+        // a plugin cannot forge what only the kernel derives.
+        if kind == "emit" {
+            let Some(name) = text.filter(|t| !t.is_empty()) else {
+                return Err("command \"emit\" needs an event name in text".to_string());
+            };
+            let name = super::events::user_event_name(&name)?;
+            return Ok(Command::Emit {
+                owner,
+                name,
+                payload,
+            });
+        }
         // The interface's own files name no session, and the verb is explicit:
         // removing a plugin is destructive, so it is never the default.
         if kind == "plugin" {
@@ -631,7 +661,7 @@ impl Command {
             "editor" => Ok(Command::Editor { session }),
             other => Err(format!(
                 "unknown command {other:?} — try create, fork, sync, copy, diff, \
-                 delete, restore, restart, send, reorder, theme or set"
+                 delete, restore, restart, send, reorder, theme, set or emit"
             )),
         }
     }
@@ -676,6 +706,9 @@ pub struct Args {
     pub owner: String,
     /// Arguments for a program a plugin asked to run.
     pub argv: Vec<String>,
+    /// Every other scalar field of the options table, for a command that
+    /// forwards them whole — an event's payload.
+    pub payload: Vec<(String, super::events::Field)>,
 }
 
 #[cfg(test)]

--- a/src/kernel/events.rs
+++ b/src/kernel/events.rs
@@ -1,0 +1,508 @@
+//! Events a plugin can subscribe to, and how the kernel's own are derived.
+//!
+//! A plugin used to learn that the world changed only by being rendered and
+//! diffing the snapshot itself — once per frame, in every pane that cared. This
+//! is the push: the loop hands each subscriber one call per change, off the
+//! render path (`plugin-events`).
+//!
+//! The kernel's events are **derived by diffing published state**, never raised
+//! by the code that mutates it. A session created by `thurbox-cli`, a cron tick
+//! or a second interface looks exactly like one the creation flow made, and no
+//! mutation site anywhere can forget to fire — the failure mode of the other
+//! design, which is also the one that would have put a kernel concern inside
+//! `session_ops`, a layer the kernel may not `use`.
+//!
+//! The set is a closed enumeration ([`KERNEL_EVENTS`]) with one reader for each
+//! of its three uses: the loader validates a subscription against it, the help
+//! modal renders it, and `thurbox-cli plugin events` prints it. One list, so a
+//! name a plugin can subscribe to is always one the kernel can emit.
+
+use std::collections::BTreeSet;
+
+use super::snapshot::{SessionRow, Snapshot};
+
+/// A value carried in an event's payload.
+///
+/// Deliberately small: a payload is a handful of facts a handler can branch on,
+/// not a document. A session's whole row is already readable from the published
+/// tables by the id the payload names.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Field {
+    Text(String),
+    Bool(bool),
+    Number(f64),
+    List(Vec<String>),
+}
+
+impl From<&str> for Field {
+    fn from(text: &str) -> Self {
+        Field::Text(text.to_string())
+    }
+}
+
+impl From<String> for Field {
+    fn from(text: String) -> Self {
+        Field::Text(text)
+    }
+}
+
+/// One thing that happened, ready to be handed to every subscriber.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Event {
+    pub name: String,
+    pub payload: Vec<(String, Field)>,
+    /// How many handler generations deep this event was emitted.
+    ///
+    /// Zero for anything the kernel derived. A user event emitted from a handler
+    /// is one deeper than the event that handler was running for, which is what
+    /// bounds a ping-pong between two plugins — see [`MAX_DEPTH`].
+    pub depth: u8,
+}
+
+impl Event {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            payload: Vec::new(),
+            depth: 0,
+        }
+    }
+
+    /// Add a field. A `None` is left out rather than published as an empty
+    /// string, so a handler can test for presence.
+    pub fn with(mut self, key: &str, value: Option<impl Into<Field>>) -> Self {
+        if let Some(value) = value {
+            self.payload.push((key.to_string(), value.into()));
+        }
+        self
+    }
+
+    /// The text value of a field, for tests and for the loop's own reads.
+    pub fn text(&self, key: &str) -> Option<&str> {
+        self.payload.iter().find_map(|(k, v)| match v {
+            Field::Text(text) if k == key => Some(text.as_str()),
+            _ => None,
+        })
+    }
+}
+
+/// How many generations of user events one dispatch may cascade through.
+///
+/// A handler for `user.a` emits `user.b`, whose handler emits `user.a` again —
+/// two plugins can do that to each other without either being wrong on its
+/// own. The fifth generation is dropped and reported once, so the loop keeps
+/// its frame cadence whatever two plugins agree to do.
+pub const MAX_DEPTH: u8 = 4;
+
+/// The prefix every plugin-emitted event carries.
+pub const USER_PREFIX: &str = "user.";
+
+/// One event the kernel emits: its name, when it fires, and its payload fields.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EventSpec {
+    pub name: &'static str,
+    pub when: &'static str,
+    pub fields: &'static [&'static str],
+}
+
+/// Every event the kernel emits. **Closed**: a subscription to a name not here
+/// (and not of the `user.` form) refuses to load.
+pub const KERNEL_EVENTS: &[EventSpec] = &[
+    EventSpec {
+        name: "session.created",
+        when: "a session row appears in the snapshot, whoever made it",
+        fields: &["session", "name", "agent", "repo"],
+    },
+    EventSpec {
+        name: "session.deleted",
+        when: "a session row leaves the snapshot",
+        fields: &["session", "name"],
+    },
+    EventSpec {
+        name: "session.status",
+        when: "a session's derived status changes",
+        fields: &["session", "name", "from", "to"],
+    },
+    EventSpec {
+        name: "session.changed",
+        when: "a session's name, branch, repositories or parent change",
+        fields: &["session", "name", "fields"],
+    },
+    EventSpec {
+        name: "session.post_create",
+        when: "this interface finished creating (or forking) a session",
+        fields: &[
+            "session", "name", "agent", "repo", "cwd", "branch", "parent",
+        ],
+    },
+    EventSpec {
+        name: "session.post_delete",
+        when: "this interface finished deleting a session",
+        fields: &["session", "name", "force"],
+    },
+    EventSpec {
+        name: "session.post_restart",
+        when: "this interface finished restarting a session",
+        fields: &["session", "name", "agent", "repo", "cwd", "branch"],
+    },
+    EventSpec {
+        name: "session.post_restore",
+        when: "this interface finished restoring a session",
+        fields: &["session", "name", "agent", "repo", "cwd", "branch"],
+    },
+    EventSpec {
+        name: "focus.session",
+        when: "the selected session changes",
+        fields: &["from", "to"],
+    },
+    EventSpec {
+        name: "focus.pane",
+        when: "focus moves to another plugin",
+        fields: &["from", "to"],
+    },
+    EventSpec {
+        name: "command.done",
+        when: "a command a plugin issued completed",
+        fields: &["kind", "session", "subject"],
+    },
+    EventSpec {
+        name: "command.failed",
+        when: "a command a plugin issued failed",
+        fields: &["kind", "session", "subject", "error"],
+    },
+    EventSpec {
+        name: "interface.reloaded",
+        when: "the interface was rebuilt from disk",
+        fields: &["reason"],
+    },
+];
+
+/// Is this a name the kernel emits?
+pub fn is_kernel_event(name: &str) -> bool {
+    KERNEL_EVENTS.iter().any(|spec| spec.name == name)
+}
+
+/// The characters a user event's name may be made of.
+fn is_identifier(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.'))
+}
+
+/// Check a name a plugin subscribes to.
+///
+/// Refused rather than ignored: a subscription to a name nothing emits is a
+/// handler that never fires, which is the one failure with no symptom. The
+/// message names what was available, the way an unknown capability's does.
+pub fn validate_subscription(name: &str) -> Result<(), String> {
+    if is_kernel_event(name) {
+        return Ok(());
+    }
+    if let Some(rest) = name.strip_prefix(USER_PREFIX) {
+        if is_identifier(rest) {
+            return Ok(());
+        }
+        return Err(format!(
+            "{name:?} is not a valid user event — the part after \"user.\" must be a name"
+        ));
+    }
+    let known: Vec<&str> = KERNEL_EVENTS.iter().map(|spec| spec.name).collect();
+    Err(format!(
+        "no event named {name:?} (available: {}, or user.<name>)",
+        known.join(", ")
+    ))
+}
+
+/// The full name a plugin's emit is delivered under, or why it may not be.
+///
+/// A plugin writes `command("emit", { text = "refresh" })` and subscribers see
+/// `user.refresh`. A kernel name is refused outright, and so is one already
+/// spelled with the prefix — `user.user.x` would be a name nobody subscribed to.
+pub fn user_event_name(name: &str) -> Result<String, String> {
+    if is_kernel_event(name) {
+        return Err(format!(
+            "command \"emit\": {name:?} is a kernel event and cannot be emitted by a plugin"
+        ));
+    }
+    if name.starts_with(USER_PREFIX) {
+        return Err(format!(
+            "command \"emit\": name {name:?} without the \"user.\" prefix — it is added for you"
+        ));
+    }
+    if !is_identifier(name) {
+        return Err(format!(
+            "command \"emit\": {name:?} is not a valid event name (letters, digits, _ - .)"
+        ));
+    }
+    Ok(format!("{USER_PREFIX}{name}"))
+}
+
+/// The facts about a session the derived events are defined over.
+#[derive(Debug, Clone, PartialEq)]
+struct Facts {
+    name: String,
+    agent: String,
+    repo: Option<String>,
+    repos: Vec<String>,
+    status: String,
+    branch: Option<String>,
+    parent: Option<String>,
+}
+
+impl Facts {
+    fn of(row: &SessionRow) -> Self {
+        Self {
+            name: row.name.clone(),
+            agent: row.agent.clone(),
+            repo: row.repo.clone(),
+            repos: row.repos.clone(),
+            status: row.status.clone(),
+            branch: row.branch.clone(),
+            parent: row.parent_id.clone(),
+        }
+    }
+}
+
+/// Turns one snapshot into the events that separate it from the last.
+///
+/// Keyed on `SnapshotStore::version`, so asking on every iteration costs one
+/// integer compare while nothing moves — and the first snapshot after a load
+/// **seeds** silently: the rows that existed before a plugin did are not news.
+#[derive(Debug, Default)]
+pub struct Deriver {
+    /// Rows as last observed, in published order.
+    rows: Vec<(String, Facts)>,
+    version: Option<u64>,
+}
+
+impl Deriver {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Everything that changed since the last call, in the order a subscriber
+    /// should hear it: departures, arrivals, status changes, other changes —
+    /// each in published row order.
+    pub fn observe(&mut self, snapshot: &Snapshot, version: u64) -> Vec<Event> {
+        if self.version == Some(version) {
+            return Vec::new();
+        }
+        let seeded = self.version.is_some();
+        self.version = Some(version);
+        let next: Vec<(String, Facts)> = snapshot
+            .sessions
+            .iter()
+            .map(|row| (row.id.clone(), Facts::of(row)))
+            .collect();
+        if !seeded {
+            self.rows = next;
+            return Vec::new();
+        }
+
+        let mut events = Vec::new();
+        let new_ids: BTreeSet<&str> = next.iter().map(|(id, _)| id.as_str()).collect();
+        for (id, facts) in &self.rows {
+            if !new_ids.contains(id.as_str()) {
+                events.push(
+                    Event::new("session.deleted")
+                        .with("session", Some(id.as_str()))
+                        .with("name", Some(facts.name.as_str())),
+                );
+            }
+        }
+        let old: std::collections::HashMap<&str, &Facts> = self
+            .rows
+            .iter()
+            .map(|(id, facts)| (id.as_str(), facts))
+            .collect();
+        for (id, facts) in &next {
+            if !old.contains_key(id.as_str()) {
+                events.push(
+                    Event::new("session.created")
+                        .with("session", Some(id.as_str()))
+                        .with("name", Some(facts.name.as_str()))
+                        .with("agent", Some(facts.agent.as_str()))
+                        .with("repo", facts.repo.as_deref()),
+                );
+            }
+        }
+        let mut changes = Vec::new();
+        for (id, facts) in &next {
+            let Some(before) = old.get(id.as_str()) else {
+                continue;
+            };
+            if before.status != facts.status {
+                events.push(
+                    Event::new("session.status")
+                        .with("session", Some(id.as_str()))
+                        .with("name", Some(facts.name.as_str()))
+                        .with("from", Some(before.status.as_str()))
+                        .with("to", Some(facts.status.as_str())),
+                );
+            }
+            let mut fields = Vec::new();
+            if before.name != facts.name {
+                fields.push("name".to_string());
+            }
+            if before.branch != facts.branch {
+                fields.push("branch".to_string());
+            }
+            if before.repo != facts.repo || before.repos != facts.repos {
+                fields.push("repos".to_string());
+            }
+            if before.parent != facts.parent {
+                fields.push("parent".to_string());
+            }
+            if !fields.is_empty() {
+                changes.push(
+                    Event::new("session.changed")
+                        .with("session", Some(id.as_str()))
+                        .with("name", Some(facts.name.as_str()))
+                        .with("fields", Some(Field::List(fields))),
+                );
+            }
+        }
+        events.extend(changes);
+        self.rows = next;
+        events
+    }
+
+    /// Forget everything, so the next snapshot seeds again.
+    ///
+    /// For a reload: the plugins that would have heard about the rows since the
+    /// last observation no longer exist, and the ones that replaced them are
+    /// told `interface.reloaded` instead.
+    pub fn reset(&mut self) {
+        self.rows.clear();
+        self.version = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn row(id: &str, status: &str) -> SessionRow {
+        SessionRow {
+            id: id.to_string(),
+            name: format!("name-{id}"),
+            agent: "claude".into(),
+            status: status.into(),
+            cwd: Some(PathBuf::from("/src/thurbox")),
+            repo: Some("thurbox".into()),
+            repos: vec!["thurbox".into()],
+            branch: Some(format!("feat/{id}")),
+            base_branch: None,
+            backend: "local-tmux".into(),
+            backend_id: None,
+            remote_host: None,
+            agent_session_id: None,
+            parent_id: None,
+            display_order: None,
+            worktree_count: 1,
+            git: None,
+            hook_state: None,
+            shell_backend_id: None,
+            member_dirs: Vec::new(),
+        }
+    }
+
+    fn snapshot(rows: Vec<SessionRow>) -> Snapshot {
+        Snapshot {
+            sessions: rows,
+            ..Snapshot::default()
+        }
+    }
+
+    #[test]
+    fn the_first_snapshot_seeds_silently() {
+        let mut deriver = Deriver::new();
+        let events = deriver.observe(&snapshot(vec![row("a", "idle"), row("b", "working")]), 1);
+        assert!(events.is_empty(), "{events:?}");
+    }
+
+    #[test]
+    fn an_unchanged_version_costs_nothing_and_says_nothing() {
+        let mut deriver = Deriver::new();
+        deriver.observe(&snapshot(vec![row("a", "idle")]), 1);
+        assert!(deriver.observe(&snapshot(vec![]), 1).is_empty());
+    }
+
+    #[test]
+    fn arrivals_departures_and_changes_each_fire_once_in_order() {
+        let mut deriver = Deriver::new();
+        deriver.observe(&snapshot(vec![row("a", "idle"), row("b", "working")]), 1);
+        let mut renamed = row("a", "blocked");
+        renamed.name = "renamed".into();
+        renamed.branch = Some("other".into());
+        let events = deriver.observe(&snapshot(vec![renamed, row("c", "idle")]), 2);
+        let names: Vec<&str> = events.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(
+            names,
+            [
+                "session.deleted",
+                "session.created",
+                "session.status",
+                "session.changed"
+            ]
+        );
+        assert_eq!(events[0].text("session"), Some("b"));
+        assert_eq!(events[1].text("session"), Some("c"));
+        assert_eq!(events[1].text("repo"), Some("thurbox"));
+        assert_eq!(events[2].text("from"), Some("idle"));
+        assert_eq!(events[2].text("to"), Some("blocked"));
+        assert_eq!(
+            events[3]
+                .payload
+                .iter()
+                .find(|(k, _)| k == "fields")
+                .map(|(_, v)| v),
+            Some(&Field::List(vec!["name".into(), "branch".into()]))
+        );
+        // And nothing fires again for the same version.
+        assert!(deriver.observe(&snapshot(vec![]), 2).is_empty());
+    }
+
+    #[test]
+    fn a_reset_makes_the_next_snapshot_seed_again() {
+        let mut deriver = Deriver::new();
+        deriver.observe(&snapshot(vec![row("a", "idle")]), 1);
+        deriver.reset();
+        assert!(deriver
+            .observe(&snapshot(vec![row("b", "idle")]), 2)
+            .is_empty());
+    }
+
+    #[test]
+    fn a_subscription_is_a_kernel_name_or_a_user_name() {
+        for spec in KERNEL_EVENTS {
+            validate_subscription(spec.name).expect(spec.name);
+        }
+        validate_subscription("user.refresh").expect("user event");
+        let error = validate_subscription("sesion.status").unwrap_err();
+        assert!(error.contains("sesion.status"), "{error}");
+        assert!(error.contains("session.status"), "{error}");
+        assert!(validate_subscription("user.").is_err());
+        assert!(validate_subscription("user.with space").is_err());
+    }
+
+    #[test]
+    fn an_emit_is_prefixed_and_a_kernel_name_is_refused() {
+        assert_eq!(user_event_name("refresh").unwrap(), "user.refresh");
+        assert!(user_event_name("session.created").is_err());
+        assert!(user_event_name("user.refresh").is_err());
+        assert!(user_event_name("").is_err());
+    }
+
+    #[test]
+    fn every_kernel_event_documents_its_payload() {
+        let mut names = BTreeSet::new();
+        for spec in KERNEL_EVENTS {
+            assert!(!spec.when.is_empty(), "{}", spec.name);
+            assert!(!spec.fields.is_empty(), "{}", spec.name);
+            assert!(names.insert(spec.name), "{} listed twice", spec.name);
+        }
+    }
+}

--- a/src/kernel/host/api.rs
+++ b/src/kernel/host/api.rs
@@ -10,6 +10,7 @@ use super::{
     instruction_budget, memory_limit, Persisted, Private, Queue, Roots, Shared, StateVersion,
 };
 use crate::kernel::command::{Args, Command, ExtraMember};
+use crate::kernel::events::Field;
 
 /// Install `require`, `state` and `store` into a fresh VM.
 #[allow(clippy::too_many_arguments)]
@@ -217,6 +218,28 @@ fn install_command(lua: &Lua, queue: Queue, current_path: Rc<RefCell<String>>) -
                                 worktree: entry.get::<Option<bool>>("worktree").ok().flatten()
                                     == Some(true),
                             })
+                        })
+                        .collect()
+                })
+                .unwrap_or_default(),
+            // Every scalar the plugin passed, for an event's payload. `text` is
+            // the event's name and is left out; nothing else is interpreted.
+            payload: opts
+                .as_ref()
+                .map(|table| {
+                    table
+                        .pairs::<String, Value>()
+                        .filter_map(Result::ok)
+                        .filter(|(key, _)| key != "text")
+                        .filter_map(|(key, value)| {
+                            let field = match value {
+                                Value::String(s) => Field::Text(s.to_string_lossy()),
+                                Value::Boolean(b) => Field::Bool(b),
+                                Value::Integer(n) => Field::Number(n as f64),
+                                Value::Number(n) => Field::Number(n),
+                                _ => return None,
+                            };
+                            Some((key, field))
                         })
                         .collect()
                 })

--- a/src/kernel/host/load.rs
+++ b/src/kernel/host/load.rs
@@ -10,7 +10,9 @@ use super::{
     instruction_budget, memory_limit, plugin_stdlib, Arrangement, Capability, Float, Plugin,
 };
 use crate::kernel::node::Size;
-use crate::kernel::registry::{binding_from, Binding, Pill, Setting, Value as SettingValue};
+use crate::kernel::registry::{
+    binding_from, Binding, CommandDecl, Pill, Setting, Value as SettingValue,
+};
 
 /// Build a VM with the deliberate stdlib set and the memory ceiling.
 pub(super) fn new_vm() -> mlua::Result<Lua> {
@@ -181,6 +183,8 @@ pub(super) fn load_plugin(lua: &Lua, path: &Path, relative: &str) -> Result<Plug
     let settings = read_settings(&def, &name)?;
     let pills = read_pills(&def, &name)?;
     let capabilities = read_capabilities(&def, &file)?;
+    let events = read_events(&def, &file)?;
+    let commands = read_commands(&def, &name)?;
 
     // A decorator transforms another pane's tree and draws nothing of its own,
     // so requiring `render` of one would mean writing a stub that returns
@@ -207,8 +211,64 @@ pub(super) fn load_plugin(lua: &Lua, path: &Path, relative: &str) -> Result<Plug
         settings,
         pills,
         capabilities,
+        events,
+        commands,
         def,
     })
+}
+
+/// Read `events = { "session.status", … }` off a declaration.
+///
+/// Each name is checked against the kernel's enumeration (or the `user.` form)
+/// here, at load, because a subscription to a name nothing emits is a handler
+/// that never fires — the one failure with no symptom at all. Refused the way
+/// an unknown capability is, with the file named and the alternatives listed.
+fn read_events(def: &Table, file: &str) -> Result<Vec<String>, String> {
+    let declared: Option<Vec<String>> = def
+        .get("events")
+        .map_err(|e| format!("{file}.events: {e}"))?;
+    let mut out = Vec::new();
+    for name in declared.unwrap_or_default() {
+        crate::kernel::events::validate_subscription(&name)
+            .map_err(|e| format!("{file}.events: {e}"))?;
+        if !out.contains(&name) {
+            out.push(name);
+        }
+    }
+    Ok(out)
+}
+
+/// Read `commands = { { action = …, desc = … } }` — the palette's rows.
+///
+/// Same shape as a key without the chord: the action id is the one `on_action`
+/// is called back with, so a command and a key for one action are one thing
+/// reached two ways.
+fn read_commands(def: &Table, plugin: &str) -> Result<Vec<CommandDecl>, String> {
+    let raw: Value = def
+        .get("commands")
+        .map_err(|e| format!("{plugin}.commands: {e}"))?;
+    let Value::Table(list) = raw else {
+        return Ok(Vec::new());
+    };
+    let mut commands = Vec::new();
+    for (index, entry) in list.sequence_values::<Table>().enumerate() {
+        let entry = entry.map_err(|e| format!("{plugin}.commands[{}]: {e}", index + 1))?;
+        let where_ = format!("{plugin}.commands[{}]", index + 1);
+        let action: String = entry
+            .get::<Option<String>>("action")
+            .map_err(|e| format!("{where_}.action: {e}"))?
+            .ok_or_else(|| format!("{where_}: needs an action"))?;
+        let description: String = entry
+            .get::<Option<String>>("desc")
+            .map_err(|e| format!("{where_}.desc: {e}"))?
+            .unwrap_or_default();
+        commands.push(CommandDecl {
+            plugin: plugin.to_string(),
+            action,
+            description,
+        });
+    }
+    Ok(commands)
 }
 
 /// Read `capabilities = { "run" }` off a declaration.
@@ -287,6 +347,12 @@ fn read_bindings(def: &Table, plugin: &str) -> Result<Vec<Binding>, String> {
             .get::<Option<String>>("key")
             .map_err(|e| format!("{where_}.key: {e}"))?
             .ok_or_else(|| format!("{where_}: needs a key"))?;
+        // An empty chord would never fire and — because a chord-less command
+        // the user binds is synthesised with an empty *default* — would be
+        // dropped on the next override pass. Refused, like a missing one.
+        if chord.trim().is_empty() {
+            return Err(format!("{where_}: needs a key"));
+        }
         let action: String = entry
             .get::<Option<String>>("action")
             .map_err(|e| format!("{where_}.action: {e}"))?

--- a/src/kernel/host/mod.rs
+++ b/src/kernel/host/mod.rs
@@ -27,9 +27,10 @@ use ratatui::layout::Rect;
 
 use super::command::{Command, InFlight};
 use super::convert;
+use super::events::{Event, Field};
 use super::layout::{Region, SlotMode};
 use super::node::{Node, Size};
-use super::registry::{Binding, Pill, Registry, Setting};
+use super::registry::{Binding, CommandDecl, Pill, Registry, Setting};
 use super::snapshot::Snapshot;
 use super::theme::Themes;
 
@@ -141,6 +142,9 @@ pub enum Phase {
     Load,
     Render,
     Key,
+    /// An `on_event` handler — off the render path, so its failure is reported
+    /// once per event rather than painted into a pane every frame.
+    Event,
 }
 
 impl Phase {
@@ -149,6 +153,7 @@ impl Phase {
             Phase::Load => "load",
             Phase::Render => "render",
             Phase::Key => "key",
+            Phase::Event => "event",
         }
     }
 }
@@ -240,6 +245,14 @@ pub struct Plugin {
     /// interface's own file list can say which files ask to run programs
     /// without anyone reading their source.
     pub capabilities: Vec<Capability>,
+    /// Events this plugin subscribed to, each validated at load against
+    /// [`super::events::KERNEL_EVENTS`] or the `user.` form.
+    ///
+    /// Data, like `keys`: a handler with no list receives nothing, so what a
+    /// plugin listens for is enumerable without calling it.
+    pub events: Vec<String>,
+    /// Actions this plugin wants reachable without a chord — the palette's rows.
+    pub commands: Vec<CommandDecl>,
     order: f64,
     def: Table,
 }
@@ -895,6 +908,120 @@ impl LuaHost {
     /// Index of a plugin by name.
     pub fn index_of(&self, name: &str) -> Option<usize> {
         self.plugins.iter().position(|p| p.name == name)
+    }
+
+    /// The name of the plugin at a path — what an event's `source` carries.
+    pub fn name_of_path(&self, path: &str) -> Option<&str> {
+        self.plugins
+            .iter()
+            .find(|plugin| plugin.path == path)
+            .map(|plugin| plugin.name.as_str())
+    }
+
+    /// Every chord-less command every loaded plugin declared.
+    pub fn commands(&self) -> Vec<CommandDecl> {
+        self.plugins
+            .iter()
+            .flat_map(|plugin| plugin.commands.iter().cloned())
+            .collect()
+    }
+
+    /// Indices of the plugins subscribed to an event, in load order.
+    pub fn subscribers(&self, event: &str) -> Vec<usize> {
+        self.plugins
+            .iter()
+            .enumerate()
+            .filter(|(_, plugin)| plugin.events.iter().any(|name| name == event))
+            .map(|(index, _)| index)
+            .collect()
+    }
+
+    /// Hand one event to every plugin subscribed to it.
+    ///
+    /// The payload table is built **once** and shared: a handler that mutates it
+    /// changes what a later subscriber reads, which is the same contract a
+    /// published table already has — and building it per subscriber would be a
+    /// table per plugin per event for a value nobody is meant to write.
+    ///
+    /// Every subscriber is called whatever the earlier ones did: a handler that
+    /// throws or overruns its budget costs itself, reported against its plugin
+    /// with the event's name, and the next handler still runs. Return values are
+    /// ignored — a handler cannot answer, only enqueue commands and write state.
+    pub fn dispatch_event(&self, event: &Event) -> Vec<PluginError> {
+        let subscribers = self.subscribers(&event.name);
+        if subscribers.is_empty() {
+            return Vec::new();
+        }
+        let mut failures = Vec::new();
+        let payload = match self.payload_table(event) {
+            Ok(table) => table,
+            Err(message) => {
+                failures.push(PluginError {
+                    plugin: "kernel".to_string(),
+                    phase: Phase::Event,
+                    message: format!("{}: {message}", event.name),
+                });
+                return failures;
+            }
+        };
+        for index in subscribers {
+            if let Err(e) = self.on_event(index, &event.name, &payload) {
+                failures.push(e);
+            }
+        }
+        failures
+    }
+
+    /// Call one plugin's `on_event` with a name and a payload table.
+    fn on_event(&self, index: usize, name: &str, payload: &Table) -> Result<(), PluginError> {
+        let Some(plugin) = self.plugins.get(index) else {
+            return Ok(());
+        };
+        let fail = |message: String| PluginError {
+            plugin: plugin.name.clone(),
+            phase: Phase::Event,
+            message: format!("{name}: {message}"),
+        };
+        let handler: Value = plugin
+            .def
+            .get("on_event")
+            .map_err(|e| fail(e.to_string()))?;
+        let Value::Function(handler) = handler else {
+            return Ok(());
+        };
+
+        self.enter(plugin);
+        let guard = Budget::arm(&self.lua);
+        let outcome: Result<Value, mlua::Error> = handler.call((name.to_string(), payload.clone()));
+        drop(guard);
+        outcome.map(|_| ()).map_err(|e| fail(clean_error(&e)))
+    }
+
+    fn payload_table(&self, event: &Event) -> Result<Table, String> {
+        let table = self.lua.create_table().map_err(|e| e.to_string())?;
+        for (key, value) in &event.payload {
+            let value = match value {
+                Field::Text(text) => {
+                    Value::String(self.lua.create_string(text).map_err(|e| e.to_string())?)
+                }
+                Field::Bool(flag) => Value::Boolean(*flag),
+                // An integral number goes in as an integer, or `count = 2` reads
+                // back as `2.0` — the same care `state` takes with its values.
+                Field::Number(n) if n.fract() == 0.0 && n.abs() < (i64::MAX as f64) => {
+                    Value::Integer(*n as i64)
+                }
+                Field::Number(n) => Value::Number(*n),
+                Field::List(items) => {
+                    let list = self.lua.create_table().map_err(|e| e.to_string())?;
+                    for (i, item) in items.iter().enumerate() {
+                        list.set(i + 1, item.clone()).map_err(|e| e.to_string())?;
+                    }
+                    Value::Table(list)
+                }
+            };
+            table.set(key.as_str(), value).map_err(|e| e.to_string())?;
+        }
+        Ok(table)
     }
 
     /// Indices of the plugins occupying one slot, in render order.

--- a/src/kernel/mod.rs
+++ b/src/kernel/mod.rs
@@ -15,6 +15,7 @@ pub mod config;
 pub mod consent;
 pub mod convert;
 pub mod diff;
+pub mod events;
 pub mod files;
 pub mod focus;
 pub mod host;

--- a/src/kernel/modals/help.rs
+++ b/src/kernel/modals/help.rs
@@ -307,6 +307,39 @@ impl HelpModal {
             ));
         }
 
+        // The events a plugin may subscribe to, from the same table the loader
+        // validates against — so what help shows is what `events = { … }` may
+        // name, and a plugin author need not leave the interface to find out.
+        lines.push(Line::default());
+        lines.push(Line::from(Span::styled(
+            "Events (for plugins: events = { … } + on_event)",
+            chrome.section_header(),
+        )));
+        let event_width = crate::kernel::events::KERNEL_EVENTS
+            .iter()
+            .map(|spec| spec.name.chars().count())
+            .max()
+            .unwrap_or(0)
+            + 2;
+        for spec in crate::kernel::events::KERNEL_EVENTS {
+            lines.push(entry_line(
+                event_width,
+                spec.name,
+                &format!("{} — {}", spec.fields.join(", "), spec.when),
+                None,
+                false,
+                chrome,
+            ));
+        }
+        lines.push(entry_line(
+            event_width,
+            &format!("{}<name>", crate::kernel::events::USER_PREFIX),
+            "source, … — a plugin ran command(\"emit\", { text = \"<name>\", … })",
+            None,
+            false,
+            chrome,
+        ));
+
         let total = lines.len();
         let height = usize::from(body.height);
         let scroll = scroll_for(total, height, selected_line);

--- a/src/kernel/modals/mod.rs
+++ b/src/kernel/modals/mod.rs
@@ -28,6 +28,7 @@
 pub mod chrome;
 pub mod help;
 pub mod interface;
+pub mod palette;
 pub mod settings;
 pub mod theme;
 
@@ -53,6 +54,8 @@ pub enum ModalKind {
     Help,
     Settings,
     Theme,
+    /// The command palette — every action in the registry, one query away.
+    Palette,
 }
 
 impl ModalKind {
@@ -66,13 +69,19 @@ impl ModalKind {
             ModalKind::Help => "help.open",
             ModalKind::Settings => "settings.open",
             ModalKind::Theme => "themes.open",
+            ModalKind::Palette => "palette.open",
         }
     }
 
     pub fn from_action(action: &str) -> Option<Self> {
-        [ModalKind::Help, ModalKind::Settings, ModalKind::Theme]
-            .into_iter()
-            .find(|kind| kind.action() == action)
+        [
+            ModalKind::Help,
+            ModalKind::Settings,
+            ModalKind::Theme,
+            ModalKind::Palette,
+        ]
+        .into_iter()
+        .find(|kind| kind.action() == action)
     }
 }
 
@@ -90,6 +99,12 @@ pub fn bindings() -> Vec<Binding> {
         ("ctrl+,", ModalKind::Settings, "open settings"),
         ("f4", ModalKind::Theme, "open theme picker"),
         ("ctrl+y", ModalKind::Theme, "open theme picker"),
+        // Taken deliberately from the list of chords held for v1's panes
+        // (`tests/v2_keymap.rs`): the automations pane it was held for is one
+        // query away in the palette once it returns. No F-key alternate — every
+        // one is bound or held, and this chord is never deferred to the agent
+        // (readline's previous-history is also the up arrow).
+        ("ctrl+p", ModalKind::Palette, "open the command palette"),
     ]
     .into_iter()
     .map(|(chord, kind, description)| {
@@ -158,6 +173,10 @@ pub struct World<'a> {
     /// path that writes an interface file and asks for the reload. Same shape as
     /// `save_settings`, for the same reason.
     pub interface_edit: &'a mut Option<interface::Edit>,
+    /// Where the palette's choice is left for the loop, which owns the one path
+    /// that runs an action. Same shape as `save_settings`, for the same reason
+    /// — and the modal has closed itself by the time the loop reads it.
+    pub run_action: &'a mut Option<palette::Dispatch>,
     /// Where the theme choice is persisted. `None` when the database could not
     /// be opened — the choice then applies for this run only.
     pub db: Option<&'a Database>,
@@ -167,6 +186,7 @@ enum Open {
     Help(help::HelpModal),
     Settings(settings::SettingsModal),
     Theme(theme::ThemeModal),
+    Palette(palette::PaletteModal),
 }
 
 /// The modal layer: at most one modal, above everything.
@@ -191,7 +211,17 @@ impl Modals {
             Some(Open::Help(_)) => Some(ModalKind::Help),
             Some(Open::Settings(_)) => Some(ModalKind::Settings),
             Some(Open::Theme(_)) => Some(ModalKind::Theme),
+            Some(Open::Palette(_)) => Some(ModalKind::Palette),
             None => None,
+        }
+    }
+
+    /// The palette's query as typed so far, for the loop's tests and for a
+    /// caller that wants to know whether typing is going anywhere.
+    pub fn palette_query(&self) -> Option<&str> {
+        match &self.open {
+            Some(Open::Palette(modal)) => Some(modal.query()),
+            _ => None,
         }
     }
 
@@ -223,6 +253,7 @@ impl Modals {
             ModalKind::Help => Open::Help(help::HelpModal::default()),
             ModalKind::Settings => Open::Settings(settings::SettingsModal::default()),
             ModalKind::Theme => Open::Theme(theme::ThemeModal::default()),
+            ModalKind::Palette => Open::Palette(palette::PaletteModal::default()),
         });
     }
 
@@ -288,6 +319,17 @@ impl Modals {
                     Some(message)
                 }
             },
+            // Closed BEFORE the loop runs the choice, so the action sees the
+            // focus state a key press would have — and cannot re-enter the modal
+            // it was chosen from.
+            Open::Palette(modal) => match modal.on_key(key, world.registry) {
+                palette::Outcome::Stay(message) => message,
+                palette::Outcome::Run(dispatch) => {
+                    self.close();
+                    *world.run_action = Some(dispatch);
+                    None
+                }
+            },
         }
     }
 
@@ -297,6 +339,8 @@ impl Modals {
             Some(Open::Help(modal)) => modal.capturing(),
             Some(Open::Settings(modal)) => modal.editing(),
             Some(Open::Theme(modal)) => modal.filtering(),
+            // Typing is the palette's only mode, so `Esc` always closes it.
+            Some(Open::Palette(_)) => false,
             None => false,
         }
     }
@@ -326,6 +370,10 @@ impl Modals {
                 // previews too — `ClickVerb::Key`'s rule, one level up.
                 modal.on_click(x, y);
                 modal.preview_selected(world.themes);
+                None
+            }
+            Open::Palette(modal) => {
+                modal.on_click(x, y);
                 None
             }
         }
@@ -378,6 +426,7 @@ impl Modals {
             Open::Help(modal) => modal.hits(),
             Open::Settings(modal) => modal.hits(),
             Open::Theme(modal) => modal.hits(),
+            Open::Palette(modal) => modal.hits(),
         })
     }
 
@@ -401,6 +450,7 @@ impl Modals {
                 modal.render(frame, area, registry, on_disk, files, chrome)
             }
             Some(Open::Theme(modal)) => modal.render(frame, area, themes, chrome),
+            Some(Open::Palette(modal)) => modal.render(frame, area, registry, chrome),
             None => return,
         }
         // One place for all three: the row band is painted over cells the modal
@@ -447,6 +497,7 @@ mod tests {
             save_settings: saved,
             inventory: &[],
             interface_edit: Box::leak(Box::new(None)),
+            run_action: Box::leak(Box::new(None)),
             db: None,
         }
     }
@@ -509,7 +560,7 @@ mod tests {
     #[test]
     fn every_modal_chord_v1_binds_is_declared() {
         let declared: Vec<String> = bindings().into_iter().map(|b| b.chord).collect();
-        for chord in ["f1", "ctrl+g", "f4", "ctrl+y", "f6", "ctrl+,"] {
+        for chord in ["f1", "ctrl+g", "f4", "ctrl+y", "f6", "ctrl+,", "ctrl+p"] {
             assert!(
                 declared.iter().any(|declared| declared == chord),
                 "{chord} opens nothing"

--- a/src/kernel/modals/palette.rs
+++ b/src/kernel/modals/palette.rs
@@ -1,0 +1,511 @@
+//! The command palette: every action the registry knows, one query away.
+//!
+//! An action used to be reachable only by its chord, in a `Ctrl+<letter>`
+//! namespace that readline, the agents and v1's muscle memory have already
+//! spent; help could *list* an action but not run it. The palette lists every
+//! plugin's keys, every chord-less `commands` declaration and the kernel's own,
+//! filters them as you type, and runs the chosen one through the same
+//! `on_action` path a key press takes — so a plugin cannot tell the two apart
+//! (`command-palette`).
+//!
+//! Chrome like help and settings: plugins contribute rows by declaring data,
+//! the kernel draws and dispatches.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::Style;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::Paragraph;
+use ratatui::Frame;
+
+use super::chrome::{self, Chrome, Hits, Pill, Replay};
+use super::{ModalKind, OWNER};
+use crate::kernel::registry::{PaletteRow, Registry, QUIT_CHORD};
+
+/// Non-list rows the modal always spends: both borders, the query line, the
+/// footer and one spacer.
+const CHROME: u16 = 5;
+const MAX_FRAME_PCT: u16 = 80;
+const MIN_HEIGHT: u16 = 8;
+const WIDTH_PCT: u16 = 60;
+const RIGHT_GUTTER: usize = 1;
+
+/// Two actions the kernel handles before the registry is consulted, and so has
+/// no binding for — listed here so the palette can still run them.
+pub const RELOAD_ACTION: &str = "kernel.reload";
+pub const QUIT_ACTION: &str = "kernel.quit";
+
+/// What `Enter` chose: the owner and the action id, exactly as a resolved key
+/// carries them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Dispatch {
+    pub plugin: String,
+    pub action: String,
+}
+
+pub enum Outcome {
+    Stay(Option<String>),
+    /// An action was chosen; the layer closes the modal *before* the loop runs
+    /// it, so the action sees the focus state a key press would have.
+    Run(Dispatch),
+}
+
+/// Every row the palette offers, in listing order.
+///
+/// The registry's rows, minus the palette's own chord (opening it from inside
+/// itself is not an action anyone means), plus the two reserved chords that no
+/// binding backs.
+pub fn rows(registry: &Registry) -> Vec<PaletteRow> {
+    let mut rows: Vec<PaletteRow> = registry
+        .palette_rows()
+        .into_iter()
+        .filter(|row| row.action != ModalKind::Palette.action())
+        .collect();
+    rows.push(PaletteRow {
+        plugin: OWNER.to_string(),
+        action: RELOAD_ACTION.to_string(),
+        description: "reload the interface from disk".to_string(),
+        chords: Some("f10".to_string()),
+    });
+    rows.push(PaletteRow {
+        plugin: OWNER.to_string(),
+        action: QUIT_ACTION.to_string(),
+        description: "quit (sessions keep running)".to_string(),
+        chords: Some(QUIT_CHORD.to_string()),
+    });
+    rows
+}
+
+/// Subsequence match, case-folded: the query's characters in order, not
+/// necessarily together. The same rule `ui/lib/fuzzy.lua` applies to the
+/// session list and the search strip, so the three cannot disagree about what
+/// `thm` finds.
+fn subsequence(query: &[char], haystack: &str) -> bool {
+    if query.is_empty() {
+        return true;
+    }
+    let mut wanted = 0;
+    for c in haystack.chars().flat_map(char::to_lowercase) {
+        if c == query[wanted] {
+            wanted += 1;
+            if wanted == query.len() {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Indices of the rows a query keeps, in listing order.
+pub fn matches(rows: &[PaletteRow], query: &str) -> Vec<usize> {
+    let needle: Vec<char> = query.chars().flat_map(char::to_lowercase).collect();
+    rows.iter()
+        .enumerate()
+        .filter(|(_, row)| {
+            subsequence(&needle, &row.description)
+                || subsequence(&needle, &row.action)
+                || subsequence(&needle, &row.plugin)
+        })
+        .map(|(index, _)| index)
+        .collect()
+}
+
+#[derive(Default)]
+pub struct PaletteModal {
+    query: String,
+    /// Cursor within the *matches*, not the full list.
+    selected: usize,
+    /// Rows the list showed last frame, so `PgUp`/`PgDn` step a screenful.
+    page: usize,
+    hits: Hits,
+}
+
+impl PaletteModal {
+    pub fn hits(&self) -> &Hits {
+        &self.hits
+    }
+
+    pub fn query(&self) -> &str {
+        &self.query
+    }
+
+    pub fn on_key(&mut self, key: &KeyEvent, registry: &Registry) -> Outcome {
+        let rows = rows(registry);
+        let matched = matches(&rows, &self.query);
+        let total = matched.len();
+        let highlighted = matched.get(self.selected).copied();
+
+        match key.code {
+            // Typing is the primary mode, so a bare letter is query text and
+            // navigation lives on the keys that cannot be typed.
+            KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.query.push(c);
+                self.keep_highlighted(&rows, highlighted);
+            }
+            KeyCode::Backspace => {
+                self.query.pop();
+                self.keep_highlighted(&rows, highlighted);
+            }
+            KeyCode::Down => self.move_by(1, total),
+            KeyCode::Up => self.move_by(-1, total),
+            KeyCode::Char('n') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.move_by(1, total)
+            }
+            KeyCode::PageDown => self.move_by(self.page.max(1) as isize, total),
+            KeyCode::PageUp => self.move_by(-(self.page.max(1) as isize), total),
+            KeyCode::Home => self.selected = 0,
+            KeyCode::End => self.selected = total.saturating_sub(1),
+            KeyCode::Enter => {
+                let Some(row) = matched.get(self.selected).and_then(|i| rows.get(*i)) else {
+                    return Outcome::Stay(None);
+                };
+                return Outcome::Run(Dispatch {
+                    plugin: row.plugin.clone(),
+                    action: row.action.clone(),
+                });
+            }
+            _ => {}
+        }
+        Outcome::Stay(None)
+    }
+
+    fn move_by(&mut self, step: isize, total: usize) {
+        if total == 0 {
+            self.selected = 0;
+            return;
+        }
+        let next = self.selected as isize + step;
+        self.selected = next.clamp(0, total as isize - 1) as usize;
+    }
+
+    /// Keep the cursor on the same action across a query edit, when it
+    /// survived — the cursor indexes matches, so holding the index would run a
+    /// different action than the one that was highlighted.
+    fn keep_highlighted(&mut self, rows: &[PaletteRow], highlighted: Option<usize>) {
+        let matched = matches(rows, &self.query);
+        self.selected = highlighted
+            .and_then(|row| matched.iter().position(|index| *index == row))
+            .unwrap_or(0);
+    }
+
+    /// A click selects the row under it; `Enter` still runs.
+    pub fn on_click(&mut self, x: u16, y: u16) {
+        if let Some(index) = self.hits.row_at(x, y) {
+            self.selected = index;
+        }
+    }
+
+    pub fn render(&mut self, frame: &mut Frame, area: Rect, registry: &Registry, chrome: Chrome) {
+        self.hits.clear();
+        let rows = rows(registry);
+        let matched = matches(&rows, &self.query);
+        self.selected = self.selected.min(matched.len().saturating_sub(1));
+
+        let desired = (matched.len() as u16)
+            .saturating_add(CHROME)
+            .max(MIN_HEIGHT);
+        let cap = (area.height * MAX_FRAME_PCT / 100).max(MIN_HEIGHT);
+        let height = desired.min(cap).min(area.height);
+        let modal = chrome::centered_fixed_height_rect(WIDTH_PCT, height, area);
+        let inner = chrome::modal_frame(frame, modal, "Commands", chrome);
+        if inner.width == 0 || inner.height == 0 {
+            return;
+        }
+
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(1),
+                Constraint::Min(1),
+                Constraint::Length(1),
+            ])
+            .split(inner);
+
+        self.render_head(frame, chunks[0], matched.len(), rows.len(), chrome);
+        self.render_rows(frame, chunks[1], &rows, &matched, chrome);
+
+        self.hits.buttons = chrome::button_bar(
+            frame,
+            chunks[2],
+            &[
+                Pill {
+                    label: "Run",
+                    primary: true,
+                    key: Replay::ENTER,
+                },
+                Pill {
+                    label: "Close",
+                    primary: false,
+                    key: Replay::ESC,
+                },
+            ],
+            chrome,
+        );
+        let hint_width = self
+            .hits
+            .buttons
+            .first()
+            .map_or(chunks[2].width, |(rect, _)| {
+                rect.x.saturating_sub(chunks[2].x + 1)
+            });
+        frame.render_widget(
+            Paragraph::new(chrome::hint_line(
+                &[("type", " filter  "), ("↑/↓", " move  "), ("Enter", " run")],
+                chrome,
+            )),
+            Rect {
+                width: hint_width,
+                ..chunks[2]
+            },
+        );
+    }
+
+    fn render_head(
+        &self,
+        frame: &mut Frame,
+        area: Rect,
+        matched: usize,
+        total: usize,
+        chrome: Chrome,
+    ) {
+        let count = format!("{matched}/{total}");
+        let mut head = vec![Span::styled(
+            " > ",
+            Style::default().fg(chrome.palette.accent),
+        )];
+        if self.query.is_empty() {
+            head.push(Span::styled("type to filter commands", chrome.muted()));
+        } else {
+            head.push(Span::styled(self.query.clone(), chrome.normal_item()));
+        }
+        head.push(Span::styled(
+            "█",
+            Style::default().fg(chrome.palette.accent),
+        ));
+        let used: usize = head.iter().map(|span| span.content.chars().count()).sum();
+        let pad =
+            usize::from(area.width).saturating_sub(used + count.chars().count() + RIGHT_GUTTER);
+        head.push(Span::raw(" ".repeat(pad)));
+        head.push(Span::styled(count, chrome.muted()));
+        frame.render_widget(Paragraph::new(Line::from(head)), area);
+    }
+
+    fn render_rows(
+        &mut self,
+        frame: &mut Frame,
+        area: Rect,
+        rows: &[PaletteRow],
+        matched: &[usize],
+        chrome: Chrome,
+    ) {
+        if matched.is_empty() || area.height == 0 || area.width == 0 {
+            frame.render_widget(
+                Paragraph::new(Line::from(Span::styled(
+                    "  no matching command",
+                    chrome.muted(),
+                ))),
+                area,
+            );
+            self.page = 0;
+            return;
+        }
+        let (rows_area, track) =
+            chrome::reserve_track(area, matched.len(), usize::from(area.height));
+        let height = usize::from(rows_area.height);
+        let start = scroll_for(matched.len(), height, self.selected);
+        let width = usize::from(rows_area.width);
+        // The owner column is as wide as the widest owner on screen, so the
+        // descriptions line up; the chord is right-aligned against the border.
+        let owner_width = matched
+            .iter()
+            .filter_map(|index| rows.get(*index))
+            .map(|row| row.plugin.chars().count())
+            .max()
+            .unwrap_or(0);
+
+        let mut lines: Vec<Line> = Vec::new();
+        for (on_screen, match_index) in (start..matched.len().min(start + height)).enumerate() {
+            let row = &rows[matched[match_index]];
+            let selected = match_index == self.selected;
+            self.hits.rows.push((
+                Rect::new(
+                    rows_area.x,
+                    rows_area.y + on_screen as u16,
+                    rows_area.width,
+                    1,
+                ),
+                match_index,
+            ));
+            let marker = if selected { " ▸ " } else { "   " };
+            let owner = chrome::pad(&row.plugin, owner_width + 1);
+            let chord = row.chords.clone().unwrap_or_default();
+            let description = if row.description.is_empty() {
+                row.action.clone()
+            } else {
+                row.description.clone()
+            };
+            // Two columns of air before the chord, so a truncated description
+            // never runs into it.
+            let fixed = marker.chars().count() + owner.chars().count() + chord.chars().count() + 3;
+            let room = width.saturating_sub(fixed);
+            let description = chrome::truncate(&description, room);
+            let gap = room.saturating_sub(description.chars().count());
+            let (owner_style, text_style) = if selected {
+                (chrome.selected_item(), chrome.selected_item())
+            } else {
+                (chrome.muted(), chrome.normal_item())
+            };
+            lines.push(Line::from(vec![
+                Span::styled(marker.to_string(), text_style),
+                Span::styled(owner, owner_style),
+                Span::styled(description, text_style),
+                Span::raw(" ".repeat(gap + 2)),
+                Span::styled(chord, chrome.keybind()),
+            ]));
+        }
+        self.page = self.hits.rows.len();
+        frame.render_widget(Paragraph::new(lines), rows_area);
+
+        if let Some(track) = track {
+            chrome::scrollbar(frame, track, matched.len(), height, self.selected, chrome);
+        }
+    }
+}
+
+/// Keep the selection visible, roughly centred.
+fn scroll_for(total: usize, height: usize, selected: usize) -> usize {
+    if total <= height || height == 0 {
+        return 0;
+    }
+    selected.saturating_sub(height / 2).min(total - height)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kernel::registry::{binding_from, CommandDecl, Setting};
+
+    fn registry() -> Registry {
+        let mut registry = Registry::default();
+        registry.declare(
+            vec![
+                binding_from(
+                    "sessions",
+                    "ctrl+d",
+                    "sessions.delete",
+                    "delete the selected session",
+                    Some("global"),
+                    false,
+                    None,
+                ),
+                binding_from(
+                    "agent",
+                    "f8",
+                    "shell.open",
+                    "open a shell",
+                    None,
+                    false,
+                    None,
+                ),
+            ],
+            Vec::<Setting>::new(),
+        );
+        registry.declare_commands(vec![CommandDecl {
+            plugin: "mine".into(),
+            action: "mine.export".into(),
+            description: "export the list".into(),
+        }]);
+        registry
+    }
+
+    #[test]
+    fn every_kind_of_action_is_a_row() {
+        let rows = rows(&registry());
+        let actions: Vec<&str> = rows.iter().map(|row| row.action.as_str()).collect();
+        assert!(actions.contains(&"sessions.delete"));
+        assert!(actions.contains(&"shell.open"));
+        assert!(actions.contains(&"mine.export"));
+        assert!(actions.contains(&RELOAD_ACTION));
+        assert!(actions.contains(&QUIT_ACTION));
+        let export = rows.iter().find(|row| row.action == "mine.export").unwrap();
+        assert_eq!(export.chords, None, "a chord-less command shows no chord");
+        let delete = rows
+            .iter()
+            .find(|row| row.action == "sessions.delete")
+            .unwrap();
+        assert_eq!(delete.chords.as_deref(), Some("ctrl+d"));
+    }
+
+    #[test]
+    fn the_filter_is_a_subsequence_over_description_id_and_owner() {
+        let rows = rows(&registry());
+        let by_description = matches(&rows, "dls");
+        assert!(by_description
+            .iter()
+            .any(|i| rows[*i].action == "sessions.delete"));
+        let by_id = matches(&rows, "mine.exp");
+        assert_eq!(by_id.len(), 1);
+        let by_owner = matches(&rows, "agent");
+        assert!(by_owner.iter().any(|i| rows[*i].action == "shell.open"));
+        assert!(matches(&rows, "zzzz").is_empty());
+        assert_eq!(matches(&rows, "").len(), rows.len());
+    }
+
+    #[test]
+    fn enter_runs_the_highlighted_row_and_refining_keeps_it() {
+        let registry = registry();
+        let mut modal = PaletteModal::default();
+        let press = |code| KeyEvent::new(code, KeyModifiers::NONE);
+        for c in "export".chars() {
+            modal.on_key(&press(KeyCode::Char(c)), &registry);
+        }
+        match modal.on_key(&press(KeyCode::Enter), &registry) {
+            Outcome::Run(dispatch) => {
+                assert_eq!(dispatch.plugin, "mine");
+                assert_eq!(dispatch.action, "mine.export");
+            }
+            Outcome::Stay(_) => panic!("Enter must run the selection"),
+        }
+    }
+
+    #[test]
+    fn refining_the_query_keeps_the_cursor_on_the_same_action() {
+        let mut registry = Registry::default();
+        registry.declare(
+            vec![
+                binding_from("a", "1", "a.one", "delete session", None, false, None),
+                binding_from("a", "2", "a.two", "delete all", None, false, None),
+            ],
+            Vec::<Setting>::new(),
+        );
+        let mut modal = PaletteModal::default();
+        let press = |code| KeyEvent::new(code, KeyModifiers::NONE);
+        for c in "delete".chars() {
+            modal.on_key(&press(KeyCode::Char(c)), &registry);
+        }
+        modal.on_key(&press(KeyCode::Down), &registry);
+        // Both still match; the cursor must stay on "delete all" rather than
+        // snapping back to the first match.
+        for c in " a".chars() {
+            modal.on_key(&press(KeyCode::Char(c)), &registry);
+        }
+        match modal.on_key(&press(KeyCode::Enter), &registry) {
+            Outcome::Run(dispatch) => assert_eq!(dispatch.action, "a.two"),
+            Outcome::Stay(_) => panic!("Enter must run the selection"),
+        }
+    }
+
+    #[test]
+    fn nothing_matching_means_enter_does_nothing() {
+        let registry = registry();
+        let mut modal = PaletteModal::default();
+        let press = |code| KeyEvent::new(code, KeyModifiers::NONE);
+        for c in "zzzz".chars() {
+            modal.on_key(&press(KeyCode::Char(c)), &registry);
+        }
+        assert!(matches!(
+            modal.on_key(&press(KeyCode::Enter), &registry),
+            Outcome::Stay(None)
+        ));
+    }
+}

--- a/src/kernel/registry.rs
+++ b/src/kernel/registry.rs
@@ -108,6 +108,30 @@ pub struct Pill {
     pub priority: i64,
 }
 
+/// An action a plugin wants reachable **without** a chord.
+///
+/// The palette's row. Declared as data beside `keys`, with the same `action`
+/// namespace and the same `on_action` handler, so an action need not spend a
+/// chord to exist — and a user may give it one later through the ordinary
+/// rebinding surface, at which point it is a [`Binding`] like any other.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandDecl {
+    pub plugin: String,
+    pub action: String,
+    pub description: String,
+}
+
+/// One row of the command palette: an action, who owns it, and its chord if it
+/// has one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PaletteRow {
+    pub plugin: String,
+    pub action: String,
+    pub description: String,
+    /// Every chord bound to the action, joined as help joins them.
+    pub chords: Option<String>,
+}
+
 /// A setting's value. Deliberately small — a setting is a knob, not a document.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Value {
@@ -166,6 +190,8 @@ pub struct Registry {
     bindings: Vec<Binding>,
     settings: Vec<Setting>,
     pills: Vec<Pill>,
+    /// Chord-less commands, declared for the palette.
+    commands: Vec<CommandDecl>,
     conflicts: Vec<Conflict>,
     /// Persisted overrides: action → chord.
     binding_overrides: BTreeMap<String, String>,
@@ -297,8 +323,55 @@ impl Registry {
         self.detect_conflicts();
     }
 
+    /// Replace the chord-less commands after a reload.
+    ///
+    /// Separate from [`Self::declare_all`] so the many callers that only care
+    /// about keys need not pass an empty list; the overrides are re-applied
+    /// because a command the user gave a chord to becomes a binding here.
+    pub fn declare_commands(&mut self, commands: Vec<CommandDecl>) {
+        self.mark_changed();
+        self.commands = commands;
+        self.apply_overrides();
+        self.conflicts.clear();
+        self.detect_conflicts();
+    }
+
     fn apply_overrides(&mut self) {
+        // A command the user bound a chord to is a binding from then on, so it
+        // resolves, appears in help and can be reset there. Synthesised on every
+        // pass rather than kept, because `declare_all` replaces the list — and
+        // recognisable by its empty default chord, so the previous pass's copies
+        // are dropped before this one's are added.
+        self.bindings
+            .retain(|binding| !binding.default_chord.is_empty());
+        for command in &self.commands {
+            let already_bound = self
+                .bindings
+                .iter()
+                .any(|binding| binding.action == command.action);
+            if already_bound {
+                continue;
+            }
+            if let Some(chord) = self.binding_overrides.get(&command.action) {
+                self.bindings.push(Binding {
+                    plugin: command.plugin.clone(),
+                    action: command.action.clone(),
+                    default_chord: String::new(),
+                    chord: chord.clone(),
+                    overridden: true,
+                    description: command.description.clone(),
+                    scope: Scope::Plugin,
+                    passthrough: false,
+                    group: command.plugin.clone(),
+                });
+            }
+        }
         for binding in &mut self.bindings {
+            // A synthesised binding has no default to fall back to; it exists
+            // only while its override does.
+            if binding.default_chord.is_empty() {
+                continue;
+            }
             // The default is restored when no override remains, so clearing one
             // takes effect on the next keystroke rather than on the next reload
             // — which is what "reset this action" has to mean in the help
@@ -499,6 +572,64 @@ impl Registry {
         &self.settings
     }
 
+    /// Every declared chord-less command, in declaration order.
+    pub fn commands(&self) -> &[CommandDecl] {
+        &self.commands
+    }
+
+    /// Everything the palette lists: one row per action, from the bindings and
+    /// the chord-less commands alike, de-duplicated on `(plugin, action)`.
+    ///
+    /// A binding's row carries its chords, joined the way help joins an action's
+    /// alternates; a command's row carries none unless the user bound one. The
+    /// order is declaration order — the plugins' load order, then the kernel's —
+    /// which is what makes the unfiltered list stable across runs.
+    pub fn palette_rows(&self) -> Vec<PaletteRow> {
+        let mut rows: Vec<PaletteRow> = Vec::new();
+        for binding in &self.bindings {
+            if let Some(row) = rows
+                .iter_mut()
+                .find(|row| row.plugin == binding.plugin && row.action == binding.action)
+            {
+                let chords = row.chords.get_or_insert_with(String::new);
+                if !chords.split(" / ").any(|chord| chord == binding.chord) {
+                    if !chords.is_empty() {
+                        chords.push_str(" / ");
+                    }
+                    chords.push_str(&binding.chord);
+                }
+                continue;
+            }
+            rows.push(PaletteRow {
+                plugin: binding.plugin.clone(),
+                action: binding.action.clone(),
+                description: binding.description.clone(),
+                chords: Some(binding.chord.clone()),
+            });
+        }
+        for command in &self.commands {
+            let bound = rows
+                .iter_mut()
+                .find(|row| row.plugin == command.plugin && row.action == command.action);
+            match bound {
+                // The key's row already exists; a command's description wins
+                // when the key declared none.
+                Some(row) => {
+                    if row.description.is_empty() {
+                        row.description = command.description.clone();
+                    }
+                }
+                None => rows.push(PaletteRow {
+                    plugin: command.plugin.clone(),
+                    action: command.action.clone(),
+                    description: command.description.clone(),
+                    chords: None,
+                }),
+            }
+        }
+        rows
+    }
+
     pub fn conflicts(&self) -> &[Conflict] {
         &self.conflicts
     }
@@ -521,7 +652,11 @@ impl Registry {
                 if RESERVED.contains(&chord.as_str()) {
                     return Err(format!("{chord} is reserved and cannot be rebound"));
                 }
-                if !self.bindings.iter().any(|b| b.action == action) {
+                // A chord-less command is a legal target: binding one is how it
+                // becomes a key, which `apply_overrides` then synthesises.
+                if !self.bindings.iter().any(|b| b.action == action)
+                    && !self.commands.iter().any(|c| c.action == action)
+                {
                     return Err(format!("no action named {action:?}"));
                 }
                 self.binding_overrides.insert(action.to_string(), chord);

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,6 +157,11 @@ struct TrackedCommand {
     session: String,
     label: Option<String>,
     failed: bool,
+    /// The name a creation or a fork was given, so `session.post_create` can
+    /// find the row it made — the command itself names no session.
+    name: Option<String>,
+    /// Whether a delete was a force delete, for `session.post_delete`.
+    force: bool,
 }
 
 struct App {
@@ -473,6 +478,9 @@ struct App {
     trust_stale: bool,
     /// Whether the perf counters are painted over the interface (F12).
     hud: bool,
+    /// Events queued for plugins, and what the kernel's own are derived from.
+    /// See `coordinator::events`.
+    events: coordinator::events::Events,
     quit: bool,
 }
 

--- a/tests/kernel_limits.rs
+++ b/tests/kernel_limits.rs
@@ -26,6 +26,33 @@ fn ctx() -> RenderContext {
 }
 
 #[test]
+fn an_event_handler_that_never_returns_is_interrupted_and_reported() {
+    host::set_instruction_budget(200_000);
+    let dir = plugin_dir(
+        r#"return {
+             name = "spinner", slot = "a",
+             events = { "session.status" },
+             on_event = function() while true do end end,
+             render = function() return { text = "" } end,
+           }"#,
+    );
+    let spinner = LuaHost::new(dir.path());
+    assert!(spinner.error.is_none(), "{:?}", spinner.error);
+    let failures = spinner.dispatch_event(
+        &thurbox::kernel::events::Event::new("session.status").with("session", Some("s1")),
+    );
+    host::set_instruction_budget(0);
+    assert_eq!(failures.len(), 1, "{failures:?}");
+    assert_eq!(failures[0].plugin, "spinner");
+    assert_eq!(failures[0].phase, host::Phase::Event);
+    assert!(
+        failures[0].message.contains("instruction budget"),
+        "{}",
+        failures[0].message
+    );
+}
+
+#[test]
 fn the_limits_are_settable_and_enforced() {
     // --- memory ------------------------------------------------------------
     // A small ceiling, so exhausting it is a test rather than an ordeal.

--- a/tests/v2_events.rs
+++ b/tests/v2_events.rs
@@ -1,0 +1,421 @@
+//! Plugin events, through the real kernel: a plugin declares what it listens
+//! for, the kernel derives what changed and hands each subscriber one call per
+//! change, and a handler that fails costs only itself
+//! (`openspec/changes/plugin-events-and-command-palette`).
+//!
+//! What lives in the loop — the dispatch point, the cascade bound, focus and
+//! command events, the reload — is the binary's and is asserted by its unit
+//! tests and the design; this file covers the kernel's half, which is the half
+//! a plugin author can observe.
+
+use std::path::PathBuf;
+
+use thurbox::kernel::command::Command;
+use thurbox::kernel::events::{Deriver, Event, Field};
+use thurbox::kernel::host::{LuaHost, Phase, Published, RenderContext};
+use thurbox::kernel::registry::Registry;
+use thurbox::kernel::snapshot::{SessionRow, Snapshot};
+use thurbox::kernel::theme::Themes;
+
+/// An interface directory holding the given plugins, each `(file, source)`.
+fn interface(plugins: &[(&str, &str)]) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let plugins_dir = dir.path().join("plugins");
+    std::fs::create_dir_all(&plugins_dir).expect("mkdir");
+    for (file, source) in plugins {
+        std::fs::write(plugins_dir.join(file), source).expect("write");
+    }
+    dir
+}
+
+fn host_of(plugins: &[(&str, &str)]) -> (tempfile::TempDir, LuaHost) {
+    let dir = interface(plugins);
+    let host = LuaHost::new(dir.path());
+    assert!(host.error.is_none(), "{:?}", host.error);
+    (dir, host)
+}
+
+fn row(name: &str, status: &str) -> SessionRow {
+    SessionRow {
+        id: format!("{name}-0000-0000-0000-000000000000"),
+        name: name.to_string(),
+        agent: "claude".to_string(),
+        status: status.to_string(),
+        cwd: Some(PathBuf::from("/src/thurbox")),
+        repo: Some("thurbox".to_string()),
+        repos: vec!["thurbox".to_string()],
+        branch: Some(format!("feat/{name}")),
+        base_branch: None,
+        backend: "local-tmux".to_string(),
+        backend_id: Some("%1".to_string()),
+        remote_host: None,
+        agent_session_id: None,
+        parent_id: None,
+        display_order: None,
+        worktree_count: 1,
+        git: None,
+        hook_state: None,
+        shell_backend_id: None,
+        member_dirs: Vec::new(),
+    }
+}
+
+fn publish(host: &LuaHost, snapshot: &Snapshot) {
+    let themes = Themes::load(None);
+    let mut registry = Registry::default();
+    let (bindings, settings) = host.declarations();
+    registry.declare(bindings, settings);
+    let diffs = thurbox::kernel::diff::DiffStore::new();
+    let repos = thurbox::kernel::repos::RepoStore::with_hosts(Default::default());
+    host.publish(&Published {
+        epoch: thurbox::kernel::host::Epoch::always_fresh(),
+        snapshot,
+        attach_errors: &Default::default(),
+        inflight: &[],
+        themes: &themes,
+        registry: &registry,
+        diffs: &diffs,
+        links: &Default::default(),
+        content: &Default::default(),
+        meta: &Default::default(),
+        metrics: &Default::default(),
+        status_rows: 0,
+        can_open: true,
+        inventory: &[],
+        ui_dir: "ui",
+        settings: &Default::default(),
+        repos: &repos,
+        wants: &Default::default(),
+        focus: None,
+        hovered: None,
+    })
+    .expect("publish");
+}
+
+fn status_event(session: &str, from: &str, to: &str) -> Event {
+    Event::new("session.status")
+        .with("session", Some(session))
+        .with("name", Some(session))
+        .with("from", Some(from))
+        .with("to", Some(to))
+}
+
+/// A plugin that records every event it receives in the shared `store`, so a
+/// test can read what it saw without rendering it.
+const RECORDER: &str = r#"
+return {
+  name = "recorder", slot = "a",
+  events = { "session.status" },
+  on_event = function(name, payload)
+    store.seen = (store.seen or 0) + 1
+    store.last = name .. " " .. tostring(payload.session) .. " " .. tostring(payload.from) .. ">" .. tostring(payload.to)
+  end,
+  render = function() return { text = tostring(store.seen or 0) } end,
+}
+"#;
+
+#[test]
+fn a_declared_subscription_fires_once_with_its_payload() {
+    let (_dir, host) = host_of(&[("10_recorder.lua", RECORDER)]);
+    let failures = host.dispatch_event(&status_event("s1", "idle", "blocked"));
+    assert!(failures.is_empty(), "{failures:?}");
+    assert_eq!(
+        host.shared_string("last").as_deref(),
+        Some("session.status s1 idle>blocked")
+    );
+    // Once: a second dispatch of a different event is not a second call.
+    host.dispatch_event(&Event::new("session.created").with("session", Some("s2")));
+    assert_eq!(
+        host.shared_string("last").as_deref(),
+        Some("session.status s1 idle>blocked"),
+        "an undeclared event must not reach the handler"
+    );
+}
+
+#[test]
+fn a_handler_with_no_subscriptions_receives_nothing() {
+    let (_dir, host) = host_of(&[(
+        "10_mute.lua",
+        r#"return {
+             name = "mute", slot = "a",
+             on_event = function() store.heard = true end,
+             render = function() return { text = "" } end,
+           }"#,
+    )]);
+    host.dispatch_event(&status_event("s1", "idle", "blocked"));
+    assert_eq!(host.shared_bool("heard"), None);
+}
+
+#[test]
+fn a_subscription_to_a_name_the_kernel_does_not_emit_refuses_to_load() {
+    let dir = interface(&[(
+        "10_typo.lua",
+        r#"return {
+             name = "typo", slot = "a",
+             events = { "sesion.status" },
+             on_event = function() end,
+             render = function() return { text = "" } end,
+           }"#,
+    )]);
+    let host = LuaHost::new(dir.path());
+    let error = host.error.clone().expect("the plugin must not load");
+    assert!(error.contains("sesion.status"), "{error}");
+    assert!(
+        error.contains("session.status"),
+        "the message should list what was available: {error}"
+    );
+    // The `user.` form loads, so plugins can talk to each other by name.
+    let dir = interface(&[(
+        "10_user.lua",
+        r#"return {
+             name = "user", slot = "a",
+             events = { "user.refresh" },
+             on_event = function() end,
+             render = function() return { text = "" } end,
+           }"#,
+    )]);
+    assert!(LuaHost::new(dir.path()).error.is_none());
+}
+
+#[test]
+fn one_subscriber_throwing_costs_neither_the_others_nor_its_own_pane() {
+    let (_dir, host) = host_of(&[
+        (
+            "10_thrower.lua",
+            r#"return {
+                 name = "thrower", slot = "a",
+                 events = { "session.status" },
+                 on_event = function() error("no thanks") end,
+                 render = function() return { text = "still drawing" } end,
+               }"#,
+        ),
+        ("20_recorder.lua", RECORDER),
+    ]);
+    let failures = host.dispatch_event(&status_event("s1", "idle", "blocked"));
+    assert_eq!(failures.len(), 1, "{failures:?}");
+    assert_eq!(failures[0].plugin, "thrower");
+    assert_eq!(failures[0].phase, Phase::Event);
+    assert!(
+        failures[0].message.contains("session.status") && failures[0].message.contains("no thanks"),
+        "the failure names the event and the plugin's own message: {}",
+        failures[0].message
+    );
+    // The second subscriber still ran.
+    assert_eq!(
+        host.shared_string("last").as_deref(),
+        Some("session.status s1 idle>blocked")
+    );
+    // And the thrower's pane still renders on the next frame.
+    let rendered = host
+        .render(
+            host.index_of("thrower").expect("loaded"),
+            RenderContext {
+                width: 20,
+                height: 3,
+                focused: false,
+                elapsed: 0.0,
+                frame: 1,
+            },
+        )
+        .expect("render");
+    assert!(format!("{:?}", rendered.node).contains("still drawing"));
+}
+
+#[test]
+fn a_handler_reads_the_published_tables_and_can_only_enqueue() {
+    let (_dir, host) = host_of(&[(
+        "10_reader.lua",
+        r#"return {
+             name = "reader", slot = "a",
+             events = { "session.status" },
+             on_event = function(name, payload)
+               local first = thurbox.sessions[1]
+               store.name = first and first.name or "nobody"
+               command("send", { session = payload.session, text = "you are " .. payload.to })
+               return "ignored"
+             end,
+             render = function() return { text = "" } end,
+           }"#,
+    )]);
+    let snapshot = Snapshot {
+        sessions: vec![row("fix-osc52", "idle")],
+        ..Snapshot::default()
+    };
+    publish(&host, &snapshot);
+    let failures = host.dispatch_event(&status_event("s1", "idle", "blocked"));
+    assert!(failures.is_empty(), "{failures:?}");
+    assert_eq!(host.shared_string("name").as_deref(), Some("fix-osc52"));
+    let issued = host.drain_commands();
+    assert_eq!(
+        issued,
+        vec![Command::Send {
+            session: "s1".into(),
+            text: "you are blocked".into()
+        }]
+    );
+}
+
+#[test]
+fn a_plugin_emits_a_user_event_and_another_receives_it_with_the_source() {
+    let (_dir, host) = host_of(&[
+        (
+            "10_sender.lua",
+            r#"return {
+                 name = "sender", slot = "a",
+                 keys = { { key = "e", action = "sender.emit", desc = "emit" } },
+                 on_action = function()
+                   command("emit", { text = "refresh", scope = "x", count = 2, urgent = true })
+                   return true
+                 end,
+                 render = function() return { text = "" } end,
+               }"#,
+        ),
+        (
+            "20_listener.lua",
+            r#"return {
+                 name = "listener", slot = "b",
+                 events = { "user.refresh" },
+                 on_event = function(name, payload)
+                   store.got = name .. " from " .. tostring(payload.source) .. " scope=" .. tostring(payload.scope)
+                     .. " count=" .. tostring(payload.count) .. " urgent=" .. tostring(payload.urgent)
+                 end,
+                 render = function() return { text = "" } end,
+               }"#,
+        ),
+    ]);
+    let sender = host.index_of("sender").expect("loaded");
+    assert!(host.on_action(sender, "sender.emit").expect("on_action"));
+    let issued = host.drain_commands();
+    let Some(Command::Emit {
+        owner,
+        name,
+        payload,
+    }) = issued.first().cloned()
+    else {
+        panic!("expected an emit, got {issued:?}");
+    };
+    // Owner is stamped from the executing plugin, never read from Lua.
+    assert_eq!(owner, "plugins/10_sender.lua");
+    assert_eq!(name, "user.refresh");
+    assert!(payload.contains(&("scope".to_string(), Field::Text("x".into()))));
+    assert!(payload.contains(&("count".to_string(), Field::Number(2.0))));
+    assert!(payload.contains(&("urgent".to_string(), Field::Bool(true))));
+
+    // As the loop delivers it: the source is the emitting plugin's NAME.
+    let source = host.name_of_path(&owner).expect("the owner is loaded");
+    let mut event = Event::new(name);
+    event.payload = payload;
+    event.payload.push(("source".into(), source.into()));
+    let failures = host.dispatch_event(&event);
+    assert!(failures.is_empty(), "{failures:?}");
+    assert_eq!(
+        host.shared_string("got").as_deref(),
+        Some("user.refresh from sender scope=x count=2 urgent=true")
+    );
+}
+
+#[test]
+fn a_plugin_cannot_emit_a_kernel_event() {
+    let (_dir, host) = host_of(&[(
+        "10_forger.lua",
+        r#"return {
+             name = "forger", slot = "a",
+             keys = { { key = "e", action = "forger.emit", desc = "forge" } },
+             on_action = function()
+               command("emit", { text = "session.created", session = "fake" })
+               return true
+             end,
+             render = function() return { text = "" } end,
+           }"#,
+    )]);
+    let error = host
+        .on_action(host.index_of("forger").expect("loaded"), "forger.emit")
+        .expect_err("a kernel name must be refused");
+    assert!(error.message.contains("kernel event"), "{}", error.message);
+    assert!(host.drain_commands().is_empty(), "nothing was queued");
+}
+
+#[test]
+fn emit_is_reachable_only_through_command() {
+    // No new global: the event bus rides the one write channel plugins have.
+    let (_dir, host) = host_of(&[(
+        "10_probe.lua",
+        r#"return {
+             name = "probe", slot = "a",
+             render = function()
+               return { text = tostring(rawget(_G, "emit")) .. " " .. tostring(rawget(_G, "on_event")) }
+             end,
+           }"#,
+    )]);
+    let rendered = host
+        .render(
+            0,
+            RenderContext {
+                width: 20,
+                height: 1,
+                focused: false,
+                elapsed: 0.0,
+                frame: 1,
+            },
+        )
+        .expect("render");
+    assert!(format!("{:?}", rendered.node).contains("nil nil"));
+}
+
+#[test]
+fn what_the_deriver_says_changed_is_what_a_subscriber_hears() {
+    // The kernel's half of "a session created by another process": the row
+    // appears in a snapshot, and every subscriber hears `session.created` once —
+    // whoever wrote it.
+    let (_dir, host) = host_of(&[(
+        "10_watcher.lua",
+        r#"return {
+             name = "watcher", slot = "a",
+             events = { "session.created", "session.deleted", "session.status" },
+             on_event = function(name, payload)
+               store.log = (store.log or "") .. name .. ":" .. tostring(payload.name) .. ";"
+             end,
+             render = function() return { text = "" } end,
+           }"#,
+    )]);
+    let mut deriver = Deriver::new();
+    let first = Snapshot {
+        sessions: vec![row("a", "idle")],
+        ..Snapshot::default()
+    };
+    // Seeds: the rows that existed before the plugin did are not news.
+    for event in deriver.observe(&first, 1) {
+        host.dispatch_event(&event);
+    }
+    assert_eq!(host.shared_string("log"), None);
+
+    let second = Snapshot {
+        sessions: vec![row("a", "blocked"), row("b", "idle")],
+        ..Snapshot::default()
+    };
+    for event in deriver.observe(&second, 2) {
+        let failures = host.dispatch_event(&event);
+        assert!(failures.is_empty(), "{failures:?}");
+    }
+    assert_eq!(
+        host.shared_string("log").as_deref(),
+        Some("session.created:b;session.status:a;")
+    );
+    // Same version again: nothing is re-delivered.
+    for event in deriver.observe(&second, 2) {
+        host.dispatch_event(&event);
+    }
+    assert_eq!(
+        host.shared_string("log").as_deref(),
+        Some("session.created:b;session.status:a;")
+    );
+}
+
+#[test]
+fn a_subscription_is_listed_as_data() {
+    let (_dir, host) = host_of(&[("10_recorder.lua", RECORDER)]);
+    let plugin = &host.plugins[host.index_of("recorder").expect("loaded")];
+    assert_eq!(plugin.events, vec!["session.status".to_string()]);
+    assert_eq!(host.subscribers("session.status"), vec![0]);
+    assert!(host.subscribers("session.created").is_empty());
+}

--- a/tests/v2_keymap.rs
+++ b/tests/v2_keymap.rs
@@ -150,8 +150,12 @@ fn fire(host: &LuaHost, chord: &str) {
 /// below, in `CHORDS_AWAITING_THEIR_PANE`. They are listed rather than dropped so
 /// re-adding a pane has an obvious place to reconnect, and so the shortfall is
 /// counted rather than forgotten.
-const GLOBAL_CHORDS: [(&str, &str); 22] = [
+const GLOBAL_CHORDS: [(&str, &str); 23] = [
     ("ctrl+n", "new_session.open"),
+    // Reassigned deliberately, not reused quietly: v1 spent it on the
+    // automations pane, and the palette is the way *into* that pane — and every
+    // other — once it returns. See `CHORDS_AWAITING_THEIR_PANE`, which it left.
+    ("ctrl+p", "palette.open"),
     ("ctrl+u", "restore.open"),
     // One declaration, three spellings: the kernel folds the encodings a
     // terminal may deliver `Ctrl+/` as, where v1 bound all three by hand.
@@ -181,8 +185,11 @@ const GLOBAL_CHORDS: [(&str, &str); 22] = [
 /// v1 chords with no v2 owner, each named with the pane that would bring it
 /// back. Asserted to be *unbound* — a chord that silently resolved to something
 /// else would be worse than one that does nothing.
-const CHORDS_AWAITING_THEIR_PANE: [(&str, &str); 9] = [
-    ("ctrl+p", "automations"),
+///
+/// `ctrl+p` was here for the automations pane and was reassigned to the command
+/// palette on purpose (`GLOBAL_CHORDS`): a deliberate, recorded reassignment is
+/// the one thing this list does not forbid.
+const CHORDS_AWAITING_THEIR_PANE: [(&str, &str); 8] = [
     ("ctrl+w", "tasks"),
     ("ctrl+x", "review"),
     ("ctrl+b", "info"),
@@ -398,6 +405,12 @@ fn the_chords_v1_leaves_to_the_agent_are_marked_and_no_others_are() {
             else {
                 continue;
             };
+            // The one deliberate divergence: v1 deferred `ctrl+p` (automations) to
+            // the agent, and the palette on the same chord must NOT be — it has
+            // to open from a focused terminal, which is where the user mostly is.
+            if binding.action == "palette.open" {
+                continue;
+            }
             assert_eq!(
                 binding.passthrough,
                 action.terminal_passthrough(),

--- a/tests/v2_modals.rs
+++ b/tests/v2_modals.rs
@@ -444,6 +444,7 @@ fn closing_the_picker_by_its_own_chord_also_reverts() {
             save_settings: &mut None,
             inventory: &[],
             interface_edit: &mut None,
+            run_action: &mut None,
             registry: &mut registry,
             themes: &mut themes,
             db: None,
@@ -473,6 +474,7 @@ fn send(
         save_settings: &mut None,
         inventory: &[],
         interface_edit: &mut None,
+        run_action: &mut None,
         registry,
         themes,
         db,
@@ -515,6 +517,7 @@ fn every_modal_chord_v1_binds_opens_its_modal() {
         ("ctrl+y", ModalKind::Theme),
         ("f6", ModalKind::Settings),
         ("ctrl+,", ModalKind::Settings),
+        ("ctrl+p", ModalKind::Palette),
     ] {
         let binding = registry
             .resolve(&key_press(chord), None)
@@ -1036,6 +1039,7 @@ fn click(
         save_settings: &mut None,
         inventory: &[],
         interface_edit: &mut None,
+        run_action: &mut None,
         registry,
         themes,
         db,

--- a/tests/v2_new_session.rs
+++ b/tests/v2_new_session.rs
@@ -762,13 +762,13 @@ fn a_path_just_added_is_the_row_that_gets_selected() {
 }
 
 #[test]
-fn ctrl_p_imports_the_typed_path_as_a_folder() {
+fn alt_p_imports_the_typed_path_as_a_folder() {
     let host = host();
     let world = World::default();
     open(&host, &world);
     press(&host, &world, "tab");
     type_text(&host, &world, "/src");
-    press(&host, &world, "ctrl+p");
+    press(&host, &world, "alt+p");
     assert_eq!(
         host.drain_commands(),
         vec![Command::Bookmark {
@@ -1196,7 +1196,7 @@ fn every_key_the_flow_uses_is_declared_rather_than_only_handled() {
         .iter()
         .map(|binding| binding.chord.as_str())
         .collect();
-    for chord in ["ctrl+n", "j", "k", "space", "w", "d", "/", "ctrl+p"] {
+    for chord in ["ctrl+n", "j", "k", "space", "w", "d", "/", "alt+p"] {
         assert!(
             declared.contains(&chord),
             "{chord} is not declared: {declared:?}"

--- a/tests/v2_palette.rs
+++ b/tests/v2_palette.rs
@@ -1,0 +1,472 @@
+//! The command palette against the real bundled plugins: every action the
+//! registry knows is a row, typing filters them, and `Enter` runs the chosen one
+//! through the same path a key press takes
+//! (`openspec/changes/plugin-events-and-command-palette`).
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::backend::TestBackend;
+use ratatui::layout::Rect;
+use ratatui::Terminal;
+
+use thurbox::kernel::host::{KeyPress, LuaHost};
+use thurbox::kernel::modals::interface::Files;
+use thurbox::kernel::modals::palette::{self, Dispatch, QUIT_ACTION, RELOAD_ACTION};
+use thurbox::kernel::modals::{self, ModalKind, Modals, World};
+use thurbox::kernel::registry::{binding_from, CommandDecl, Registry, Scope, Setting};
+use thurbox::kernel::theme::Themes;
+
+fn host() -> LuaHost {
+    let dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("ui");
+    let host = LuaHost::new(dir);
+    assert!(host.error.is_none(), "{:?}", host.error);
+    host
+}
+
+/// The registry the binary builds: the plugins' declarations, their chord-less
+/// commands, and the kernel's own chords.
+fn registry(host: &LuaHost) -> Registry {
+    let mut registry = Registry::default();
+    let (mut bindings, settings) = host.declarations();
+    bindings.extend(modals::bindings());
+    registry.declare(bindings, settings);
+    registry.declare_commands(host.commands());
+    registry
+}
+
+fn key_press(chord: &str) -> KeyPress {
+    let mut key = KeyPress::default();
+    for part in chord.split('+') {
+        match part {
+            "ctrl" => key.ctrl = true,
+            "alt" => key.alt = true,
+            "shift" => key.shift = true,
+            name => {
+                key.name = name.to_string();
+                let mut chars = name.chars();
+                key.ch = match (chars.next(), chars.next()) {
+                    (Some(c), None) => Some(c),
+                    _ => None,
+                };
+            }
+        }
+    }
+    key
+}
+
+fn press(code: KeyCode) -> KeyEvent {
+    KeyEvent::new(code, KeyModifiers::NONE)
+}
+
+/// Publish an empty world, so a plugin's handler has `thurbox.*` to read.
+fn publish(host: &LuaHost, registry: &Registry) {
+    let themes = Themes::load(None);
+    let diffs = thurbox::kernel::diff::DiffStore::new();
+    let repos = thurbox::kernel::repos::RepoStore::with_hosts(Default::default());
+    host.publish(&thurbox::kernel::host::Published {
+        epoch: thurbox::kernel::host::Epoch::always_fresh(),
+        snapshot: &Default::default(),
+        attach_errors: &Default::default(),
+        inflight: &[],
+        themes: &themes,
+        registry,
+        diffs: &diffs,
+        links: &Default::default(),
+        content: &Default::default(),
+        meta: &Default::default(),
+        metrics: &Default::default(),
+        status_rows: 0,
+        can_open: true,
+        inventory: &[],
+        ui_dir: "ui",
+        settings: &Default::default(),
+        repos: &repos,
+        wants: &Default::default(),
+        focus: None,
+        hovered: None,
+    })
+    .expect("publish");
+}
+
+/// Drive the modal layer the way the loop does, and hand back what the palette
+/// asked the loop to run, if anything.
+fn modal_key(
+    modals: &mut Modals,
+    key: KeyEvent,
+    chord: &str,
+    registry: &mut Registry,
+    themes: &mut Themes,
+) -> Option<Dispatch> {
+    let mut run = None;
+    let mut world = World {
+        settings_on_disk: &Default::default(),
+        save_settings: &mut None,
+        inventory: &[],
+        interface_edit: &mut None,
+        run_action: &mut run,
+        registry,
+        themes,
+        db: None,
+    };
+    modals.on_key(&key, chord, &mut world);
+    run
+}
+
+fn type_query(modals: &mut Modals, text: &str, registry: &mut Registry, themes: &mut Themes) {
+    for c in text.chars() {
+        modal_key(
+            modals,
+            press(KeyCode::Char(c)),
+            &c.to_string(),
+            registry,
+            themes,
+        );
+    }
+}
+
+#[test]
+fn every_kind_of_action_is_a_row() {
+    let host = host();
+    let mut registry = registry(&host);
+    registry.declare_commands(vec![CommandDecl {
+        plugin: "mine".into(),
+        action: "mine.export".into(),
+        description: "export the list".into(),
+    }]);
+    let rows = palette::rows(&registry);
+    let find = |action: &str| rows.iter().find(|row| row.action == action);
+
+    // A key-bound action, with its chord beside it.
+    let delete = find("sessions.delete").expect("a plugin's key is a row");
+    // Its alternates joined as help joins them: the pane-scoped `d` and the
+    // global `ctrl+d` are one action.
+    assert_eq!(delete.chords.as_deref(), Some("d / ctrl+d"));
+    assert_eq!(delete.plugin, "sessions");
+    // A chord-less command, with none.
+    let export = find("mine.export").expect("a chord-less command is a row");
+    assert_eq!(export.chords, None);
+    assert_eq!(export.description, "export the list");
+    // The kernel's own: the modals with their chords, plus reload and quit,
+    // which no binding backs.
+    let help = find("help.open").expect("a kernel modal is a row");
+    assert_eq!(help.plugin, modals::OWNER);
+    assert_eq!(help.chords.as_deref(), Some("f1 / ctrl+g"));
+    assert_eq!(find(RELOAD_ACTION).unwrap().chords.as_deref(), Some("f10"));
+    assert_eq!(find(QUIT_ACTION).unwrap().chords.as_deref(), Some("ctrl+q"));
+    // Not itself: opening the palette from inside it is not an action.
+    assert!(find("palette.open").is_none());
+}
+
+#[test]
+fn a_disabled_plugins_actions_are_absent() {
+    let mut host = host();
+    host.set_disabled(vec!["plugins/65_search.lua".to_string()]);
+    host.reload();
+    assert!(host.error.is_none(), "{:?}", host.error);
+    let rows = palette::rows(&registry(&host));
+    assert!(
+        !rows.iter().any(|row| row.action == "search.open"),
+        "a plugin turned off declares nothing, so it has no rows"
+    );
+}
+
+#[test]
+fn ctrl_p_opens_the_palette_from_a_focused_terminal_and_over_another_modal() {
+    let host = host();
+    let registry = registry(&host);
+    // Global and never deferred to the agent: the palette has to open from the
+    // terminal, which is where the user mostly is.
+    let binding = registry
+        .resolve(&key_press("ctrl+p"), Some("agent"))
+        .expect("ctrl+p is bound");
+    assert_eq!(binding.action, "palette.open");
+    assert_eq!(binding.scope, Scope::Global);
+    assert!(!binding.passthrough);
+    assert_eq!(
+        ModalKind::from_action(&binding.action),
+        Some(ModalKind::Palette)
+    );
+
+    let mut modals = Modals::default();
+    modals.toggle(ModalKind::Help);
+    modals.toggle(ModalKind::Palette);
+    assert_eq!(
+        modals.kind(),
+        Some(ModalKind::Palette),
+        "opening one closes another"
+    );
+    assert!(
+        !modals.captures_everything(),
+        "the reserved chords still escape it"
+    );
+    assert!(modals::escapes(&KeyEvent::new(
+        KeyCode::Char('q'),
+        KeyModifiers::CONTROL
+    )));
+}
+
+#[test]
+fn typing_filters_and_enter_runs_the_selection_through_on_action() {
+    let host = host();
+    let mut registry = registry(&host);
+    let mut themes = Themes::load(None);
+    let mut modals = Modals::default();
+    modals.toggle(ModalKind::Palette);
+
+    type_query(&mut modals, "search.open", &mut registry, &mut themes);
+    assert_eq!(modals.palette_query(), Some("search.open"));
+    let dispatch = modal_key(
+        &mut modals,
+        press(KeyCode::Enter),
+        "enter",
+        &mut registry,
+        &mut themes,
+    )
+    .expect("Enter hands the loop an action");
+    assert_eq!(dispatch.plugin, "search");
+    assert_eq!(dispatch.action, "search.open");
+    assert!(!modals.is_open(), "closed before the loop runs it");
+
+    // What the loop then does: the owning plugin's `on_action`, whether or not
+    // it is focused — and the strip opens exactly as `ctrl+/` opens it.
+    publish(&host, &registry);
+    let index = host.index_of(&dispatch.plugin).expect("the search pane");
+    assert!(host.on_action(index, &dispatch.action).expect("on_action"));
+    assert_eq!(host.shared_bool("panels.search"), Some(true));
+}
+
+#[test]
+fn nothing_matching_means_enter_runs_nothing_and_esc_runs_nothing() {
+    let host = host();
+    let mut registry = registry(&host);
+    let mut themes = Themes::load(None);
+    let mut modals = Modals::default();
+    modals.toggle(ModalKind::Palette);
+    type_query(&mut modals, "zzzzzz", &mut registry, &mut themes);
+    assert!(modal_key(
+        &mut modals,
+        press(KeyCode::Enter),
+        "enter",
+        &mut registry,
+        &mut themes
+    )
+    .is_none());
+    assert!(modals.is_open());
+    assert!(modal_key(
+        &mut modals,
+        press(KeyCode::Esc),
+        "esc",
+        &mut registry,
+        &mut themes
+    )
+    .is_none());
+    assert!(!modals.is_open(), "Esc closes without choosing");
+}
+
+#[test]
+fn a_chord_less_command_can_be_given_a_chord_and_is_then_a_key() {
+    let mut registry = Registry::default();
+    registry.declare(
+        vec![binding_from(
+            "mine",
+            "j",
+            "mine.next",
+            "next item",
+            None,
+            false,
+            None,
+        )],
+        Vec::<Setting>::new(),
+    );
+    registry.declare_commands(vec![CommandDecl {
+        plugin: "mine".into(),
+        action: "mine.export".into(),
+        description: "export the list".into(),
+    }]);
+    assert!(registry.resolve(&key_press("f7"), Some("mine")).is_none());
+
+    registry
+        .rebind("mine.export", Some("f7"))
+        .expect("a command is a legal rebind target");
+    let binding = registry
+        .resolve(&key_press("f7"), Some("mine"))
+        .expect("the chord now fires the command");
+    assert_eq!(binding.action, "mine.export");
+    assert!(binding.overridden);
+    // Help lists it, since it is a binding now; the palette shows the chord.
+    assert!(registry
+        .bindings()
+        .iter()
+        .any(|b| b.action == "mine.export"));
+    let rows = palette::rows(&registry);
+    let export = rows.iter().find(|row| row.action == "mine.export").unwrap();
+    assert_eq!(export.chords.as_deref(), Some("f7"));
+    // One row, not two, even though it is both a command and a key.
+    assert_eq!(
+        rows.iter()
+            .filter(|row| row.action == "mine.export")
+            .count(),
+        1
+    );
+
+    // Reset, and it is chord-less again.
+    registry.rebind("mine.export", None).expect("reset");
+    assert!(registry.resolve(&key_press("f7"), Some("mine")).is_none());
+    assert!(!registry
+        .bindings()
+        .iter()
+        .any(|b| b.action == "mine.export"));
+}
+
+#[test]
+fn a_key_and_a_command_for_one_action_are_one_row_with_the_chord() {
+    let mut registry = Registry::default();
+    registry.declare(
+        vec![binding_from(
+            "mine",
+            "x",
+            "mine.export",
+            "",
+            None,
+            false,
+            None,
+        )],
+        Vec::<Setting>::new(),
+    );
+    registry.declare_commands(vec![CommandDecl {
+        plugin: "mine".into(),
+        action: "mine.export".into(),
+        description: "export the list".into(),
+    }]);
+    let rows = palette::rows(&registry);
+    let export: Vec<_> = rows
+        .iter()
+        .filter(|row| row.action == "mine.export")
+        .collect();
+    assert_eq!(export.len(), 1);
+    assert_eq!(export[0].chords.as_deref(), Some("x"));
+    assert_eq!(
+        export[0].description, "export the list",
+        "the command's description fills the key's blank"
+    );
+}
+
+/// The palette's frame, pinned cell for cell over a fixed registry.
+#[test]
+fn the_palette_frame_is_pinned() {
+    let mut registry = Registry::default();
+    registry.declare(
+        vec![
+            binding_from(
+                "sessions",
+                "ctrl+d",
+                "sessions.delete",
+                "delete the selected session",
+                Some("global"),
+                false,
+                None,
+            ),
+            binding_from(
+                "agent",
+                "f8",
+                "shell.open",
+                "open a shell",
+                None,
+                false,
+                None,
+            ),
+        ],
+        Vec::<Setting>::new(),
+    );
+    registry.declare_commands(vec![CommandDecl {
+        plugin: "mine".into(),
+        action: "mine.export".into(),
+        description: "export the list".into(),
+    }]);
+    let mut themes = Themes::load(None);
+    let mut modals = Modals::default();
+    modals.toggle(ModalKind::Palette);
+    type_query(&mut modals, "e", &mut registry, &mut themes);
+
+    let mut terminal = Terminal::new(TestBackend::new(60, 12)).expect("terminal");
+    terminal
+        .draw(|frame| {
+            modals.render(
+                frame,
+                Rect::new(0, 0, 60, 12),
+                &registry,
+                &themes,
+                &Default::default(),
+                Files {
+                    rows: &[],
+                    dir: "ui",
+                },
+            );
+        })
+        .expect("draw");
+    let buffer = terminal.backend().buffer();
+    let actual: Vec<String> = (0..buffer.area.height)
+        .map(|y| {
+            (0..buffer.area.width)
+                .map(|x| buffer[(x, y)].symbol().to_string())
+                .collect::<String>()
+                .trim_end()
+                .to_string()
+        })
+        .collect();
+    let expected = [
+        "",
+        "",
+        "            ╭ Commands ────────────────────────╮",
+        "            │ > e█                         5/5 │",
+        "            │ ▸ sessions delete the s…  ctrl+d │",
+        "            │   agent    open a shell       f8 │",
+        "            │   mine     export the list       │",
+        "            │   kernel   reload the inte…  f10 │",
+        "            │   kernel   quit (sessio…  ctrl+q │",
+        "            │type filter  ↑/↓ mov  Run   Close │",
+        "            ╰──────────────────────────────────╯",
+        "",
+    ];
+    if actual
+        .iter()
+        .map(String::as_str)
+        .ne(expected.iter().copied())
+    {
+        let literal = actual
+            .iter()
+            .map(|line| format!("        {line:?},"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        panic!("frame differs from the expected literal.\nactual, as a literal:\n[\n{literal}\n]");
+    }
+}
+
+#[test]
+fn the_agent_pane_is_reachable_by_name_from_the_palette() {
+    // The pane's tabs were click-only roles and focusing it was only ever the
+    // session list's `Enter`, so "open the agent" had no row. Now it has three,
+    // none spending a chord, and the focus one issues the same command the
+    // list's Enter does.
+    let host = host();
+    let registry = registry(&host);
+    let rows = palette::rows(&registry);
+    for action in ["terminal.focus", "terminal.agent", "terminal.shell"] {
+        let row = rows
+            .iter()
+            .find(|row| row.action == action)
+            .unwrap_or_else(|| panic!("{action} is not a palette row"));
+        assert_eq!(row.plugin, "agent");
+        assert_eq!(row.chords, None, "{action} is chord-less");
+    }
+    publish(&host, &registry);
+    let index = host.index_of("agent").expect("the agent pane");
+    assert!(host.on_action(index, "terminal.focus").expect("on_action"));
+    let issued = host.drain_commands();
+    assert_eq!(
+        issued,
+        vec![thurbox::kernel::command::Command::Focus {
+            plugin: "agent".into(),
+            toggle: false
+        }]
+    );
+}

--- a/tests/v2_render_props.rs
+++ b/tests/v2_render_props.rs
@@ -434,3 +434,98 @@ fn normalizing_ambiguous_width_strips_the_selector_and_nothing_else() {
         }
     });
 }
+
+// --- the command palette ---------------------------------------------------
+
+/// Any keystroke the modal layer can be handed, as a `KeyEvent` rather than a
+/// `KeyPress`: the palette is chrome, so it takes the terminal's own events.
+fn any_modal_key() -> impl Strategy<Value = crossterm::event::KeyEvent> {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    let named = prop::sample::select(vec![
+        KeyCode::Esc,
+        KeyCode::Enter,
+        KeyCode::Tab,
+        KeyCode::Backspace,
+        KeyCode::Delete,
+        KeyCode::Up,
+        KeyCode::Down,
+        KeyCode::Left,
+        KeyCode::Right,
+        KeyCode::Home,
+        KeyCode::End,
+        KeyCode::PageUp,
+        KeyCode::PageDown,
+        KeyCode::F(1),
+        KeyCode::F(10),
+    ]);
+    let code = prop_oneof![
+        3 => proptest::char::range(' ', '~').prop_map(KeyCode::Char),
+        1 => named,
+    ];
+    (code, any::<bool>(), any::<bool>()).prop_map(|(code, ctrl, alt)| {
+        let mut modifiers = KeyModifiers::NONE;
+        if ctrl {
+            modifiers |= KeyModifiers::CONTROL;
+        }
+        if alt {
+            modifiers |= KeyModifiers::ALT;
+        }
+        KeyEvent::new(code, modifiers)
+    })
+}
+
+#[test]
+fn no_key_sequence_makes_the_palette_throw_or_stop_drawing() {
+    // Every keystroke is query text or navigation; none may panic the modal
+    // layer, and after any sequence the palette still paints at any size.
+    use thurbox::kernel::modals::{ModalKind, Modals, World};
+    use thurbox::kernel::theme::Themes;
+
+    let host = host();
+
+    proptest!(ProptestConfig::with_cases(48), |(
+        keys in proptest::collection::vec(any_modal_key(), 1..30),
+        width in 1u16..=160,
+        height in 1u16..=50,
+    )| {
+        // Per case: the closure is `Fn`, and the modal layer writes through both.
+        let mut registry = registry(&host);
+        registry.declare_commands(host.commands());
+        let mut themes = Themes::load(None);
+        let mut modals = Modals::default();
+        modals.toggle(ModalKind::Palette);
+        for key in &keys {
+            if !modals.is_open() {
+                break;
+            }
+            let mut run = None;
+            let mut world = World {
+                settings_on_disk: &Default::default(),
+                save_settings: &mut None,
+                inventory: &[],
+                interface_edit: &mut None,
+                run_action: &mut run,
+                registry: &mut registry,
+                themes: &mut themes,
+                db: None,
+            };
+            let chord = format!("{:?}", key.code).to_lowercase();
+            modals.on_key(key, &chord, &mut world);
+        }
+        if modals.is_open() {
+            let mut terminal = Terminal::new(TestBackend::new(width, height)).expect("terminal");
+            terminal
+                .draw(|frame| {
+                    modals.render(
+                        frame,
+                        Rect::new(0, 0, width, height),
+                        &registry,
+                        &themes,
+                        &Default::default(),
+                        thurbox::kernel::modals::interface::Files { rows: &[], dir: "ui" },
+                    );
+                })
+                .expect("draw");
+        }
+    });
+}

--- a/thurbox.yml
+++ b/thurbox.yml
@@ -15,7 +15,10 @@
 # that to plain functions but not to a table's fields, so `os.time()` passed
 # review while `dofile` was caught. Verified by probing both.
 #
-# Keep in step with `plugin_stdlib` and `install_api` in `src/kernel/host.rs`.
+# Keep in step with `plugin_stdlib` and `install_api` in `src/kernel/host/`.
+# Events and the palette add nothing here on purpose: `events`, `commands` and
+# `on_event` are fields of the declaration table, and `emit` is a kind of
+# `command` — the one write channel a plugin already has.
 # Arguments are declared as varargs: the value here is knowing a name exists and
 # is reachable, not policing arity that Lua itself does not.
 

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -95,7 +95,7 @@ pane from being the thing that makes the whole interface feel slow:
 - **Declare `pure = true` unless the render writes.** The kernel then reuses
   your last tree until something you read changes, and skips your Lua on every
   other frame. It is only wrong if `render` writes `store`/`state` or calls
-  `command` — move those into `on_key`/`on_action`/`on_click`. Floats
+  `command` — move those into `on_key`/`on_action`/`on_click`/`on_event`. Floats
   especially: a float renders every frame *even while closed*.
 - **Memoize on table identity.** The published groups (`thurbox.sessions`,
   `thurbox.theme`, `thurbox.registry`, `thurbox.bookmarks`, …) keep the *same

--- a/ui/README.md
+++ b/ui/README.md
@@ -93,6 +93,19 @@ return {
     { id = "loud", desc = "say it twice", default = false },
   },
 
+  -- Reachable from the Ctrl+P palette without spending a chord.
+  commands = {
+    { action = "example.open", desc = "show the example" },
+  },
+
+  -- Told once per change, off the render path: `thurbox-cli plugin events`.
+  events = { "session.status" },
+  on_event = function(name, payload)
+    if payload.to == "blocked" then
+      state.needs_you = payload.session
+    end
+  end,
+
   render = function(ctx)
     -- ctx carries the RESOLVED rect: ctx.width, ctx.height, ctx.focused.
     local rows = {}
@@ -141,6 +154,12 @@ the base functions (`pairs`, `ipairs`, `type`, `tostring`, `tonumber`, `select`,
 | `run(key, cmd, opts)` | run a program and read its output — **only if trusted**, see below |
 | `files` | bounded reads the kernel performs for you |
 | `thurbox.platform` | `os` and `arch`, so a plugin shipping several builds can pick one |
+
+**Events**: declare `events = { "session.status", … }` and an `on_event(name,
+payload)` and the kernel calls you once per change, with the same environment a
+render has. `command("emit", { text = "x", … })` reaches every plugin subscribed
+to `user.x`. `commands = { { action, desc } }` puts an action in the `Ctrl+P`
+palette with no chord. The list of events is `thurbox-cli plugin events`.
 
 `thurbox.granted` tells you which capabilities *this* file has been granted
 (`granted.run`, `granted.program`). It exists because not every capability can be

--- a/ui/plugins/20_agent.lua
+++ b/ui/plugins/20_agent.lua
@@ -55,6 +55,8 @@ end
 
 local AGENT_TAB, SHELL_TAB = "agent", "shell"
 local SELECT_AGENT, SELECT_SHELL = "terminal.agent", "terminal.shell"
+--- Bring the input focus onto this pane, from anywhere.
+local FOCUS = "terminal.focus"
 
 --- The session the list published, resolved against the current snapshot.
 local function selected()
@@ -776,8 +778,22 @@ return {
     return false
   end,
 
+  -- The palette's rows (Ctrl+P). None of these spends a chord: the tabs are
+  -- already click targets on the border, and focusing the pane is what the
+  -- session list's Enter does — but neither was reachable by name until now.
+  commands = {
+    { action = FOCUS, desc = "focus the agent terminal" },
+    { action = SELECT_AGENT, desc = "show the agent tab" },
+    { action = SELECT_SHELL, desc = "show the shell tab" },
+  },
+
   on_action = function(action)
     local id = store.selected
+    if action == FOCUS then
+      -- Where `sessions.open` sends focus too: the pane that shows the session.
+      command("focus", { text = NAME })
+      return true
+    end
     if action == "shell.open" then
       -- v1 `toggle_shell_view`: the chord flips between the two views, where
       -- the chips select outright. Swallowed without a session, because there

--- a/ui/plugins/70_new_session.lua
+++ b/ui/plugins/70_new_session.lua
@@ -531,7 +531,7 @@ local function render_repo(flow)
     hints = {
       { "tab", suggestion ~= "" and "complete" or "browse" },
       { "enter", "add repo" },
-      { "ctrl+p", "import parent" },
+      { "alt+p", "import parent" },
       { "s-tab", "list" },
     }
   end
@@ -857,7 +857,9 @@ return {
       group = "New session",
     },
     {
-      key = "ctrl+p",
+      -- `alt`, not `ctrl`: `ctrl+p` is the command palette everywhere, and a
+      -- float's own claim on a global chord is a conflict the registry reports.
+      key = "alt+p",
       action = "new_session.import",
       desc = "import a folder of repositories",
       group = "New session",
@@ -1035,7 +1037,7 @@ return {
       -- Works from any focus, as v1's does, because it acts on the typed path.
       local path = (flow.input.value or ""):match("^%s*(.-)%s*$")
       if path == "" then
-        flow.message = "Type a folder path, then ctrl+p to import its repos as a parent"
+        flow.message = "Type a folder path, then alt+p to import its repos as a parent"
       else
         command("bookmark", { host = flow.host, repo = path, action = "parent" })
         textinput.clear(flow.input)

--- a/website/docs/deprecated.html
+++ b/website/docs/deprecated.html
@@ -241,11 +241,14 @@ thurbox-cli automation run &lt;id&gt;    # fire one now</code></pre>
 </h2>
 <p>
   <kbd>Ctrl</kbd>+<kbd>X</kbd>, <kbd>Ctrl</kbd>+<kbd>E</kbd>, <kbd>Ctrl</kbd>+<kbd>B</kbd>,
-  <kbd>Ctrl</kbd>+<kbd>W</kbd>, <kbd>Ctrl</kbd>+<kbd>P</kbd> and
+  <kbd>Ctrl</kbd>+<kbd>W</kbd> and
   <kbd>F2</kbd>/<kbd>F3</kbd>/<kbd>F5</kbd>/<kbd>F7</kbd> do nothing rather than something else. That
   is deliberate and it is asserted by a test: muscle memory that finds nothing is a much smaller
   problem than muscle memory that finds a different feature. When one of these panes returns &mdash;
-  from us or from you &mdash; its chord is waiting for it.
+  from us or from you &mdash; its chord is waiting for it. The one exception is
+  <kbd>Ctrl</kbd>+<kbd>P</kbd>: it was held for the automations pane and was reassigned, on the
+  record, to the <a href="keybindings.html">command palette</a> &mdash; which is the way into any
+  pane, that one included, once it is back.
 </p>
 
 <h2 id="bringing-one-back">

--- a/website/docs/features.html
+++ b/website/docs/features.html
@@ -117,7 +117,7 @@ breadcrumb: 'Features'
               </tr>
               <tr>
                 <td><a href="#automations">Automations</a></td>
-                <td><kbd>Ctrl</kbd>+<kbd>P</kbd></td>
+                <td>&mdash;</td>
                 <td>CLI only</td>
                 <td><code>thurbox-cli automation</code></td>
               </tr>

--- a/website/docs/keybindings.html
+++ b/website/docs/keybindings.html
@@ -40,6 +40,7 @@ breadcrumb: 'Keybindings'
     <tr><td><kbd>F1</kbd> or <kbd>Ctrl</kbd>+<kbd>G</kbd></td><td>Keybindings help &mdash; the registry, rendered</td></tr>
     <tr><td><kbd>F6</kbd> or <kbd>Ctrl</kbd>+<kbd>,</kbd></td><td>Settings. <kbd>]</kbd> crosses to the Interface tab</td></tr>
     <tr><td><kbd>F4</kbd> or <kbd>Ctrl</kbd>+<kbd>Y</kbd></td><td>Theme picker (<kbd>Ctrl</kbd>+<kbd>Y</kbd> is DSUSP in some terminals, hence <kbd>F4</kbd>)</td></tr>
+    <tr><td><kbd>Ctrl</kbd>+<kbd>P</kbd></td><td>Command palette &mdash; every action the registry knows, filtered as you type; <kbd>Enter</kbd> runs one</td></tr>
     <tr><td><kbd>F10</kbd></td><td>Reload the interface from disk</td></tr>
     <tr><td><kbd>F12</kbd></td><td>Perf HUD (needs <code>[features] perf_hud</code>)</td></tr>
   </tbody>
@@ -121,7 +122,7 @@ breadcrumb: 'Keybindings'
     <tr><td><kbd>Space</kbd></td><td>Select a repository, or fold a folder. Multi-select &mdash; that is how one session spans several repositories</td></tr>
     <tr><td><kbd>w</kbd></td><td>Give that repository its own worktree</td></tr>
     <tr><td><kbd>/</kbd></td><td>Filter the list</td></tr>
-    <tr><td><kbd>Ctrl</kbd>+<kbd>P</kbd></td><td>Import a folder of repositories</td></tr>
+    <tr><td><kbd>Alt</kbd>+<kbd>P</kbd></td><td>Import a folder of repositories</td></tr>
     <tr><td><kbd>d</kbd></td><td>Forget a remembered repository</td></tr>
     <tr><td><kbd>Enter</kbd></td><td>Confirm the step</td></tr>
     <tr><td><kbd>Esc</kbd></td><td>Back out. Nothing is created until the last step</td></tr>
@@ -208,7 +209,7 @@ breadcrumb: 'Keybindings'
   Several are gone with the panes they opened: <kbd>Ctrl</kbd>+<kbd>X</kbd>/<kbd>F7</kbd> (code
   review), <kbd>Ctrl</kbd>+<kbd>E</kbd>/<kbd>F3</kbd> (file viewer),
   <kbd>Ctrl</kbd>+<kbd>B</kbd>/<kbd>F2</kbd> (info panel), <kbd>F5</kbd> (tasks),
-  and <kbd>Ctrl</kbd>+<kbd>P</kbd> (automations, now the folder import). Two of them are one
+  and <kbd>Ctrl</kbd>+<kbd>P</kbd> (automations, now the command palette). Two of them are one
   install away:
   <a href="https://github.com/Thurbeen/thurbox-code-review" target="_blank" rel="noopener">thurbox-code-review</a>
   claims <kbd>Ctrl</kbd>+<kbd>X</kbd>/<kbd>F7</kbd> back and

--- a/website/docs/tutorial.html
+++ b/website/docs/tutorial.html
@@ -145,7 +145,7 @@ extraCss: ['tutorial.css']
     <tr><td><kbd>/</kbd></td><td>Filter a long list</td></tr>
     <tr><td><kbd>d</kbd></td><td>Forget a remembered repository</td></tr>
     <tr>
-      <td><kbd>Ctrl</kbd>+<kbd>P</kbd></td>
+      <td><kbd>Alt</kbd>+<kbd>P</kbd></td>
       <td>
         Import a <strong>folder of repositories</strong> at once &mdash; type a parent path, press it,
         and every git subdirectory is added under one header

--- a/website/docs/v2-interface.html
+++ b/website/docs/v2-interface.html
@@ -296,6 +296,10 @@ columns[#columns + 1] = { slot = "center" }</code></pre>
       <td>The same inventory the settings Interface tab shows, with each file's origin</td>
     </tr>
     <tr>
+      <td><code>thurbox-cli plugin events</code></td>
+      <td>Every event a plugin may subscribe to (<code>events = { &hellip; }</code> + <code>on_event</code>), with its payload</td>
+    </tr>
+    <tr>
       <td><code>thurbox-cli plugin install &lt;src&gt;</code></td>
       <td>Fetches a pane and records it in <code>plugins.toml</code></td>
     </tr>
@@ -346,6 +350,26 @@ columns[#columns + 1] = { slot = "center" }</code></pre>
   <em>within</em>
   one version still show up, because from outside a local edit and an upstream substitution are the
   same thing.
+</p>
+<p>
+  <strong>A plugin can react as well as draw.</strong>
+  Declare
+  <code>events = { "session.status", &hellip; }</code>
+  and an
+  <code>on_event(name, payload)</code>
+  handler, and the kernel calls it once per change, off the render path &mdash; a session
+  appearing, leaving or changing status, the selection moving, a command finishing, the interface
+  reloading. The events are derived by diffing the snapshot, so a session made by
+  <code>thurbox-cli</code>
+  or a cron tick fires the same one the creation flow does; a subscription to a name nothing
+  emits refuses to load, and
+  <code>thurbox-cli plugin events</code>
+  lists them all. Plugins reach each other with
+  <code>command("emit", &hellip;)</code>. And an action need not spend a chord to exist:
+  <code>commands = { { action, desc } }</code>
+  puts it in the
+  <kbd>Ctrl</kbd>+<kbd>P</kbd>
+  command palette beside every declared key, run through the same handler a key press takes.
 </p>
 <p>
   A broken plugin does not cost you the interface: the error is reported in place, and the bundled

--- a/website/llms.txt
+++ b/website/llms.txt
@@ -61,7 +61,7 @@
 - [Configuration](https://thurbox.thurbeen.eu/docs/configuration.html): every config file and knob — agents.toml, hosts.toml, hooks.toml (session lifecycle hooks), settings.toml, themes, keybindings.
 - [Deprecated surfaces](https://thurbox.thurbeen.eu/docs/deprecated.html): the six panes 1.x had that the current interface does not — code review and the info panel, now the installable thurbox-code-review and thurbox-info-panel plugins; the file viewer, with no replacement; and the tasks/automations/restore panes that moved to thurbox-cli.
 - [Using v1](https://thurbox.thurbeen.eu/docs/v1.html): thurbox 1.x is still maintained — what it has that the current interface does not, how to stay on it or go back, and what it will receive.
-- [The Interface](https://thurbox.thurbeen.eu/docs/v2-interface.html): every pane is an editable Lua plugin — how to move, disable, replace or write one, how to have a coding agent do it for you, what the kernel refuses a plugin, and the two v1 panes (thurbox-code-review, thurbox-info-panel) you install as plugins.
+- [The Interface](https://thurbox.thurbeen.eu/docs/v2-interface.html): every pane is an editable Lua plugin — how to move, disable, replace or write one, how a plugin reacts to events and puts actions in the Ctrl+P command palette, how to have a coding agent do it for you, what the kernel refuses a plugin, and the two v1 panes (thurbox-code-review, thurbox-info-panel) you install as plugins.
 - [Architecture](https://thurbox.thurbeen.eu/docs/architecture.html): the Lua-on-Rust plugin kernel and its five rules, module isolation, the tmux session backend, and design decisions (including the Elm Architecture the interface used before 2.0).
 
 ## Extensions


### PR DESCRIPTION
## Summary
- **Plugin events.** A plugin declares `events = { … }` and an `on_event(name, payload)` handler; the loop calls it once per change, off the render path, under the render's instruction budget. The kernel's events are *derived* by diffing published state (session rows, the focus ring, the command bus, reloads) — never raised from `session_ops` — so a session another process made fires the same `session.created`. `session.post_*` share their names with `hooks.toml`. The set is closed (`KERNEL_EVENTS`): an unknown subscription refuses to load, and one table renders in `F1` and `thurbox-cli plugin events`. `command("emit", …)` delivers `user.<name>` to other plugins with `source` stamped by the kernel; cascades stop at `MAX_DEPTH`. Dispatch never marks the frame dirty itself (`frame-cost`).
- **Command palette** on `Ctrl+P` (kernel chrome): every declared key, the new chord-less `commands = { { action, desc } }` declarations and the kernel's own actions, subsequence-filtered; `Enter` runs the row through the same `on_action` a key press takes, focused or not, after the modal has closed. A command a user rebinds from `F1` becomes a binding. The agent pane contributes "focus the agent terminal" and its two tabs.
- `Ctrl+P` is reassigned on the record from the chords held for v1's panes (`tests/v2_keymap.rs`); the creation flow's folder import moves to `Alt+P`.
- Docs: `docs/PLUGINS.md` (Events, Palette, two traps), `V2-KERNEL.md`, `CLAUDE.md`, `ui/README.md`, `ui-skill`, `CONFIG.md`/`FEATURES.md` cross-references, website keybindings/interface/deprecated pages, `docs/examples/events.lua`. OpenSpec change archived with its specs synced (`plugin-events`, `command-palette`, `frame-cost` delta).

## Test plan
- [x] `cargo nextest run --all` — 2018 passed
- [x] `cargo clippy --all-targets --all-features -D warnings`, `cargo doc -D warnings`, `cargo fmt`
- [x] `selene` / `stylua` / `rumdl`
- [x] New: `tests/v2_events.rs`, `tests/v2_palette.rs` (incl. a pinned frame and a key-fuzz proptest), budget-overrun case in `kernel_limits.rs`, `plugin check` refuses an unknown subscription
- [ ] CI: `lua-language-server --check`, website linters (not installed locally)

https://claude.ai/code/session_012eSZfgFYK5hEfs5q7m32HU
