### PR TITLE
fix(core): stop retrying an unprovisionable host every minute

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1236,6 +1236,22 @@ network, a different schema) or with `share_sessions = false` is used exactly
 as ADR-13 describes: worktrees over ssh, the hooks rewrite, the pane-option
 status channel, which are now the **legacy path for non-shareable hosts**.
 
+The verdict is cached per host, and a failing one **backs off**:
+`host_cli::retry_after` doubles `PROBE_RETRY` (60 s) per consecutive failure
+up to `PROBE_RETRY_MAX` (15 min), the count reset by the first usable answer
+and by `forget` (what `session sync` calls, since somebody running it by hand
+has usually just fixed the host). A flat interval was wrong because the
+failures divide in two and only one of them is transient: a host that is
+rebooting answers on the next pass, while a host whose shell will not take a
+10 MB payload fails *identically* every time — and each of those attempts
+re-downloaded the release archive and opened an ssh, once a minute, for as
+long as thurbox ran. The transfer itself reaps its transport child on both
+paths (`git::stream_into_child`, killing it first when the write failed):
+`Child`'s `Drop` neither kills nor waits, so returning on the `EPIPE`
+`write_all` saw left one orphaned `ssh` per attempt. It also reports the
+peer's own stderr in preference to that `EPIPE`, which is the symptom of the
+remote dying and never the reason.
+
 **Why**: two thurboxes already shared a host's tmux server — a laptop spawning
 on `ssh:devbox` and a thurbox on devbox both use `tmux -L thurbox` there —
 but each kept its own database, so each saw only what it made. The laptop

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -476,6 +476,13 @@ has the rationale; the shape:
   says so (`sharing` in its JSON, a line in `thurbox.log`). Sessions
   created that way are listed by `session sync` as unknown to the host;
   `session sync --host <name> --adopt` registers them there.
+- **Retrying.** A host that answers "no usable CLI" is asked again
+  after 60 s, and each further consecutive failure doubles that up to
+  15 minutes — so a host that is merely rebooting is picked up on the
+  next pass, while one that can never be provisioned stops costing an
+  archive download and a connection every minute. The first usable
+  answer resets it, and so does `session sync`, since running it by
+  hand usually means the host was just fixed.
 - **Status.** Hooks on a shared host call the host's own `thurbox-cli
   session signal`, which writes the host's database (mirrored at 10 s)
   **and** the pane option a remote observer's control-mode subscription

--- a/openspec/changes/share-remote-sessions/specs/shared-sessions/spec.md
+++ b/openspec/changes/share-remote-sessions/specs/shared-sessions/spec.md
@@ -127,6 +127,38 @@ render path and SHALL never block the interface's start.
 - **THEN** a matching one is provisioned under thurbox's directory and used
   in preference; H's own install is not touched
 
+### Requirement: A host that cannot be made usable is asked less and less often
+
+A host that answers "no usable CLI" SHALL be left alone for a growing interval
+before it is probed again — the base interval on the first failure, doubling
+with each consecutive one up to a ceiling — and the count SHALL reset the
+moment the host answers usably. Obtaining and shipping the release artifact
+SHALL never leave a transport process behind: whatever the outcome of the
+transfer, the process fronting it SHALL be reaped before the attempt returns,
+and the reported reason SHALL be what the host said rather than the local end
+noticing the connection close.
+
+#### Scenario: A host that can never be provisioned
+
+- **WHEN** H fails provisioning for a reason that will not change on its own —
+  its shell will not accept a payload that size, no artifact exists for its
+  platform
+- **THEN** the retry interval grows to the ceiling instead of re-downloading
+  the release archive and opening a connection on the base interval for as
+  long as thurbox runs
+
+#### Scenario: A host that was only briefly away
+
+- **WHEN** H is unreachable for one pass and answers on the next
+- **THEN** it is asked again at the base interval, and its verdict is cached
+  as usable with no penalty carried forward
+
+#### Scenario: The transfer dies mid-payload
+
+- **WHEN** the host's end exits while the artifact is being streamed to it
+- **THEN** the attempt reports the host's own stderr, and no transport process
+  survives the attempt
+
 ### Requirement: Hosts are mirrored on a cadence and after every operation
 
 The system SHALL mirror every shareable host on a slow cadence from a worker,

--- a/openspec/changes/share-remote-sessions/tasks.md
+++ b/openspec/changes/share-remote-sessions/tasks.md
@@ -31,6 +31,8 @@
 - [x] 4.4 Reaper: a mirrored (remote) row is never reaped here — `reap_soft_deleted` already returns `Ok(false)` for a remote backend, so the reaper's `Reap` command is a no-op for them; the host's tick reaps its own overdue soft deletes
 - [x] 4.5 Sharing note: `SpawnResult.sharing` → `session create` JSON (`sharing`) and human output, and a `warn` line in `thurbox.log` for the interface's creation (v2 has no info panel of its own; `hook_wiring` is not published either)
 - [x] 4.6 Tests `tests/v2_shared_sessions.rs` (in-memory DB, fake host runner returning canned `list`/`list --deleted` JSON): a host row is adopted with the same id and `ssh:H`; facts update; a host-deleted row is soft-deleted with the force mark and the reaper forgets it; a host-restored row is restored; an unknown local row is reported, and adopted with `--adopt` through `register`; an idle pass writes nothing (`data_version` unchanged); hook state echo does not re-write; a mirrored row with no window issues `restart --if-missing` and launches nothing locally
+- [x] 4.7 Failure backoff: `host_cli::retry_after` doubles `PROBE_RETRY` per consecutive `No` up to `PROBE_RETRY_MAX` (15 min), the count carried on the cached `Verdict` and reset by the first `Yes` (and by `forget`, which `session sync` already calls); `git::stream_into_child` reaps the transport child on **both** paths — killing it first when the write failed — and prefers the peer's stderr over our `EPIPE`, since `Child`'s `Drop` neither kills nor waits and a failed provisioning left one orphaned `ssh` per attempt. Tests: `a_failing_host_is_asked_less_and_less_often`, `git::tests::stream_into_child::*`
+
 
 ## 5. CLI + headless
 

--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -472,8 +472,6 @@ pub(super) fn powershell_quote(s: &str) -> String {
 /// the agent — launched with a `--settings <path>` that thurbox generated
 /// against the *local* config dir — finds the file at that path there too.
 pub fn copy_bytes_to_remote(host: &HostDef, bytes: &[u8], remote_path: &str) -> Result<()> {
-    use std::io::Write;
-
     let parent = Path::new(remote_path)
         .parent()
         .map(|p| p.to_string_lossy().into_owned())
@@ -486,21 +484,12 @@ pub fn copy_bytes_to_remote(host: &HostDef, bytes: &[u8], remote_path: &str) -> 
         file = posix_quote(remote_path),
     );
 
-    let mut child = host_shell_c(host, &script)
+    let child = host_shell_c(host, &script)
         .stdin(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
         .context("failed to spawn remote file-copy")?;
-    child
-        .stdin
-        .take()
-        .context("remote file-copy stdin unavailable")?
-        .write_all(bytes)
-        .context("failed to stream file to remote")?;
-    let output = child
-        .wait_with_output()
-        .context("failed to wait on remote file-copy")?;
-    remote_output_or_stderr(output, "file-copy").map(|_| ())
+    stream_into_child(child, bytes, "file-copy").map(|_| ())
 }
 
 /// [`copy_bytes_to_remote`] for a **native-Windows** SSH host: `cat > file`
@@ -559,8 +548,6 @@ pub fn copy_stream_to_remote_windows(
     bytes: &[u8],
     remote_path: &str,
 ) -> Result<()> {
-    use std::io::Write;
-
     let parent = Path::new(remote_path)
         .parent()
         .map(|p| p.to_string_lossy().replace('\\', "/"))
@@ -573,21 +560,59 @@ pub fn copy_stream_to_remote_windows(
         parent = powershell_quote(&parent),
         path = powershell_quote(remote_path),
     );
-    let mut child = host_powershell_c(host, &script)
+    let child = host_powershell_c(host, &script)
         .stdin(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
         .context("failed to spawn windows remote stream-copy")?;
-    child
+    stream_into_child(child, bytes, "windows stream-copy").map(|_| ())
+}
+
+/// Write `bytes` into `child`'s stdin and collect what it said, reaping it
+/// whichever way that goes.
+///
+/// The write is the half that fails in practice: the peer dies mid-payload — a
+/// remote shell that will not take one that size, a dropped connection — and
+/// the next `write_all` gets `EPIPE`. Returning on that without waiting is what
+/// left one `ssh` behind per attempt: [`std::process::Child`]'s `Drop` neither
+/// kills nor waits, so the process outlives the error, and once thurbox exits
+/// it is reparented and keeps running. The kill is what bounds the wait — the
+/// peer is already gone, so there is nothing left to collect but the stderr it
+/// managed to write before it went.
+///
+/// A broken pipe is the *symptom* and never the cause, so the remote's own
+/// stderr is preferred as the reported error; ours is the fallback for a peer
+/// that died silently.
+pub(super) fn stream_into_child(
+    mut child: std::process::Child,
+    bytes: &[u8],
+    action: &str,
+) -> Result<Vec<u8>> {
+    use std::io::Write;
+
+    let mut stdin = child
         .stdin
         .take()
-        .context("remote stream-copy stdin unavailable")?
-        .write_all(bytes)
-        .context("failed to stream file to remote")?;
+        .with_context(|| format!("remote {action} stdin unavailable"))?;
+    let written = stdin.write_all(bytes);
+    // Before the wait, not at the end of the scope: the peer reads to EOF, so a
+    // handle still held here is a deadlock on the success path.
+    drop(stdin);
+    if written.is_err() {
+        let _ = child.kill();
+    }
     let output = child
         .wait_with_output()
-        .context("failed to wait on remote stream-copy")?;
-    remote_output_or_stderr(output, "windows stream-copy").map(|_| ())
+        .with_context(|| format!("failed to wait on remote {action}"))?;
+    if let Err(e) = written {
+        let detail = reportable_stderr(&output.stderr);
+        if detail.is_empty() {
+            return Err(anyhow::Error::new(e)
+                .context(format!("failed to stream the payload for remote {action}")));
+        }
+        anyhow::bail!("remote {action} failed: {detail}");
+    }
+    remote_output_or_stderr(output, action)
 }
 
 /// Expand a leading `~` in a remote path against the host's `$HOME`. Remote

--- a/src/git/tests.rs
+++ b/src/git/tests.rs
@@ -1260,3 +1260,55 @@ fn parse_url_trailing_slash() {
         None
     );
 }
+
+/// A peer that reads the whole payload is the ordinary path, and one that dies
+/// holding the pipe open is the path that used to leak an `ssh` per attempt:
+/// `write_all` returned `EPIPE`, the `?` skipped the wait, and `Child`'s `Drop`
+/// neither killed nor reaped it. Unix-only because both need a POSIX shell.
+#[cfg(unix)]
+mod stream_into_child {
+    use std::process::{Command, Stdio};
+
+    fn peer(script: &str) -> std::process::Child {
+        Command::new("sh")
+            .arg("-c")
+            .arg(script)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn the test peer")
+    }
+
+    #[test]
+    fn a_payload_the_peer_reads_is_delivered() {
+        let child = peer("cat > /dev/null; echo done");
+        let out = super::super::stream_into_child(child, &vec![b'x'; 1 << 20], "test-copy")
+            .expect("a peer that reads the payload succeeds");
+        assert_eq!(String::from_utf8_lossy(&out).trim(), "done");
+    }
+
+    #[test]
+    fn a_peer_that_dies_mid_payload_reports_its_own_stderr() {
+        // Big enough to outrun the pipe buffer, so the write is still going
+        // when the peer exits and `write_all` really does see `EPIPE`.
+        let child = peer("echo 'no room on device' >&2; exit 1");
+        let error = super::super::stream_into_child(child, &vec![b'x'; 8 << 20], "test-copy")
+            .expect_err("a peer that exits mid-payload fails");
+        // The remote's reason, not our end noticing a broken pipe.
+        assert!(
+            format!("{error:#}").contains("no room on device"),
+            "{error:#}"
+        );
+    }
+
+    #[test]
+    fn a_peer_that_dies_silently_still_returns() {
+        // Nothing on stderr to explain it: the write error is the fallback, and
+        // the point is that this returns at all rather than waiting forever.
+        let child = peer("exit 1");
+        let error = super::super::stream_into_child(child, &vec![b'x'; 8 << 20], "test-copy")
+            .expect_err("a silent peer still fails");
+        assert!(format!("{error:#}").contains("test-copy"), "{error:#}");
+    }
+}

--- a/src/session_ops/host_cli.rs
+++ b/src/session_ops/host_cli.rs
@@ -26,10 +26,43 @@ use crate::session::HostDef;
 pub const HOST_BIN_DIR: &str = "bin";
 
 /// How long a host that answered "no usable CLI" is left alone before it is
-/// asked again. Bounds what an unreachable host costs the mirror worker: one
-/// ssh connect attempt (its own `ConnectTimeout`) per this interval, not per
-/// pass.
+/// asked again — the **first** time. Keeps what an unreachable host costs the
+/// mirror worker to one ssh connect attempt (its own `ConnectTimeout`) per
+/// interval rather than per pass; a host that keeps failing is then spaced out
+/// further still, up to [`PROBE_RETRY_MAX`].
 pub const PROBE_RETRY: Duration = Duration::from_secs(60);
+
+/// The ceiling `retry_after` climbs to after repeated failures.
+///
+/// A host that cannot be provisioned *at all* — no release artifact for its
+/// platform, a remote shell that will not take a payload that size — fails
+/// identically every time it is asked, and on the flat [`PROBE_RETRY`] that
+/// cost a release-archive download, an ssh connect and a 10 MB stream once a
+/// minute for as long as thurbox ran. Backing off to this bounds a permanent
+/// failure at a few attempts an hour, while a transient one (a host rebooting,
+/// a laptop off the network) is still picked up within the minute because its
+/// first success resets the count.
+pub const PROBE_RETRY_MAX: Duration = Duration::from_secs(15 * 60);
+
+/// How long to leave a host alone after `failures` consecutive `No`s:
+/// [`PROBE_RETRY`] doubled once per failure, capped at [`PROBE_RETRY_MAX`].
+fn retry_after(failures: u32) -> Duration {
+    // Capped before the shift rather than after: 20 doublings of a minute is
+    // already far past the ceiling, and it keeps the shift in range.
+    let doublings = failures.saturating_sub(1).min(20);
+    PROBE_RETRY
+        .saturating_mul(1 << doublings)
+        .min(PROBE_RETRY_MAX)
+}
+
+/// A cached probe verdict: what the host said, when it said it, and how many
+/// times in a row it has now failed — which is what sets the next retry's
+/// distance. A `Yes` carries `failures: 0` and never expires.
+struct Verdict {
+    usable: Usable,
+    at: Instant,
+    failures: u32,
+}
 
 /// What a host's `thurbox-cli version --json` said about itself.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -56,14 +89,16 @@ pub enum Usable {
 
 /// The probe verdict for each host, so a spawn, a delete and the mirror do not
 /// each pay an ssh round trip to learn the same thing. Keyed by backend name.
-fn verdicts() -> &'static Mutex<HashMap<String, (Usable, Instant)>> {
-    static VERDICTS: OnceLock<Mutex<HashMap<String, (Usable, Instant)>>> = OnceLock::new();
+fn verdicts() -> &'static Mutex<HashMap<String, Verdict>> {
+    static VERDICTS: OnceLock<Mutex<HashMap<String, Verdict>>> = OnceLock::new();
     VERDICTS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
 /// Whether `host` has — or can be given — a `thurbox-cli` this binary can
 /// delegate to. Cached per host: a `Yes` for the process lifetime (the host's
-/// CLI does not change under us), a `No` for [`PROBE_RETRY`].
+/// CLI does not change under us), a `No` for `retry_after` its consecutive
+/// failure count — [`PROBE_RETRY`] the first time, doubling towards
+/// [`PROBE_RETRY_MAX`] for a host that cannot be made usable at all.
 ///
 /// A host with `share_sessions = false` is never contacted: it is used
 /// exactly as before sharing existed.
@@ -76,15 +111,19 @@ pub fn usable(host: &HostDef) -> Usable {
         return forced;
     }
     let key = host.backend_name();
+    // Carried across the re-probe below, so a host that keeps failing keeps
+    // backing off instead of restarting at `PROBE_RETRY` on every attempt.
+    let mut failures = 0;
     if let Ok(cache) = verdicts().lock() {
-        if let Some((verdict, at)) = cache.get(&key) {
-            let fresh = match verdict {
+        if let Some(verdict) = cache.get(&key) {
+            let fresh = match &verdict.usable {
                 Usable::Yes(_) => true,
-                Usable::No(_) => at.elapsed() < PROBE_RETRY,
+                Usable::No(_) => verdict.at.elapsed() < retry_after(verdict.failures),
             };
             if fresh {
-                return verdict.clone();
+                return verdict.usable.clone();
             }
+            failures = verdict.failures;
         }
     }
     let verdict = establish(host);
@@ -93,8 +132,27 @@ pub fn usable(host: &HostDef) -> Usable {
             crate::agent::tmux::learn_host_socket(host, socket);
         }
     }
+    let failures = match &verdict {
+        Usable::Yes(_) => 0,
+        Usable::No(reason) => {
+            let failures = failures.saturating_add(1);
+            tracing::debug!(
+                "host '{}' is not usable ({reason}); asking again in {}s",
+                host.name,
+                retry_after(failures).as_secs()
+            );
+            failures
+        }
+    };
     if let Ok(mut cache) = verdicts().lock() {
-        cache.insert(key, (verdict.clone(), Instant::now()));
+        cache.insert(
+            key,
+            Verdict {
+                usable: verdict.clone(),
+                at: Instant::now(),
+                failures,
+            },
+        );
     }
     verdict
 }
@@ -731,5 +789,19 @@ mod tests {
             "{windows}"
         );
         assert!(windows.contains("version --json"));
+    }
+
+    #[test]
+    fn a_failing_host_is_asked_less_and_less_often() {
+        // The first failure keeps the flat interval, so a host that is merely
+        // rebooting is picked up as promptly as it always was.
+        assert_eq!(retry_after(0), PROBE_RETRY);
+        assert_eq!(retry_after(1), PROBE_RETRY);
+        assert_eq!(retry_after(2), PROBE_RETRY * 2);
+        assert_eq!(retry_after(3), PROBE_RETRY * 4);
+        // And a host that can never be provisioned settles at the ceiling
+        // rather than costing an archive download a minute forever.
+        assert_eq!(retry_after(10), PROBE_RETRY_MAX);
+        assert_eq!(retry_after(u32::MAX), PROBE_RETRY_MAX);
     }
 }


### PR DESCRIPTION
## Summary

A shareable host that cannot be given a `thurbox-cli` fails **identically every time** it is asked — no release artifact for its platform, or a remote shell that will not take a 10 MB payload. Two defects turned that into a permanent loop:

- **No backoff.** The verdict cache left such a host on a flat 60 s `PROBE_RETRY`, so it re-downloaded the release archive, opened an ssh and streamed the payload *once a minute for as long as thurbox ran*. `retry_after` now doubles per consecutive failure up to `PROBE_RETRY_MAX` (15 min), the count carried on the cached `Verdict` and reset by the first usable answer — and by `forget`, which `session sync` already calls, since running it by hand usually means the host was just fixed. A host that was only briefly away is still picked up on the next pass.
- **A leaked transport process.** `write_all` got `EPIPE` when the peer died mid-payload and the `?` skipped the wait — but `Child`s `Drop` neither kills nor waits, so an orphaned `ssh` outlived every attempt (observed: one still running 2 h 24 m later, plus `[ssh] <defunct>` accumulating under the TUI). `git::stream_into_child` now reaps it on **both** paths, killing it first when the write failed, and reports the peer's own stderr in preference to the `EPIPE` — which is the symptom of the remote dying and never the reason.

Found while investigating high CPU: `thurbox.log` was repeating `mirror of ssh:win-host skipped: could not copy thurbox-cli … Broken pipe` every 10 s with a full re-probe every 60 s. (The CPU itself is a separate matter — the busy thread is the render loop, and every worker is idle; that is still being measured.)

## Test plan

- `a_failing_host_is_asked_less_and_less_often` — the first failure keeps the flat interval, then doubling, capped at `PROBE_RETRY_MAX` (including `u32::MAX`).
- `git::tests::stream_into_child::*` (unix) — a peer that reads the payload succeeds; one that dies mid-payload reports **its own stderr** rather than our broken pipe; one that dies silently still returns instead of waiting forever.
- Full gates green via the pre-commit hooks: fmt, clippy `-D warnings`, check, nextest (2108), architecture rules, cargo-deny advisories + bans/licenses/sources, cargo doc, rumdl, `cog verify`.
- `openspec validate share-remote-sessions` passes; the change gains a requirement covering backoff and transport reaping, with ADR-24 and `docs/FEATURES.md` updated to match.

Note: `tui_e2e::a_click_is_not_a_selection_so_ctrl_c_still_interrupts_the_shell` flakes on this machine under load — verified failing on clean `origin/main` without these changes, so it is pre-existing and unrelated.