### PR TITLE
fix(core): make one wheel notch step the selection once

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -2395,8 +2395,19 @@ recorded before their pane's whole-rect focus fallback.
 - **Hover**: the clickable row under the pointer is underlined
   (driven by mouse-move events; applied post-render from the same
   click registry).
+- **One notch, one step**: a wheel *notch* is not one report. A
+  terminal turns a detent into its line-scroll count — three, for
+  ghostty, kitty and xterm — and under mouse reporting sends that
+  many reports back to back, so one flick of the wheel used to walk
+  the session list through three sessions and open each one on the
+  way. Reports closer together than a person can turn a wheel
+  (20 ms) are folded into the notch that started them, and a
+  direction change always steps. A tick **forwarded to a pty** is
+  deliberately left whole: there the three reports are the three
+  lines the terminal means to scroll, and the program inside owns
+  what they do.
 - **Modal scrolling**: while a modal is open the wheel steps its
-  selection (one row per tick, like `j`/`k`); overflowing picker
+  selection (one row per notch, like `j`/`k`); overflowing picker
   lists window around the selection and draw a draggable scrollbar
   (`ScrollTarget::Modal`) in their rightmost column. Drag replays
   Up/Down through the modal's own key handler, so clamping and side

--- a/src/coordinator/boot.rs
+++ b/src/coordinator/boot.rs
@@ -190,6 +190,7 @@ pub(crate) async fn run() -> Result<(), Box<dyn Error>> {
         animation_tick: 0,
         animation_step: 0,
         selection: None,
+        wheel_notch: crate::coordinator::mouse::WheelNotch::default(),
         notifier: {
             let settings = thurbox::session::settings::global();
             Notifier::new(settings.features.notifications, settings.notifications)

--- a/src/coordinator/mod.rs
+++ b/src/coordinator/mod.rs
@@ -24,7 +24,7 @@ pub(crate) mod events;
 mod focus;
 mod input;
 mod interface;
-mod mouse;
+pub(crate) mod mouse;
 pub(crate) mod paste;
 mod publish;
 

--- a/src/coordinator/mouse.rs
+++ b/src/coordinator/mouse.rs
@@ -48,6 +48,13 @@ impl App {
     /// its own: every scrollable pane already declares those, so the wheel and
     /// the arrow keys cannot come to mean different things — the same reasoning
     /// behind the `key:<chord>` click role.
+    ///
+    /// One notch of a wheel is **not** one report, so every leg that steps a
+    /// selection asks [`WheelNotch`] first — without it a single detent walked
+    /// the session list through three sessions and opened each one on the way.
+    /// A tick *forwarded to a pty* is deliberately left alone: there the three
+    /// reports are the three lines the terminal means to scroll, and the
+    /// program inside owns what they do.
     pub(crate) fn on_scroll(&mut self, x: u16, y: u16, up: bool) {
         // The selection is in screen cells and the text under them is about
         // to move; v1 drops it on every scroll for the same reason.
@@ -59,7 +66,7 @@ impl App {
         // covers. While help is capturing a chord it is left alone: the capture
         // would record the synthesized keystroke as the new binding.
         if self.modals.is_open() {
-            if !self.modals.captures_everything() {
+            if !self.modals.captures_everything() && self.wheel_notch.opens(Instant::now(), up) {
                 self.dispatch_modal_key(&key);
             }
             return;
@@ -67,8 +74,10 @@ impl App {
 
         // A float owns the wheel for the same reason it owns clicks.
         if let Some(index) = self.grabbed {
-            self.dispatch_key_to(index, &key);
-            self.dirty = true;
+            if self.wheel_notch.opens(Instant::now(), up) {
+                self.dispatch_key_to(index, &key);
+                self.dirty = true;
+            }
             return;
         }
 
@@ -78,8 +87,10 @@ impl App {
         }
 
         if let Some(target) = self.target_at(x, y) {
-            self.dispatch_key_to(target.plugin, &key);
-            self.dirty = true;
+            if self.wheel_notch.opens(Instant::now(), up) {
+                self.dispatch_key_to(target.plugin, &key);
+                self.dirty = true;
+            }
         }
     }
 
@@ -559,5 +570,98 @@ impl App {
                     .get(index)
                     .is_some_and(|(float, _)| float.intersects(rect))
         })
+    }
+}
+
+/// How close two reports have to be to belong to the same wheel notch.
+///
+/// A detent's reports are written in one go — microseconds apart, well inside
+/// this — while nobody can turn a wheel twice in 20 ms. So nothing a person
+/// meant as two steps is folded into one, and a held spin still steps fifty
+/// times a second.
+const WHEEL_NOTCH: Duration = Duration::from_millis(20);
+
+/// The wheel notch in progress: when its first report arrived, and which way it
+/// pointed.
+///
+/// A terminal turns one detent into its line-scroll count — three, for ghostty,
+/// kitty and xterm — and under mouse reporting sends that many reports back to
+/// back. The report that opens a notch steps; the ones riding behind it do not.
+#[derive(Default)]
+pub(crate) struct WheelNotch {
+    /// The report that opened the notch in progress, if one is open.
+    opened: Option<(Instant, bool)>,
+}
+
+impl WheelNotch {
+    /// Whether this report opens a new notch, recording it when it does.
+    ///
+    /// Timed from the last report that *stepped*, never from the ones dropped
+    /// behind it: extending the window on every report would let a continuous
+    /// spin hold it open forever and stop the list dead. A direction change
+    /// always opens one — the reports of a single detent all point the same way.
+    fn opens(&mut self, now: Instant, up: bool) -> bool {
+        if let Some((at, direction)) = self.opened {
+            if direction == up && now.duration_since(at) < WHEEL_NOTCH {
+                return false;
+            }
+        }
+        self.opened = Some((now, up));
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Ghostty, kitty and xterm send one report per line of their scroll
+    /// setting: three for one detent. Each report steps the selection and opens
+    /// what it lands on, so the tail of the burst has to go.
+    #[test]
+    fn a_burst_of_reports_is_one_notch() {
+        let start = Instant::now();
+        let mut notch = WheelNotch::default();
+        let mut steps = 0;
+        for offset in [0, 1, 2] {
+            if notch.opens(start + Duration::from_micros(offset * 200), false) {
+                steps += 1;
+            }
+        }
+        assert_eq!(steps, 1, "one detent must move the selection once");
+    }
+
+    /// The window is timed from the report that stepped, not from the ones
+    /// dropped behind it — otherwise a continuous spin holds it open and the
+    /// list never moves again.
+    #[test]
+    fn a_held_spin_keeps_stepping() {
+        let start = Instant::now();
+        let mut notch = WheelNotch::default();
+        let mut steps = 0;
+        // A report every 5 ms for a fifth of a second: a burst per notch that
+        // never stops.
+        for tick in 0..40 {
+            if notch.opens(start + Duration::from_millis(tick * 5), false) {
+                steps += 1;
+            }
+        }
+        assert_eq!(steps, 10, "a spin must keep moving, at one step per notch");
+    }
+
+    #[test]
+    fn reversing_steps_immediately() {
+        let now = Instant::now();
+        let mut notch = WheelNotch::default();
+        assert!(notch.opens(now, false));
+        assert!(notch.opens(now, true), "a direction change is a new notch");
+    }
+
+    #[test]
+    fn separated_notches_both_step() {
+        let start = Instant::now();
+        let mut notch = WheelNotch::default();
+        assert!(notch.opens(start, false));
+        assert!(notch.opens(start + WHEEL_NOTCH, false));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -242,6 +242,9 @@ struct App {
     data_epoch: u64,
     /// Active mouse text selection over a terminal surface, if any.
     selection: Option<Selection>,
+    /// The wheel notch in progress, so the tail of one detent's reports does
+    /// not step a selection again. See `coordinator::mouse`.
+    wheel_notch: coordinator::mouse::WheelNotch,
     themes: Themes,
     /// Which occupant of each `switch` slot is visible, by slot name.
     ///


### PR DESCRIPTION
## Summary

- A wheel **notch** is not one report: a terminal turns a detent into its line-scroll count — three, for ghostty, kitty and xterm — and under mouse reporting sends that many reports back to back. Every leg of `on_scroll` that turns a report into an `up`/`down` keystroke stepped once per report, so one flick of the wheel over the session list walked the selection through three sessions and attached each one on the way. The modal and float legs had it too: the theme picker, the restore list and the palette all jumped three rows a notch.
- `WheelNotch` (`src/coordinator/mouse.rs`) keeps the report that opened the notch in progress and drops the ones riding behind it — same direction, closer together than a person can turn a wheel (20 ms). It is timed from the report that *stepped*, never from the ones dropped after it, so a held spin keeps moving instead of holding the window open forever; a direction change always opens a notch, since the reports of one detent all point the same way.
- A tick **forwarded to a pty** is deliberately left whole: there the three reports are the three lines the terminal means to scroll, and the program inside owns what they do.
- `docs/FEATURES.md` → Mouse Navigation documents the rule.

## Test plan

- Four unit tests in `coordinator::mouse::tests`: a burst is one notch, a held spin keeps stepping (one per notch, not one and then nothing), reversing steps immediately, notches a full window apart both step.
- Driven against the real binary on a pty with a copy of a 20-session database: three back-to-back `\e[<65;…M` reports (one ghostty detent) move the selection **one** session; three detents 40 ms apart move three. Before the change each report stepped.
- `cargo nextest run --all` green, clippy `-D warnings` clean, `cargo doc` clean, `rumdl` clean.

Note: `tui_e2e::a_click_is_not_a_selection_so_ctrl_c_still_interrupts_the_shell` is flaky on this machine (fails ~1 run in 3 in the full suite, passes in isolation) — verified failing identically on pristine `main`, so it is unrelated to this diff.