### PR TITLE
feat(ui): let the session list jump to a session you just created

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -247,15 +247,28 @@ not applicable.
    session. Skipped when only one agent is defined in
    `agents.toml`.
 
-**Creating a session moves nothing.** The new row appears in the list and waits
-to be picked; the selection, the pane showing it and the keyboard all stay where
-they were. Creation is a command that finishes on a worker seconds after the flow
-closed, so the moment it lands is not a moment the user chose — steering the view
-then interrupted whatever they had gone back to reading, and made creating three
-sessions in a row a fight with the cursor. `Ctrl+F` fork behaves the same way.
-Selection is still *steerable*, by the two requests that are deliberate: a
-clicked notification and `thurbox-cli session focus`, both through
-`focus_session`, which the list follows by id rather than by row number.
+**Creating a session moves nothing — unless you ask it to.** By default the new
+row appears in the list and waits to be picked; the selection, the pane showing
+it and the keyboard all stay where they were. Creation is a command that
+finishes on a worker seconds after the flow closed, so the moment it lands is
+not a moment the user chose — steering the view then interrupted whatever they
+had gone back to reading, and made creating three sessions in a row a fight with
+the cursor. `Ctrl+F` fork behaves the same way. Selection is still *steerable*,
+by the two requests that are deliberate: a clicked notification and
+`thurbox-cli session focus`, both through `focus_session`, which the list
+follows by id rather than by row number.
+
+Not having to hunt for the row you just asked for is worth that interruption to
+some people, so it is **a setting rather than a decision**: the session list's
+`focus_new_session` (settings → Sessions, off by default) makes a create or a
+fork select the new session and give the agent pane the keyboard, exactly as
+`Enter` on its row would. It is the *list's* setting rather than a core one
+because the list owns the selection — it subscribes to `session.post_create`
+and does there what `Enter` does. That event fires only for a create **this
+interface** performed, which is what keeps a `thurbox-cli session create`, an
+automation or a second instance from taking the keyboard out from under you;
+and the cursor only *follows* the new id, so moving it yourself in the meantime
+wins.
 
 A session is fully described by its repos and agent. There is no
 per-session model selection, permissions, prompt, tool, or skill

--- a/tests/v2_session_list.rs
+++ b/tests/v2_session_list.rs
@@ -7,8 +7,9 @@
 //! that; here it is a value two plugins share, so the rule has to be asserted.
 
 use thurbox::kernel::command::Command;
+use thurbox::kernel::events::Event;
 use thurbox::kernel::host::{KeyPress, LuaHost, Published, RenderContext};
-use thurbox::kernel::registry::Registry;
+use thurbox::kernel::registry::{Registry, Value};
 use thurbox::kernel::snapshot::{GitState, SessionRow, Snapshot};
 use thurbox::kernel::theme::Themes;
 
@@ -54,10 +55,20 @@ fn snapshot() -> Snapshot {
 }
 
 fn publish_in(host: &LuaHost, snapshot: &Snapshot) {
-    let themes = Themes::load(None);
+    publish_with(host, snapshot, &registry_for(host));
+}
+
+/// The registry the kernel would build from what the bundled plugins declare —
+/// separate so a test can override a setting before publishing it.
+fn registry_for(host: &LuaHost) -> Registry {
     let mut registry = Registry::default();
     let (bindings, settings) = host.declarations();
     registry.declare(bindings, settings);
+    registry
+}
+
+fn publish_with(host: &LuaHost, snapshot: &Snapshot, registry: &Registry) {
+    let themes = Themes::load(None);
     let diffs = thurbox::kernel::diff::DiffStore::new();
     let repos = thurbox::kernel::repos::RepoStore::with_hosts(Default::default());
     host.publish(&Published {
@@ -66,7 +77,7 @@ fn publish_in(host: &LuaHost, snapshot: &Snapshot) {
         attach_errors: &Default::default(),
         inflight: &[],
         themes: &themes,
-        registry: &registry,
+        registry,
         diffs: &diffs,
         links: &Default::default(),
         content: &Default::default(),
@@ -91,7 +102,11 @@ fn render(host: &LuaHost) {
 }
 
 fn render_in(host: &LuaHost, snapshot: &Snapshot) {
-    publish_in(host, snapshot);
+    render_with(host, snapshot, &registry_for(host));
+}
+
+fn render_with(host: &LuaHost, snapshot: &Snapshot, registry: &Registry) {
+    publish_with(host, snapshot, registry);
     let index = host.index_of(PLUGIN).expect("no sessions plugin");
     host.render(
         index,
@@ -207,6 +222,110 @@ fn a_session_that_went_away_does_not_freeze_the_selection() {
         host.shared_string("selected").as_deref(),
         Some("aaa"),
         "the cursor stayed on a row that exists"
+    );
+}
+
+/// What the kernel hands the list when a create or a fork this interface asked
+/// for has landed, with the row already resolved in the snapshot.
+fn post_create(id: &str, name: &str) -> Event {
+    Event::new("session.post_create")
+        .with("session", Some(id))
+        .with("name", Some(name))
+        .with("agent", Some("claude"))
+}
+
+/// The setting on, in the registry the plugin reads its value back from.
+fn following_new_sessions(host: &LuaHost) -> Registry {
+    let mut registry = registry_for(host);
+    registry
+        .set_setting(PLUGIN, "focus_new_session", Some(Value::Bool(true)))
+        .expect("set focus_new_session");
+    registry
+}
+
+#[test]
+fn a_session_this_interface_created_moves_nothing_by_default() {
+    // The default this interface has always had: the row appears and waits to
+    // be picked. Asserted rather than assumed, because the machinery that can
+    // move the cursor is now loaded either way — only the setting is off.
+    let host = host();
+    render(&host);
+
+    let failures = host.dispatch_event(&post_create("bbb", "second"));
+    assert!(failures.is_empty(), "{failures:?}");
+    render(&host);
+    assert_eq!(
+        host.shared_string("selected").as_deref(),
+        Some("aaa"),
+        "creating a session must not move the selection unless asked"
+    );
+    assert!(
+        host.drain_commands().is_empty(),
+        "and must not take the keyboard either"
+    );
+}
+
+#[test]
+fn with_the_setting_on_a_created_session_is_selected_and_opened() {
+    // The whole of what the setting buys: the two halves `Enter` performs, for
+    // a row the user did not have to find.
+    let host = host();
+    let registry = following_new_sessions(&host);
+    render_with(&host, &snapshot(), &registry);
+
+    // Nothing is drained first: a render that started issuing commands should
+    // fail this assertion rather than hide behind a reset buffer.
+    host.dispatch_event(&post_create("bbb", "second"));
+    assert_eq!(
+        host.drain_commands(),
+        vec![Command::Focus {
+            plugin: "agent".into(),
+            toggle: false,
+        }],
+        "the agent pane is what shows a session, so opening one focuses it"
+    );
+    render_with(&host, &snapshot(), &registry);
+    assert_eq!(
+        host.shared_string("selected").as_deref(),
+        Some("bbb"),
+        "the cursor followed the session that was just created"
+    );
+}
+
+#[test]
+fn a_pending_jump_loses_to_the_users_own_cursor_move() {
+    // The follow is sticky, not a lock: moving the cursor yourself after the
+    // jump is a choice made later, so it stands.
+    let host = host();
+    let registry = following_new_sessions(&host);
+    render_with(&host, &snapshot(), &registry);
+
+    host.dispatch_event(&post_create("bbb", "second"));
+    render_with(&host, &snapshot(), &registry);
+    press(&host, "k");
+    render_with(&host, &snapshot(), &registry);
+    assert_eq!(
+        host.shared_string("selected").as_deref(),
+        Some("aaa"),
+        "the jump must not pull the cursor back"
+    );
+}
+
+#[test]
+fn only_a_create_this_interface_made_is_subscribed_to() {
+    // `session.created` fires for every row that appears, whoever made it —
+    // subscribing to it would let a `thurbox-cli session create`, an automation
+    // or a second instance take the keyboard out from under the user.
+    let host = host();
+    let index = host.index_of(PLUGIN).expect("no sessions plugin");
+    let events = &host.plugins[index].events;
+    assert!(
+        events.iter().any(|name| name == "session.post_create"),
+        "the list must hear about the creates this interface performed: {events:?}"
+    );
+    assert!(
+        !events.iter().any(|name| name == "session.created"),
+        "a session created elsewhere must not move this cursor: {events:?}"
     );
 }
 

--- a/ui/plugins/10_sessions.lua
+++ b/ui/plugins/10_sessions.lua
@@ -366,6 +366,17 @@ local function soft_delete()
   return plugin_settings.feature("soft_delete", true) ~= false
 end
 
+--- Does a session this interface just created take the cursor and the keyboard?
+---
+--- Off by default, because a spawn finishes on a worker seconds after the flow
+--- closed: the moment the row lands is not a moment you chose, and being moved
+--- then interrupts whatever you went back to reading. Turned on, it saves
+--- hunting for the row you just asked for — which is the whole of the trade,
+--- so it is yours to make rather than ours.
+local function focus_new_session()
+  return plugin_settings.enabled("sessions", "focus_new_session", false)
+end
+
 --- What deleting this session would destroy, itemised — or nil when it would
 --- destroy nothing.
 ---
@@ -488,15 +499,28 @@ return {
   -- Declared as DATA, not just handled. That is what lets the kernel list these
   -- in help, detect a clash with another plugin, and let you rebind them —
   -- none of which it could do if they only existed inside on_key.
-  --- Declared as data, so the settings modal renders a row for it without
-  --- knowing what a repo group is. Read back through `lib.settings`.
+  --- Declared as data, so the settings modal renders a row for each without
+  --- knowing what a repo group is or what creating a session does. Read back
+  --- through `lib.settings`.
   settings = {
     {
       id = "group_by_repo",
       desc = "Group sessions under a repo header",
       default = true,
     },
+    {
+      id = "focus_new_session",
+      desc = "Select and open a session when you create or fork it",
+      default = false,
+    },
   },
+
+  -- The one event this pane needs: a create or a fork THIS interface finished.
+  -- A session `thurbox-cli`, an automation or another instance made arrives as
+  -- `session.created` instead, and subscribing to that would let a background
+  -- spawn take the keyboard out from under you — so it deliberately is not
+  -- subscribed to.
+  events = { "session.post_create" },
 
   keys = {
     { key = "j", action = "sessions.next", desc = "next session", group = "Navigation" },
@@ -802,6 +826,33 @@ return {
     children[#children + 1] = { type = "text", len = 1, text = { chrome.cells_to_spans(bottom) } }
 
     return { type = "box", children = children }
+  end,
+
+  --- Go to a session you just made, when you asked to be taken there.
+  ---
+  --- The event fires once the spawn has landed and the snapshot has been
+  --- re-read, so the row exists by now and the jump is a single frame.
+  on_event = function(name, payload)
+    if name ~= "session.post_create" or not focus_new_session() then
+      return
+    end
+    -- No id means the row could not be resolved from the name (a spawn that
+    -- landed nothing, or two sessions sharing a name). Nothing to go to, and
+    -- taking the keyboard to the agent pane anyway would only re-open the
+    -- session already selected.
+    local id = payload.session
+    if not id then
+      return
+    end
+    -- The two halves `Enter` performs, for the row you did not have to find:
+    -- the cursor follows the id — sticky until a render lands on it, and
+    -- dropped the moment you move the cursor yourself — while the agent pane,
+    -- the one that shows a session, takes the keyboard. `store.selected` is
+    -- written here as well as followed, because a pane that draws before this
+    -- one otherwise shows the previous session for a frame.
+    state.follow = id
+    store.selected = id
+    command("focus", { text = "agent" })
   end,
 
   -- A click on a row selects it, exactly as `j`/`k` would — v1's


### PR DESCRIPTION
## Summary

- Creating a session still **moves nothing by default** — the documented decision that completion-time steering lands at a moment the user did not choose stands. Not having to hunt for the row you just asked for is worth that interruption to *some* people, so it becomes **a setting rather than a decision**: `focus_new_session` (settings → Sessions, off by default) makes a create or a fork select the new session and give the agent pane the keyboard, exactly as `Enter` on its row would.
- **No kernel change — this is ~30 lines of Lua.** The list owns the selection, so it is the list that subscribes to `session.post_create`, an event that fires only for a create *this interface* performed. That is what keeps a `thurbox-cli session create`, an automation or a second instance from taking the keyboard out from under you, and the cursor merely *follows* the new id, so moving it yourself in the meantime still wins (the follow is dropped by `select_row`/`on_click`, as it already was).
- Supersedes #1023, which did the same thing unconditionally and in Rust. The one thing this cannot do is steer at **submit** rather than at **completion**: the id does not exist until the worker mints it, so that half needs #1023's `mint_session_id`. If it is wanted later, the clean shape is to keep this setting as the gate and have `dispatch_tracked` read it — otherwise the two jumps are live at once and the switch looks broken when it is off.
- `docs/FEATURES.md`'s "Creating a session moves nothing" paragraph is rewritten to record the opt-in and why it lives in the plugin rather than in `settings.toml`.

## Test plan

- [x] `cargo nextest run --all` — 2112 passed (and again through the pre-commit hooks)
- [x] Four new tests in `tests/v2_session_list.rs`: off ⇒ a `session.post_create` moves nothing and issues no command; on ⇒ the row is selected and `Focus { plugin: "agent" }` is issued; a later cursor move beats the pending jump; the pane subscribes to `session.post_create` and **not** to `session.created`
- [x] `cargo clippy --all-targets --all-features -D warnings`, `cargo fmt --check`, `selene ui`, `stylua --check ui`, `rumdl`
- [x] `thurbox-cli plugin check` loads all six bundled panes
- [ ] Manual sandbox check (`scripts/dev/sandbox.sh`): with the setting off, Ctrl+N and Ctrl+F move nothing; with it on, both land on the new session with the agent pane focused; `thurbox-cli session create` from outside moves nothing either way

🤖 Generated with [Claude Code](https://claude.com/claude-code)