### PR TITLE
fix: AltGr characters and tab-to-browse in the creation flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1834,6 +1834,14 @@ because `ratatui::restore()` does not). That is what makes `cmd+…` bindable at
 leaves free. F-keys need `Fn` on Mac laptops unless "Use F1, F2, etc. as standard
 function keys" is on.
 
+**Windows.** The console reports AltGr as `Ctrl`+`Alt`, so the pair is dropped at
+the input boundary (`coordinator::input::resolve_altgr`) for any character no key
+produces unmodified — punctuation, or a non-ASCII letter. Without it every AltGr
+character (`\` on AZERTY, `@`/`[`/`]` on QWERTZ) was swallowed by every text
+field and reached the agent ESC-wrapped. A `Ctrl+Alt`+letter/digit chord is
+untouched, and the rule is Windows-only: elsewhere the terminal composes AltGr
+itself before thurbox sees the key.
+
 ## Themes
 
 Thirty-six palettes — twenty-eight dark, eight light; the enumeration is in

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -581,6 +581,22 @@ exists). Beyond that:
   unless function keys are set to standard; `Cmd+V` already pastes
   through the terminal's native paste → bracketed paste path.
 
+### Windows
+
+- **AltGr is not a chord.** The Windows console reports an AltGr press
+  as left-`Ctrl` plus right-`Alt`, so every character a layout hides
+  behind AltGr (`\` and `|` on AZERTY; `@`, `[`, `]`, `{`, `}` and `~`
+  on QWERTZ) arrives carrying two modifiers. Thurbox drops that pair
+  before anything looks at the keystroke
+  (`coordinator::input::resolve_altgr`), so the character is typed into
+  a field and sent to the agent as itself rather than being swallowed as
+  an unbound chord or wrapped in an `ESC`. The pair is dropped only for
+  a character no key produces unmodified — punctuation, or a non-ASCII
+  letter (`ą`, `€`) — so a real `Ctrl+Alt`+letter/digit chord still
+  resolves as one. Off Windows, AltGr is a level-3 shift the terminal
+  composes before thurbox sees it, and `Ctrl+Alt`+punctuation stays
+  bindable.
+
 ---
 
 ## Session Lifecycle

--- a/src/coordinator/input.rs
+++ b/src/coordinator/input.rs
@@ -71,6 +71,10 @@ impl App {
                 // here as keys and has to be recognised as one — the coalescer
                 // hands back whichever of the two this turned out to be.
                 Event::Key(key) if key.kind == KeyEventKind::Press => {
+                    // Before anything else looks at it, so the coalescer, the
+                    // registry, the fields and the pty encoder all see the same
+                    // keystroke. See `resolve_altgr`.
+                    let key = resolve_altgr(key, cfg!(windows));
                     for input in self.paste_burst.push(key, Instant::now()) {
                         self.apply_input(input, &mut published);
                     }
@@ -548,5 +552,121 @@ impl App {
             return;
         };
         self.on_paste(text);
+    }
+}
+
+/// Undo Windows' spelling of AltGr, which is `Ctrl+Alt`.
+///
+/// The Windows console reports an AltGr press as left-Ctrl plus right-Alt and
+/// crossterm passes that through, so every character a layout hides behind
+/// AltGr arrives carrying two modifiers. Nothing downstream types one: a text
+/// field swallows any key with `ctrl` or `alt` on it rather than inserting it,
+/// and `agent::input::key_to_bytes` wraps it in an ESC, so a focused agent
+/// reads `Alt+\` where a backslash was typed. On an AZERTY keyboard that is
+/// `\` and `|`; on a German one `@`, `[`, `]`, `{`, `}` and `~` — characters
+/// a path or a shell command cannot do without, and they worked in no field
+/// and no terminal.
+///
+/// Crossterm has already resolved the layout, so the character on the event
+/// **is** the one that was typed and the modifiers only describe how it was
+/// reached. They are dropped for a character no keyboard produces unshifted:
+/// punctuation, or a non-ASCII letter (Polish `ą`, a `€`). An ASCII letter or
+/// digit is left alone, so a real `Ctrl+Alt+d` chord still resolves as one —
+/// no layout puts a bare ASCII alphanumeric behind AltGr, since that is the
+/// key's own unmodified output.
+///
+/// `windows` is a parameter rather than a `cfg!` inside so the rule is
+/// testable on any platform, as [`super::paste::PasteBurst`] does for the same
+/// reason. Elsewhere AltGr is a level-3 shift the terminal composes before
+/// thurbox ever sees it, and `Ctrl+Alt+<punctuation>` is a chord someone may
+/// have rebound onto.
+fn resolve_altgr(key: KeyEvent, windows: bool) -> KeyEvent {
+    if !windows {
+        return key;
+    }
+    let altgr = KeyModifiers::CONTROL | KeyModifiers::ALT;
+    if !key.modifiers.contains(altgr) {
+        return key;
+    }
+    let KeyCode::Char(ch) = key.code else {
+        return key;
+    };
+    if ch.is_ascii_alphanumeric() || ch.is_control() {
+        return key;
+    }
+    KeyEvent {
+        modifiers: key.modifiers - altgr,
+        ..key
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn altgr(ch: char) -> KeyEvent {
+        KeyEvent::new(KeyCode::Char(ch), KeyModifiers::CONTROL | KeyModifiers::ALT)
+    }
+
+    /// The reported bug: AltGr+8 on an AZERTY layout is a backslash, and it has
+    /// to reach a field and a pty as one.
+    #[test]
+    fn altgr_punctuation_is_typed_rather_than_treated_as_a_chord() {
+        for ch in ['\\', '|', '@', '[', ']', '{', '}', '~', '#', '€', 'ą'] {
+            let resolved = resolve_altgr(altgr(ch), true);
+            assert_eq!(resolved.code, KeyCode::Char(ch));
+            assert!(
+                resolved.modifiers.is_empty(),
+                "{ch:?} kept {:?}",
+                resolved.modifiers
+            );
+            // And the pty encoding is the character itself, not an ESC-wrapped
+            // one — which is what a focused agent actually receives.
+            assert_eq!(
+                thurbox::agent::input::key_to_bytes(resolved.code, resolved.modifiers),
+                Some(ch.to_string().into_bytes()),
+            );
+        }
+    }
+
+    /// A chord someone could genuinely press, and could have rebound onto: no
+    /// layout puts a bare ASCII alphanumeric behind AltGr, so it is left whole.
+    #[test]
+    fn a_real_ctrl_alt_chord_is_left_alone() {
+        for ch in ['d', 'D', '7'] {
+            assert_eq!(resolve_altgr(altgr(ch), true), altgr(ch));
+        }
+    }
+
+    /// Off the Windows console AltGr is a level-3 shift the terminal composes
+    /// itself, so `Ctrl+Alt` there means what it says.
+    #[test]
+    fn other_platforms_keep_ctrl_alt_as_a_chord() {
+        assert_eq!(resolve_altgr(altgr('\\'), false), altgr('\\'));
+    }
+
+    /// Only the pair is an AltGr artifact: either modifier on its own is a
+    /// chord in the ordinary way, `alt+p` among them.
+    #[test]
+    fn one_modifier_alone_is_never_altgr() {
+        for modifiers in [KeyModifiers::CONTROL, KeyModifiers::ALT] {
+            let key = KeyEvent::new(KeyCode::Char('\\'), modifiers);
+            assert_eq!(resolve_altgr(key, true), key);
+        }
+    }
+
+    /// Shift rides along on some layouts (AltGr+Shift is a fourth level); only
+    /// the Ctrl+Alt pair is removed, so what is left still says so.
+    #[test]
+    fn a_fourth_level_press_keeps_its_shift() {
+        let key = KeyEvent::new(
+            KeyCode::Char('¤'),
+            KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT,
+        );
+        assert_eq!(
+            resolve_altgr(key, true).modifiers,
+            KeyModifiers::SHIFT,
+            "the layout level that produced the character is not a chord"
+        );
     }
 }

--- a/tests/v2_new_session.rs
+++ b/tests/v2_new_session.rs
@@ -596,6 +596,62 @@ fn a_dotted_prefix_offers_the_hidden_entries() {
 }
 
 #[test]
+fn tab_on_an_empty_field_browses_home() {
+    // The regression behind "tab no longer browses directories": the flow asked
+    // for a listing only once something had been typed, so `tab` on a fresh
+    // field opened a dropdown whose want was never published — it sat on "(no
+    // subdirectories)" forever. An empty field means home, exactly as a bare
+    // `~` does.
+    let host = host();
+    let mut world = World::default();
+    world.repos.set_listing_for_test(
+        "",
+        "~",
+        Listing::Ready(vec![BrowseEntry {
+            name: "src".into(),
+            is_git: false,
+        }]),
+    );
+    world.wants.browse = Some((String::new(), "~".into()));
+    open(&host, &world);
+    press(&host, &world, "tab");
+    // Nothing typed yet, and nothing to complete — so this `tab` opens the
+    // browser rather than taking a suggestion.
+    press(&host, &world, "tab");
+    assert_eq!(
+        host.shared_string("want_browse").as_deref(),
+        Some("\0~"),
+        "the open dropdown asks for home"
+    );
+    let screen = drawn(&host, &world);
+    assert!(screen.contains("src/"), "home is listed: {screen}");
+}
+
+#[test]
+fn a_closed_dropdown_over_an_empty_field_asks_for_no_listing() {
+    // The other half of the same rule: a flow only picking from memory must not
+    // pay for a directory read. The want is restated on every render, so what a
+    // frame asks for is read after one — closing the browser stops the asking.
+    let host = host();
+    let world = World::default();
+    open(&host, &world);
+    press(&host, &world, "tab");
+    drawn(&host, &world);
+    assert_eq!(
+        host.shared_string("want_browse"),
+        None,
+        "an empty field with no dropdown has nothing to list"
+    );
+    press(&host, &world, "tab");
+    drawn(&host, &world);
+    assert_eq!(host.shared_string("want_browse").as_deref(), Some("\0~"));
+    // Shift+Tab closes the dropdown and hands focus back to the list.
+    press(&host, &world, "backtab");
+    drawn(&host, &world);
+    assert_eq!(host.shared_string("want_browse"), None);
+}
+
+#[test]
 fn a_bare_tilde_browses_home_rather_than_filtering_by_it() {
     // v1's exception: `~` is where to look, not something to match names against.
     let host = host();

--- a/ui/plugins/70_new_session.lua
+++ b/ui/plugins/70_new_session.lua
@@ -130,8 +130,15 @@ local function ask(flow)
   -- The listing of the typed path's directory. Requested whether or not the
   -- dropdown is open, because the ghost completion is derived from it — which is
   -- how completion works for a remote target here and does not in v1.
+  --
+  -- An EMPTY field still names a directory: `split_typed` answers `~` for it,
+  -- exactly as it does for a bare `~`. Asking only once something had been typed
+  -- is what made `tab` on a fresh field open a dropdown nothing could ever fill —
+  -- and `tab` on a fresh field is how browsing starts, so it read as "tab no
+  -- longer browses". The want is still dropped the moment the dropdown closes, so
+  -- a flow that is only picking from memory asks for no listing at all.
   local typed = flow.step == "repo" and (flow.input.value or "") or ""
-  if typed ~= "" then
+  if flow.step == "repo" and (typed ~= "" or flow.browse) then
     local dir = pathpicker.split_typed(typed)
     store.want_browse = (flow.host or "") .. "\0" .. dir
   else


### PR DESCRIPTION
## Summary

Two reported v2.7.0 regressions, both hit on Windows 11 with an AZERTY keyboard.

- **`\` worked nowhere (#1015).** The Windows console reports AltGr as left-Ctrl
  plus right-Alt and crossterm passes that through, so every character a layout
  hides behind AltGr arrived carrying two modifiers. Nothing downstream typed
  one: `textinput.key` swallows any key with `ctrl`/`alt` on it rather than
  inserting it, and `key_to_bytes` fell through to `alt_bytes` — a focused agent
  read `Alt+\` where a backslash was typed. Beyond `\` and `|` on AZERTY this
  also broke `@ [ ] { } ~` on QWERTZ. A new `coordinator::input::resolve_altgr`
  drops the pair at the single input boundary, before the paste coalescer, the
  registry, the fields and the pty encoder — so all four see the same keystroke.
  Crossterm has already resolved the layout, so the character on the event *is*
  what was typed. The pair is dropped only for a character no key produces
  unmodified (punctuation, or a non-ASCII letter like `ą`/`€`); an ASCII letter
  or digit is left alone, so a real `Ctrl+Alt+d` chord still resolves as one.
  Windows-only, since elsewhere AltGr is a level-3 shift the terminal composes
  itself and `Ctrl+Alt`+punctuation stays bindable.

- **Tab no longer browsed directories (#1014).** The creation flow published
  `want_browse` only once something had been typed, so `tab` on a fresh path
  field opened a dropdown whose listing was never requested — it sat on
  `(no subdirectories)` for good. That is the one keystroke browsing starts
  with. An empty field does name a directory: `pathpicker.split_typed` already
  answers `~` for it, exactly as it does for a bare `~`. The want now follows
  what is actually on screen, and a flow only picking from memory still asks for
  no listing.

Docs updated per the repo rule: a **Windows** subsection in `docs/FEATURES.md`
mirroring the existing macOS one, plus the matching note in `CLAUDE.md`.

Closes #1015
Closes #1014

## Test plan

- `coordinator::input` — 5 new unit tests for `resolve_altgr`: AltGr punctuation
  and non-ASCII letters are typed (asserting the *pty bytes* are the bare
  character, not an ESC-wrapped one), a real `Ctrl+Alt` chord is untouched,
  one modifier alone is never AltGr, a fourth-level press keeps its `Shift`,
  and non-Windows keeps `Ctrl+Alt` as a chord.
- `v2_new_session` — 2 new tests: `tab` on an empty field asks for `~` and lists
  it, and a closed dropdown over an empty field asks for no listing at all. The
  first fails on the unpatched Lua and passes with it (verified by reverting).
- Full suite: `v2_new_session` 42/42, `v2_keymap` 54/54, `kernel_mvp` 75/75,
  `v2_frames`, `v2_modals`, `v2_events`, `kernel_frame_cost` all green.
- `cargo clippy --all-targets --all-features -- -D warnings` clean; `cargo fmt`
  applied.

Note: `tui_e2e`, `v2_attach_by_name`, `create_e2e` (tmux-dependent) and a couple
of shared-process-state tests fail identically on a clean checkout in a
sandbox without tmux — artifacts of `cargo test`'s in-process parallelism, not
regressions. They pass under CI's `cargo nextest` process-per-test.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MqTYUYSfQSK9jqBuDr7sVF)_