### PR TITLE
feat(core): select and focus a newly created session at submit

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -247,15 +247,20 @@ not applicable.
    session. Skipped when only one agent is defined in
    `agents.toml`.
 
-**Creating a session moves nothing.** The new row appears in the list and waits
-to be picked; the selection, the pane showing it and the keyboard all stay where
-they were. Creation is a command that finishes on a worker seconds after the flow
-closed, so the moment it lands is not a moment the user chose — steering the view
-then interrupted whatever they had gone back to reading, and made creating three
-sessions in a row a fight with the cursor. `Ctrl+F` fork behaves the same way.
-Selection is still *steerable*, by the two requests that are deliberate: a
-clicked notification and `thurbox-cli session focus`, both through
-`focus_session`, which the list follows by id rather than by row number.
+**Creating a session selects it — at submit, not at completion.** Confirming
+the flow (and `Ctrl+F` fork) mints the new session's id on the spot, moves the
+keyboard to the agent pane at once, and sets the list *following* that id
+(`focus_session`, the same channel a clicked notification and `thurbox-cli
+session focus` use — by id, never by row number). The spawn itself still
+finishes on a worker seconds later, and that landing moves nothing: the follow
+is sticky until the row appears, so the cursor is already waiting on it — while
+completion-time steering yanked the view at a moment the user did not choose.
+Until the row lands the agent pane keeps showing the previous session; moving
+the cursor yourself in the meantime wins over the pending jump (and clears a
+follow left dangling by a failed spawn); creating several sessions in a row
+follows only the last one. Headless creates (`thurbox-cli session create`,
+automations, task dispatch) still move nothing — only `session focus` steers
+cross-process.
 
 A session is fully described by its repos and agent. There is no
 per-session model selection, permissions, prompt, tool, or skill

--- a/src/coordinator/commands.rs
+++ b/src/coordinator/commands.rs
@@ -226,9 +226,10 @@ impl App {
             // the command made, which only exists here once the rows are.
             self.snapshots.refresh();
             self.report_finished_commands();
-            // A finished creation is deliberately not acted on here: see
-            // `focus_on_session` for why a session that just spawned does not
-            // pull the view onto itself.
+            // A finished creation moves nothing here: the view started
+            // following its pre-minted id back at dispatch (`dispatch_tracked`)
+            // — the moment the user chose — so by the time the row lands the
+            // cursor is already waiting on it.
             self.note_data_change();
         } else {
             self.snapshots.refresh_if_due();
@@ -318,8 +319,15 @@ impl App {
     ///
     /// It is also the only moment the subject can be resolved: a delete's row is
     /// gone by the time it reports.
-    pub(crate) fn dispatch_tracked(&mut self, command: thurbox::kernel::command::Command) {
+    pub(crate) fn dispatch_tracked(&mut self, mut command: thurbox::kernel::command::Command) {
         use thurbox::kernel::command::Command;
+        // A creation or fork gets its id here, at the moment the user asked for
+        // it, so the selection can follow the row before the worker finishes —
+        // completion-time steering is what yanked the cursor at a moment the
+        // user did not choose (see `focus_on_session`).
+        if let Some(id) = command.mint_session_id() {
+            self.focus_on_session(&id.to_string());
+        }
         let kind = command.kind();
         let session = command.session().to_string();
         let label = self

--- a/src/coordinator/focus.rs
+++ b/src/coordinator/focus.rs
@@ -112,12 +112,16 @@ impl App {
 
     /// Select a session and put the input focus on the pane that shows it.
     ///
-    /// Only for a request made *now*: a clicked notification, or
-    /// `thurbox-cli session focus`. A session this instance just created is
-    /// deliberately not one — creation finishes on a worker seconds after the
-    /// wizard closed, so steering the view then lands at a moment the user did
-    /// not choose, and taking the selection back after every one of them made
-    /// creating several sessions in a row a fight with the cursor.
+    /// Only for a request made *now*, at a moment the user chose: a clicked
+    /// notification, `thurbox-cli session focus`, or a create/fork the user
+    /// just submitted (stamped at dispatch in `dispatch_tracked`). The line
+    /// that matters is submit-time vs completion-time: a spawn finishes on a
+    /// worker seconds after the wizard closed, and steering the view *then*
+    /// yanked the cursor at a moment the user did not choose — which is why
+    /// nothing acts on a finished creation. Instead the list *follows* the
+    /// pre-minted id: sticky until the row appears, overridden by the user's
+    /// own next cursor move, and a failed spawn's dangling follow dies the
+    /// same way.
     ///
     /// The selection travels through the store rather than being set here,
     /// because the list is a plugin and it is the only thing that knows the

--- a/src/kernel/command/execute.rs
+++ b/src/kernel/command/execute.rs
@@ -12,9 +12,10 @@ use crate::storage::Database;
 
 /// Run one command. Called on the command's own thread, never the UI thread.
 ///
-/// Only the outcome travels back. A creation and a fork each mint a session id,
-/// and neither reports it: a session that finished spawning is a row in the
-/// list, not a reason to move the user's selection onto it.
+/// Only the outcome travels back. A creation and a fork carry their session id
+/// *in* rather than reporting it out: the loop minted it at dispatch
+/// (`Command::mint_session_id`) and is already steering the view onto it, so
+/// nothing here needs to say which row appeared.
 pub(super) fn execute(
     command: &Command,
     id: u64,
@@ -36,9 +37,21 @@ pub(super) fn execute(
         agent,
         host,
         extras,
+        session_id,
     } = command
     {
-        return create(name, repo, branch, base, agent, host, extras, id, progress);
+        return create(
+            name,
+            repo,
+            branch,
+            base,
+            agent,
+            host,
+            extras,
+            *session_id,
+            id,
+            progress,
+        );
     }
 
     // Repository memory names a path, not a session, so it too runs before the
@@ -97,10 +110,13 @@ pub(super) fn execute(
     let path = crate::paths::database_file().ok_or("could not resolve the database path")?;
     let db = Database::open(&path).map_err(|e| format!("open database: {e}"))?;
 
-    // A fork mints a session too; like a creation, the new row simply appears
-    // in the list rather than pulling the selection onto itself.
-    if let Command::Fork { name, .. } = command {
-        return fork(&db, id, name);
+    // A fork carries its pre-minted id like a creation does; the selection is
+    // already following it by the time the row appears.
+    if let Command::Fork {
+        name, session_id, ..
+    } = command
+    {
+        return fork(&db, id, name, *session_id);
     }
 
     match command {
@@ -177,6 +193,7 @@ fn create(
     agent: &Option<String>,
     host: &Option<String>,
     extras: &[ExtraMember],
+    session_id: Option<SessionId>,
     id: u64,
     progress: &Sender<Progress>,
 ) -> Result<(), String> {
@@ -215,6 +232,7 @@ fn create(
         base_branch: base.clone(),
         agent: agent.clone(),
         host: host.clone(),
+        session_id,
         // Each extra either takes its own worktree on the shared branch — off
         // its own base, which here is the session's — or is attached as it is.
         // Two or more members is what makes the agent launch in a symlink
@@ -379,7 +397,12 @@ fn bookmark_add(
 }
 
 /// Fork a session: a new one on the same repository, recording its parent.
-fn fork(db: &Database, id: SessionId, name: &str) -> Result<(), String> {
+fn fork(
+    db: &Database,
+    id: SessionId,
+    name: &str,
+    session_id: Option<SessionId>,
+) -> Result<(), String> {
     let source = db
         .get_session_by_id(id)
         .map_err(|e| format!("get session: {e}"))?
@@ -409,6 +432,7 @@ fn fork(db: &Database, id: SessionId, name: &str) -> Result<(), String> {
     let request = crate::session_ops::spawn::SpawnRequest {
         name,
         repo_path,
+        session_id,
         // No new worktree (the defaults): a fork works beside its parent, on
         // the same branch.
         agent: Some(source.agent.clone()),

--- a/src/kernel/command/mod.rs
+++ b/src/kernel/command/mod.rs
@@ -23,6 +23,7 @@ mod execute;
 pub use bus::{CommandBus, InFlight, Phase};
 
 use super::registry::Value as SettingValue;
+use crate::session::SessionId;
 
 /// A state change a plugin asked for.
 #[derive(Debug, Clone, PartialEq)]
@@ -85,6 +86,10 @@ pub enum Command {
         /// whole thing back on failure, and a session half-created by three
         /// commands has no owner.
         extras: Vec<ExtraMember>,
+        /// The id the spawn will use, stamped by the loop at dispatch
+        /// (`mint_session_id`) so the view can follow the row before the
+        /// worker finishes. `None` as parsed.
+        session_id: Option<SessionId>,
     },
     /// Remember, forget, or import a folder of repositories.
     ///
@@ -105,6 +110,8 @@ pub enum Command {
     Fork {
         session: String,
         name: String,
+        /// The forked session's own id, stamped at dispatch like `Create`'s.
+        session_id: Option<SessionId>,
     },
     /// Bring a session's worktree up to date with the branch it came from.
     Sync {
@@ -347,6 +354,24 @@ impl Command {
         }
     }
 
+    /// Stamp a creation or fork with the id its spawn will use.
+    ///
+    /// Called by the loop at dispatch — the moment the user's submit becomes a
+    /// command — so the selection can start following the new session before
+    /// the worker finishes. Returns the minted id, `None` for every other
+    /// variant. `DispatchTask` is deliberately not stamped: it can fire from
+    /// contexts that are not "the user just asked for this session".
+    pub fn mint_session_id(&mut self) -> Option<SessionId> {
+        match self {
+            Command::Create { session_id, .. } | Command::Fork { session_id, .. } => {
+                let id = SessionId::default();
+                *session_id = Some(id);
+                Some(id)
+            }
+            _ => None,
+        }
+    }
+
     /// The session this command concerns.
     pub fn session(&self) -> &str {
         match self {
@@ -549,6 +574,8 @@ impl Command {
                 agent: agent.filter(|a| !a.is_empty()),
                 host: host.filter(|h| !h.is_empty()),
                 extras,
+                // Minting is the loop's, at dispatch — parse stays pure.
+                session_id: None,
             });
         }
         // Repository memory names a path and a host, not a session. The verb is
@@ -658,6 +685,7 @@ impl Command {
             "fork" => Ok(Command::Fork {
                 session,
                 name: text.unwrap_or_default(),
+                session_id: None,
             }),
             "sync" => Ok(Command::Sync { session }),
             "copy" => Ok(Command::Copy { session }),
@@ -766,6 +794,56 @@ mod tests {
                 delta: -1
             })
         );
+    }
+
+    #[test]
+    fn minting_stamps_a_creation_and_a_fork_and_nothing_else() {
+        // The loop stamps the id at dispatch so the view can follow the row
+        // before the spawn finishes; the stored field and the returned id must
+        // be the same one, or the worker and the selection chase different
+        // sessions.
+        let mut create = Command::parse(
+            "create",
+            Args {
+                repo: Some("/src/thurbox".into()),
+                ..Args::default()
+            },
+        )
+        .expect("parse create");
+        assert!(
+            matches!(
+                create,
+                Command::Create {
+                    session_id: None,
+                    ..
+                }
+            ),
+            "parse leaves minting to the loop"
+        );
+        let minted = create.mint_session_id().expect("a create mints");
+        assert!(matches!(
+            create,
+            Command::Create { session_id: Some(id), .. } if id == minted
+        ));
+
+        let mut fork = Command::parse(
+            "fork",
+            Args {
+                session: "s1".into(),
+                ..Args::default()
+            },
+        )
+        .expect("parse fork");
+        let minted = fork.mint_session_id().expect("a fork mints");
+        assert!(matches!(
+            fork,
+            Command::Fork { session_id: Some(id), .. } if id == minted
+        ));
+
+        let mut sync = Command::Sync {
+            session: "s1".into(),
+        };
+        assert_eq!(sync.mint_session_id(), None);
     }
 
     #[test]

--- a/src/session_ops/spawn.rs
+++ b/src/session_ops/spawn.rs
@@ -36,6 +36,11 @@ pub struct SpawnRequest {
     /// Optional pre-generated agent session UUID. When unset one is generated
     /// so callers can return it to the user immediately.
     pub agent_session_id: Option<String>,
+    /// Optional pre-minted thurbox [`SessionId`]. When set, the spawn uses it
+    /// instead of minting one — so a caller that must know the id *before* the
+    /// worker finishes (the TUI steering the view onto the row it just asked
+    /// for) can hand it in rather than wait for the result.
+    pub session_id: Option<SessionId>,
     /// Optional remote host name (from `hosts.toml`). When set, the session is
     /// created on that host over SSH (worktree + tmux window live remotely).
     pub host: Option<String>,
@@ -195,11 +200,11 @@ pub fn spawn_session_headless_with_progress(
     let mut agent_def = super::resolve_agent_def(req.agent.as_deref());
     let agent_name = agent_def.name.clone();
 
-    // Both ids are minted before anything happens, so the pre-create hook can
-    // name the session it is being asked about — and correlate with the
-    // post-create one — and so `THURBOX_SESSION` is in the process env before
-    // the agent launches.
-    let session_id = SessionId::default();
+    // Both ids are known before anything happens — the caller's pre-mint, or
+    // minted here — so the pre-create hook can name the session it is being
+    // asked about — and correlate with the post-create one — and so
+    // `THURBOX_SESSION` is in the process env before the agent launches.
+    let session_id = req.session_id.unwrap_or_default();
     let agent_session_id = req
         .agent_session_id
         .clone()

--- a/tests/create_e2e.rs
+++ b/tests/create_e2e.rs
@@ -105,6 +105,9 @@ fn creating_a_session_produces_a_worktree_a_row_and_a_window() {
     )
     .expect("write agents.toml");
 
+    // Pre-minted, the way the TUI stamps a create at dispatch so it can steer
+    // the view onto the row before the worker finishes.
+    let minted = thurbox::session::SessionId::default();
     let result = thurbox::session_ops::spawn::spawn_session_headless(
         &db,
         thurbox::session_ops::spawn::SpawnRequest {
@@ -114,6 +117,7 @@ fn creating_a_session_produces_a_worktree_a_row_and_a_window() {
             base_branch: Some("main".into()),
             agent: Some("shell".into()),
             agent_session_id: None,
+            session_id: Some(minted),
             host: None,
             parent_session_id: None,
             task_id: None,
@@ -135,6 +139,9 @@ fn creating_a_session_produces_a_worktree_a_row_and_a_window() {
             panic!("creation failed: {e}");
         }
     };
+
+    // The spawn honored the pre-mint: the row's id is the one handed in.
+    assert_eq!(spawned.session_id, minted);
 
     // The row exists, and carries what a plugin needs to draw it.
     let row = db
@@ -470,6 +477,7 @@ fn a_vetoed_creation_reports_through_the_command_bus() {
         agent: Some("shell".into()),
         host: None,
         extras: Vec::new(),
+        session_id: None,
     });
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
     while std::time::Instant::now() < deadline {

--- a/tests/kernel_mvp.rs
+++ b/tests/kernel_mvp.rs
@@ -2051,6 +2051,7 @@ fn the_spawn_pipeline_reports_the_stage_it_reached() {
             base_branch: None,
             agent: None,
             agent_session_id: None,
+            session_id: None,
             host: None,
             parent_session_id: None,
             task_id: None,

--- a/tests/tui_e2e.rs
+++ b/tests/tui_e2e.rs
@@ -172,21 +172,29 @@ impl Drop for Profile {
 fn openpty(rows: u16, cols: u16) -> (OwnedFd, OwnedFd) {
     let mut master = -1;
     let mut slave = -1;
-    let size = libc::winsize {
+    let mut size = libc::winsize {
         ws_row: rows,
         ws_col: cols,
         ws_xpixel: 0,
         ws_ypixel: 0,
     };
+    // macOS declares openpty's termios/winsize params `*mut`, Linux `*const`,
+    // so neither `&size` nor `&mut size` is portable at the call site: the
+    // first fails to compile on macOS, the second trips
+    // `clippy::unnecessary_mut_passed` on Linux. A raw `*mut` in a local
+    // satisfies both — it coerces to `*const` where that is what is wanted,
+    // and is not a `&mut` for the lint to see.
+    let winsize: *mut libc::winsize = &mut size;
     // SAFETY: openpty writes two valid descriptors into the out-params on
-    // success; the name and termios pointers are allowed to be null.
+    // success; the name and termios pointers are allowed to be null, and
+    // `winsize` points at a live local for the duration of the call.
     let rc = unsafe {
         libc::openpty(
             &mut master,
             &mut slave,
             std::ptr::null_mut(),
-            std::ptr::null(),
-            &size,
+            std::ptr::null_mut(),
+            winsize,
         )
     };
     assert_eq!(rc, 0, "openpty failed: {}", std::io::Error::last_os_error());

--- a/tests/v2_new_session.rs
+++ b/tests/v2_new_session.rs
@@ -899,6 +899,8 @@ fn a_plain_selection_names_the_session_then_the_agent() {
             agent: Some("claude".into()),
             host: None,
             extras: Vec::new(),
+            // The id is minted by the loop at dispatch, never by the flow.
+            session_id: None,
         }]
     );
     assert_eq!(drawn(&host, &world), "", "the flow closes when it commits");
@@ -938,6 +940,7 @@ fn an_untouched_name_takes_the_repository_it_just_picked() {
             agent: Some("claude".into()),
             host: None,
             extras: Vec::new(),
+            session_id: None,
         }]
     );
 }
@@ -1013,6 +1016,7 @@ fn a_worktree_selection_asks_for_a_base_branch_and_a_branch_name() {
             agent: Some("claude".into()),
             host: None,
             extras: Vec::new(),
+            session_id: None,
         }]
     );
 }

--- a/tests/v2_session_list.rs
+++ b/tests/v2_session_list.rs
@@ -210,6 +210,61 @@ fn a_session_that_went_away_does_not_freeze_the_selection() {
     );
 }
 
+#[test]
+fn a_focus_request_waits_for_the_row_to_appear() {
+    // What creating a session leans on: the loop requests focus on the
+    // pre-minted id at submit, seconds before the spawn lands the row. The
+    // follow must survive those frames — selection stays put while the id is
+    // absent, then lands on the row the moment it exists.
+    let host = host();
+    render(&host);
+    host.set_shared_string("focus_session", "ccc");
+    render(&host);
+    assert_eq!(
+        host.shared_string("selected").as_deref(),
+        Some("aaa"),
+        "an id not yet in the list moves nothing"
+    );
+    render(&host);
+    assert_eq!(
+        host.shared_string("selected").as_deref(),
+        Some("aaa"),
+        "the request is not forgotten by an intervening frame either"
+    );
+
+    let mut landed = snapshot();
+    landed.sessions.push(row("ccc", "third"));
+    render_in(&host, &landed);
+    assert_eq!(
+        host.shared_string("selected").as_deref(),
+        Some("ccc"),
+        "the cursor was already waiting on the row when it appeared"
+    );
+}
+
+#[test]
+fn the_users_own_cursor_move_wins_over_a_pending_focus_request() {
+    // Moving the cursor while a spawn is in flight is a choice made later than
+    // the submit, so it wins: the follow is dropped and the row appearing does
+    // not yank the selection.
+    let host = host();
+    render(&host);
+    host.set_shared_string("focus_session", "ccc");
+    render(&host);
+    press(&host, "j");
+    render(&host);
+    assert_eq!(host.shared_string("selected").as_deref(), Some("bbb"));
+
+    let mut landed = snapshot();
+    landed.sessions.push(row("ccc", "third"));
+    render_in(&host, &landed);
+    assert_eq!(
+        host.shared_string("selected").as_deref(),
+        Some("bbb"),
+        "the appearing row did not steal the selection back"
+    );
+}
+
 /// A worktree with nothing in it that a delete could not put back.
 fn clean() -> GitState {
     GitState {


### PR DESCRIPTION
## Summary
- Creating a session (Ctrl+N flow) or forking one (Ctrl+F) now selects the new session and moves keyboard focus to the agent pane **at submit time**: the loop mints the `SessionId` in `dispatch_tracked` and steers the view onto it before handing the command to the worker, and the session list's sticky follow puts the cursor on the row the moment the spawn lands it.
- This deliberately reverses the documented "creating a session moves nothing" decision while keeping its rationale: the objection was to *completion-time* steering (the spawn finishes on a worker seconds after the wizard closed). Submit time is a moment the user chose; completion still moves nothing. The old-decision comments/docs (`focus_on_session`, `execute.rs`, `poll_command_bus`, `docs/FEATURES.md`) are rewritten to record the new line.
- No Lua changes: the follow mechanism was already sticky-until-found — a failed spawn's dangling follow is harmless, the user's own cursor move mid-spawn wins, several rapid creates follow only the last id, and headless creates (`thurbox-cli`, automations, task dispatch) never pass through the mint so they keep moving nothing.
- Rides along: `test(core)` portability fix for `tests/tui_e2e.rs` — its `libc::openpty` call used Linux's `*const` signature, which does not compile on macOS and blocked every local pre-commit run there.

## Test plan
- [x] `cargo nextest run --all` (1950+ tests, via pre-commit hooks on both commits)
- [x] New `v2_session_list` tests pin the load-bearing semantics: a focus request for an id not yet in the snapshot waits (sticky follow), and a user cursor move mid-wait wins over the pending jump
- [x] New `mint_session_id` unit test: stamps `Create`/`Fork`, returns `None` for everything else; `create_e2e` asserts the spawn echoes a pre-minted id
- [ ] Manual sandbox check (`scripts/dev/sandbox.sh`): Ctrl+N through the wizard → focus lands on the agent pane at Enter, cursor lands on the new row when it appears; same for Ctrl+F; `thurbox-cli session create` moves nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)