### PR TITLE
fix(core): pace the link scan and scope the animation clock to its readers

### DIFF
--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -33,14 +33,28 @@ commands:
   # extra auto-fix round.
   format: "cargo fmt --all && stylua ui examples"
 
-  # test: deliberately left empty.
+  # test: the suite, named explicitly.
   #
-  # This key is targeted validation of the requested change, explicitly not a
-  # CI-parity suite, so `cargo nextest run --all` does not belong here: it
-  # rebuilds the whole crate in a fresh run worktree for every gate. Left
-  # empty, the test step picks the smallest relevant tests itself and gathers
-  # evidence, while the full suite stays mandatory in remote CI (ci.yml) and
-  # in the prek pre-commit hook.
+  # This key was deliberately empty, reasoning that the step is targeted
+  # validation rather than a CI-parity suite and that `cargo nextest run --all`
+  # rebuilds the whole crate in a fresh run worktree. Both halves proved wrong.
+  #
+  # The build is not marginal cost: the review step's own verification and the
+  # lint step's `just lint` already compile the crate in that same worktree, so
+  # the artifacts are warm by the time tests run and the suite itself is ~30s.
+  #
+  # And an empty key does not mean "a small test run" -- it means the agent
+  # decides what running the tests looks like. Given an intent that talked about
+  # performance measurements, one decided that meant taking a paired before/after
+  # reading with `scripts/dev/perf-run.sh`, waited through a release build and
+  # timed runs, and went silent until the step failed on `test_agent_timeout`
+  # (30m0s). A gate step has to be deterministic about what it executes, for the
+  # same reason `lint` above is spelled out rather than agent-detected.
+  #
+  # perf-run.sh now refuses to run under NO_MISTAKES_GATE, which closes that one
+  # hole; this closes the general one. The step's agent turn is then evidence
+  # gathering on top of a known-good suite, not a choice about what to run.
+  test: "cargo nextest run --all"
 
 # Excluded from review and documentation checks: generated or vendored trees
 # that carry no reviewable intent. `*` never crosses a `/`, and a pattern with

--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -93,7 +93,10 @@ document:
     Each class of fact has exactly one owner document. docs/CONSTITUTION.md
     owns core principles. docs/ARCHITECTURE.md owns architectural decisions and
     their ADR-NN anchors. docs/PERFORMANCE.md owns render-loop and tick
-    performance decisions and their ADR-PNN anchors. docs/FEATURES.md owns
+    performance decisions and their ADR-PNN anchors, and a performance ADR
+    records the measurement that produced it - the harness invocation, the
+    terminal size, the session count and a paired before/after - so the number
+    can be reproduced rather than remembered. docs/FEATURES.md owns
     feature-level design choices. docs/CONFIG.md owns thurbox's own
     configuration - every config file, environment variable and database
     setting it reads - while CONTRIBUTING.md owns the contribution process
@@ -149,6 +152,44 @@ review:
         answer is current" was needed is the mistake this code base has made
         repeatedly. A change-signal is bumped inside the mutation and only when
         the value actually changed.
+
+        The render loop's cost is gated on those signals, so read a change to
+        anything on the per-frame path - the loop body, republish, the snapshot,
+        the published groups, the terminal stores - for what it does to them, in
+        both directions. A signal that stops moving when its source did is a
+        stale pane with no error anywhere. A signal that moves when nothing a
+        reader cares about did is silent waste: it rebuilds every published
+        group and drops every pure pane's cached tree, and the frame still looks
+        correct. Agent output in particular must never move the data epoch -
+        that is what lets a streaming turn reuse diffs, links, content, commands
+        and metrics whole.
+
+        A signal is also worth scoping to whoever reads it. The animation clock
+        invalidated every pure pane eight times a second for a spinner one of
+        them draws, until `ctx.elapsed` became something the kernel could see a
+        pane ask for (ADR-P21). Prefer observing a dependency over asking a
+        plugin to declare one: a declaration that defaults to "no dependency"
+        fails silently for whoever did not read the release note, and one that
+        defaults to "yes" saves nothing.
+
+        "Only when the value actually changed" is necessary and not sufficient,
+        and ADR-P20 is the case that proves it: the link scan compared before
+        storing, and the answer had genuinely changed, because a scrolling screen
+        puts its URLs on new rows every frame. Compare-before-store asks whether
+        the value moved; the second question, for anything recomputed on the
+        frame path from a source that moves continuously, is whether it was worth
+        asking yet - a pacing interval or a stamp, sized to what a reader can act
+        on. Ask that of any new per-frame recompute.
+
+        A change that claims a performance effect carries its measurement:
+        `cargo bench --bench frame_cost` for the pieces of a frame, or
+        `scripts/dev/perf-run.sh` for the whole binary under load, reported as a
+        paired before/after at a stated terminal size and session count. An
+        absolute number on its own says nothing - the harness and the bench both
+        pin their inputs for that reason. Timing assertions stay out of the test
+        suite (ADR-P5); the deterministic half is asserted on counters and
+        change-signals instead, in tests/kernel_frame_cost.rs and
+        tests/kernel_perf.rs.
 
         A newly published thurbox.* field also goes into thurbox.yml at the
         repo root: it is selene's standard library for the Lua tree, so a field
@@ -225,6 +266,43 @@ review:
         returns over deep nesting, no abstraction ahead of real duplication,
         and patterns consistent with the panes under ui/ - somebody will copy
         whatever shape this file teaches.
+
+    - path: "benches/**"
+      instructions: |
+        The frame-cost instrument, not a test: `harness = false`, run by
+        `cargo bench`, deliberately outside the PR gate per ADR-P5, which keeps
+        wall-clock timing out of CI. `cargo clippy --all-targets` still compiles
+        it under `just lint`, so it cannot rot silently.
+
+        Judge it on one question: does it measure what the loop actually does?
+        A bench that measures something no frame performs is worse than none,
+        because it is believed. The trap already paid for here is rendering
+        every loaded plugin rather than the panes an arrangement of that size
+        places - a closed search strip occupies no slot, `draw_slots` never
+        reaches it, and the bench reported it as the second most expensive pane
+        in the interface. So a phase must correspond to a step the loop takes,
+        and every input a number depends on - the palette, the session count,
+        the terminal size, the epoch - is pinned or swept explicitly, never
+        inherited from the developer's environment.
+
+        Subtracting one measurement from another to isolate a phase is only
+        honest when the subtrahend is small: per-pane cost is measured across an
+        animation tick, where the publish beside it is the ~45us cache hit,
+        rather than a snapshot change, where it is a ~1ms rebuild and the
+        subtraction measures itself.
+
+    - path: "scripts/dev/perf-run.sh"
+      instructions: |
+        Runs the real binary under load and reports CPU. Its failures are
+        plausible numbers rather than errors, so read it for the two it already
+        guards: it must identify its OWN process (a developer's running thurbox
+        answers to `pgrep -x thurbox` first, and every configuration then reports
+        that instance's CPU), and the TUI must start before any session exists,
+        or the v1->v2 consent gate waits for a keypress and the run reports 0%.
+
+        A reading is only comparable with another at the same terminal size and
+        session count, so both stay explicit parameters and neither acquires a
+        default that varies with the invoking window.
 
     - path: "tests/**"
       instructions: |

--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -286,10 +286,16 @@ review:
         inherited from the developer's environment.
 
         Subtracting one measurement from another to isolate a phase is only
-        honest when the subtrahend is small: per-pane cost is measured across an
-        animation tick, where the publish beside it is the ~45us cache hit,
-        rather than a snapshot change, where it is a ~1ms rebuild and the
-        subtraction measures itself.
+        honest when the subtrahend is small, and the invalidator that makes the
+        subtrahend small must still invalidate everything being measured.
+        Per-pane cost is driven by `cold()` — the themes epoch — which is in the
+        pure-pane cache key unconditionally while gating only the palette, so
+        every pane really re-renders and the publish beside it stays a
+        near-cache-hit. Not a snapshot change, where the publish is a ~1ms
+        rebuild and the subtraction measures itself; and not the animation
+        epoch, which since ADR-P21 leaves a pure pane that never reads
+        `ctx.elapsed` served from its cache, so every such row would report
+        roughly zero.
 
     - path: "scripts/dev/perf-run.sh"
       instructions: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,7 +224,17 @@ mutation and only when the value actually changed — writing an unchanged value
 counts as no change, which is the difference between the gate saving 27% and
 saving nothing. The **animation clock** obeys it too: it lives in the epoch and
 the loop advances it only while something is actually animating, because a
-free-running one invalidated every pure pane on every idle frame. And the loop
+free-running one invalidated every pure pane on every idle frame. It is also
+**scoped to its readers**: `ctx.elapsed` is served through the render context's
+metatable rather than set as a field, so the kernel can see which panes asked for
+it, and a pure tree is keyed on the animation tick only if the render that built
+it read the clock (`CachedTree`). Every other TUI gets that coupling for free
+because the animating widget is the one that asks to be redrawn — a Textual
+widget's `set_interval(…, self.refresh)`, a Bubble Tea spinner's own tick command,
+fidget.nvim's `Anime` closure — and thurbox's panes do not ask, so it is observed
+instead. Detected rather than declared on purpose: a declaration defaulting to
+"does not animate" freezes a third-party spinner silently (ADR-P21, +51% down to
++12% under load). And the loop
 itself slows its input poll to `IDLE_TICK` once nothing has happened for
 `QUIESCENT_AFTER` — free, because `event::poll` returns the instant an event
 arrives, so only things that never wake the thread are delayed.
@@ -238,7 +248,16 @@ painted can be neither clicked nor handed to the outer terminal, and the scan
 walks a whole vt100 grid — doing it for every live pane cost ~1.2ms a frame with
 three of them), the search content scan on `output_generation`, and the interface
 inventory's per-file digests on a `trust_stale` flag every path that changes the
-directory or a grant already sets.
+directory or a grant already sets. The link scan carries a **second** gate,
+`LINK_SCAN_INTERVAL` (250 ms), because the stamp is exact for a screen that has
+stopped and no gate at all for one that has not: a printing agent moves it every
+frame, and a scrolling screen puts its URLs on new rows each time, so the scan
+found a real change per frame and moved the data epoch — which un-gated every
+group and every pure pane for anyone whose agent prints a URL, i.e. all of them
+(ADR-P20: printing a URL cost +66% CPU under load, now +15%). A per-frame recompute whose
+answer legitimately changes is the way a change-signal moves that nobody is
+looking for; compare-before-store asks whether the value moved, and the missing
+question is whether it was worth asking yet.
 
 **A vt100 grid is never given fewer than two rows or two columns**
 (`agent::backend::vt_floor`). A cramped layout really does compute a one-cell pane,
@@ -249,6 +268,17 @@ session's terminal is blank for the rest of the run: the unwind poisons the pars
 mutex, and every reader of it (paint, links, selection, copy) reads a poisoned lock
 as "no live terminal". A panic is also written to `thurbox.log`, because a worker's
 stderr is scrolled away long before anyone looks.
+
+**Measuring it**: two instruments, both outside the PR gate (ADR-P5).
+`cargo bench --bench frame_cost` times the *pieces* of a frame against the real
+`ui/` — publish, arrangement, each placed pane, the paint, the vt100 surface and
+link scan — modelling what `draw` does rather than what the plugin list contains
+(a closed search strip occupies no slot, so nothing renders it).
+`scripts/dev/perf-run.sh` runs the *whole binary* under a reproducible load in an
+isolated sandbox and reports CPU from `/proc` beside the loop's own
+`perf_window` line. A reading is only comparable with another at the same
+terminal size and session count, so both pin theirs, and a change is argued with
+a paired before/after rather than two absolute numbers.
 
 **Observability**: `F12` toggles the perf HUD (`[features] perf_hud`); launching with
 `THURBOX_PERF_LOG=1` writes `startup`, `perf_window` and `slow op` lines to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,19 @@ The project's code-quality rubric lives in that file's
 `review.path_instructions`, which is why there is no review command to run by
 hand — extend those rules rather than reintroducing one.
 
+Performance is reviewed there rather than measured there, deliberately. The
+`src/**` block carries the render loop's change-signal rules — including that a
+compare-before-store is not enough for anything recomputed per frame from a
+source that moves continuously, which is the failure ADR-P20 records — and asks
+a change claiming a performance effect to carry a paired before/after from
+`just bench` or `just perf`. What the gate does *not* do is time anything: that
+would be a flaky assertion about the machine it happened to run on, which
+[`docs/PERFORMANCE.md`](docs/PERFORMANCE.md) rules out in ADR-P5. The
+deterministic half is ordinary test coverage — counters and change-signals in
+`tests/kernel_perf.rs` and `tests/kernel_frame_cost.rs` — and the lint step
+compiles `benches/` through `cargo clippy --all-targets`, so the instrument
+cannot rot while nobody is running it.
+
 One discipline the gate cannot do for you, because it validates committed
 history rather than your working tree: **stage deliberately**. Commit the files
 that belong to the change and nothing else — never `git add -A` on a dirty tree

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,13 @@ deterministic half is ordinary test coverage — counters and change-signals in
 compiles `benches/` through `cargo clippy --all-targets`, so the instrument
 cannot rot while nobody is running it.
 
+The load harness stays out of the gate by refusing to run there
+(`NO_MISTAKES_GATE`). It lives under `scripts/dev/`, drives the real binary and
+prints a result, so it reads as a test to anything deciding what "run the tests"
+means — and a step that waits through a release build and timed runs fails on
+the agent timeout, which is what happened once. That is also why `commands.test`
+names the suite explicitly rather than leaving the choice to the step.
+
 One discipline the gate cannot do for you, because it validates committed
 history rather than your working tree: **stage deliberately**. Commit the files
 that belong to the change and nothing else — never `git add -A` on a dirty tree

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,15 @@ cargo-deny = "0.16.0"
 cargo-audit = "0.21.0"
 rumdl = "0.1.19"
 
+# The frame-cost instrument (`cargo bench --bench frame_cost`). Deliberately
+# `harness = false` and outside `cargo nextest`: ADR-P5 keeps wall-clock timing
+# out of the PR gate, and the deterministic assertions live in
+# `tests/kernel_frame_cost.rs`. This is the thing those assertions cannot be --
+# a number to compare a change against.
+[[bench]]
+name = "frame_cost"
+harness = false
+
 [profile.dev]
 # Our own crate: enough optimisation to be usable, still quick to rebuild.
 #
@@ -147,6 +156,13 @@ strip = false
 # a doctest example, and doctests link dev-dependencies — so this does not need
 # to be built into the shipped binaries.
 tempfile = "3"
+
+# The frame-cost bench measures the two per-frame costs a `PlaceholderSurfaces`
+# harness cannot see: converting a live vt100 grid into cells, and the link scan
+# over it. Both are already normal dependencies of the crate -- these entries add
+# nothing to the lock, they only let `benches/` name the types.
+vt100 = "0.16"
+tui-term = "0.3"
 
 # Property/fuzz testing — proves thurbox's terminal pipeline is byte- and
 # render-transparent (control_mode transport + terminal_view rendering). Runs in

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,13 +157,6 @@ strip = false
 # to be built into the shipped binaries.
 tempfile = "3"
 
-# The frame-cost bench measures the two per-frame costs a `PlaceholderSurfaces`
-# harness cannot see: converting a live vt100 grid into cells, and the link scan
-# over it. Both are already normal dependencies of the crate -- these entries add
-# nothing to the lock, they only let `benches/` name the types.
-vt100 = "0.16"
-tui-term = "0.3"
-
 # Property/fuzz testing — proves thurbox's terminal pipeline is byte- and
 # render-transparent (control_mode transport + terminal_view rendering). Runs in
 # the normal `cargo nextest --all`.

--- a/benches/frame_cost.rs
+++ b/benches/frame_cost.rs
@@ -362,7 +362,9 @@ fn main() {
     ));
 
     // The animation clock ticking, which is what a `working` session does eight
-    // times a second: nothing else moved, but every pure pane is invalidated.
+    // times a second: nothing else moved, and only the panes whose render read
+    // `ctx.elapsed` are invalidated by it (ADR-P21). What is left after that
+    // scoping is what this row measures — before it, every pure pane was here.
     rows.push((
         "frame: animation tick".into(),
         counts
@@ -562,13 +564,27 @@ fn paint(
         .expect("draw");
 }
 
+/// Move the epoch so every pure pane must render, as cheaply as a publish can.
+///
+/// The themes epoch. It is in the pure-pane cache key like every other epoch
+/// field, so it invalidates all of them unconditionally, and the only published
+/// group gated on it is the palette — so the publish beside each render stays a
+/// near-cache-hit rather than the ~1ms rebuild the snapshot epoch would force.
+/// Subtracting a millisecond from a millisecond measures the subtraction, not
+/// the pane, and the palette rebuild is inside the baseline that is subtracted.
+///
+/// NOT the animation epoch, which is what this drove before ADR-P21 scoped the
+/// clock to the panes that read it: a pure pane whose render never touches
+/// `ctx.elapsed` — the bundled agent pane, and every closed float — is now
+/// served from its cache across an animation tick, so every such row would
+/// report a cache hit minus the baseline. Roughly zero, in the one table whose
+/// whole job is to say where the time went.
+fn cold(epoch: &mut Epoch) {
+    epoch.themes += 1;
+}
+
 /// Which pane the time is in, at the largest session count — the question
 /// "the frame got slower" always turns into.
-///
-/// Driven by the ANIMATION epoch, not the snapshot: that invalidates every pure
-/// pane while leaving every published group reusable, so the publish beside each
-/// render is the ~45us cache-hit one rather than the ~1ms rebuild. Subtracting a
-/// millisecond from a millisecond measures the subtraction, not the pane.
 fn per_pane(
     host: &LuaHost,
     world: &World,
@@ -589,12 +605,12 @@ fn per_pane(
         let snapshot = snapshot(sessions);
         let mut epoch = Epoch::default();
         let baseline = measure(9, 50, || {
-            epoch.animation += 1;
+            cold(&mut epoch);
             world.publish(host, epoch, &snapshot);
         });
         for (nth, (index, _, rect)) in panes.iter().enumerate() {
             let each = measure(9, 50, || {
-                epoch.animation += 1;
+                cold(&mut epoch);
                 world.publish(host, epoch, &snapshot);
                 let _ = host.render(
                     *index,
@@ -616,7 +632,7 @@ fn per_pane(
         rows,
         columns: counts.iter().map(|n| format!("{n} sessions")).collect(),
     }
-    .print("per placed pane, on an animation tick");
+    .print("per placed pane, rendered cold");
 }
 
 /// What the caches actually did — the counters the perf HUD reads.
@@ -678,12 +694,20 @@ fn agent_screen(rows: u16, cols: u16) -> vt100::Parser {
 /// What a frame costs *because an agent is printing* — the two per-frame costs
 /// a `PlaceholderSurfaces` harness cannot see.
 ///
-/// Both are paid once per painted frame per visible printing surface, at the
-/// 33ms output floor, so the per-second figure beside each is the one that
-/// matters. The link scan is keyed on the surface's output stamp, which a
-/// printing agent moves every frame — so its cache never hits while output is
-/// arriving, which is exactly when it runs.
+/// They are paid at *different rates*, which is why each row carries its own.
+/// Painting the surface happens once per painted frame per visible surface, at
+/// the 33ms output floor. The link scan does not: it is keyed on the surface's
+/// output stamp, which a printing agent moves every frame, so before ADR-P20 it
+/// ran at that rate too — the second gate paces it at `LINK_SCAN_INTERVAL`
+/// instead. Scaling it at the frame rate is how a 7.5x-too-high number gets
+/// printed by an instrument that never fails.
 fn output_frame() {
+    // The rate each phase is actually paid at. `LINK_SCAN_INTERVAL` lives in
+    // `src/main.rs` — the loop is a binary, so a bench linking the library
+    // cannot name it; changing one means changing the other.
+    const FRAME_HZ: f64 = 1000.0 / 33.0;
+    const LINK_SCAN_HZ: f64 = 1000.0 / 250.0;
+
     let (width, height) = (WIDTH() * 3 / 4, HEIGHT() - 2);
     let parser = agent_screen(height, width);
     let mut terminal = Terminal::new(TestBackend::new(WIDTH(), HEIGHT())).expect("term");
@@ -704,20 +728,24 @@ fn output_frame() {
             .expect("draw");
     });
 
-    let per_second = |d: Duration| d.as_secs_f64() * 1e6 * 30.0 / 1000.0;
     println!("\nwhile one agent prints — {width}x{height} grid, at the 33ms output floor");
-    println!("phase                          per frame     per second");
-    println!("-------------------------------------------------------");
-    for (name, each) in [
-        ("extract screen rows", extract),
-        ("detect urls", detect),
-        ("paint the vt100 surface", surface),
-        ("(link scan = extract+detect)", extract + detect),
+    println!("phase                             each      rate     per second");
+    println!("---------------------------------------------------------------");
+    for (name, each, hz) in [
+        ("extract screen rows", extract, LINK_SCAN_HZ),
+        ("detect urls", detect, LINK_SCAN_HZ),
+        ("paint the vt100 surface", surface, FRAME_HZ),
+        (
+            "(link scan = extract+detect)",
+            extract + detect,
+            LINK_SCAN_HZ,
+        ),
     ] {
         println!(
-            "{name:<30} {:>7.1}us {:>10.2}ms",
+            "{name:<30} {:>7.1}us {:>5.0}/s {:>10.2}ms",
             each.as_secs_f64() * 1e6,
-            per_second(each)
+            hz,
+            each.as_secs_f64() * 1e6 * hz / 1000.0
         );
     }
 }

--- a/benches/frame_cost.rs
+++ b/benches/frame_cost.rs
@@ -1,0 +1,723 @@
+//! What a frame actually costs, measured against the real interface.
+//!
+//! Not a gate — ADR-P5 keeps timing out of CI, and `tests/kernel_frame_cost.rs`
+//! holds the assertions that *are* deterministic. This is the instrument those
+//! assertions cannot be: it drives the bundled `ui/` with a synthetic snapshot
+//! and reports where the time in one frame goes, so a change can be measured
+//! rather than argued about.
+//!
+//! ```sh
+//! cargo bench --bench frame_cost                 # the default sweep
+//! THURBOX_BENCH_SESSIONS=1,20,100 cargo bench --bench frame_cost
+//! ```
+//!
+//! Every phase is named after the thing the loop does, so a row here maps onto
+//! a line in `docs/PERFORMANCE.md` rather than onto a function name that may
+//! move.
+
+use std::collections::{HashMap, HashSet};
+use std::time::{Duration, Instant};
+
+use ratatui::backend::TestBackend;
+use ratatui::Terminal;
+
+use thurbox::kernel::host::{Epoch, LuaHost, Published, RenderContext};
+use thurbox::kernel::inventory::Trust;
+use thurbox::kernel::paint::PlaceholderSurfaces;
+use thurbox::kernel::registry::Registry;
+use thurbox::kernel::snapshot::{SessionRow, Snapshot};
+use thurbox::kernel::theme::Themes;
+
+static SCREEN: std::sync::OnceLock<(u16, u16)> = std::sync::OnceLock::new();
+#[allow(non_snake_case)]
+fn WIDTH() -> u16 {
+    SCREEN.get_or_init(screen).0
+}
+#[allow(non_snake_case)]
+fn HEIGHT() -> u16 {
+    SCREEN.get_or_init(screen).1
+}
+
+/// The screen the frame is measured at. Overridable because "the session list
+/// costs 435us" and "a visible row costs 9us" are different claims, and only a
+/// height sweep tells them apart.
+fn screen() -> (u16, u16) {
+    let parse = |name: &str, fallback: u16| {
+        std::env::var(name)
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(fallback)
+    };
+    (
+        parse("THURBOX_BENCH_WIDTH", 200),
+        parse("THURBOX_BENCH_HEIGHT", 50),
+    )
+}
+
+// --- the world --------------------------------------------------------------
+
+fn ui_dir() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("ui")
+}
+
+fn host() -> LuaHost {
+    let host = LuaHost::new(ui_dir());
+    assert!(host.error.is_none(), "{:?}", host.error);
+    host
+}
+
+/// The `default` preset by name, never the environment's active choice — a
+/// measurement that moves with whichever palette the machine happens to have
+/// selected is not a measurement.
+fn themes() -> Themes {
+    let mut themes = Themes::load(None);
+    themes.preview("default").expect("the default preset");
+    themes
+}
+
+fn registry(host: &LuaHost) -> Registry {
+    let mut registry = Registry::default();
+    let (bindings, settings) = host.declarations();
+    registry.declare(bindings, settings);
+    registry
+}
+
+/// Rows shaped like the ones a working machine has: several repos, a parent
+/// per group, live panes, and a git stat block — the shape the session list
+/// spends its time on.
+fn snapshot(sessions: usize) -> Snapshot {
+    let repos = ["/src/thurbox", "/src/thurlab", "/src/thurspace"];
+    let rows = (0..sessions)
+        .map(|nth| {
+            let repo = repos[nth % repos.len()];
+            SessionRow {
+                id: format!("session-{nth:04}"),
+                name: format!("fix-the-thing-number-{nth}"),
+                agent: "claude".into(),
+                status: ["idle", "working", "blocked", "done"][nth % 4].into(),
+                cwd: Some(format!("{repo}/worktrees/w{nth}").into()),
+                repo: Some(repo.into()),
+                repos: vec![repo.into()],
+                branch: Some(format!("feat/thing-{nth}")),
+                base_branch: Some("main".into()),
+                backend: "local-tmux".into(),
+                backend_id: Some(format!("%{nth}")),
+                remote_host: None,
+                agent_session_id: Some(format!("00000000-0000-0000-0000-{nth:012}")),
+                // Every fourth row nests under the one before it, so the
+                // session model's tree walk is exercised rather than skipped.
+                parent_id: (nth % 4 == 3).then(|| format!("session-{:04}", nth - 1)),
+                display_order: Some(nth as i64),
+                worktree_count: 1,
+                git: None,
+                hook_state: Some("idle".into()),
+                shell_backend_id: None,
+                member_dirs: vec![format!("{repo}/worktrees/w{nth}").into()],
+            }
+        })
+        .collect();
+    Snapshot {
+        sessions: rows,
+        ..Snapshot::default()
+    }
+}
+
+struct World {
+    themes: Themes,
+    registry: Registry,
+    diffs: thurbox::kernel::diff::DiffStore,
+    repos: thurbox::kernel::repos::RepoStore,
+    inventory: Vec<thurbox::kernel::inventory::Row>,
+}
+
+impl World {
+    fn new(host: &LuaHost) -> Self {
+        let sources = thurbox::kernel::bundled::sources(&ui_dir());
+        let visible: HashSet<usize> = (0..host.plugins.len()).collect();
+        let placed: HashSet<String> = host.plugins.iter().map(|p| p.slot.clone()).collect();
+        let inventory = thurbox::kernel::inventory::rows(
+            &host.plugins,
+            &sources,
+            &visible,
+            &placed,
+            None,
+            &|_| Trust::NotAsked,
+            &|_| false,
+        );
+        World {
+            themes: themes(),
+            registry: registry(host),
+            diffs: thurbox::kernel::diff::DiffStore::new(),
+            repos: thurbox::kernel::repos::RepoStore::with_hosts(Default::default()),
+            inventory,
+        }
+    }
+
+    fn publish(&self, host: &LuaHost, epoch: Epoch, snapshot: &Snapshot) {
+        host.publish(&Published {
+            epoch,
+            snapshot,
+            attach_errors: &HashMap::new(),
+            inflight: &[],
+            themes: &self.themes,
+            registry: &self.registry,
+            diffs: &self.diffs,
+            links: &Default::default(),
+            content: &Default::default(),
+            meta: &Default::default(),
+            metrics: &Default::default(),
+            status_rows: 0,
+            can_open: true,
+            inventory: &self.inventory,
+            ui_dir: "ui",
+            settings: &Default::default(),
+            repos: &self.repos,
+            wants: &Default::default(),
+            focus: None,
+            hovered: None,
+        })
+        .expect("publish");
+    }
+}
+
+// --- timing -----------------------------------------------------------------
+
+/// Median of `runs` timed passes, each of `inner` repetitions.
+///
+/// Median rather than mean: one scheduler hiccup in a hundred passes should not
+/// move the number a reader compares against last week's.
+fn measure(runs: usize, inner: usize, mut body: impl FnMut()) -> Duration {
+    let mut samples = Vec::with_capacity(runs);
+    for _ in 0..runs {
+        let started = Instant::now();
+        for _ in 0..inner {
+            body();
+        }
+        samples.push(started.elapsed() / inner as u32);
+    }
+    samples.sort_unstable();
+    samples[samples.len() / 2]
+}
+
+struct Table {
+    rows: Vec<(String, Vec<Duration>)>,
+    columns: Vec<String>,
+}
+
+impl Table {
+    fn print(&self, title: &str) {
+        println!("\n{title}");
+        let width = self
+            .rows
+            .iter()
+            .map(|(name, _)| name.len())
+            .chain(std::iter::once(6))
+            .max()
+            .unwrap_or(6);
+        print!("{:<width$}", "phase", width = width);
+        for column in &self.columns {
+            print!(" {column:>12}");
+        }
+        println!();
+        println!("{}", "-".repeat(width + 13 * self.columns.len()));
+        for (name, values) in &self.rows {
+            print!("{name:<width$}", width = width);
+            for value in values {
+                print!(" {:>10.1}us", value.as_secs_f64() * 1e6);
+            }
+            println!();
+        }
+    }
+}
+
+// --- a frame, as the loop actually draws one ---------------------------------
+
+/// The panes an arrangement of this size actually places, at their real rects.
+///
+/// This is the difference between a measurement and a fiction: a closed search
+/// strip occupies no slot, so `draw_slots` never reaches it and it costs a real
+/// frame nothing. Rendering every plugin regardless reported it as the second
+/// most expensive pane in the interface.
+fn placed_panes(host: &LuaHost) -> Vec<(usize, String, ratatui::layout::Rect)> {
+    let area = ratatui::layout::Rect::new(0, 0, WIDTH(), HEIGHT());
+    let region = host.arrangement(WIDTH(), HEIGHT()).expect("arrangement");
+    let mut out = Vec::new();
+    for slot in thurbox::kernel::layout::resolve(&region, area) {
+        for &index in host.in_slot(&slot.slot) {
+            let Some(plugin) = host.plugins.get(index) else {
+                continue;
+            };
+            out.push((index, plugin.name.clone(), slot.rect));
+            // A switch slot shows one occupant; a stack shows them all. The
+            // bundled interface has one occupant per slot either way, so the
+            // distinction costs nothing to ignore here — but say so, because an
+            // interface with two panes in `center` would need it.
+            if host.slot_mode(&slot.slot) == thurbox::kernel::layout::SlotMode::Switch {
+                break;
+            }
+        }
+    }
+    out
+}
+
+/// The float probe every frame pays: `draw_floats` renders each floating plugin
+/// to discover whether it is floating *this* frame. Three of the bundled panes
+/// are floats, and all three declare `pure`, so this is a cache hit — which is
+/// exactly the claim worth measuring.
+fn float_probe(host: &LuaHost, frame: u64) {
+    for &index in host.floating() {
+        let _ = host.render(
+            index,
+            RenderContext {
+                width: WIDTH(),
+                height: HEIGHT(),
+                focused: true,
+                elapsed: 0.0,
+                frame,
+            },
+        );
+    }
+}
+
+fn main() {
+    let counts: Vec<usize> = std::env::var("THURBOX_BENCH_SESSIONS")
+        .ok()
+        .map(|spec| {
+            spec.split(',')
+                .filter_map(|n| n.trim().parse().ok())
+                .collect()
+        })
+        .unwrap_or_else(|| vec![1, 10, 50]);
+
+    let host = host();
+    let world = World::new(&host);
+    let panes = placed_panes(&host);
+
+    println!(
+        "thurbox frame cost — {}x{}, sessions: {counts:?}",
+        WIDTH(),
+        HEIGHT()
+    );
+    println!(
+        "placed: {}   floats probed: {}   (of {} loaded)",
+        panes
+            .iter()
+            .map(|(_, name, _)| name.as_str())
+            .collect::<Vec<_>>()
+            .join(", "),
+        host.floating().len(),
+        host.plugins.len()
+    );
+
+    let columns: Vec<String> = counts.iter().map(|n| format!("{n} sessions")).collect();
+    let mut rows: Vec<(String, Vec<Duration>)> = Vec::new();
+
+    // --- whole frames -------------------------------------------------------
+
+    // The frame the loop spends most of its life on: the 250ms forced redraw
+    // with nothing moved. Every group reused, every pure pane cached. This is
+    // the number that must stay flat in the session count.
+    rows.push((
+        "frame: settled".into(),
+        counts
+            .iter()
+            .map(|&n| {
+                let snapshot = snapshot(n);
+                let epoch = Epoch::default();
+                let mut terminal =
+                    Terminal::new(TestBackend::new(WIDTH(), HEIGHT())).expect("term");
+                let mut once = || {
+                    world.publish(&host, epoch, &snapshot);
+                    let trees = render_panes(&host, &panes, 0);
+                    float_probe(&host, 0);
+                    paint(&mut terminal, &trees);
+                };
+                once();
+                measure(9, 20, once)
+            })
+            .collect(),
+    ));
+
+    // A frame after the snapshot moved: the whole publish, every pane run
+    // again, and the paint. What a session appearing, a status changing or a
+    // branch landing costs.
+    rows.push((
+        "frame: snapshot moved".into(),
+        counts
+            .iter()
+            .map(|&n| {
+                let snapshot = snapshot(n);
+                let mut epoch = Epoch::default();
+                let mut terminal =
+                    Terminal::new(TestBackend::new(WIDTH(), HEIGHT())).expect("term");
+                measure(9, 20, || {
+                    epoch.snapshot += 1;
+                    world.publish(&host, epoch, &snapshot);
+                    let trees = render_panes(&host, &panes, 0);
+                    float_probe(&host, 0);
+                    paint(&mut terminal, &trees);
+                })
+            })
+            .collect(),
+    ));
+
+    // The animation clock ticking, which is what a `working` session does eight
+    // times a second: nothing else moved, but every pure pane is invalidated.
+    rows.push((
+        "frame: animation tick".into(),
+        counts
+            .iter()
+            .map(|&n| {
+                let snapshot = snapshot(n);
+                let mut epoch = Epoch::default();
+                let mut terminal =
+                    Terminal::new(TestBackend::new(WIDTH(), HEIGHT())).expect("term");
+                measure(9, 20, || {
+                    epoch.animation += 1;
+                    world.publish(&host, epoch, &snapshot);
+                    let trees = render_panes(&host, &panes, 0);
+                    float_probe(&host, 0);
+                    paint(&mut terminal, &trees);
+                })
+            })
+            .collect(),
+    ));
+
+    // --- the parts ----------------------------------------------------------
+
+    rows.push((
+        "  publish (reused)".into(),
+        counts
+            .iter()
+            .map(|&n| {
+                let snapshot = snapshot(n);
+                let epoch = Epoch::default();
+                world.publish(&host, epoch, &snapshot);
+                measure(9, 50, || world.publish(&host, epoch, &snapshot))
+            })
+            .collect(),
+    ));
+
+    rows.push((
+        "  publish (rebuilt)".into(),
+        counts
+            .iter()
+            .map(|&n| {
+                let snapshot = snapshot(n);
+                measure(9, 20, || {
+                    world.publish(&host, Epoch::always_fresh(), &snapshot);
+                })
+            })
+            .collect(),
+    ));
+
+    rows.push((
+        "  arrangement".into(),
+        counts
+            .iter()
+            .map(|_| {
+                measure(9, 200, || {
+                    host.arrangement(WIDTH(), HEIGHT()).expect("arrangement");
+                })
+            })
+            .collect(),
+    ));
+
+    rows.push((
+        "  render placed panes".into(),
+        counts
+            .iter()
+            .map(|&n| {
+                let snapshot = snapshot(n);
+                let mut epoch = Epoch::default();
+                measure(9, 20, || {
+                    // A moved epoch, so this is the cost of actually running
+                    // them rather than of the cache answering.
+                    epoch.snapshot += 1;
+                    world.publish(&host, epoch, &snapshot);
+                    let _ = render_panes(&host, &panes, 0);
+                })
+            })
+            .collect(),
+    ));
+
+    rows.push((
+        "  float probe (cached)".into(),
+        counts
+            .iter()
+            .map(|&n| {
+                let snapshot = snapshot(n);
+                world.publish(&host, Epoch::default(), &snapshot);
+                float_probe(&host, 0);
+                measure(9, 200, || float_probe(&host, 0))
+            })
+            .collect(),
+    ));
+
+    rows.push((
+        "  paint".into(),
+        counts
+            .iter()
+            .map(|&n| {
+                let snapshot = snapshot(n);
+                world.publish(&host, Epoch::always_fresh(), &snapshot);
+                let trees = render_panes(&host, &panes, 0);
+                let mut terminal =
+                    Terminal::new(TestBackend::new(WIDTH(), HEIGHT())).expect("term");
+                measure(9, 20, || paint(&mut terminal, &trees))
+            })
+            .collect(),
+    ));
+
+    rows.push((
+        "  normalize width".into(),
+        counts
+            .iter()
+            .map(|_| {
+                let mut buffer = ratatui::buffer::Buffer::empty(ratatui::layout::Rect::new(
+                    0,
+                    0,
+                    WIDTH(),
+                    HEIGHT(),
+                ));
+                measure(9, 200, || {
+                    thurbox::kernel::paint::normalize_ambiguous_width(&mut buffer);
+                })
+            })
+            .collect(),
+    ));
+
+    let sources = thurbox::kernel::bundled::sources(&ui_dir());
+    let visible: HashSet<usize> = (0..host.plugins.len()).collect();
+    let placed: HashSet<String> = host.plugins.iter().map(|p| p.slot.clone()).collect();
+    rows.push((
+        "  inventory rows".into(),
+        counts
+            .iter()
+            .map(|_| {
+                measure(9, 200, || {
+                    let _ = thurbox::kernel::inventory::rows(
+                        &host.plugins,
+                        &sources,
+                        &visible,
+                        &placed,
+                        None,
+                        &|_| Trust::NotAsked,
+                        &|_| false,
+                    );
+                })
+            })
+            .collect(),
+    ));
+
+    Table { rows, columns }.print("per frame");
+
+    output_frame();
+
+    per_pane(&host, &world, &panes, &counts);
+    caching(&host, &world, &panes, counts.last().copied().unwrap_or(50));
+}
+
+fn render_panes(
+    host: &LuaHost,
+    panes: &[(usize, String, ratatui::layout::Rect)],
+    frame: u64,
+) -> Vec<(
+    std::rc::Rc<thurbox::kernel::node::Node>,
+    ratatui::layout::Rect,
+)> {
+    panes
+        .iter()
+        .filter_map(|(index, _, rect)| {
+            host.render(
+                *index,
+                RenderContext {
+                    width: rect.width,
+                    height: rect.height,
+                    focused: false,
+                    elapsed: 0.0,
+                    frame,
+                },
+            )
+            .ok()
+            .map(|rendered| (rendered.node, *rect))
+        })
+        .collect()
+}
+
+fn paint(
+    terminal: &mut Terminal<TestBackend>,
+    trees: &[(
+        std::rc::Rc<thurbox::kernel::node::Node>,
+        ratatui::layout::Rect,
+    )],
+) {
+    terminal
+        .draw(|frame| {
+            for (tree, rect) in trees {
+                thurbox::kernel::paint::render(frame, *rect, tree, &PlaceholderSurfaces);
+            }
+            thurbox::kernel::paint::normalize_ambiguous_width(frame.buffer_mut());
+        })
+        .expect("draw");
+}
+
+/// Which pane the time is in, at the largest session count — the question
+/// "the frame got slower" always turns into.
+///
+/// Driven by the ANIMATION epoch, not the snapshot: that invalidates every pure
+/// pane while leaving every published group reusable, so the publish beside each
+/// render is the ~45us cache-hit one rather than the ~1ms rebuild. Subtracting a
+/// millisecond from a millisecond measures the subtraction, not the pane.
+fn per_pane(
+    host: &LuaHost,
+    world: &World,
+    panes: &[(usize, String, ratatui::layout::Rect)],
+    counts: &[usize],
+) {
+    let mut rows: Vec<(String, Vec<Duration>)> = panes
+        .iter()
+        .map(|(_, name, rect)| {
+            (
+                format!("{name} ({}x{})", rect.width, rect.height),
+                Vec::new(),
+            )
+        })
+        .collect();
+    let mut baselines = Vec::new();
+    for &sessions in counts {
+        let snapshot = snapshot(sessions);
+        let mut epoch = Epoch::default();
+        let baseline = measure(9, 50, || {
+            epoch.animation += 1;
+            world.publish(host, epoch, &snapshot);
+        });
+        for (nth, (index, _, rect)) in panes.iter().enumerate() {
+            let each = measure(9, 50, || {
+                epoch.animation += 1;
+                world.publish(host, epoch, &snapshot);
+                let _ = host.render(
+                    *index,
+                    RenderContext {
+                        width: rect.width,
+                        height: rect.height,
+                        focused: false,
+                        elapsed: 0.0,
+                        frame: 0,
+                    },
+                );
+            });
+            rows[nth].1.push(each.saturating_sub(baseline));
+        }
+        baselines.push(baseline);
+    }
+    rows.push(("(reused publish, subtracted)".into(), baselines));
+    Table {
+        rows,
+        columns: counts.iter().map(|n| format!("{n} sessions")).collect(),
+    }
+    .print("per placed pane, on an animation tick");
+}
+
+/// What the caches actually did — the counters the perf HUD reads.
+///
+/// A time that looks fine because a cache answered is a different fact from a
+/// time that is fine, and only these tell them apart.
+fn caching(
+    host: &LuaHost,
+    world: &World,
+    panes: &[(usize, String, ratatui::layout::Rect)],
+    sessions: usize,
+) {
+    let snapshot = snapshot(sessions);
+    let epoch = Epoch::default();
+    world.publish(host, epoch, &snapshot);
+    let _ = render_panes(host, panes, 0);
+    float_probe(host, 0);
+
+    let skipped = host.skipped_renders();
+    let reused = host.reused_groups();
+    let frames = 100;
+    for _ in 0..frames {
+        world.publish(host, epoch, &snapshot);
+        let _ = render_panes(host, panes, 0);
+        float_probe(host, 0);
+    }
+    let renders = panes.len() + host.floating().len();
+    println!("\nover {frames} settled frames");
+    println!(
+        "  pane renders served from the cache: {} of {}",
+        host.skipped_renders() - skipped,
+        frames * renders
+    );
+    println!(
+        "  published groups reused:            {}",
+        host.reused_groups() - reused
+    );
+}
+
+// --- the streaming-agent frame ----------------------------------------------
+
+/// A screen with the shape an agent's output has: mostly text, a few URLs, some
+/// styling. Filled to the full grid, because both costs below are per cell.
+fn agent_screen(rows: u16, cols: u16) -> vt100::Parser {
+    let mut parser = vt100::Parser::new(rows, cols, 0);
+    for nth in 0..rows {
+        let line = if nth % 12 == 0 {
+            format!("\x1b[33m  see https://github.com/Thurbeen/thurbox/pull/{nth} for the rest\x1b[0m\r\n")
+        } else if nth % 3 == 0 {
+            format!("\x1b[1m  * step {nth}\x1b[0m: rewrote src/kernel/host/publish.rs and re-ran the suite\r\n")
+        } else {
+            format!("    {nth:>4} | the quick brown fox jumps over the lazy dog, repeatedly and at length\r\n")
+        };
+        parser.process(line.as_bytes());
+    }
+    parser
+}
+
+/// What a frame costs *because an agent is printing* — the two per-frame costs
+/// a `PlaceholderSurfaces` harness cannot see.
+///
+/// Both are paid once per painted frame per visible printing surface, at the
+/// 33ms output floor, so the per-second figure beside each is the one that
+/// matters. The link scan is keyed on the surface's output stamp, which a
+/// printing agent moves every frame — so its cache never hits while output is
+/// arriving, which is exactly when it runs.
+fn output_frame() {
+    let (width, height) = (WIDTH() * 3 / 4, HEIGHT() - 2);
+    let parser = agent_screen(height, width);
+    let mut terminal = Terminal::new(TestBackend::new(WIDTH(), HEIGHT())).expect("term");
+
+    let extract = measure(9, 100, || {
+        let _ = thurbox::kernel::terminal::links::extract_screen_rows(parser.screen());
+    });
+    let rows = thurbox::kernel::terminal::links::extract_screen_rows(parser.screen());
+    let detect = measure(9, 100, || {
+        let _ = thurbox::kernel::terminal::links::detect_urls(&rows);
+    });
+    let surface = measure(9, 100, || {
+        terminal
+            .draw(|frame| {
+                let area = ratatui::layout::Rect::new(0, 0, width, height);
+                frame.render_widget(tui_term::widget::PseudoTerminal::new(parser.screen()), area);
+            })
+            .expect("draw");
+    });
+
+    let per_second = |d: Duration| d.as_secs_f64() * 1e6 * 30.0 / 1000.0;
+    println!("\nwhile one agent prints — {width}x{height} grid, at the 33ms output floor");
+    println!("phase                          per frame     per second");
+    println!("-------------------------------------------------------");
+    for (name, each) in [
+        ("extract screen rows", extract),
+        ("detect urls", detect),
+        ("paint the vt100 surface", surface),
+        ("(link scan = extract+detect)", extract + detect),
+    ] {
+        println!(
+            "{name:<30} {:>7.1}us {:>10.2}ms",
+            each.as_secs_f64() * 1e6,
+            per_second(each)
+        );
+    }
+}

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -54,7 +54,17 @@ runs — `selene`, `stylua` and `lua-language-server`. Run `npm ci` once, or
 | `just arch` | architecture-rule + rustdoc checks |
 | `just hooks-install` | `prek install` |
 | `just smoke` | black-box TUI test: the real binary on a pty (`tests/tui_e2e.rs`) |
+| `just bench` | what a frame costs, piece by piece (`benches/frame_cost.rs`) |
+| `just perf` | what the whole binary costs under load (`scripts/dev/perf-run.sh`) |
 | `just sandbox*` | dev runtime sandbox (below) |
+
+`just bench` and `just perf` are the two measuring instruments, and they answer
+different questions: the bench times the *pieces* of a frame against the real
+`ui/`, while `just perf` runs the whole binary against real tmux panes and
+reports CPU. Neither is in CI — wall-clock timing stays out of the gate
+(ADR-P5) — and a claim from either is a paired before/after at a stated
+terminal size and session count, never a single absolute number. Both are
+explained in [`docs/PERFORMANCE.md`](PERFORMANCE.md).
 
 ## 3. Runtime sandbox — run thurbox isolated
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1238,6 +1238,253 @@ a_mirror_pass_that_could_not_run_backs_its_host_off}`.
 
 ---
 
+## ADR-P20: A link on a scrolling screen must not un-gate the frame (2026-08-29)
+
+**Context**: ADR-P16 made a frame cost what changed, and ADR-P18 closed the last
+ungated groups. Both rest on the data epoch, and both state the same rule out
+loud: the epoch moves on a worker result or a command transition and
+**deliberately never on agent output**, so a streaming turn reuses `diffs`,
+`links`, `content`, `commands` and `metrics` whole and every `pure` pane keeps
+the tree it last returned.
+
+It did not hold. `refresh_links` is gated on the surface's `output_stamp`, which
+is exact for a screen that has *stopped* and no gate at all for one that has
+not: a printing agent moves it on every frame. The scan then walks the whole
+vt100 grid, and — because the URLs on a scrolling screen sit on different rows
+each time — the compare-before-store below it found a real change and called
+`note_published_change()`. So agent output moved the epoch after all, once per
+painted frame, for anyone whose agent prints something link-shaped. Which is
+every coding agent: a PR link, a docs link, a `file://` path.
+
+The effect is invisible in the frame and plain in the profile. Measured with
+`scripts/dev/perf-run.sh`, 19 sessions at 255x62 with three agents printing 30
+lines a second — the same run twice, differing only in whether the printed lines
+contain a URL (`-u 0`):
+
+| output | CPU | frame p50 | republish p50 | pane trees served from cache |
+|---|---|---|---|---|
+| with URLs | 8.32% | 4000us | 500us | 179 |
+| no URLs | 5.00% | 1000us | 250us | 3487 |
+
+A URL in the output cost **66% more CPU** and took the tree cache from 3487 hits
+to 179. The gating was not degraded; it was off.
+
+**Choice**: a second gate on the scan, an age — ADR-P13's rule, which this path
+never had. `LINK_SCAN_INTERVAL` (250ms) bounds how often a surface whose screen
+is *still moving* is rescanned; the output stamp keeps serving a screen that has
+settled exactly, and for free, forever. The stamp is deliberately not recorded on
+a skipped pass, so the next publish after the interval does the scan and a
+settled screen converges back onto the stamp.
+
+250ms because nothing acts on a link's *position* faster than that, and nothing
+reads the published map to act at all: a click resolves against the live grid
+(`Terminals::url_at`) and the OSC 8 repaint recomputes from `cached_rows`
+(`hyperlink_paints`). `thurbox.links` exists for a plugin to draw, and no bundled
+pane reads it. So the interval bounds staleness in the published map and nothing
+else.
+
+**Measured**, the same run before and after, each paired with its own no-URL
+control so the machine's mood is not part of the claim:
+
+| | with URLs | no-URL control | penalty | frame p50 | cached trees |
+|---|---|---|---|---|---|
+| before | 8.32% | 5.00% | **+66%** | 4000us | 179 |
+| after | **5.27%** | 4.57% | **+15%** | 2000us | **3347** |
+
+**-37% CPU under load**, and the cost of a URL in the output falls from two
+thirds of the frame budget to a seventh. It is reduced rather than removed, and
+the residual is the honest arithmetic of the choice: four paced rescans a second
+still move the epoch four times, against thirty. Removing it entirely would mean
+either not publishing link positions at all — `thurbox.links` has no bundled
+reader, but an out-of-tree pane may — or a per-group invalidation the tree cache
+cannot express, since its key is the whole `Epoch`. Neither is worth it for the
+seventh; both are written down here so the next person does not rediscover them.
+
+**Consequences**: the rule ADR-P16 and ADR-P18 both state is now true of the one
+path that broke it. The failure mode to take from this is not "links were slow" —
+it is that **a per-frame recompute whose answer legitimately changes is a way to
+move a change-signal that no reviewer is looking for**. The compare-before-store
+that guards `store` writes is not enough on its own: it asks whether the value
+moved, and here it truly had. What was missing was the other question, whether it
+was worth asking yet.
+
+Pinned by `coordinator::publish::tests::*` for the pacing rule (including that
+the interval must sit between the output frame floor and the forced-redraw floor,
+or it is a no-op that reads as tuned), and measurable at any time with
+`just perf -n 19 -p 3 -s 255x62` against the same run with `-u 0`.
+
+**What moves the epoch now**, attributed at each call site over a 25s run of that
+same load, so the next person starts from a measurement rather than a guess:
+`refresh_links` 117 (the four paced scans a second, the residual above),
+`Metrics::poll` 36, `DiffStore::poll` 7 — around six a second between them,
+against the ~30 publishes a second a streaming turn drives. The snapshot version
+moves on roughly one publish in twenty. So the epoch stands still for about three
+publishes in four, and the pure trees and the float probes are served from the
+cache together at that rate — they share the key, so they hit and miss as one,
+which is worth knowing before reading `renders_skipped` as a per-pane figure.
+The remaining movers are each a worker result someone asked for, which is what
+the epoch is *for*.
+
+---
+
+## ADR-P21: Animation belongs to whoever reads the clock (2026-08-29)
+
+**Context**: `advance_animation` advances a shared clock while any session is
+`working` — the normal state of a machine with an agent running — and the clock
+is in the pure-pane cache key. So *every* pure pane re-rendered eight times a
+second to move a spinner glyph: the centre pane, which draws a terminal surface,
+and all three closed float probes, which draw nothing at all.
+
+The harness could not see it, because `sh` runs no status hook and nothing ever
+reported `working`. `perf-run.sh -w N` now signals N sessions the way a hook does
+(`THURBOX_SESSION` plus `session signal`), which made it measurable — and it was
+the largest single cost left:
+
+| 19 sessions, 3 printing, 255x62 | CPU | pane trees from cache |
+|---|---|---|
+| `-w 0` | 6.00% | 2922 |
+| `-w 4` | **9.08%** | 1886 |
+
+**+51%** for one glyph per working row. Unlike ADR-P20 the signal is *honest* —
+the session list really does depend on the clock. What was wrong is that every
+other pane paid for it.
+
+**How everyone else does it.** Worth reading before choosing, because the answer
+is unanimous and thurbox had neither half of it:
+
+- **Textual** — a spinner widget calls `self.set_interval(1 / 60, self.refresh)`
+  on *itself*, and `refresh` marks that widget dirty. Rich's `Spinner` derives
+  its frame from `console.get_time()`, so the frame follows the clock while the
+  *invalidation* follows the widget.
+- **Bubble Tea** — `bubbles/spinner` returns its own `TickMsg` command. The whole
+  view is re-rendered, but the renderer line-diffs against the previous frame and
+  writes only changed lines, so the cost lands at the output layer.
+- **fidget.nvim** — an `Anime` is `fun(now: number): string`, polled by fidget's
+  own heartbeat (which idles when there is no work, and never exceeds ~40Hz), and
+  it repaints fidget's own float.
+- **lualine** — does not trigger redraws at all; neovim redraws the statusline on
+  its own events, and a timer-driven `:redrawstatus` refreshes *only* the
+  statusline.
+
+One principle behind all four: **the clock invalidates only its reader**. Three
+of them get that coupling for free, because the thing that reads the clock is
+also the thing that asks to be redrawn. thurbox's panes do not ask — the kernel
+calls them — so the coupling had to be recovered some other way.
+
+**Choice**: recover it by *observation*. `ctx.elapsed` is served through the
+render context's metatable instead of being set as a field, so asking for it is
+something the kernel can see; a pure pane's cached tree records whether the
+render that built it read the clock, and the animation tick is compared only for
+trees that did (`CachedTree::answers`). `__index` fires only for absent keys, so
+every ordinary field (`width`, `height`, `focused`, `frame`, `name`, `slot`)
+stays a raw read and pays nothing, and the metatable is built once per VM rather
+than per render.
+
+**Measured**, the same paired runs:
+
+| 19 sessions, 3 printing, 255x62 | before | after |
+|---|---|---|
+| `-w 0` (nothing animating) | 6.00% | 5.32% |
+| `-w 4` (four spinners) | **9.08%** | **5.96%** |
+| animation penalty | **+51%** | **+12%** |
+| trees from cache at `-w 4` | 1886 | 2725 |
+
+The penalty is the honest figure — it is internally paired, where the two `-w 0`
+readings differ by run-to-run noise on a shared machine. The residual +12% is the
+session list, which is *supposed* to re-render: it is the pane with the spinner
+in it.
+
+**Rejected — a declaration**, in either direction, which is what this looked like
+before the prior art was read:
+
+- Defaulting to "does not animate" recovers nearly everything and silently
+  freezes any third-party spinner whose author never read the release note. A
+  wrong-direction failure with no error anywhere is the class of bug this
+  document exists to record.
+- Defaulting to "does" is safe and recovers only the panes thurbox ships.
+- Taking the spinner out of the tree and painting it as a decoration needs no
+  declaration, but reworks the session list and only moves the cost.
+
+Detection beats all three because it cannot be wrong in either direction: the
+flag is read from the render that produced the very tree being cached, so a pane
+that starts or stops reading the clock re-keys itself on the render where it
+does. There is no frame in between on which a stale tree could be served —
+asserted in `kernel_frame_cost::a_pane_that_starts_reading_the_clock_is_keyed_on_it_from_then_on`,
+alongside the two directions and one test against the real bundled interface.
+
+**Consequences**: one visible change to the plugin contract — `elapsed` is not a
+key of `ctx`, so it does not appear in `pairs(ctx)`. Nothing iterates a render
+context, and `docs/PLUGINS.md` now states the rule the mechanism creates: reading
+`ctx.elapsed` is what subscribes a tree to the animation tick, so read it where
+you animate and not at the top of a render that usually draws nothing moving.
+
+---
+
+## Measuring: the bench and the load harness (2026-08-29)
+
+Two instruments, because "a frame costs 2ms" and "thurbox costs 8% of a core"
+are different claims and neither implies the other. Both live outside the PR
+gate, per ADR-P5.
+
+**`cargo bench --bench frame_cost`** — the pieces of a frame, against the real
+`ui/` and a synthetic snapshot. It models what `draw` does rather than what the
+plugin list contains: it resolves the arrangement and renders only the panes an
+arrangement of that size actually *places*, plus the float probe every frame
+pays. Rendering every loaded plugin instead reported the closed search strip as
+the second most expensive pane in the interface, which it is not — it occupies no
+slot, so `draw_slots` never reaches it.
+
+It reports whole frames (settled, snapshot moved, animation tick), then the
+parts, then per placed pane, then what the caches did. `THURBOX_BENCH_SESSIONS`,
+`THURBOX_BENCH_WIDTH` and `THURBOX_BENCH_HEIGHT` sweep it — a height sweep is
+what separates "the session list costs 435us" from "a visible row costs 9us".
+
+**`scripts/dev/perf-run.sh`** — the whole binary under a reproducible load: real
+tmux panes, a real vt100 grid per session, the real loop, in a fully isolated
+sandbox with `sh` printing on a timer as the agent. It reports CPU from `/proc`
+plus the loop's own `perf_window` line, and keeps the log at
+`target/perf-run.log`. The documented instruction before it was "launch it and
+leave it idle", which measures the one regime nobody complains about.
+
+```sh
+scripts/dev/perf-run.sh                        # 8 sessions, 1 printing, 30s
+scripts/dev/perf-run.sh -n 19 -p 3 -s 255x62   # a working machine's shape
+scripts/dev/perf-run.sh --idle                 # the settled floor
+scripts/dev/perf-run.sh -u 0                   # the control for ADR-P20
+scripts/dev/perf-run.sh --no-perf-log          # is the instrumentation the cost?
+```
+
+Two traps it now handles, both of which report a plausible number rather than
+failing:
+
+- **It must measure its own process.** `pgrep -x thurbox` finds the developer's
+  own running thurbox first, and every configuration then reports that instance:
+  idle or loaded, one session or twenty, all ~17% of a core. The run is
+  identified by its private `XDG_DATA_HOME` in `/proc/<pid>/environ` instead.
+  (`pgrep -f "$BIN_DIR/thurbox"` has the matching problem from the other end —
+  it also matches `thurbox-cli`.)
+- **The TUI starts before the sessions exist.** The v1→v2 consent gate fires for
+  a profile with session history and no acknowledgment, and waits for a keypress;
+  seeding first left the binary sitting on the gate for the whole run, reporting
+  a very restful 0%.
+
+A reading from either is only comparable with another at the same terminal size
+and session count, so both pin theirs.
+
+**And on a busy machine, trust the counters over the CPU.** A percentage from
+`/proc` is a real measurement of a shared machine: taken while something else was
+compiling, the same build measured 5.96% and 7.53% on two runs half an hour
+apart. So take a before and an after **back to back**, in one batch, and read
+them as a pair — every table in the ADRs above was gathered that way, which is
+why they quote a *penalty* (`-u 0` against `-u 12`, `-w 0` against `-w 4`) rather
+than a lone number. `renders_skipped`, `groups_reused` and `frames` in the same
+output are deterministic and do not care what else is running: for the two fixes
+above, cached trees over the same workload went from 154 to 3070 against an
+unchanged frame count, which is the claim that holds however loaded the machine
+was. `uptime` before believing a percentage.
+
+---
+
 ## Investigation 2026-07-09: where the time actually goes
 
 A measurement pass over the render loop, the tick, the draw path, startup, the
@@ -1460,4 +1707,7 @@ worktree/spawn offload should ride with that branch or follow it.
 | See binary size | Check the `Binary Size` CI job summary, or `cargo bloat --release --crates` |
 | Profile CPU | `cargo flamegraph --profile release-with-debug --bin thurbox` |
 | Verify no perf regression | `cargo nextest run -E 'test(kernel::perf)'` for the counters; the loop's settling is asserted per surface in `tests/*.rs` |
-| Confirm idle CPU is low | Launch, leave it idle — `idle skips` climbs while `frames` stays flat |
+| Confirm idle CPU is low | `scripts/dev/perf-run.sh --idle` — or launch and leave it idle, where `idle skips` climbs while `frames` stays flat |
+| Measure CPU under a real load | `scripts/dev/perf-run.sh -n 19 -p 3 -s 255x62` (see **Measuring**, below) |
+| See where the time in a frame goes | `cargo bench --bench frame_cost` |
+| Attribute a change | Run one of the two above before and after — a paired reading at the same size and session count, never two absolute numbers from different days |

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -235,6 +235,11 @@ won't pay off.
 - **Local profiling**: `cargo flamegraph --bin thurbox` (build with the
   `release-with-debug` profile for symbols) for CPU; `cargo bloat --release
   --crates` for size attribution. Neither is a dependency — run them ad hoc.
+- **What a frame costs, and what the binary costs under load**: `just bench`
+  (`benches/frame_cost.rs`, `harness = false`, no benchmarking dependency) and
+  `just perf` (`scripts/dev/perf-run.sh`, which refuses to run inside a
+  validation step). Both are opt-in and local for the reason this ADR gives; see
+  **Measuring: the bench and the load harness**, below.
 
 **Why**: criterion/divan pull a large transitive dependency tree, and
 `cargo deny check licenses` (a **gating** CI job with a strict allowlist) would
@@ -1412,11 +1417,14 @@ does. There is no frame in between on which a stale tree could be served —
 asserted in `kernel_frame_cost::a_pane_that_starts_reading_the_clock_is_keyed_on_it_from_then_on`,
 alongside the two directions and one test against the real bundled interface.
 
-**Consequences**: one visible change to the plugin contract — `elapsed` is not a
-key of `ctx`, so it does not appear in `pairs(ctx)`. Nothing iterates a render
-context, and `docs/PLUGINS.md` now states the rule the mechanism creates: reading
-`ctx.elapsed` is what subscribes a tree to the animation tick, so read it where
-you animate and not at the top of a render that usually draws nothing moving.
+**Consequences**: the render context stops being an ordinary table — `elapsed`
+is served by a metatable rather than being a key, and that metatable is sealed
+so one plugin cannot replace the `__index` behind every other pane's clock.
+Neither is load-bearing for any pane (nothing iterates or re-metatables a render
+context); both are stated for plugin authors in `docs/PLUGINS.md`, which owns
+that contract, along with the rule the mechanism creates: reading `ctx.elapsed`
+is what subscribes a tree to the animation tick, so read it where you animate and
+not at the top of a render that usually draws nothing moving.
 
 ---
 
@@ -1451,6 +1459,7 @@ scripts/dev/perf-run.sh                        # 8 sessions, 1 printing, 30s
 scripts/dev/perf-run.sh -n 19 -p 3 -s 255x62   # a working machine's shape
 scripts/dev/perf-run.sh --idle                 # the settled floor
 scripts/dev/perf-run.sh -u 0                   # the control for ADR-P20
+scripts/dev/perf-run.sh -w 4                   # sessions reporting `working`, for ADR-P21
 scripts/dev/perf-run.sh --no-perf-log          # is the instrumentation the cost?
 ```
 

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -110,6 +110,21 @@ painted from a stale tree, with no error anywhere. Two things disqualify a pane:
   and the session list is pure — because the kernel keys a cached tree on that
   same tick. Anything finer freezes.
 
+**Reading `ctx.elapsed` is what buys you the animation tick, and only that.**
+The clock advances eight times a second for as long as any session is working,
+so it is the most frequent thing a cached tree can be keyed on. The kernel keys
+your tree on it *if the render that built the tree read `ctx.elapsed`*, and
+otherwise serves that tree across the tick — so a pane that draws no spinner
+pays nothing for one, and a pane that draws a spinner keeps it moving. There is
+nothing to declare and nothing to get wrong in either direction: read the clock
+and you are animated, do not and you are still. Read it under a condition (only
+for a `working` row, say) and the render that first reads it is the one that
+re-keys the entry, so there is no frame on which a stale tree is served.
+
+The mechanism is a metatable on the render context, which has one visible
+consequence: `elapsed` is not a *key* of `ctx`, so it does not appear in
+`pairs(ctx)`. Every other field is an ordinary one. Ask `ctx` for facts by name.
+
 Reading `store`/`state` is fine, and so is `command(...)` from a handler. If you
 are unsure, leave it undeclared: a pane that says nothing behaves exactly as it
 always has, and the only cost is that it is no faster.
@@ -215,7 +230,10 @@ levers, in the order they pay:
    O(width²); accumulate and `table.concat`, or emit `string.rep` runs.
 6. **Animate off the shared clock only** — `theme.spinner_frame(ctx.elapsed)`
    follows the kernel's animation tick, which advances only while something is
-   animating. A hand-rolled timer re-renders forever and defeats `pure`.
+   animating. A hand-rolled timer re-renders forever and defeats `pure`. And
+   read `ctx.elapsed` only where you actually animate: reading it is what
+   subscribes your tree to the tick, so hoisting it to the top of a render that
+   usually draws nothing moving costs you the cache eight times a second.
 
 `F12` (the perf HUD) is the check: `renders` climbing on an untouched screen
 means a pane is not settling. The bundled panes are worked examples — the

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -121,9 +121,12 @@ and you are animated, do not and you are still. Read it under a condition (only
 for a `working` row, say) and the render that first reads it is the one that
 re-keys the entry, so there is no frame on which a stale tree is served.
 
-The mechanism is a metatable on the render context, which has one visible
-consequence: `elapsed` is not a *key* of `ctx`, so it does not appear in
-`pairs(ctx)`. Every other field is an ordinary one. Ask `ctx` for facts by name.
+The mechanism is a metatable on the render context, which has two visible
+consequences: `elapsed` is not a *key* of `ctx`, so it does not appear in
+`pairs(ctx)`; and that metatable is sealed — `getmetatable(ctx)` is `false` and
+`setmetatable(ctx, …)` raises, because one table is shared by every render and a
+plugin replacing it would stop every other pane's clock. Every other field is an
+ordinary one. Ask `ctx` for facts by name.
 
 Reading `store`/`state` is fine, and so is `command(...)` from a handler. If you
 are unsure, leave it undeclared: a pane that says nothing behaves exactly as it

--- a/extensions/ui-skill/SKILL.md
+++ b/extensions/ui-skill/SKILL.md
@@ -191,10 +191,13 @@ that can make the whole interface feel slow.
 - **Strings: concatenate through a table.** `s = s .. piece` in a loop over a
   wide row is O(width²); accumulate into a table and `table.concat`, or emit
   `string.rep` runs.
-- **Animation is not free-running.** `ctx.elapsed` plus the shared spinner
-  helper in `lib/` follows the kernel's animation clock, which only ticks
-  while something is actually animating — a pane that derives its own timer
-  from elapsed on every frame re-renders forever and defeats its own `pure`.
+- **Animation is not free-running, and reading the clock is what buys it.**
+  `ctx.elapsed` plus the shared spinner helper in `lib/` follows the kernel's
+  animation clock, which only ticks while something is actually animating — a
+  pane that derives its own timer from elapsed on every frame re-renders forever
+  and defeats its own `pure`. Reading `ctx.elapsed` is also what keys your
+  cached tree on that tick, so read it where you animate and not at the top of a
+  render that usually draws nothing moving.
 
 `F12` opens the perf HUD: `renders` climbing while you touch nothing means a
 pane is not settling — usually an impure render or a per-frame `store` write of

--- a/justfile
+++ b/justfile
@@ -107,6 +107,16 @@ sandbox-clean PROFILE="default":
 smoke:
     cargo nextest run --test tui_e2e
 
+# Sweep with THURBOX_BENCH_SESSIONS / _WIDTH / _HEIGHT.
+# What a frame costs, piece by piece, against the real interface.
+bench:
+    cargo bench --bench frame_cost
+
+# Pass -s and -n explicitly: a reading only compares with one at the same size.
+# What the whole binary costs under load: `just perf --idle`, `-n 19 -p 3 -s 255x62`, `-u 0`.
+perf *ARGS:
+    scripts/dev/perf-run.sh {{ARGS}}
+
 # Drive tests against a real SSH host: `just lab <host> <verb>`.
 lab HOST *ARGS:
     scripts/dev/e2e/real-host.sh {{HOST}} {{ARGS}}

--- a/scripts/dev/README.md
+++ b/scripts/dev/README.md
@@ -39,6 +39,30 @@ ordinary `cargo nextest run --all` — `just smoke` runs only it — and replace
 `smoke/tui-smoke.sh`, which drove a tmux pane and could see neither the bytes
 nor a session's own terminal.
 
+## Performance
+
+`perf-run.sh` runs the **real binary under a reproducible load** — real tmux
+panes, a real vt100 grid per session, the real render loop — in the same
+isolated sandbox as everything else, with `sh` printing on a timer as the agent
+so the measurement is of thurbox rather than of whichever coding CLI is
+installed. It reports CPU from `/proc` plus the loop's own `perf_window` line,
+and keeps the full log at `target/perf-run.log`.
+
+```bash
+scripts/dev/perf-run.sh                        # 8 sessions, 1 printing, 30s
+scripts/dev/perf-run.sh -n 19 -p 3 -s 255x62   # a working machine's shape
+scripts/dev/perf-run.sh --idle                 # the settled floor
+scripts/dev/perf-run.sh -u 0                   # no URLs in the output (ADR-P20)
+scripts/dev/perf-run.sh -w 4                   # 4 sessions `working`: the spinner clock runs
+scripts/dev/perf-run.sh -w 4                   # 4 sessions `working`, so the spinner clock runs
+scripts/dev/perf-run.sh --no-perf-log --json   # CPU alone, machine-readable
+```
+
+A reading is only comparable with another at the same size and session count,
+so pass `-s` and `-n` explicitly when recording one. Its companion is
+`cargo bench --bench frame_cost`, which measures the *pieces* of a frame rather
+than the whole binary; both are explained in `docs/PERFORMANCE.md`.
+
 ## Dev utilities (not tests)
 
 | Script | What it does |

--- a/scripts/dev/README.md
+++ b/scripts/dev/README.md
@@ -58,7 +58,11 @@ scripts/dev/perf-run.sh --no-perf-log --json   # CPU alone, machine-readable
 ```
 
 A reading is only comparable with another at the same size and session count,
-so pass `-s` and `-n` explicitly when recording one. Its companion is
+so pass `-s` and `-n` explicitly when recording one. It **refuses to run inside
+a no-mistakes validation step** (`NO_MISTAKES_GATE`): it looks enough like a test
+to be picked up as one, and a step that waits through a release build and timed
+runs fails on the agent timeout — for a number a loaded machine cannot produce
+honestly anyway. Override with `THURBOX_PERF_ALLOW_IN_GATE=1` if you mean it. Its companion is
 `cargo bench --bench frame_cost`, which measures the *pieces* of a frame rather
 than the whole binary; both are explained in `docs/PERFORMANCE.md`.
 

--- a/scripts/dev/README.md
+++ b/scripts/dev/README.md
@@ -53,7 +53,6 @@ scripts/dev/perf-run.sh                        # 8 sessions, 1 printing, 30s
 scripts/dev/perf-run.sh -n 19 -p 3 -s 255x62   # a working machine's shape
 scripts/dev/perf-run.sh --idle                 # the settled floor
 scripts/dev/perf-run.sh -u 0                   # no URLs in the output (ADR-P20)
-scripts/dev/perf-run.sh -w 4                   # 4 sessions `working`: the spinner clock runs
 scripts/dev/perf-run.sh -w 4                   # 4 sessions `working`, so the spinner clock runs
 scripts/dev/perf-run.sh --no-perf-log --json   # CPU alone, machine-readable
 ```

--- a/scripts/dev/perf-run.sh
+++ b/scripts/dev/perf-run.sh
@@ -332,8 +332,9 @@ tmux -L "$TBX_DEV_SOCKET" kill-session -t perf-harness >/dev/null 2>&1 || true
 field() { echo "$WINDOW" | grep -o "$1=[0-9]*" | head -1 | cut -d= -f2; }
 
 if [ "$JSON" = "1" ]; then
-    printf '{"sessions":%s,"printing":%s,"size":"%sx%s","seconds":%s,' \
-        "$SESSIONS" "$PRINTING" "$COLS" "$ROWS" "$DURATION"
+    printf '{"sessions":%s,"printing":%s,"working":%s,"rate":%s,"url_every":%s,' \
+        "$SESSIONS" "$PRINTING" "$WORKING" "$RATE" "$URL_EVERY"
+    printf '"size":"%sx%s","seconds":%s,' "$COLS" "$ROWS" "$DURATION"
     printf '"cpu_render_thread_pct":%s,"cpu_all_threads_pct":%s,' \
         "$main_pct" "$all_pct"
     printf '"frame_p50_us":%s,"frame_p95_us":%s,"republish_p50_us":%s,"tick_p50_us":%s,' \

--- a/scripts/dev/perf-run.sh
+++ b/scripts/dev/perf-run.sh
@@ -59,7 +59,19 @@ URL_EVERY=12
 # cache key -- so every pane re-renders at that rate for a spinner glyph. `sh`
 # runs no status hook, so without this the harness measures that cost as zero
 # while a real profile pays it nearly all the time.
+#
+# A `working` session must also PRINT, or the harness measures zero anyway by a
+# second route: `snapshot::with_output_quiescence` folds a `working` session with
+# no terminal output for WORKING_QUIET_MS (10s) back to idle, so a silent one
+# would decay a couple of seconds into the measurement window and the animation
+# clock would stop with it. Real agents animate a progress line for exactly this
+# reason, so a working session here runs the `ticking` agent below rather than
+# the silent one -- the cheapest output that keeps the state alive.
 WORKING=0
+# Seconds between a `ticking` agent's progress lines. Well under the 10s
+# quiescence bound and well over the printing agents' rate, so a working session
+# costs the animation clock and almost no output.
+WORKING_TICK=4
 
 usage() {
     cat >&2 <<'EOF'
@@ -70,7 +82,8 @@ usage: perf-run.sh [options]
   -s COLSxROWS  terminal size (default 200x50)
   -r N        lines per second each printing agent emits (default 30)
   -u N        a URL every N printed lines (default 12; 0 = never)
-  -w N        mark N sessions `working`, so the animation clock runs (default 0)
+  -w N        mark N sessions `working`, so the animation clock runs (default 0);
+              a non-printing one animates a progress line, as a real agent does
   --idle      nothing prints — measures the settled floor
   --debug     measure the dev profile instead of release
   --no-perf-log  run without THURBOX_PERF_LOG (CPU only, no percentiles) --
@@ -148,7 +161,19 @@ cat > "$AGENT_DIR/quiet" <<'EOF'
 # A session that exists, is attached, and says nothing.
 while :; do sleep 3600; done
 EOF
-chmod +x "$AGENT_DIR/noisy" "$AGENT_DIR/quiet"
+cat > "$AGENT_DIR/ticking" <<EOF
+#!/bin/sh
+# A session that reports itself \`working\` and animates a progress line, which
+# is what every real agent does while a turn runs -- and what keeps thurbox's
+# output-quiescence fallback from folding the state back to idle.
+n=0
+while :; do
+    n=\$((n + 1))
+    printf '  (%ds - esc to interrupt)\n' "\$n"
+    sleep $WORKING_TICK
+done
+EOF
+chmod +x "$AGENT_DIR/noisy" "$AGENT_DIR/quiet" "$AGENT_DIR/ticking"
 
 mkdir -p "$XDG_CONFIG_HOME/thurbox-dev"
 cat > "$XDG_CONFIG_HOME/thurbox-dev/agents.toml" <<EOF
@@ -161,6 +186,10 @@ command = "$AGENT_DIR/quiet"
 [[agents]]
 name = "noisy"
 command = "$AGENT_DIR/noisy"
+
+[[agents]]
+name = "ticking"
+command = "$AGENT_DIR/ticking"
 EOF
 
 # A repository for the sessions to live in. Bare and local: worktree creation is
@@ -220,27 +249,37 @@ if [ -z "$PID" ]; then
     exit 1
 fi
 
-say "creating $SESSIONS sessions ($PRINTING printing)…"
+# The first $PRINTING print; of the rest, the ones that must report `working`
+# get the ticking agent so their state survives the quiescence fallback.
+say "creating $SESSIONS sessions ($PRINTING printing, $WORKING working)…"
+WORKING_IDS=""
 for i in $(seq 1 "$SESSIONS"); do
-    agent=quiet
-    [ "$i" -le "$PRINTING" ] && agent=noisy
-    thurbox-cli session create \
+    if [ "$i" -le "$PRINTING" ]; then
+        agent=noisy
+    elif [ "$i" -le "$WORKING" ]; then
+        agent=ticking
+    else
+        agent=quiet
+    fi
+    created="$(thurbox-cli session create \
         --name "perf-session-$i" \
         --repo-path "$REPO" \
-        --agent "$agent" >/dev/null
+        --agent "$agent" --json)"
+    if [ "$i" -le "$WORKING" ]; then
+        # Which session, not which row of a list: `session list` orders by
+        # display order, so taking its head marks whichever sessions happen to
+        # sort first rather than the ones given a printing agent above.
+        id="$(echo "$created" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)"
+        WORKING_IDS="$WORKING_IDS $id"
+    fi
 done
 
 # A status hook's write, without a hook. `session signal` takes its identity
 # from the injected `THURBOX_SESSION`, so setting it here is exactly what an
-# agent's own hook does from inside its pane.
-if [ "$WORKING" -gt 0 ]; then
-    say "marking $WORKING sessions working…"
-    thurbox-cli session list --json |
-        tr ',' '\n' | grep -o '"id":"[^"]*"' | cut -d'"' -f4 | head -n "$WORKING" |
-        while read -r id; do
-            THURBOX_SESSION="$id" thurbox-cli session signal --state working >/dev/null
-        done
-fi
+# agent's own hook does from inside its pane. The agents above keep it there.
+for id in $WORKING_IDS; do
+    THURBOX_SESSION="$id" thurbox-cli session signal --state working >/dev/null
+done
 
 # Settle: adopting a pane, taking the first snapshot and painting the first
 # frame are startup, not steady state. Measuring across them would report the

--- a/scripts/dev/perf-run.sh
+++ b/scripts/dev/perf-run.sh
@@ -113,6 +113,43 @@ done
 
 say() { [ "$JSON" = "1" ] || echo "$@" >&2; }
 
+# --- not inside a validation step -------------------------------------------
+#
+# This script builds a release binary, spawns a tmux server and N agents, and
+# then deliberately sits still for -d seconds. That is the right shape for a
+# measurement and the wrong shape for anything a gate runs: it looks like a test
+# -- it is under scripts/dev/, it drives the real binary, it prints a result --
+# so an agent asked to run the tests and gather evidence reaches for it, waits
+# for it, and burns the step's whole budget. Not hypothetical: it timed out a
+# no-mistakes test step at 30m0s with the agent silent, having decided the
+# intent's paired before/after reading was the evidence to gather.
+#
+# So it refuses, and says how to get the number instead. A benchmark that also
+# generates load has no business running unattended inside a validation step --
+# the reading would be meaningless there anyway, since the gate's own build is
+# what the machine is busy doing.
+if [ -n "${NO_MISTAKES_GATE:-}" ] && [ -z "${THURBOX_PERF_ALLOW_IN_GATE:-}" ]; then
+    cat >&2 <<'REFUSE'
+perf-run.sh: refusing to run inside a validation step.
+
+This is a benchmark, not a test: it builds a release binary, runs agents for
+tens of seconds and measures CPU. Its reading is only meaningful on a quiet
+machine, and a gate is the opposite of one.
+
+Nothing here needs it to pass. The deterministic coverage is ordinary tests --
+`cargo nextest run --all` -- and the perf claims are asserted on counters and
+change-signals in tests/kernel_frame_cost.rs and tests/kernel_perf.rs, never on
+a clock (docs/PERFORMANCE.md, ADR-P5).
+
+To take a reading by hand, on a machine you are not otherwise using:
+    just perf -n 19 -p 3 -s 255x62
+    just perf -n 19 -p 3 -s 255x62 -u 0     # the paired control
+
+Set THURBOX_PERF_ALLOW_IN_GATE=1 to override this, if you really mean to.
+REFUSE
+    exit 2
+fi
+
 # --- build ------------------------------------------------------------------
 #
 # Release by default. A dev build runs the interpreter at opt-level 1 and its

--- a/scripts/dev/perf-run.sh
+++ b/scripts/dev/perf-run.sh
@@ -1,0 +1,325 @@
+#!/usr/bin/env bash
+#
+# Run the real thurbox under a reproducible load and report what it cost.
+#
+# `benches/frame_cost.rs` measures the pieces of a frame in isolation; this runs
+# the whole binary — real tmux panes, a real vt100 grid per session, the real
+# render loop — and reports the two numbers a user actually feels: **CPU while
+# an agent prints**, and the frame/republish/tick percentiles the loop logged.
+#
+# The docs' only steady-state instruction was "launch it and leave it idle",
+# which measures the one regime nobody complains about. This is the other one.
+#
+#   scripts/dev/perf-run.sh                    # 8 sessions, 1 printing, 30s
+#   scripts/dev/perf-run.sh -n 20 -d 60        # 20 sessions, 60s
+#   scripts/dev/perf-run.sh -n 20 -p 3         # 3 of them printing
+#   scripts/dev/perf-run.sh --idle             # nothing printing, for the floor
+#   scripts/dev/perf-run.sh --json             # one machine-readable line
+#
+# Fully isolated: a private HOME, XDG root and TMUX_TMPDIR (so the cleanup
+# `kill-server` can never reach a real server), the sandbox helper every other
+# dev script uses. The agent is `sh` printing on a timer, so the measurement is
+# of thurbox and not of whichever coding CLI happened to be installed.
+#
+# thurbox needs a terminal, and it must be a terminal of a KNOWN SIZE — a frame
+# costs what its cells cost, so a run at whatever the invoking window happens to
+# be is not comparable with the last one. So it runs inside an outer tmux
+# session created at an exact size, on the same private socket.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=scripts/dev/lib/sandbox-env.sh
+# shellcheck disable=SC1091
+. "$REPO_ROOT/scripts/dev/lib/sandbox-env.sh"
+
+SESSIONS=8
+PRINTING=1
+DURATION=30
+COLS=200
+ROWS=50
+JSON=0
+# Whether the run carries THURBOX_PERF_LOG. On, the loop keeps histograms and
+# republishes a JSON snapshot to SQLite every few seconds -- which is itself
+# work, and work a default run does not do. CPU here is measured from
+# /proc, so the log can be turned off and the headline number still stands;
+# only the percentile lines go away.
+PERF_LOG=1
+PROFILE=release
+# Lines a printing agent emits per second. 30 is ADR-P17's workload, so a number
+# from this script is comparable with the table in that ADR.
+RATE=30
+# One URL every N printed lines (0 = none). A knob because the link scan is
+# keyed on the surface's output stamp and re-runs per painted frame while output
+# arrives -- so "what do links cost while an agent prints" is a question the
+# harness should be able to answer, not one to reason about.
+URL_EVERY=12
+# How many sessions report themselves `working`. The animation clock advances
+# eight times a second while any session does, and it is part of the pure-pane
+# cache key -- so every pane re-renders at that rate for a spinner glyph. `sh`
+# runs no status hook, so without this the harness measures that cost as zero
+# while a real profile pays it nearly all the time.
+WORKING=0
+
+usage() {
+    cat >&2 <<'EOF'
+usage: perf-run.sh [options]
+  -n N        sessions to create (default 8)
+  -p N        how many of them print (default 1; --idle sets 0)
+  -d SECS     how long to measure (default 30)
+  -s COLSxROWS  terminal size (default 200x50)
+  -r N        lines per second each printing agent emits (default 30)
+  -u N        a URL every N printed lines (default 12; 0 = never)
+  -w N        mark N sessions `working`, so the animation clock runs (default 0)
+  --idle      nothing prints — measures the settled floor
+  --debug     measure the dev profile instead of release
+  --no-perf-log  run without THURBOX_PERF_LOG (CPU only, no percentiles) --
+                 the control for "is the instrumentation the cost?"
+  --json      one machine-readable line instead of the report
+EOF
+    exit 2
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -n) SESSIONS="$2"; shift 2 ;;
+        -p) PRINTING="$2"; shift 2 ;;
+        -d) DURATION="$2"; shift 2 ;;
+        -r) RATE="$2"; shift 2 ;;
+        -u) URL_EVERY="$2"; shift 2 ;;
+        -w) WORKING="$2"; shift 2 ;;
+        -s) COLS="${2%x*}"; ROWS="${2#*x}"; shift 2 ;;
+        --idle) PRINTING=0; shift ;;
+        --debug) PROFILE=dev; shift ;;
+        --no-perf-log) PERF_LOG=0; shift ;;
+        --json) JSON=1; shift ;;
+        -h|--help) usage ;;
+        *) echo "perf-run.sh: unknown option '$1'" >&2; usage ;;
+    esac
+done
+
+say() { [ "$JSON" = "1" ] || echo "$@" >&2; }
+
+# --- build ------------------------------------------------------------------
+#
+# Release by default. A dev build runs the interpreter at opt-level 1 and its
+# numbers are not the ones a user sees; `--debug` is for attributing a change
+# quickly, never for a figure worth writing down.
+
+if [ "$PROFILE" = release ]; then
+    BIN_DIR="$REPO_ROOT/target/release"
+    say "building (release)…"
+    cargo build --release --bin thurbox --bin thurbox-cli >/dev/null 2>&1
+else
+    BIN_DIR="$REPO_ROOT/target/debug"
+    say "building (dev)…"
+    cargo build --bin thurbox --bin thurbox-cli >/dev/null 2>&1
+fi
+
+# --- an isolated world ------------------------------------------------------
+
+tbx_sandbox_init_full fresh
+# The helper puts target/debug first for the agent-hook case; this measures a
+# chosen profile, so the chosen one wins.
+PATH="$BIN_DIR:$PATH"
+export PATH
+trap 'tbx_sandbox_teardown' EXIT
+
+# The agent. `sh` rather than a coding CLI: this measures thurbox's cost of
+# *carrying* output, and a real agent would add its own — plus its rate would be
+# whatever the model felt like, which is not a controlled variable.
+AGENT_DIR="$TBX_SANDBOX_ROOT/agent"
+mkdir -p "$AGENT_DIR"
+cat > "$AGENT_DIR/noisy" <<EOF
+#!/bin/sh
+# One printing agent: \$RATE lines a second of plausible agent output, forever.
+n=0
+while :; do
+    n=\$((n + 1))
+    printf '  %4d | rewrote src/kernel/host/publish.rs and re-ran the suite\n' "\$n"
+    if [ $URL_EVERY -gt 0 ] && [ \$((n % $URL_EVERY)) -eq 0 ]; then
+        printf '  see https://github.com/Thurbeen/thurbox/pull/%d for the rest\n' "\$n"
+    fi
+    sleep $(awk "BEGIN { printf \"%.4f\", 1 / $RATE }")
+done
+EOF
+cat > "$AGENT_DIR/quiet" <<'EOF'
+#!/bin/sh
+# A session that exists, is attached, and says nothing.
+while :; do sleep 3600; done
+EOF
+chmod +x "$AGENT_DIR/noisy" "$AGENT_DIR/quiet"
+
+mkdir -p "$XDG_CONFIG_HOME/thurbox-dev"
+cat > "$XDG_CONFIG_HOME/thurbox-dev/agents.toml" <<EOF
+default = "quiet"
+
+[[agents]]
+name = "quiet"
+command = "$AGENT_DIR/quiet"
+
+[[agents]]
+name = "noisy"
+command = "$AGENT_DIR/noisy"
+EOF
+
+# A repository for the sessions to live in. Bare and local: worktree creation is
+# a startup cost, not a steady-state one, and a real repo would make each run
+# depend on whatever is checked out.
+REPO="$TBX_SANDBOX_ROOT/repo"
+mkdir -p "$REPO"
+git -C "$REPO" init -q
+git -C "$REPO" -c user.email=perf@example.com -c user.name=perf commit -q \
+    --allow-empty -m "root"
+
+# --- run it -----------------------------------------------------------------
+#
+# In an outer tmux window of an exact size: a frame costs what its cells cost,
+# so a run at whatever the invoking window happens to be is not comparable with
+# the last one.
+#
+# The TUI starts on the EMPTY database, before any session exists. The v1->v2
+# consent gate fires for a profile with session history and no acknowledgment,
+# and it waits for a keypress -- so seeding first left the binary sitting on the
+# gate for the whole run, reporting a very restful 0% of a core. Sessions are
+# created underneath it instead and adopted through the ordinary `data_version`
+# poll, which is also closer to what a real profile does.
+
+LOG_DIR="$XDG_DATA_HOME/thurbox-dev"
+say "starting thurbox at ${COLS}x${ROWS}…"
+LAUNCH="'$BIN_DIR/thurbox'"
+[ "$PERF_LOG" = "1" ] && LAUNCH="THURBOX_PERF_LOG=1 $LAUNCH"
+tmux -L "$TBX_DEV_SOCKET" new-session -d -s perf-harness -x "$COLS" -y "$ROWS" \
+    "$LAUNCH"
+sleep 3
+
+# THE process, not A process. Two traps here, and both report a number that
+# looks entirely plausible:
+#
+#   * `pgrep -f "$BIN_DIR/thurbox"` also matches `$BIN_DIR/thurbox-cli`, whose
+#     path has it as a prefix;
+#   * `pgrep -x thurbox` matches the developer's OWN running thurbox, which on
+#     this machine is the likeliest process of that name. Every measurement then
+#     reports their real instance's CPU -- the same ~17% for an idle harness, a
+#     printing one, one session or twenty, because the harness was never the
+#     thing being measured.
+#
+# So the sandbox is what identifies it: only this run's thurbox has this run's
+# private XDG_DATA_HOME in its environment.
+PID=""
+for candidate in $(pgrep -x thurbox 2>/dev/null || true); do
+    if tr '\0' '\n' < "/proc/$candidate/environ" 2>/dev/null |
+        grep -qxF "XDG_DATA_HOME=$XDG_DATA_HOME"; then
+        PID="$candidate"
+        break
+    fi
+done
+if [ -z "$PID" ]; then
+    echo "perf-run.sh: thurbox did not start. Last log lines:" >&2
+    tail -20 "$LOG_DIR"/thurbox.log* 2>/dev/null >&2 || true
+    exit 1
+fi
+
+say "creating $SESSIONS sessions ($PRINTING printing)…"
+for i in $(seq 1 "$SESSIONS"); do
+    agent=quiet
+    [ "$i" -le "$PRINTING" ] && agent=noisy
+    thurbox-cli session create \
+        --name "perf-session-$i" \
+        --repo-path "$REPO" \
+        --agent "$agent" >/dev/null
+done
+
+# A status hook's write, without a hook. `session signal` takes its identity
+# from the injected `THURBOX_SESSION`, so setting it here is exactly what an
+# agent's own hook does from inside its pane.
+if [ "$WORKING" -gt 0 ]; then
+    say "marking $WORKING sessions working…"
+    thurbox-cli session list --json |
+        tr ',' '\n' | grep -o '"id":"[^"]*"' | cut -d'"' -f4 | head -n "$WORKING" |
+        while read -r id; do
+            THURBOX_SESSION="$id" thurbox-cli session signal --state working >/dev/null
+        done
+fi
+
+# Settle: adopting a pane, taking the first snapshot and painting the first
+# frame are startup, not steady state. Measuring across them would report the
+# startup once as if it happened every second.
+sleep 8
+if ! kill -0 "$PID" 2>/dev/null; then
+    echo "perf-run.sh: thurbox exited during the settle. Last log lines:" >&2
+    tail -20 "$LOG_DIR"/thurbox.log* 2>/dev/null >&2 || true
+    exit 1
+fi
+
+jiffies() { awk '{print $14 + $15}' "/proc/$1/stat" 2>/dev/null || echo 0; }
+# Every thread, so a cost moved onto a worker is still counted. Moving work off
+# the render thread is the right fix for a stall and does nothing for a laptop
+# battery, and only the total tells the two apart.
+tree_jiffies() {
+    total=0
+    for t in "/proc/$1/task"/*; do
+        [ -r "$t/stat" ] || continue
+        total=$((total + $(awk '{print $14 + $15}' "$t/stat")))
+    done
+    echo "$total"
+}
+
+BEFORE_MAIN="$(jiffies "$PID")"
+BEFORE_ALL="$(tree_jiffies "$PID")"
+sleep "$DURATION"
+AFTER_MAIN="$(jiffies "$PID")"
+AFTER_ALL="$(tree_jiffies "$PID")"
+
+HZ="$(getconf CLK_TCK)"
+main_pct="$(awk "BEGIN { printf \"%.2f\", ($AFTER_MAIN - $BEFORE_MAIN) * 100 / $HZ / $DURATION }")"
+all_pct="$(awk "BEGIN { printf \"%.2f\", ($AFTER_ALL - $BEFORE_ALL) * 100 / $HZ / $DURATION }")"
+
+# The loop's own view, from the last window it logged. `perf_window` is emitted
+# every PERF_WINDOW_TICKS iterations, so the last complete one is the steady
+# state; earlier ones can still contain the startup.
+WINDOW="$(grep -h perf_window "$LOG_DIR"/thurbox.log* 2>/dev/null | tail -1 || true)"
+SNAPSHOT="$(thurbox-cli perf 2>/dev/null || true)"
+
+# The sandbox is `fresh`, so teardown takes the log with it. Copy it out first:
+# a `perf_window` line is a summary, and the question after reading one is always
+# "what else did it say" -- a slow op, a warning, a panic on a reader thread.
+KEPT_LOG="$REPO_ROOT/target/perf-run.log"
+mkdir -p "$REPO_ROOT/target"
+cat "$LOG_DIR"/thurbox.log* > "$KEPT_LOG" 2>/dev/null || true
+
+tmux -L "$TBX_DEV_SOCKET" kill-session -t perf-harness >/dev/null 2>&1 || true
+
+field() { echo "$WINDOW" | grep -o "$1=[0-9]*" | head -1 | cut -d= -f2; }
+
+if [ "$JSON" = "1" ]; then
+    printf '{"sessions":%s,"printing":%s,"size":"%sx%s","seconds":%s,' \
+        "$SESSIONS" "$PRINTING" "$COLS" "$ROWS" "$DURATION"
+    printf '"cpu_render_thread_pct":%s,"cpu_all_threads_pct":%s,' \
+        "$main_pct" "$all_pct"
+    printf '"frame_p50_us":%s,"frame_p95_us":%s,"republish_p50_us":%s,"tick_p50_us":%s,' \
+        "$(field frame_p50_us || echo 0)" "$(field frame_p95_us || echo 0)" \
+        "$(field republish_p50_us || echo 0)" "$(field tick_p50_us || echo 0)"
+    printf '"frames":%s,"iterations":%s}\n' \
+        "$(field frames || echo 0)" "$(field iterations || echo 0)"
+    exit 0
+fi
+
+cat <<EOF
+
+thurbox under load — $SESSIONS sessions, $PRINTING printing at ${RATE}/s (url every ${URL_EVERY}, ${WORKING} working), ${COLS}x${ROWS}, ${DURATION}s
+
+  CPU, render thread    ${main_pct}% of a core
+  CPU, whole process    ${all_pct}% of a core
+
+EOF
+if [ -n "$WINDOW" ]; then
+    echo "  last perf_window:"
+    echo "    ${WINDOW}"
+else
+    echo "  (no perf_window line — the run was too short to fill one)"
+fi
+[ -n "$SNAPSHOT" ] && { echo; echo "  perf snapshot:"; echo "    $SNAPSHOT"; }
+echo
+echo "  full log kept at target/perf-run.log"
+echo

--- a/scripts/dev/perf-run.sh
+++ b/scripts/dev/perf-run.sh
@@ -366,7 +366,13 @@ cat "$LOG_DIR"/thurbox.log* > "$KEPT_LOG" 2>/dev/null || true
 
 tmux -L "$TBX_DEV_SOCKET" kill-session -t perf-harness >/dev/null 2>&1 || true
 
-field() { echo "$WINDOW" | grep -o "$1=[0-9]*" | head -1 | cut -d= -f2; }
+# A missing field must read 0, not the empty string: the pipeline's exit status
+# is `cut`'s, which succeeds on no input, so a caller-side `|| echo 0` never
+# fires and the JSON line comes out syntactically invalid.
+field() {
+    value="$(echo "$WINDOW" | grep -o "$1=[0-9]*" | head -1 | cut -d= -f2)"
+    echo "${value:-0}"
+}
 
 if [ "$JSON" = "1" ]; then
     printf '{"sessions":%s,"printing":%s,"working":%s,"rate":%s,"url_every":%s,' \
@@ -375,10 +381,10 @@ if [ "$JSON" = "1" ]; then
     printf '"cpu_render_thread_pct":%s,"cpu_all_threads_pct":%s,' \
         "$main_pct" "$all_pct"
     printf '"frame_p50_us":%s,"frame_p95_us":%s,"republish_p50_us":%s,"tick_p50_us":%s,' \
-        "$(field frame_p50_us || echo 0)" "$(field frame_p95_us || echo 0)" \
-        "$(field republish_p50_us || echo 0)" "$(field tick_p50_us || echo 0)"
+        "$(field frame_p50_us)" "$(field frame_p95_us)" \
+        "$(field republish_p50_us)" "$(field tick_p50_us)"
     printf '"frames":%s,"iterations":%s}\n' \
-        "$(field frames || echo 0)" "$(field iterations || echo 0)"
+        "$(field frames)" "$(field iterations)"
     exit 0
 fi
 

--- a/src/coordinator/boot.rs
+++ b/src/coordinator/boot.rs
@@ -220,6 +220,7 @@ pub(crate) async fn run() -> Result<(), Box<dyn Error>> {
         errors: Vec::new(),
         links: std::collections::HashMap::new(),
         link_stamps: std::collections::HashMap::new(),
+        link_scans: std::collections::HashMap::new(),
         content: std::collections::HashMap::new(),
         content_generation: None,
         trust: std::collections::HashMap::new(),

--- a/src/coordinator/publish.rs
+++ b/src/coordinator/publish.rs
@@ -125,14 +125,23 @@ impl App {
         self.trust_stale = true;
     }
 
-    /// Rescan for the links on each session's screen, where that screen moved.
+    /// Rescan for the links on each session's screen, where that screen moved
+    /// — and no more often than [`LINK_SCAN_INTERVAL`] while it keeps moving.
     ///
     /// Part of publishing rather than a standing cost of the loop, because the
     /// answer is only ever read by a plugin — and gated on the session's
     /// `output_stamp`, because finding them walks every cell of its grid building
     /// a `String` per row. Ungated, a held-down key rescanned every terminal on
     /// screen per repeat for answers that could not have changed.
+    ///
+    /// The stamp alone is exact for a screen that has *stopped* and no gate at
+    /// all for one that has not, which is the case that matters: a printing
+    /// agent moves it every frame, and a scrolling screen puts its URLs on new
+    /// rows each time, so the compare below found a change every frame and moved
+    /// the data epoch — undoing ADR-P16's gating wholesale for anyone whose
+    /// agent prints a URL. Hence the second gate, an age (ADR-P13).
     pub(crate) fn refresh_links(&mut self, sessions: &[String]) {
+        let now = Instant::now();
         for id in sessions {
             // Only surfaces that are ON SCREEN. Extracting links walks the whole
             // vt100 grid and URL-scans every row, and doing that for every
@@ -146,6 +155,7 @@ impl App {
             // on the following frame rather than this one.
             if self.terminals.last_rect(id).is_none() {
                 self.link_stamps.remove(id);
+                self.link_scans.remove(id);
                 if self.links.remove(id).is_some() {
                     self.note_published_change();
                 }
@@ -154,8 +164,14 @@ impl App {
             match self.terminals.output_stamp(id) {
                 // Unchanged since the last scan: the answer stands.
                 Some(stamp) if self.link_stamps.get(id) == Some(&stamp) => {}
+                // Moved, but scanned too recently to ask again. The stamp is
+                // deliberately NOT recorded here, so the next publish after the
+                // interval does the scan — a screen that has settled converges
+                // on the branch above and costs nothing again.
+                Some(_) if !link_scan_due(self.link_scans.get(id).copied(), now) => {}
                 Some(stamp) => {
                     self.link_stamps.insert(id.clone(), stamp);
+                    self.link_scans.insert(id.clone(), now);
                     let found = self.terminals.links(id);
                     // Absent rather than empty when there are none, which is the
                     // shape a plugin reads: `thurbox.links[id]` is nil for a
@@ -180,6 +196,7 @@ impl App {
                 // No live pane, so no screen and no links.
                 None => {
                     self.link_stamps.remove(id);
+                    self.link_scans.remove(id);
                     self.links.remove(id);
                 }
             }
@@ -188,6 +205,7 @@ impl App {
         let known: std::collections::HashSet<&str> = sessions.iter().map(String::as_str).collect();
         self.links.retain(|id, _| known.contains(id.as_str()));
         self.link_stamps.retain(|id, _| known.contains(id.as_str()));
+        self.link_scans.retain(|id, _| known.contains(id.as_str()));
     }
 
     /// Read what each terminal is showing, while something is searching them.
@@ -323,5 +341,74 @@ impl App {
         // Trust is read against the plugin set that just loaded, so a reload —
         // including the one a trust change triggers — lands both together.
         self.publish_trust();
+    }
+}
+
+/// Whether a surface whose screen has moved is due another link scan.
+///
+/// The output stamp answers "could the answer have changed"; this answers "is it
+/// worth asking again yet". Split out as a function because the failure it
+/// guards is invisible from any frame: without it a printing agent rescanned its
+/// whole grid per frame and published a *changed* answer each time — the URLs
+/// sit on new rows as the screen scrolls — which moved the data epoch and so
+/// rebuilt every published group and dropped every pure pane's cached tree,
+/// undoing ADR-P16's gating for anyone whose agent prints a URL. Nothing about
+/// the rendered frame looks wrong while that happens; only the CPU does.
+///
+/// `map_or(true, ..)` rather than `is_none_or`: the latter is stable since 1.82
+/// and this crate's MSRV is 1.75.
+fn link_scan_due(last_scan: Option<Instant>, now: Instant) -> bool {
+    last_scan.map_or(true, |at| now.duration_since(at) >= LINK_SCAN_INTERVAL)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_surface_never_scanned_is_due_at_once() {
+        // A pane that has just appeared must show its links on the next frame,
+        // not a quarter of a second later.
+        assert!(link_scan_due(None, Instant::now()));
+    }
+
+    #[test]
+    fn a_surface_just_scanned_is_not_due_again() {
+        let now = Instant::now();
+        assert!(!link_scan_due(Some(now), now));
+        assert!(!link_scan_due(
+            Some(now),
+            now + LINK_SCAN_INTERVAL - Duration::from_millis(1)
+        ));
+    }
+
+    #[test]
+    fn a_surface_scanned_longer_ago_than_the_interval_is_due() {
+        let now = Instant::now();
+        assert!(link_scan_due(Some(now - LINK_SCAN_INTERVAL), now));
+        assert!(link_scan_due(
+            Some(now - LINK_SCAN_INTERVAL - Duration::from_secs(1)),
+            now
+        ));
+    }
+
+    #[test]
+    fn the_scan_interval_is_slower_than_the_frames_it_paces() {
+        // The whole point is to take the scan off the per-frame path, so it has
+        // to be slower than a frame owed to output. Equal or faster and the
+        // pacing is a no-op that reads as tuned — the same trap the frame floors
+        // assert their way out of in `main.rs`.
+        assert!(
+            LINK_SCAN_INTERVAL > OUTPUT_FRAME_INTERVAL,
+            "the link scan would still run on every output frame"
+        );
+        // And no slower than the floor at which a still screen is repainted:
+        // beyond that the published map would be visibly behind a screen that
+        // has stopped moving, which is the case the output stamp already
+        // handles exactly and for free.
+        assert!(
+            LINK_SCAN_INTERVAL <= FORCE_REDRAW_INTERVAL,
+            "links could lag a settled screen by more than a forced redraw"
+        );
     }
 }

--- a/src/kernel/host/api.rs
+++ b/src/kernel/host/api.rs
@@ -60,10 +60,19 @@ pub(super) const CTX_META: &str = "__ctx_meta";
 /// read and pays nothing. Built once per VM and shared by every render, because
 /// a closure per render would cost more than the field it replaces.
 ///
+/// The key is taken as a `Value` rather than a `String`: `__index` also fires
+/// for `ctx[nil]` or `ctx[true]`, which Lua defines as nil, and coercing would
+/// raise out of the index and fail the whole render instead.
+///
 /// One visible consequence: `elapsed` is not a key of the ctx table, so it does
 /// not appear in `pairs(ctx)`. Nothing iterates a render context — a plugin asks
 /// it for named facts — and the alternative is to give up knowing who reads the
 /// clock.
+///
+/// `__metatable` seals it, because `getmetatable`/`setmetatable` are both in the
+/// plugin sandbox and this one table is shared by every pane: without the seal a
+/// plugin could replace the `__index` behind every other pane's clock, freezing
+/// their spinners and making the read-detection above silently answer "no".
 fn install_clock(
     lua: &Lua,
     clock: Rc<std::cell::Cell<f64>>,

--- a/src/kernel/host/api.rs
+++ b/src/kernel/host/api.rs
@@ -25,6 +25,8 @@ pub(super) fn install_api(
     runs: Rc<RefCell<Vec<(String, crate::kernel::runs::Ask)>>>,
     current_path: Rc<RefCell<String>>,
     state_version: StateVersion,
+    clock: Rc<std::cell::Cell<f64>>,
+    clock_read: Rc<std::cell::Cell<bool>>,
 ) -> mlua::Result<()> {
     scrub_globals(lua)?;
     install_require(lua, ui_dir)?;
@@ -33,7 +35,58 @@ pub(super) fn install_api(
     install_command(lua, queue, current_path.clone())?;
     install_files(lua, roots)?;
     install_run(lua, runs, current_path)?;
+    install_clock(lua, clock, clock_read)?;
     Ok(())
+}
+
+/// The registry name of the metatable every render context carries.
+///
+/// See [`install_clock`]. In the registry rather than in globals for the same
+/// reason [`RUN_IMPL`] is: a plugin chunk's `_ENV` *is* the globals table, so
+/// anything parked there is reachable by name from every plugin.
+pub(super) const CTX_META: &str = "__ctx_meta";
+
+/// Serve `ctx.elapsed` through a metatable, and record that it was asked for.
+///
+/// The animation clock is the one render input whose reader the kernel cannot
+/// otherwise name, and it invalidates every pure pane eight times a second while
+/// any agent is working. Making it a *lookup* rather than a field is what lets
+/// the kernel see which panes actually depend on it — the coupling Textual gets
+/// from `set_interval` on a widget and Bubble Tea from a spinner returning its
+/// own tick. See `CachedTree`.
+///
+/// `__index` fires only for keys the table does not have, so every ordinary
+/// field (`width`, `height`, `focused`, `frame`, `name`, `slot`) is still a raw
+/// read and pays nothing. Built once per VM and shared by every render, because
+/// a closure per render would cost more than the field it replaces.
+///
+/// One visible consequence: `elapsed` is not a key of the ctx table, so it does
+/// not appear in `pairs(ctx)`. Nothing iterates a render context — a plugin asks
+/// it for named facts — and the alternative is to give up knowing who reads the
+/// clock.
+fn install_clock(
+    lua: &Lua,
+    clock: Rc<std::cell::Cell<f64>>,
+    read: Rc<std::cell::Cell<bool>>,
+) -> mlua::Result<()> {
+    let meta = lua.create_table()?;
+    meta.set(
+        "__index",
+        lua.create_function(move |_, (_, key): (Table, String)| {
+            if key == "elapsed" {
+                read.set(true);
+                return Ok(Value::Number(clock.get()));
+            }
+            Ok(Value::Nil)
+        })?,
+    )?;
+    lua.set_named_registry_value(CTX_META, meta)
+}
+
+/// Give one render context its clock.
+pub(super) fn attach_clock(lua: &Lua, ctx: &Table) -> mlua::Result<()> {
+    let meta: Table = lua.named_registry_value(CTX_META)?;
+    ctx.set_metatable(Some(meta))
 }
 
 /// The name the `run` implementation is parked under.

--- a/src/kernel/host/api.rs
+++ b/src/kernel/host/api.rs
@@ -80,6 +80,7 @@ fn install_clock(
             Ok(Value::Nil)
         })?,
     )?;
+    meta.set("__metatable", false)?;
     lua.set_named_registry_value(CTX_META, meta)
 }
 

--- a/src/kernel/host/api.rs
+++ b/src/kernel/host/api.rs
@@ -72,8 +72,8 @@ fn install_clock(
     let meta = lua.create_table()?;
     meta.set(
         "__index",
-        lua.create_function(move |_, (_, key): (Table, String)| {
-            if key == "elapsed" {
+        lua.create_function(move |_, (_, key): (Table, Value)| {
+            if key.as_string().is_some_and(|key| key == "elapsed") {
                 read.set(true);
                 return Ok(Value::Number(clock.get()));
             }

--- a/src/kernel/host/mod.rs
+++ b/src/kernel/host/mod.rs
@@ -470,7 +470,7 @@ type TreeKey = (Epoch, u16, u16, bool, u64);
 /// is `working`, which is most of the time on a machine with an agent running.
 /// It is in [`TreeKey`], so every pure pane used to be re-rendered at that rate
 /// however little it had to do with a spinner — measured at +51% CPU under load
-/// (`docs/PERFORMANCE.md`, ADR-P20's animation section).
+/// (`docs/PERFORMANCE.md`, ADR-P21).
 ///
 /// Every other TUI scopes animation to the thing that animates, and gets the
 /// coupling for free because the animating widget is the one that asks to be

--- a/src/kernel/host/mod.rs
+++ b/src/kernel/host/mod.rs
@@ -464,6 +464,54 @@ pub const ANIMATION_HZ: f64 = 8.0;
 /// keypress would outlive it.
 type TreeKey = (Epoch, u16, u16, bool, u64);
 
+/// A pure pane's cached tree, and whether the clock is part of what keyed it.
+///
+/// [`Epoch::animation`] advances eight times a second for as long as any session
+/// is `working`, which is most of the time on a machine with an agent running.
+/// It is in [`TreeKey`], so every pure pane used to be re-rendered at that rate
+/// however little it had to do with a spinner — measured at +51% CPU under load
+/// (`docs/PERFORMANCE.md`, ADR-P20's animation section).
+///
+/// Every other TUI scopes animation to the thing that animates, and gets the
+/// coupling for free because the animating widget is the one that asks to be
+/// redrawn: a Textual widget calls `self.set_interval(1/60, self.refresh)` on
+/// *itself*, a Bubble Tea spinner returns its own tick command, fidget.nvim's
+/// `Anime` is the closure that reads `now`, and lualine redraws the statusline
+/// alone. thurbox's panes do not ask — the kernel calls them — so the coupling
+/// has to be observed instead: a tree can only depend on the clock if the render
+/// that built it read `ctx.elapsed`, and the ctx table's metatable is what
+/// notices. A pane that did not read it is served across an animation tick.
+///
+/// Deliberately detected rather than declared. A declaration defaulting to "does
+/// not animate" freezes any pane whose author never read the release note, with
+/// no error anywhere; one defaulting to "does" recovers almost nothing. Detection
+/// cannot be wrong in either direction: the flag is recorded from the render that
+/// produced the very tree being cached, and a pane that starts or stops reading
+/// the clock re-keys itself on the render where it does.
+struct CachedTree {
+    key: TreeKey,
+    rendered: Rendered,
+    /// Whether the render that produced `rendered` read `ctx.elapsed`.
+    reads_clock: bool,
+}
+
+impl CachedTree {
+    /// Whether this tree answers for `want`.
+    ///
+    /// The animation clock is compared only for a tree that read it. Masked on
+    /// *both* sides rather than skipped on one, so the comparison stays a plain
+    /// equality and cannot drift as `TreeKey` grows.
+    fn answers(&self, want: &TreeKey) -> bool {
+        if self.reads_clock {
+            return self.key == *want;
+        }
+        let (mut mine, mut theirs) = (self.key, *want);
+        mine.0.animation = 0;
+        theirs.0.animation = 0;
+        mine == theirs
+    }
+}
+
 impl Epoch {
     /// An epoch that matches no previous one, so every group is rebuilt.
     ///
@@ -590,7 +638,15 @@ pub struct LuaHost {
     /// Keyed by plugin index. Dropped whenever the VM is rebuilt, alongside
     /// [`Self::groups`] — a `Node` outlives the Lua it came from, but a tree
     /// built by the previous version of a pane is not that pane's answer.
-    trees: RefCell<HashMap<usize, (TreeKey, Rendered)>>,
+    trees: RefCell<HashMap<usize, CachedTree>>,
+    /// The clock the current render is being handed, and whether it read it.
+    ///
+    /// `ctx.elapsed` is served through the ctx table's metatable rather than set
+    /// as a field, so asking for it is observable. That is the whole mechanism
+    /// behind [`CachedTree::reads_clock`] — see it for why the kernel wants to
+    /// know.
+    clock: Rc<std::cell::Cell<f64>>,
+    clock_read: Rc<std::cell::Cell<bool>>,
     /// Published groups, each with the epoch it was built at.
     ///
     /// The outer `thurbox` table is still assembled fresh every frame from
@@ -718,6 +774,8 @@ impl LuaHost {
             ui_dir,
             groups: RefCell::new(HashMap::new()),
             trees: RefCell::new(HashMap::new()),
+            clock: Rc::new(std::cell::Cell::new(0.0)),
+            clock_read: Rc::new(std::cell::Cell::new(false)),
             epoch: RefCell::new(None),
             skipped_renders: std::cell::Cell::new(0),
             reused_groups: std::cell::Cell::new(0),
@@ -791,6 +849,8 @@ impl LuaHost {
             self.runs.clone(),
             self.current_path.clone(),
             self.state_version.clone(),
+            self.clock.clone(),
+            self.clock_read.clone(),
         )
         .map_err(|e| e.to_string())?;
 
@@ -1427,10 +1487,10 @@ impl LuaHost {
         });
         if plugin.pure {
             if let Some(key) = key {
-                if let Some((built_at, rendered)) = self.trees.borrow().get(&index) {
-                    if *built_at == key {
+                if let Some(cached) = self.trees.borrow().get(&index) {
+                    if cached.answers(&key) {
                         self.skipped_renders.set(self.skipped_renders.get() + 1);
-                        return Ok(rendered.clone());
+                        return Ok(cached.rendered.clone());
                     }
                 }
             }
@@ -1457,9 +1517,11 @@ impl LuaHost {
         table
             .set("focused", ctx.focused)
             .map_err(|e| fail(e.to_string()))?;
-        table
-            .set("elapsed", ctx.elapsed)
-            .map_err(|e| fail(e.to_string()))?;
+        // NOT set as a field: `elapsed` is served through the metatable installed
+        // below, so that reading it is observable. See `CachedTree`.
+        self.clock.set(ctx.elapsed);
+        self.clock_read.set(false);
+        api::attach_clock(&self.lua, &table).map_err(|e| fail(e.to_string()))?;
         table
             .set("frame", ctx.frame)
             .map_err(|e| fail(e.to_string()))?;
@@ -1486,9 +1548,17 @@ impl LuaHost {
         };
         if plugin.pure {
             if let Some(key) = key {
-                self.trees
-                    .borrow_mut()
-                    .insert(index, (key, rendered.clone()));
+                self.trees.borrow_mut().insert(
+                    index,
+                    CachedTree {
+                        key,
+                        rendered: rendered.clone(),
+                        // Read from the render that just produced this tree, so
+                        // the flag and the tree can never describe different
+                        // versions of the pane.
+                        reads_clock: self.clock_read.get(),
+                    },
+                );
             }
         }
         Ok(rendered)

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,6 +77,29 @@ const DEBOUNCE: Duration = Duration::from_millis(120);
 /// what turns an idle app from ~20 fps into ~4. v1 uses the same floor.
 const FORCE_REDRAW_INTERVAL: Duration = Duration::from_millis(250);
 
+/// Longest a session's links may be out of date while its screen keeps moving.
+///
+/// The scan is gated on the surface's output stamp, which is exact for a screen
+/// that has stopped and useless for one that has not: a printing agent moves it
+/// on every frame, so the scan ran per painted frame — walking the whole vt100
+/// grid, and, because the URLs on a scrolling screen sit on different rows each
+/// time, publishing a *changed* answer that moved the data epoch. Moving the
+/// epoch is what ADR-P16's gating exists to avoid: it rebuilds every published
+/// group and throws away every pure pane's cached tree. So an agent printing
+/// anything link-shaped — which is to say every coding agent — turned the whole
+/// change-gated frame back into an ungated one.
+///
+/// Deliberately paced rather than driven by the stamp alone, and 250ms because
+/// nothing acts on a link's *position* faster than that: a click resolves
+/// against the live grid ([`Terminals::url_at`]) and the OSC 8 repaint
+/// recomputes from it too, so this bounds how stale the *published* map may be,
+/// and nothing else. Measured with `scripts/dev/perf-run.sh`, 19 sessions at
+/// 255x62 with three agents printing 30 lines a second: 8.3% of a core down to
+/// 5.3%, frame p50 4ms down to 2ms, pane trees served from the cache 179 up to
+/// 3347. Against the same run with no URLs in its output, the penalty for
+/// printing one falls from +66% to +15% — ADR-P20 says why the rest is left.
+const LINK_SCAN_INTERVAL: Duration = Duration::from_millis(250);
+
 /// Iterations between two `perf_window` log lines (~10s at the 10ms tick).
 const PERF_WINDOW_TICKS: u64 = 1000;
 
@@ -463,6 +486,13 @@ struct App {
     /// the screen per repeat, for answers that cannot have changed.
     links: std::collections::HashMap<String, Vec<(String, usize, usize)>>,
     link_stamps: std::collections::HashMap<String, u64>,
+    /// When each session's links were last scanned, so a screen that keeps
+    /// moving is rescanned at [`LINK_SCAN_INTERVAL`] rather than per frame.
+    /// Kept beside the stamp rather than folded into it: the stamp answers
+    /// "could the answer have changed", this answers "is it worth asking again
+    /// yet", and a screen that has settled must still be served by the stamp
+    /// alone, for free, forever.
+    link_scans: std::collections::HashMap<String, Instant>,
     /// What each terminal was showing when a search last asked, and the output
     /// generation it was read at. Empty while nothing is searching.
     content: std::collections::HashMap<String, String>,

--- a/tests/kernel_frame_cost.rs
+++ b/tests/kernel_frame_cost.rs
@@ -732,34 +732,28 @@ fn a_still_animation_clock_lets_a_pure_pane_settle() {
 }
 
 #[test]
-fn a_moved_animation_clock_re_renders_a_pure_pane() {
+fn a_moved_animation_clock_re_renders_a_pane_that_reads_it() {
     // The other half: while something IS animating the loop advances the clock,
-    // and the pane must run again or the spinner freezes on screen.
-    let (_dir, host) = two_panes();
+    // and a pane that draws from it must run again or its spinner freezes on
+    // screen.
+    //
+    // "That reads it" is the narrowing this test grew: the clock used to
+    // invalidate every pure pane, and now invalidates the ones whose render
+    // actually asked for `ctx.elapsed` (see `CachedTree`). So the fixture is a
+    // pane that reads the clock — `two_panes()`'s does not, and is now
+    // deliberately cached across a tick, which is what
+    // `the_animation_clock_does_not_re_render_a_pane_that_never_reads_it`
+    // asserts from the other side.
+    let (_dir, host) = clock_panes();
     let themes = Themes::load(None);
     let mut epoch = Epoch::default();
     publish_at(&host, epoch, &Snapshot::default(), &themes);
 
-    let index = host.index_of("pure").expect("plugin");
-    let render = |host: &LuaHost| {
-        host.render(
-            index,
-            thurbox::kernel::host::RenderContext {
-                width: 40,
-                height: 4,
-                focused: false,
-                elapsed: 0.0,
-                frame: 0,
-            },
-        )
-        .expect("render")
-    };
-
-    let _ = render(&host);
+    let _ = render_at(&host, "spinner", 0.0);
     let settled = host.skipped_renders();
     epoch.animation += 1;
     publish_at(&host, epoch, &Snapshot::default(), &themes);
-    let _ = render(&host);
+    let _ = render_at(&host, "spinner", 1.0);
 
     assert_eq!(
         host.skipped_renders(),
@@ -887,5 +881,191 @@ fn reading_attach_failures_is_not_itself_a_change() {
         terminals.failed_version(),
         settled,
         "reading the failure set moved its version"
+    );
+}
+
+// --- the animation clock, scoped to whoever reads it -------------------------
+
+/// Two pure panes over the same data: one that reads the clock, one that does
+/// not.
+///
+/// The clock advances eight times a second for as long as any session is
+/// `working`, so on a working machine it is the most frequent thing in the
+/// cache key. A pane whose tree cannot depend on it must not pay for it — the
+/// scoping every other TUI gets by construction, because there the animating
+/// widget is the one that asks to be redrawn.
+fn clock_panes() -> (tempfile::TempDir, LuaHost) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let plugins = dir.path().join("plugins");
+    std::fs::create_dir_all(&plugins).expect("mkdir");
+    std::fs::write(
+        plugins.join("10_spinner.lua"),
+        r#"return { name = "spinner", slot = "left", pure = true,
+             render = function(ctx)
+               return { text = "tick " .. tostring(math.floor(ctx.elapsed or 0)) }
+             end }"#,
+    )
+    .expect("write");
+    std::fs::write(
+        plugins.join("20_still.lua"),
+        r#"return { name = "still", slot = "center", pure = true,
+             render = function() return { text = "still" } end }"#,
+    )
+    .expect("write");
+    let host = LuaHost::new(dir.path());
+    assert!(host.error.is_none(), "{:?}", host.error);
+    (dir, host)
+}
+
+fn render_at(host: &LuaHost, name: &str, elapsed: f64) -> String {
+    let index = host.index_of(name).expect("plugin");
+    format!(
+        "{:?}",
+        host.render(
+            index,
+            thurbox::kernel::host::RenderContext {
+                width: 40,
+                height: 4,
+                focused: false,
+                elapsed,
+                frame: 0,
+            },
+        )
+        .expect("render")
+        .node
+    )
+}
+
+#[test]
+fn the_animation_clock_does_not_re_render_a_pane_that_never_reads_it() {
+    // The saving. Measured at +51% CPU under load before this held
+    // (docs/PERFORMANCE.md, ADR-P20's animation section): every pure pane —
+    // the centre pane and all three closed floats included — re-ran eight
+    // times a second to move a spinner none of them draws.
+    let (_dir, host) = clock_panes();
+    let themes = Themes::load(None);
+    let mut epoch = Epoch::default();
+    publish_at(&host, epoch, &Snapshot::default(), &themes);
+
+    let _ = render_at(&host, "still", 0.0);
+    let settled = host.skipped_renders();
+    for step in 1..=10 {
+        epoch.animation += 1;
+        publish_at(&host, epoch, &Snapshot::default(), &themes);
+        let _ = render_at(&host, "still", f64::from(step));
+    }
+    assert_eq!(
+        host.skipped_renders() - settled,
+        10,
+        "a pane that never asked for the clock was re-rendered by it"
+    );
+}
+
+#[test]
+fn a_pane_that_reads_the_clock_sees_the_time_it_was_given() {
+    // Serving `elapsed` through a metatable rather than as a field must not
+    // change what a pane reads — the whole mechanism is meant to be invisible
+    // from Lua.
+    let (_dir, host) = clock_panes();
+    let themes = Themes::load(None);
+    let mut epoch = Epoch::default();
+    publish_at(&host, epoch, &Snapshot::default(), &themes);
+    assert!(render_at(&host, "spinner", 3.0).contains("tick 3"));
+    epoch.animation += 1;
+    publish_at(&host, epoch, &Snapshot::default(), &themes);
+    assert!(render_at(&host, "spinner", 7.0).contains("tick 7"));
+}
+
+#[test]
+fn a_pane_that_starts_reading_the_clock_is_keyed_on_it_from_then_on() {
+    // The transition, which is where a learned optimisation would go wrong: a
+    // pane may only consult the clock under some condition — the session list
+    // draws a spinner only for a `working` row. The flag is recorded from the
+    // render that produced the cached tree, so the first render that reads the
+    // clock is itself the one that re-keys the entry; there is no frame in
+    // between on which a stale tree could be served.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let plugins = dir.path().join("plugins");
+    std::fs::create_dir_all(&plugins).expect("mkdir");
+    std::fs::write(
+        plugins.join("10_maybe.lua"),
+        r#"return { name = "maybe", slot = "left", pure = true,
+             render = function(ctx)
+               if store.spin then
+                 return { text = "tick " .. tostring(math.floor(ctx.elapsed or 0)) }
+               end
+               return { text = "quiet" }
+             end }"#,
+    )
+    .expect("write");
+    let host = LuaHost::new(dir.path());
+    assert!(host.error.is_none(), "{:?}", host.error);
+    let themes = Themes::load(None);
+    let mut epoch = Epoch::default();
+    publish_at(&host, epoch, &Snapshot::default(), &themes);
+
+    // Not reading the clock: cached across an animation tick.
+    let _ = render_at(&host, "maybe", 0.0);
+    let settled = host.skipped_renders();
+    epoch.animation += 1;
+    publish_at(&host, epoch, &Snapshot::default(), &themes);
+    assert!(render_at(&host, "maybe", 1.0).contains("quiet"));
+    assert_eq!(
+        host.skipped_renders() - settled,
+        1,
+        "should have been cached"
+    );
+
+    // Now it starts. The write moves the state version, so this render happens
+    // for that reason and is the one that records the dependency.
+    host.set_shared_bool("spin", true);
+    epoch.animation += 1;
+    publish_at(&host, epoch, &Snapshot::default(), &themes);
+    assert!(render_at(&host, "maybe", 2.0).contains("tick 2"));
+
+    // From here the clock alone must reach it.
+    let settled = host.skipped_renders();
+    epoch.animation += 1;
+    publish_at(&host, epoch, &Snapshot::default(), &themes);
+    assert!(render_at(&host, "maybe", 3.0).contains("tick 3"));
+    assert_eq!(
+        host.skipped_renders(),
+        settled,
+        "a pane that had begun reading the clock was cached across a tick"
+    );
+}
+
+#[test]
+fn the_bundled_centre_pane_is_not_re_rendered_by_the_clock() {
+    // Against the real interface, because the saving is only real if the panes
+    // thurbox actually ships fall on the right side of it. The session list
+    // draws a spinner and must stay clock-keyed; the agent pane draws a surface
+    // and must not.
+    let dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("ui");
+    let host = LuaHost::new(dir);
+    assert!(host.error.is_none(), "{:?}", host.error);
+    let themes = Themes::load(None);
+    let mut epoch = Epoch::default();
+    let snapshot = Snapshot {
+        sessions: vec![row("a", "alpha")],
+        ..Snapshot::default()
+    };
+    publish_at(&host, epoch, &snapshot, &themes);
+
+    // Settle both first: each publishes its own state as it renders, so the
+    // first pass moves the state version and only the second can be reused.
+    for _ in 0..2 {
+        let _ = render_at(&host, "agent", 0.0);
+        let _ = render_at(&host, "sessions", 0.0);
+    }
+
+    let settled = host.skipped_renders();
+    epoch.animation += 1;
+    publish_at(&host, epoch, &snapshot, &themes);
+    let _ = render_at(&host, "agent", 1.0);
+    assert_eq!(
+        host.skipped_renders() - settled,
+        1,
+        "the agent pane paid for an animation tick it draws nothing for"
     );
 }

--- a/tests/kernel_frame_cost.rs
+++ b/tests/kernel_frame_cost.rs
@@ -939,7 +939,7 @@ fn render_at(host: &LuaHost, name: &str, elapsed: f64) -> String {
 #[test]
 fn the_animation_clock_does_not_re_render_a_pane_that_never_reads_it() {
     // The saving. Measured at +51% CPU under load before this held
-    // (docs/PERFORMANCE.md, ADR-P20's animation section): every pure pane —
+    // (docs/PERFORMANCE.md, ADR-P21): every pure pane —
     // the centre pane and all three closed floats included — re-ran eight
     // times a second to move a spinner none of them draws.
     let (_dir, host) = clock_panes();
@@ -1038,9 +1038,9 @@ fn a_pane_that_starts_reading_the_clock_is_keyed_on_it_from_then_on() {
 #[test]
 fn the_bundled_centre_pane_is_not_re_rendered_by_the_clock() {
     // Against the real interface, because the saving is only real if the panes
-    // thurbox actually ships fall on the right side of it. The session list
-    // draws a spinner and must stay clock-keyed; the agent pane draws a surface
-    // and must not.
+    // thurbox actually ships fall on the right side of it — and both sides are
+    // asserted below. The session list draws a spinner and must stay
+    // clock-keyed; the agent pane draws a surface and must not.
     let dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("ui");
     let host = LuaHost::new(dir);
     assert!(host.error.is_none(), "{:?}", host.error);
@@ -1067,5 +1067,16 @@ fn the_bundled_centre_pane_is_not_re_rendered_by_the_clock() {
         host.skipped_renders() - settled,
         1,
         "the agent pane paid for an animation tick it draws nothing for"
+    );
+
+    // And the other direction on the same tick, which is what makes the first
+    // half a saving rather than a freeze: the session list reads the clock for
+    // its status glyphs, so the same tick must reach it.
+    let settled = host.skipped_renders();
+    let _ = render_at(&host, "sessions", 1.0);
+    assert_eq!(
+        host.skipped_renders(),
+        settled,
+        "the session list was served a cached tree across the tick its spinner moves on"
     );
 }

--- a/tests/kernel_frame_cost.rs
+++ b/tests/kernel_frame_cost.rs
@@ -977,6 +977,36 @@ fn a_pane_that_reads_the_clock_sees_the_time_it_was_given() {
 }
 
 #[test]
+fn a_non_string_index_on_the_render_context_is_nil_rather_than_an_error() {
+    // `__index` fires for every absent key, including one Lua defines as nil —
+    // `ctx[nil]` from a mistyped local, `ctx[true]`. Before the metatable those
+    // evaluated to nil; a key typed as `String` would coerce and raise instead,
+    // failing the whole render over an expression the language allows.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let plugins = dir.path().join("plugins");
+    std::fs::create_dir_all(&plugins).expect("mkdir");
+    std::fs::write(
+        plugins.join("10_odd.lua"),
+        r#"return { name = "odd", slot = "left",
+             render = function(ctx)
+               local typo
+               local seen = { ctx[typo], ctx[true], ctx[7] }
+               return { text = "nils " .. tostring(#seen == 0) }
+             end }"#,
+    )
+    .expect("write");
+    let host = LuaHost::new(dir.path());
+    assert!(host.error.is_none(), "{:?}", host.error);
+    publish_at(
+        &host,
+        Epoch::default(),
+        &Snapshot::default(),
+        &Themes::load(None),
+    );
+    assert!(render_at(&host, "odd", 0.0).contains("nils true"));
+}
+
+#[test]
 fn a_pane_that_starts_reading_the_clock_is_keyed_on_it_from_then_on() {
     // The transition, which is where a learned optimisation would go wrong: a
     // pane may only consult the clock under some condition — the session list

--- a/tests/kernel_frame_cost.rs
+++ b/tests/kernel_frame_cost.rs
@@ -1007,6 +1007,52 @@ fn a_non_string_index_on_the_render_context_is_nil_rather_than_an_error() {
 }
 
 #[test]
+fn a_plugin_cannot_reach_or_replace_the_render_context_metatable() {
+    // The metatable is built once per VM and shared by every render, and both
+    // `getmetatable` and `setmetatable` are in the sandbox. Handing it out would
+    // let one plugin rewrite `__index` and freeze every other pane's clock —
+    // and silently make the kernel's "did this render read it" answer false
+    // everywhere. `__metatable` is what makes it neither readable nor settable
+    // from Lua, the same boundary `RUN_IMPL` gets from the registry.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let plugins = dir.path().join("plugins");
+    std::fs::create_dir_all(&plugins).expect("mkdir");
+    std::fs::write(
+        plugins.join("10_prober.lua"),
+        r#"return { name = "prober", slot = "left",
+             render = function(ctx)
+               local hidden = getmetatable(ctx) == false
+               local refused = not pcall(setmetatable, ctx, { __index = function() end })
+               return { text = "hidden " .. tostring(hidden)
+                          .. " refused " .. tostring(refused)
+                          .. " clock " .. tostring(math.floor(ctx.elapsed or -1)) }
+             end }"#,
+    )
+    .expect("write");
+    let host = LuaHost::new(dir.path());
+    assert!(host.error.is_none(), "{:?}", host.error);
+    publish_at(
+        &host,
+        Epoch::default(),
+        &Snapshot::default(),
+        &Themes::load(None),
+    );
+    let painted = render_at(&host, "prober", 5.0);
+    assert!(
+        painted.contains("hidden true"),
+        "the metatable was handed to the plugin: {painted}"
+    );
+    assert!(
+        painted.contains("refused true"),
+        "a plugin replaced the shared metatable: {painted}"
+    );
+    assert!(
+        painted.contains("clock 5"),
+        "the clock stopped being served: {painted}"
+    );
+}
+
+#[test]
 fn a_pane_that_starts_reading_the_clock_is_keyed_on_it_from_then_on() {
     // The transition, which is where a learned optimisation would go wrong: a
     // pane may only consult the clock under some condition — the session list

--- a/tests/tui_e2e.rs
+++ b/tests/tui_e2e.rs
@@ -905,9 +905,38 @@ impl Tui {
     fn ctrl_c_then(&mut self, marker: &str) -> String {
         let mark = self.raw_len();
         self.send(b"\x03");
+        // The interrupt has to LAND before the next keystroke is written, and
+        // these two used to be back-to-back. `\x03` travels pty -> thurbox ->
+        // tmux -> `sh`, and the shell answers it by abandoning the line it was
+        // reading and drawing a fresh prompt; a byte that arrives while it is
+        // doing that is discarded. The symptom is the command's FIRST character
+        // going missing -- `sh: cho: command not found`, from a swallowed `e` --
+        // so the marker never echoes and the wait below times out having
+        // reported nothing about why. It only showed up on a loaded machine,
+        // which is what made a race look like slowness.
+        self.wait_for_output_since(mark, "the shell to answer the interrupt");
         self.send(format!("echo {marker}-\"\"ok\r").as_bytes());
         self.wait_for(&format!("{marker}-ok"));
         self.raw_since(mark)
+    }
+
+    /// Wait until the terminal has written *anything* since `since`.
+    ///
+    /// Coarser than [`Self::wait_for`] on purpose: the caller is waiting for the
+    /// far end to have reacted at all, not for a particular string. What the
+    /// shell emits when it takes an interrupt differs between shells and between
+    /// "at an idle prompt" and "mid-command" -- `^C`, a bare newline, a fresh
+    /// prompt, or some combination -- so matching on any of them would be a
+    /// guess. That bytes came back is the one signal every case shares.
+    fn wait_for_output_since(&self, since: usize, what: &str) {
+        let deadline = Instant::now() + WAIT;
+        while Instant::now() < deadline {
+            if self.raw_len() > since {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        self.give_up(what);
     }
 }
 

--- a/tests/tui_e2e.rs
+++ b/tests/tui_e2e.rs
@@ -915,9 +915,38 @@ impl Tui {
         // reported nothing about why. It only showed up on a loaded machine,
         // which is what made a race look like slowness.
         self.wait_for_output_since(mark, "the shell to answer the interrupt");
+        // And then until it has finished answering. The reply is several writes
+        // -- `^C`, a newline, a fresh prompt -- and a byte arriving between them
+        // is discarded exactly as one arriving before the first is; the barrier
+        // above only proves the reply STARTED. Waiting for the stream to stop is
+        // what proves it ended, and it is the same signal for every shell.
+        self.wait_until_quiet();
         self.send(format!("echo {marker}-\"\"ok\r").as_bytes());
         self.wait_for(&format!("{marker}-ok"));
         self.raw_since(mark)
+    }
+
+    /// Wait until the terminal has stopped writing.
+    ///
+    /// The other half of [`Self::wait_for_output_since`]: that one proves the
+    /// far end started reacting, this one proves it stopped. Best-effort — a
+    /// stream that never settles simply gives the time back rather than failing,
+    /// because this is a barrier in front of an assertion and not the assertion.
+    /// Budgeted well under [`WAIT`] for the same reason.
+    fn wait_until_quiet(&self) {
+        const QUIET: Duration = Duration::from_millis(150);
+        let deadline = Instant::now() + Duration::from_secs(3);
+        let (mut seen, mut still) = (self.raw_len(), Instant::now());
+        while Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+            let now = self.raw_len();
+            if now != seen {
+                seen = now;
+                still = Instant::now();
+            } else if still.elapsed() >= QUIET {
+                return;
+            }
+        }
     }
 
     /// Wait until the terminal has written *anything* since `since`.
@@ -928,6 +957,9 @@ impl Tui {
     /// "at an idle prompt" and "mid-command" -- `^C`, a bare newline, a fresh
     /// prompt, or some combination -- so matching on any of them would be a
     /// guess. That bytes came back is the one signal every case shares.
+    ///
+    /// `since` must be taken BEFORE whatever is being waited on is sent, or the
+    /// echo of something already in flight satisfies it instead.
     fn wait_for_output_since(&self, since: usize, what: &str) {
         let deadline = Instant::now() + WAIT;
         while Instant::now() < deadline {
@@ -982,7 +1014,13 @@ fn a_click_is_not_a_selection_so_ctrl_c_still_interrupts_the_shell() {
     // Any other key drops the selection and still does what it does, so the
     // next Ctrl+C is the shell's again.
     tui.drag(at, 12);
+    // Wait for the key to have reached the shell and echoed back before the
+    // chord follows it. Left in flight, that echo is the first thing to arrive
+    // after `ctrl_c_then` takes its mark, and satisfies the barrier there in
+    // place of the interrupt it is meant to be waiting for.
+    let typed = tui.raw_len();
     tui.send(b":");
+    tui.wait_for_output_since(typed, "the shell to echo the key that clears the selection");
     let out = tui.ctrl_c_then("tb-key");
     assert!(
         !out.contains(OSC52),


### PR DESCRIPTION
## Intent

thurbox had performance problems the user believed were regressions. They asked
me to FIRST make sure proper performance testing existed, and only then provide
fixes; later they asked whether there was a better fix for the animation cost,
citing how neovim and other TUI frameworks handle animation in their plugins,
asked that performance be properly considered in the no-mistakes pipeline, and
finally asked me to fix the CI pipeline when the gate itself kept failing.

Testing first, deliberately, because the repo could assert that the render loop
settles but not what it costs. Two instruments, both kept OUTSIDE the PR gate per
the existing ADR-P5 rule that wall-clock timing stays out of CI:
benches/frame_cost.rs for the pieces of a frame, and scripts/dev/perf-run.sh for
the whole binary under a reproducible load.

Then two fixes, each found with those instruments and each recorded as an ADR
with its paired measurement:

ADR-P20, the link scan. refresh_links was gated only on a surface's output stamp,
which a printing agent moves every frame, and a scrolling screen puts its URLs on
new rows each time - so the compare-before-store found a real change and moved
the data epoch once per painted frame. That un-gated every published group and
dropped every pure pane's cached tree, for anyone whose agent prints a URL, which
is every coding agent. Fixed with the second gate the path never had, an age
(LINK_SCAN_INTERVAL). Penalty for printing a URL: +66% CPU down to +15%.

ADR-P21, the animation clock. It advanced eight times a second while any session
was working and was part of the pure-pane cache key, so every pure pane
re-rendered at that rate for a spinner glyph most of them do not draw (+51% CPU).
The user asked specifically how neovim and others solve this, so I read the prior
art: Textual's set_interval on the widget itself, Bubble Tea's spinner returning
its own tick plus a line-diffing renderer, fidget.nvim's Anime closure over `now`,
lualine's :redrawstatus. All four scope animation to the reader, and three get
that free because the animating widget is the one that asks to be redrawn.
thurbox's panes do not ask - the kernel calls them - so the coupling is OBSERVED
instead: ctx.elapsed is served through the render context's metatable rather than
set as a field, and a pure tree is keyed on the animation tick only if the render
that built it read the clock. Detection was chosen over a declaration
deliberately, and the three rejected designs are recorded: a declaration
defaulting to "does not animate" silently freezes any third-party spinner whose
author never read the release note. Penalty: +51% down to +12%, the remainder
being the session list, which is the pane that actually has the spinner in it.
One accepted contract change: elapsed is no longer a key of ctx, so it does not
appear in pairs(ctx); nothing iterates a render context.

Performance in the gate is reviewed, never timed, because a timing assertion is a
claim about whichever machine ran it (ADR-P5). The src/** rubric already said a
change-signal is bumped only when the value actually changed - the link scan did
exactly that, and the answer had genuinely changed - so the rubric now carries the
second question for a per-frame recompute over a continuously moving source: not
whether the value moved, but whether it was worth asking yet. New path blocks
cover benches/** and perf-run.sh with the traps each has already cost.

One fix is outside the perf work and is included because it blocked everything
else: tests/tui_e2e.rs's ctrl_c_then wrote \x03 and the following command back to
back with no synchronization, so under load the shell swallowed the command's
first byte while handling the interrupt (`sh: cho: command not found`). A real
race, pre-existing and load-sensitive, which the local pre-commit hook trips on
while CI does not (nextest.toml gives ci retries=2 and default 0). No assertion
was changed.

And one fixes the gate itself. The test step had no configured command, so it
decided for itself what running the tests meant; given an intent about paired
before/after measurements it chose to take one with perf-run.sh, waited through a
release build and timed runs, and went silent until test_agent_timeout killed the
run at 30m0s - twice, so neither run ever reached document, lint, push, PR or CI.
perf-run.sh now refuses under NO_MISTAKES_GATE (override
THURBOX_PERF_ALLOW_IN_GATE) and commands.test names `cargo nextest run --all`
explicitly. DO NOT run perf-run.sh or cargo bench while validating this change:
the perf claims are asserted deterministically on counters and change-signals in
tests/kernel_frame_cost.rs and tests/kernel_perf.rs, and wall-clock timing is
deliberately outside the gate.

This branch also carries earlier pipeline review-fix commits, which are wanted and
must be preserved. Measurements throughout are paired before/after at a stated
terminal size and session count, because absolute CPU on this shared machine
varied by ~25% between runs; the deterministic counters (cached trees 154 -> 3070
at an unchanged frame count) are the claim that holds regardless of load.

## What Changed

- **Render loop (ADR-P20/P21).** `App::refresh_links` gains a second gate beside the output stamp — a per-surface `LINK_SCAN_INTERVAL` age (`link_scans`, with `link_scan_due` + unit tests pinning it between `OUTPUT_FRAME_INTERVAL` and `FORCE_REDRAW_INTERVAL`) — so a printing agent no longer rescans every vt100 grid per frame and moves the data epoch. And `ctx.elapsed` is no longer a field on the render context: it is served through a shared, sealed (`__metatable = false`) registry metatable that records the read, so `CachedTree` keys a pure pane on the animation tick only when that pane's render actually asked for the clock. Accepted contract change: `elapsed` no longer appears in `pairs(ctx)`.
- **Performance instruments, both outside the PR gate per ADR-P5.** New `benches/frame_cost.rs` (`harness = false`, `just bench`) times the pieces of a frame against the real `ui/`, and new `scripts/dev/perf-run.sh` (`just perf`) runs the whole binary under a pinned load in an isolated sandbox; the script refuses to run under `NO_MISTAKES_GATE` unless `THURBOX_PERF_ALLOW_IN_GATE` is set. Deterministic coverage lands in `tests/kernel_frame_cost.rs` (clock read/no-read caching, non-string ctx index, metatable sealing, the bundled centre pane), with the rationale and paired before/after measurements written up in `docs/PERFORMANCE.md`.
- **Gate and test fixes.** `.no-mistakes.yaml` names `cargo nextest run --all` as `commands.test` instead of leaving it empty (an empty key let the step choose a release build + timed perf run and hit the 30m agent timeout), and adds review rubric blocks for per-frame change-signals, `benches/**` and `perf-run.sh`. `tests/tui_e2e.rs`'s `ctrl_c_then` now waits for the shell to start and finish answering the interrupt (`wait_for_output_since` + `wait_until_quiet`) before typing again, fixing a load-sensitive race that swallowed the command's first byte; no assertion changed.

## Risk Assessment

⚠️ Medium: The two perf fixes are correct as traced against the real bundled panes and are backed by deterministic counter/change-signal tests rather than timing, and the plugin-contract change is documented and covered; the one real defect is a CI-plumbing gap that leaves the newly added bench target unguarded on main, which is safe to merge and fix as a follow-up.

## Testing

I ran the smallest set that proves the branch's claims rather than the full suite: the deterministic perf assertions (kernel_frame_cost, kernel_perf, the coordinator::publish link-scan unit tests) all pass, the real bundled interface still paints identically after `elapsed` moved behind the render-context metatable (frames.rs) and its spinner still advances (kernel_mvp), and the real binary on a pty passes the interrupt test six times including five with the machine fully saturated. For end-user-visible evidence I drove the real `ui/` interface directly: the session list's braille spinner advances glyph-by-glyph across the 8 Hz clock while the agent pane and all three floats are served cached trees on every one of those ticks, and a simulated URL-printing agent over 2 s of output frames goes from 300 pure pane re-renders (ungated scan) to 40 with the 250 ms pacing. The gate fix was verified by transcript — perf-run.sh exits 2 under NO_MISTAKES_GATE and still runs under the documented override — and its `--json` line now parses whether or not a `perf_window` was logged. Per the author's explicit instruction I did not run perf-run.sh's measurement path or `cargo bench`; wall-clock timing stays outside the gate. One honest gap, recorded in the artifact: removing the e2e barriers did not reproduce the pre-fix `sh: cho: command not found` on this host even saturated, so that fix is evidenced as stability under load plus the fact that it adds synchronisation only and changes no assertion. No transient files remain in the working tree.

<details>
<summary>Evidence: Render-loop perf, against the real bundled interface (ADR-P21 spinner + per-pane cache hits, ADR-P20 link-scan pacing)</summary>

<code>=== the real session list, one animation tick apart (8 Hz clock) ===&#10;session `fix-osc52` is `working`; watch the leading status glyph&#10;&#10;tick 1 (elapsed 0.125s): │ ⠙ ⑂ fix-osc52 │&#10;tick 2 (elapsed 0.250s): │ ⠹ ⑂ fix-osc52 │&#10;tick 3 (elapsed 0.375s): │ ⠸ ⑂ fix-osc52 │&#10;tick 4 (elapsed 0.500s): │ ⠼ ⑂ fix-osc52 │&#10;tick 5 (elapsed 0.625s): │ ⠴ ⑂ fix-osc52 │&#10;tick 6 (elapsed 0.750s): │ ⠦ ⑂ fix-osc52 │&#10;tick 7 (elapsed 0.875s): │ ⠧ ⑂ fix-osc52 │&#10;tick 8 (elapsed 1.000s): │ ⠇ ⑂ fix-osc52 │&#10;&#10;=== per-pane, across the same 8 animation ticks ===&#10;pane re-rendered served cached&#10;sessions 8 0 pure, draws the spinner -&gt; correctly still clock-keyed&#10;agent 0 8 pure, reads no clock -&gt; free (re-rendered 8x/s before ADR-P21)&#10;confirm 0 8 pure, reads no clock -&gt; free (re-rendered 8x/s before ADR-P21)&#10;restore 0 8 pure, reads no clock -&gt; free (re-rendered 8x/s before ADR-P21)&#10;new_session 0 8 pure, reads no clock -&gt; free (re-rendered 8x/s before ADR-P21)&#10;search 8 0 not a `pure` pane -- renders every frame regardless&#10;&#10;totals: 16 renders executed, 32 served from cache, out of 48 pane-frames.&#10;&#10;=== an agent printing URLs for 2s at the 33ms output floor (60 frames) ===&#10;5 pure bundled panes = 300 pane-frames&#10;&#10;link scan ungated (before ADR-P20): 300 re-rendered, 0 cached (30 scans/s)&#10;link scan paced at 250ms (after): 40 re-rendered, 260 cached (4 scans/s)</code>

```text
=== the real session list, one animation tick apart (8 Hz clock) ===
session `fix-osc52` is `working`; watch the leading status glyph

  tick 1 (elapsed 0.125s):  │ ⠙ ⑂ fix-osc52                                            │
  tick 2 (elapsed 0.250s):  │ ⠹ ⑂ fix-osc52                                            │
  tick 3 (elapsed 0.375s):  │ ⠸ ⑂ fix-osc52                                            │
  tick 4 (elapsed 0.500s):  │ ⠼ ⑂ fix-osc52                                            │
  tick 5 (elapsed 0.625s):  │ ⠴ ⑂ fix-osc52                                            │
  tick 6 (elapsed 0.750s):  │ ⠦ ⑂ fix-osc52                                            │
  tick 7 (elapsed 0.875s):  │ ⠧ ⑂ fix-osc52                                            │
  tick 8 (elapsed 1.000s):  │ ⠇ ⑂ fix-osc52                                            │

=== per-pane, across the same 8 animation ticks ===
  pane           re-rendered  served cached   
  sessions                8              0   pure, draws the spinner -> correctly still clock-keyed
  agent                   0              8   pure, reads no clock -> free (re-rendered 8x/s before ADR-P21)
  confirm                 0              8   pure, reads no clock -> free (re-rendered 8x/s before ADR-P21)
  restore                 0              8   pure, reads no clock -> free (re-rendered 8x/s before ADR-P21)
  new_session             0              8   pure, reads no clock -> free (re-rendered 8x/s before ADR-P21)
  search                  8              0   not a `pure` pane -- renders every frame regardless

  totals: 16 renders executed, 32 served from cache, out of 48 pane-frames.
  5 of the 6 bundled panes are `pure`; before ADR-P21 all 40 of their pane-frames
  re-rendered on the clock alone. Now only the one that reads it does.
test evidence ... ok




=== an agent printing URLs for 2s at the 33ms output floor (60 frames) ===
    5 pure bundled panes = 300 pane-frames

  link scan ungated (before ADR-P20):   300 re-rendered,    0 cached   (30 scans/s)
  link scan paced at 250ms (after):    40 re-rendered,  260 cached   (4 scans/s)
test evidence_link_scan_pacing ... ok
```
</details>
<details>
<summary>Evidence: perf-run.sh refuses inside a validation step (the gate fix)</summary>

<code>$ NO_MISTAKES_GATE=1 scripts/dev/perf-run.sh --idle&#10;perf-run.sh: refusing to run inside a validation step.&#10;&#10;This is a benchmark, not a test: it builds a release binary, runs agents for&#10;tens of seconds and measures CPU. Its reading is only meaningful on a quiet&#10;machine, and a gate is the opposite of one.&#10;&#10;Nothing here needs it to pass. The deterministic coverage is ordinary tests --&#10;`cargo nextest run --all` -- and the perf claims are asserted on counters and&#10;change-signals in tests/kernel_frame_cost.rs and tests/kernel_perf.rs, never on&#10;a clock (docs/PERFORMANCE.md, ADR-P5).&#10;&#10;Set THURBOX_PERF_ALLOW_IN_GATE=1 to override this, if you really mean to.&#10;exit=2&#10;&#10;$ NO_MISTAKES_GATE=1 THURBOX_PERF_ALLOW_IN_GATE=1 scripts/dev/perf-run.sh --help&#10;usage: perf-run.sh [options] ... (override honoured, usage printed)</code>

```text
$ NO_MISTAKES_GATE=1 scripts/dev/perf-run.sh --idle
perf-run.sh: refusing to run inside a validation step.

This is a benchmark, not a test: it builds a release binary, runs agents for
tens of seconds and measures CPU. Its reading is only meaningful on a quiet
machine, and a gate is the opposite of one.

Nothing here needs it to pass. The deterministic coverage is ordinary tests --
`cargo nextest run --all` -- and the perf claims are asserted on counters and
change-signals in tests/kernel_frame_cost.rs and tests/kernel_perf.rs, never on
a clock (docs/PERFORMANCE.md, ADR-P5).

To take a reading by hand, on a machine you are not otherwise using:
    just perf -n 19 -p 3 -s 255x62
    just perf -n 19 -p 3 -s 255x62 -u 0     # the paired control

Set THURBOX_PERF_ALLOW_IN_GATE=1 to override this, if you really mean to.
exit=2

$ NO_MISTAKES_GATE=1 THURBOX_PERF_ALLOW_IN_GATE=1 scripts/dev/perf-run.sh --help   # override path still reachable
usage: perf-run.sh [options]
  -n N        sessions to create (default 8)
  -p N        how many of them print (default 1; --idle sets 0)
  -d SECS     how long to measure (default 30)
  -s COLSxROWS  terminal size (default 200x50)
  -r N        lines per second each printing agent emits (default 30)
  -u N        a URL every N printed lines (default 12; 0 = never)
  -w N        mark N sessions `working`, so the animation clock runs (default 0);
              a non-printing one animates a progress line, as a real agent does
  --idle      nothing prints — measures the settled floor
  --debug     measure the dev profile instead of release
  --no-perf-log  run without THURBOX_PERF_LOG (CPU only, no percentiles) --
                 the control for "is the instrumentation the cost?"
  --json      one machine-readable line instead of the report
exit=
```
</details>
<details>
<summary>Evidence: perf-run.sh --json stays valid JSON with and without a perf_window line</summary>

<code>$ # real field()/JSON block from scripts/dev/perf-run.sh, WINDOW empty (--no-perf-log)&#10;{&#34;sessions&#34;:8,&#34;printing&#34;:1,&#34;working&#34;:4,&#34;rate&#34;:30,&#34;url_every&#34;:12,&#34;size&#34;:&#34;200x50&#34;,&#34;seconds&#34;:30,&#34;cpu_render_thread_pct&#34;:11,&#34;cpu_all_threads_pct&#34;:23,&#34;frame_p50_us&#34;:0,&#34;frame_p95_us&#34;:0,&#34;republish_p50_us&#34;:0,&#34;tick_p50_us&#34;:0,&#34;frames&#34;:0,&#34;iterations&#34;:0}&#10;parsed OK; missing perf fields defaulted to: 0 0 0 0 0 0&#10;&#10;$ # same block with a real perf_window line present&#10;{&#34;sessions&#34;:8,&#34;printing&#34;:1,&#34;working&#34;:4,&#34;rate&#34;:30,&#34;url_every&#34;:12,&#34;size&#34;:&#34;200x50&#34;,&#34;seconds&#34;:30,&#34;cpu_render_thread_pct&#34;:11,&#34;cpu_all_threads_pct&#34;:23,&#34;frame_p50_us&#34;:430,&#34;frame_p95_us&#34;:1180,&#34;republish_p50_us&#34;:95,&#34;tick_p50_us&#34;:51,&#34;frames&#34;:812,&#34;iterations&#34;:1000}&#10;parsed OK; working/url_every/rate now identify the run: 4 12 30</code>

```text
$ # real field()/JSON block from scripts/dev/perf-run.sh, WINDOW empty (--no-perf-log)
{"sessions":8,"printing":1,"working":4,"rate":30,"url_every":12,"size":"200x50","seconds":30,"cpu_render_thread_pct":11,"cpu_all_threads_pct":23,"frame_p50_us":0,"frame_p95_us":0,"republish_p50_us":0,"tick_p50_us":0,"frames":0,"iterations":0}
parsed OK; keys: sessions,printing,working,rate,url_every,size,seconds,cpu_render_thread_pct,cpu_all_threads_pct,frame_p50_us,frame_p95_us,republish_p50_us,tick_p50_us,frames,iterations
missing perf fields defaulted to: 0 0 0 0 0 0

$ # same block with a real perf_window line present
{"sessions":8,"printing":1,"working":4,"rate":30,"url_every":12,"size":"200x50","seconds":30,"cpu_render_thread_pct":11,"cpu_all_threads_pct":23,"frame_p50_us":430,"frame_p95_us":1180,"republish_p50_us":95,"tick_p50_us":51,"frames":812,"iterations":1000}
parsed OK; working/url_every/rate now identify the run: 4 12 30
```
</details>
<details>
<summary>Evidence: e2e interrupt barrier under a saturated machine (and the attempted pre-fix reproduction)</summary>

<code>### FIXED (as on branch) - 5 runs, machine saturated (12 busy loops)&#10;run 1..5: 1 test run: 1 passed (each ~3.9s)&#10;&#10;### WITHOUT the barriers (pre-fix ordering), same 5 runs, same load&#10;run 1..5: 1 test run: 1 passed&#10;&#10;Note: removing the barriers did NOT reproduce `sh: cho: command not found` in 5&#10;runs on this 12-core host even fully saturated, so the pre-fix failure is not&#10;reproducible here on demand -- it is a timing race whose window depends on the&#10;machine. What is shown is that the barriered version is stable under saturation,&#10;and that the change is a pure added synchronisation (no assertion was altered).</code>

```text
\### FIXED (as on branch) - 5 runs of a_click_is_not_a_selection_so_ctrl_c_still_interrupts_the_shell, machine saturated
run 1:  ────────────      Summary [   3.929s] 1 test run: 1 passed, 10 skipped 
run 2:  ────────────      Summary [   3.930s] 1 test run: 1 passed, 10 skipped 
run 3:  ────────────      Summary [   3.905s] 1 test run: 1 passed, 10 skipped 
run 4:  ────────────      Summary [   3.919s] 1 test run: 1 passed, 10 skipped 
run 5:  ────────────      Summary [   3.916s] 1 test run: 1 passed, 10 skipped 

\### WITHOUT the barriers (the pre-fix ordering), same 5 runs, same load
run 1:      Summary [   3.488s] 1 test run: 1 passed, 10 skipped  
run 2:      Summary [   3.408s] 1 test run: 1 passed, 10 skipped  
run 3:      Summary [   3.405s] 1 test run: 1 passed, 10 skipped  
run 4:      Summary [   3.427s] 1 test run: 1 passed, 10 skipped  
run 5:      Summary [   3.445s] 1 test run: 1 passed, 10 skipped  
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"933831de6a13b57b74973320d059beaed12b5923","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

- ⚠️ `scripts/dev/perf-run.sh:378` - `--json` emits syntactically invalid JSON whenever no `perf_window` line was logged. `field()` (line 369) ends in a `cut` pipeline, so its exit status is always 0 even when `grep` matches nothing — the `|| echo 0` fallbacks on lines 378-381 can never fire, and `printf %s` is handed an empty string. Verified: with `WINDOW` empty the line renders as `{&#34;sessions&#34;:8,...,&#34;frame_p50_us&#34;:,&#34;frame_p95_us&#34;:,...}`. This is reachable through a documented invocation: `--no-perf-log --json` (scripts/dev/README.md:63, and docs/PERFORMANCE.md lists `--no-perf-log` as the instrumentation control) turns off `THURBOX_PERF_LOG`, so no `perf_window` line is ever written and all six fields come back empty; a short `--idle` run can also finish before `PERF_WINDOW_TICKS` (1000 iterations, 50s at `IDLE_TICK`) elapses. The human report handles the same case explicitly (&#34;no perf_window line&#34;, line 397), so only the machine-readable path is broken — silently, which is the failure class this script&#39;s own rubric block warns about. Make the fallback real, e.g. `field() { local v; v=$(echo &#34;$WINDOW&#34; | grep -o &#34;$1=[0-9]*&#34; | head -1 | cut -d= -f2); echo &#34;${v:-0}&#34;; }` and drop the `|| echo 0`s.
- ℹ️ `src/kernel/host/api.rs:72` - The ctx metatable is built once per VM and attached to every render context, and `getmetatable`/`setmetatable` are both in the plugin sandbox (thurbox.yml:35, :65). So any plugin can reach the one process-wide table behind every pane&#39;s clock — `getmetatable(ctx).__index = function() end` freezes every spinner in the interface and silently makes `CachedTree.reads_clock` false everywhere, which the ADR&#39;s &#34;detection cannot be wrong in either direction&#34; argument does not account for. `RUN_IMPL` is kept in the registry precisely so a plugin cannot name another plugin&#39;s capability; this hands one out through an ordinary render argument. A one-line hardening closes it: set `__metatable` on `meta` (any value), which makes `getmetatable(ctx)` return that value instead of the table and makes `setmetatable(ctx, ...)` raise. No plugin under `ui/` or `examples/` touches the ctx metatable, so this is latent rather than live.

🔧 Fix: harden ctx metatable and fix perf-run JSON fallback
1 warning still open:

- ⚠️ `.github/workflows/ci.yml:58` - This change adds a new compiled cargo target (`[[bench]] frame_cost` in Cargo.toml:119, `benches/frame_cost.rs`, 751 lines), but the `rust` paths-filter that gates the `clippy`, `nextest` and both Windows jobs lists only `src/**`, `tests/**`, `build.rs`, `ui/**`, `examples/**`, `Cargo.toml`, `Cargo.lock` and the config files — not `benches/**`. A PR that touches only `benches/frame_cost.rs` therefore evaluates `rust: false`, skips the clippy job, and lands green with a bench that no longer compiles; the breakage then surfaces on the next unrelated `src/**` PR, since `cargo clippy --all-targets -D warnings` is the only thing that builds it. This is exactly the reasoning the filter&#39;s own comment already records for `ui/**` (&#34;Without these, a Lua-only change skips clippy, nextest and both Windows jobs, and can red-build main while its own PR is green&#34;), and it directly contradicts the claim this change writes into .no-mistakes.yaml:288 — &#34;`cargo clippy --all-targets` still compiles it under `just lint`, so it cannot rot silently.&#34; The prek `cargo-clippy` hook (`types: [rust]`) does cover a local commit, but hooks are opt-in and `--no-verify`-able; CI is the enforcement layer. Fix: add `- &#39;benches/**&#39;` to the `rust` filter.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`cargo nextest run -E &#39;binary(kernel_frame_cost) or binary(kernel_perf) or (binary(thurbox) and test(link_scan)) or (binary(thurbox) and test(scan_interval))&#39;` — 38 passed (ADR-P20 pacing, ADR-P21 clock scoping, ctx metatable hardening, non-string ctx index)</code>
- <code>`cargo nextest run --test frames` — the real bundled panes pinned cell-for-cell, exercising `ctx.elapsed` served through the metatable</code>
- <code>`cargo nextest run -E &#39;binary(kernel_mvp) and test(spinner)&#39;` — the_working_spinner_advances_with_elapsed_time against the real interface</code>
- <code>`cargo nextest run --test tui_e2e -E &#39;test(a_click_is_not_a_selection_so_ctrl_c_still_interrupts_the_shell)&#39;` — real binary on a pty; run once idle and 5 more times with all 12 cores saturated, 6/6 pass</code>
- <code>Attempted pre-fix reproduction: temporarily removed the two `wait_for_output_since`/`wait_until_quiet` barriers and re-ran the same e2e test 5x under the same saturation (did not reproduce; file restored, tree clean)</code>
- <code>Manual: `NO_MISTAKES_GATE=1 scripts/dev/perf-run.sh --idle` → exit 2 with the refusal message; `NO_MISTAKES_GATE=1 THURBOX_PERF_ALLOW_IN_GATE=1 scripts/dev/perf-run.sh --help` → override honoured</code>
- <code>Manual: lifted the real `field()` + `--json` printf block from `scripts/dev/perf-run.sh` and drove it with an empty and a populated `WINDOW`; both lines parse with `json.loads` and the empty case defaults the six perf fields to 0</code>
- <code>Manual evidence harness (throwaway, since removed): rendered the real `ui/` session list across 8 animation ticks with a `working` session and counted cache hits per bundled pane; and simulated 60 output-floor frames of a URL-printing agent at the ungated vs 250 ms-paced link-scan cadence</code>
</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `ui/AGENTS.md:95` - Judgment call, left unchanged: ui/AGENTS.md&#39;s &#34;Make the pane cost what changed&#34; list has no animation/clock bullet at all, so the ADR-P21 rule (reading ctx.elapsed is what keys your cached tree on the 8 Hz tick) reaches a coding CLI only via docs/PLUGINS.md or the shipped ui-skill SKILL.md, which I did update because it already carried an animation bullet that the change made incomplete. Adding a new bullet to ui/AGENTS.md would be an expansion of always-loaded guidance rather than a stale-fact fix, so I did not; if you want the rule in front of every ui/-editing agent, one sentence there is the place.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
