### PR TITLE
fix(core): restore the terminal on SIGHUP/SIGTERM/SIGINT

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1748,7 +1748,17 @@ tokio::main → load config + settings → heal extensions → arm the heartbeat
 - Logging goes to `~/.local/share/thurbox/thurbox.log` (stdout is the TUI's)
 - A panic hook restores the terminal, pops the kitty flags and disables mouse
   reporting before printing — otherwise the shell inherits a raw-mode terminal
-  streaming mouse reports
+  streaming mouse reports. A **signal** gets the same treatment
+  (`coordinator::boot::install_signal_restore`): `SIGHUP`/`SIGTERM`/`SIGINT`
+  run `restore_terminal` and exit `128 + n`, since the default action runs no
+  hook and a terminal emulator closing, a session manager, or a machine waking
+  from a long sleep used to leave the next shell printing `\x1b[<64;…M` on
+  every scroll. `restore_terminal` shows the cursor itself for the same
+  reason — a signal exits from the runtime's thread and drops no `Terminal`.
+  The one case no handler reaches is a **dropped ssh connection** to a remote
+  thurbox: the `?1003l` has no pty to travel down, so the *local* emulator
+  keeps reporting — `reset` there, or run the ssh session inside a local tmux.
+  `tests/tui_e2e.rs` pins both exits' escapes.
 
 ## Pre-commit Hooks
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -2359,6 +2359,20 @@ open review lets F8 fall through to the global binding instead of swallowing
 it), and `toggle_shell_view` is review-aware — with a review open it closes it
 and lands on the shell, mirroring the Shell tab.
 
+**Giving the terminal back.** The escapes that turn reporting on are undone by
+`restore_terminal` on every exit thurbox can see: a clean `Ctrl+Q`, a panic, and
+— since the signal handler in `coordinator::boot` — a `SIGHUP`, `SIGTERM` or
+`SIGINT`, which the process used to die on with the default action and no
+cleanup, leaving the shell that came next printing `\x1b[<64;12;30M` on every
+wheel notch (thurbox asks for `?1003`, so every pointer *move* reported too).
+The exit status is the shell's `128 + signal`, so a wrapper can tell the two
+apart. What no handler can fix is a **dropped ssh connection** to a remote
+thurbox: the `?1003l` has no pty left to travel down, so the local emulator is
+left reporting exactly as a killed remote `vim` leaves it on the alternate
+screen. Type `reset` there (or `printf '\e[?1000l\e[?1003l\e[?1006l\e[?2004l\e[?1049l'`),
+or run the ssh session inside a local tmux, which owns the outer terminal's
+modes and puts them back on detach.
+
 ---
 
 ## Shell Pane Toggle

--- a/src/coordinator/boot.rs
+++ b/src/coordinator/boot.rs
@@ -41,6 +41,17 @@ pub(crate) async fn run() -> Result<(), Box<dyn Error>> {
         original_hook(info);
     }));
 
+    // The same restore for a signal, which the panic hook cannot see. A
+    // `SIGHUP` (the terminal or ssh session went away), a `SIGTERM` (a session
+    // manager, or the machine waking from a long sleep and reaping what it
+    // suspended) or a `kill -INT` ends the process with the default action,
+    // and the default action runs no hook — so mouse reporting stayed on and
+    // the next shell printed `\x1b[<64;…M` on every scroll. Spawned before the
+    // terminal is taken: every step of `restore_terminal` is a no-op for a mode
+    // that was never enabled, and a signal that lands during boot is otherwise
+    // the one this misses.
+    install_signal_restore();
+
     // File-based logging: stdout belongs to the TUI, so every `tracing` call in
     // this process — the panic hook, a worker's warning, the perf lines below —
     // has nowhere else to go. Without a subscriber they are not merely
@@ -285,6 +296,59 @@ pub(crate) async fn run() -> Result<(), Box<dyn Error>> {
     let result = app.run(terminal);
     restore_terminal();
     result
+}
+
+/// Put the terminal back and exit when a signal ends the process.
+///
+/// Exits directly rather than asking the loop to quit: the loop is on the
+/// thread blocked in `app.run`, and after a `SIGHUP` its `event::poll` may be
+/// reading a pty that is already gone, so a request would be honoured late or
+/// never. Exiting from the runtime's thread skips the loop's drops, exactly as
+/// the panic path does — tmux keeps the sessions alive, so nothing is lost.
+/// The status is the shell's convention, `128 + signal`, so a wrapper script
+/// can tell a signal from a clean quit.
+///
+/// `restore_terminal` is idempotent and takes no lock, so racing the normal
+/// exit path — a `SIGTERM` that lands while `Ctrl+Q` is being honoured —
+/// costs a redundant escape and nothing else.
+fn install_signal_restore() {
+    fn restore_and_exit(name: &str, number: i32) -> ! {
+        restore_terminal();
+        tracing::info!("exiting on {name}");
+        std::process::exit(128 + number)
+    }
+
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+        // The numbers are POSIX's (1, 2, 15 on Linux and macOS alike), spelled
+        // here because `SignalKind` does not expose them portably and `libc`
+        // is a dev-dependency only.
+        let hangup = ("SIGHUP", signal(SignalKind::hangup()), 1);
+        let terminate = ("SIGTERM", signal(SignalKind::terminate()), 15);
+        let interrupt = ("SIGINT", signal(SignalKind::interrupt()), 2);
+        for (name, stream, number) in [hangup, terminate, interrupt] {
+            match stream {
+                Ok(mut stream) => {
+                    tokio::spawn(async move {
+                        if stream.recv().await.is_some() {
+                            restore_and_exit(name, number);
+                        }
+                    });
+                }
+                Err(e) => tracing::warn!("could not listen for {name}: {e}"),
+            }
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        // Ctrl+C / Ctrl+Break / a closed console window all arrive here.
+        tokio::spawn(async {
+            if tokio::signal::ctrl_c().await.is_ok() {
+                restore_and_exit("SIGINT", 2);
+            }
+        });
+    }
 }
 
 /// Index into the host's focusable plugins for `name`, or 0.

--- a/src/coordinator/chrome.rs
+++ b/src/coordinator/chrome.rs
@@ -250,11 +250,15 @@ pub(crate) fn restore_terminal() {
     // cooked terminal.
     pop_keyboard_enhancement();
     // Unconditional: cheaper than tracking whether capture was on, and a
-    // terminal left reporting is the failure this exists to prevent.
+    // terminal left reporting is the failure this exists to prevent. The
+    // cursor is shown here too, not left to `Terminal`'s drop: a signal exits
+    // from the runtime's thread and drops nothing, and a shell with no cursor
+    // is the leftover that path had.
     let _ = crossterm::execute!(
         std::io::stdout(),
         crossterm::event::DisableMouseCapture,
-        crossterm::event::DisableBracketedPaste
+        crossterm::event::DisableBracketedPaste,
+        crossterm::cursor::Show
     );
     // The console's own mouse handling is a mode, not an escape, so the line
     // above does not give it back. Idempotent, and a no-op if we never took it.

--- a/tests/tui_e2e.rs
+++ b/tests/tui_e2e.rs
@@ -389,6 +389,25 @@ impl Tui {
     /// caller's to judge.
     fn quit(&mut self) -> ExitStatus {
         self.send(CTRL_Q);
+        self.wait_exit("Ctrl+Q")
+    }
+
+    /// Send `signal` to the binary and wait for it to go; the exit status is
+    /// the caller's to judge.
+    fn signal(&mut self, signal: libc::c_int) -> ExitStatus {
+        // SAFETY: a plain `kill(2)` on a pid this harness spawned and has not
+        // yet reaped (`poll_exit` is the only reaper, and `exited` is `None`).
+        let sent = unsafe { libc::kill(self.child.id() as libc::pid_t, signal) };
+        assert_eq!(
+            sent,
+            0,
+            "kill({signal}) failed: {}",
+            std::io::Error::last_os_error()
+        );
+        self.wait_exit(&format!("signal {signal}"))
+    }
+
+    fn wait_exit(&mut self, after: &str) -> ExitStatus {
         let deadline = Instant::now() + WAIT;
         while Instant::now() < deadline {
             if let Some(status) = self.poll_exit() {
@@ -396,7 +415,7 @@ impl Tui {
             }
             std::thread::sleep(Duration::from_millis(40));
         }
-        self.give_up("the process to exit after Ctrl+Q");
+        self.give_up(&format!("the process to exit after {after}"));
     }
 }
 
@@ -431,22 +450,53 @@ fn boots_paints_and_quits_restoring_the_terminal() {
 
     let status = tui.quit();
     assert!(status.success(), "Ctrl+Q must exit cleanly: {status:?}");
+    assert_terminal_restored(&tui.raw_since(0), "a clean exit");
+}
 
-    // A missing one of these is the "my shell is streaming mouse reports"
-    // bug, which no in-process test and no capture-pane assertion can see.
-    let raw = tui.raw_since(0);
-    for (seq, meaning) in [
-        ("\x1b[?1049l", "leave the alternate screen"),
-        ("\x1b[?1000l", "stop mouse reporting"),
-        ("\x1b[?1003l", "stop mouse motion reporting"),
-        ("\x1b[?2004l", "disable bracketed paste"),
-        ("\x1b[?25h", "show the cursor again"),
-    ] {
+/// What every exit owes the terminal. A missing one of these is the "my shell
+/// is streaming mouse reports" bug, which no in-process test and no
+/// capture-pane assertion can see.
+const RESTORE_ESCAPES: [(&str, &str); 5] = [
+    ("\x1b[?1049l", "leave the alternate screen"),
+    ("\x1b[?1000l", "stop mouse reporting"),
+    ("\x1b[?1003l", "stop mouse motion reporting"),
+    ("\x1b[?2004l", "disable bracketed paste"),
+    ("\x1b[?25h", "show the cursor again"),
+];
+
+fn assert_terminal_restored(raw: &str, exit: &str) {
+    for (seq, meaning) in RESTORE_ESCAPES {
         assert!(
             raw.contains(seq),
-            "exit must {meaning} ({seq:?} missing from the byte stream)"
+            "{exit} must {meaning} ({seq:?} missing from the byte stream)"
         );
     }
+}
+
+#[test]
+fn a_signal_restores_the_terminal_before_exiting() {
+    let profile = Profile::new();
+    let mut tui = Tui::spawn(&profile, 24, 80);
+    tui.wait_for("No sessions yet");
+    let taken = tui.raw_len();
+
+    // What a session manager, a closed ssh connection or a machine waking from
+    // a long sleep sends. The default action runs no hook, which is how the
+    // shell that came next was left printing `\x1b[<64;…M` on every scroll.
+    let status = tui.signal(libc::SIGTERM);
+    assert!(
+        !status.success(),
+        "a signalled exit must not pass for a clean one: {status:?}"
+    );
+    assert_eq!(
+        status.code(),
+        Some(128 + libc::SIGTERM),
+        "exit status follows the shell's 128 + signal convention: {status:?}"
+    );
+
+    // Only the bytes written AFTER the boot count, so a `…l` from setup could
+    // not satisfy this.
+    assert_terminal_restored(&tui.raw_since(taken), "a signalled exit");
 }
 
 // --- the kernel-owned overlays ---------------------------------------------


### PR DESCRIPTION
## Summary
- A signal (`SIGHUP` from a closed terminal/ssh session, `SIGTERM` from a session manager or a machine waking from a long sleep, `kill -INT`) ended thurbox with the default action, which runs no hook — mouse reporting stayed on and the next shell printed `\x1b[<64;…M` on every scroll. `coordinator::boot::install_signal_restore` now runs the same `restore_terminal` the panic hook does and exits `128 + n`.
- `restore_terminal` shows the cursor itself; that used to come from `Terminal`'s drop, which an exit from the runtime's thread skips.
- The one case no handler reaches — a dropped ssh connection to a *remote* thurbox, where the `…l` has no pty to travel down — is documented (CLAUDE.md, `docs/FEATURES.md`) with the local `reset` workaround.

## Test plan
- [x] New `tests/tui_e2e.rs::a_signal_restores_the_terminal_before_exiting`: sends a real `SIGTERM` to the binary on a pty, asserts exit 143 and the same `?1049l ?1000l ?1003l ?2004l ?25h` escapes the clean-quit test pins (it failed on `?25h` before the cursor fix).
- [x] `cargo nextest run --test tui_e2e` (9/9), `cargo clippy --all-targets --all-features -D warnings`, `cargo fmt --check`, `architecture_rules`.
- [ ] CI

https://claude.ai/code/session_018V3a9bYMcahkgsDgSahfpX