### PR TITLE
fix(core): fix wheel and scrollbar-drag scrolling in terminal panes

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,7 +521,8 @@ Cmd chords; everything else works there.
 | Key | Action |
 |-----|--------|
 | `PageUp` / `PageDown` | Scroll the agent's output by 10 lines |
-| Mouse drag | Select text |
+| Mouse wheel | Scroll the pane under the pointer (agent or shell tab) |
+| Mouse drag | Select text, or drag the scrollbar to travel the scrollback |
 
 ## Headless CLI (`thurbox-cli`)
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -663,9 +663,10 @@ applicable: `h/j/k/l` for navigation, semantic letters for actions
 | `Shift+Down` | Focused terminal | Scroll down 1 line | |
 | `Shift+PageUp` / `Alt+PageUp` | Focused terminal | Scroll up half page | |
 | `Shift+PageDown` / `Alt+PageDown` | Focused terminal | Scroll down half page | |
-| Mouse wheel | Focused terminal | Scroll up/down 3 lines | |
+| Mouse wheel | Terminal under the pointer | Scroll its scrollback (agent or shell tab) | |
 | Click | Session/task/automation/file row | Select the row and focus its pane | |
 | Click | Any pane | Focus the pane under the cursor | |
+| Click / drag | Terminal scrollbar | Jump to, or drag to, a place in the scrollback | |
 | Click | Picker modal row | Select and confirm (Enter; repo picker: Space toggle) | |
 | Hover | Clickable rows | Underline the row a click would hit | |
 | All other keys | Focused terminal | Forwarded to PTY (snaps to bottom if scrolled) | |
@@ -2453,6 +2454,17 @@ recorded before their pane's whole-rect focus fallback.
 - **Hover**: the clickable row under the pointer is underlined
   (driven by mouse-move events; applied post-render from the same
   click registry).
+- **The pane is asked first**: a tick over a pane reaches it as a
+  tick (`on_scroll`), and only what it declines becomes a
+  synthesized `up`/`down` keystroke. The hook is there for the one
+  pane that cannot take the keystroke: the terminal pane hands every
+  unclaimed key to the agent, so declaring `up` would take the arrow
+  keys from whatever is running in it — and the wheel therefore did
+  nothing at all over a live terminal unless the program inside had
+  asked for the mouse, which is what made it look like a fault only
+  some people had. Both terminal tabs scroll, each keeping its own
+  place in its own scrollback, and any key forwarded to the pty
+  snaps the view back to the live bottom.
 - **One notch, one step**: a wheel *notch* is not one report. A
   terminal turns a detent into its line-scroll count — three, for
   ghostty, kitty and xterm — and under mouse reporting sends that
@@ -2460,10 +2472,18 @@ recorded before their pane's whole-rect focus fallback.
   the session list through three sessions and open each one on the
   way. Reports closer together than a person can turn a wheel
   (20 ms) are folded into the notch that started them, and a
-  direction change always steps. A tick **forwarded to a pty** is
+  direction change always steps. That folding is the *keystroke*
+  path's, so it applies to the panes that step a selection. A tick
+  **forwarded to a pty**, and one taken by `on_scroll`, are
   deliberately left whole: there the three reports are the three
-  lines the terminal means to scroll, and the program inside owns
-  what they do.
+  lines the terminal means to scroll.
+- **A program that asked for the mouse gets the tick**: a live
+  terminal whose program turned on mouse reporting is sent the wheel
+  (SGR, or xterm's original encoding for a program that asked for
+  no better one) rather than scrolled locally — it is almost
+  certainly on the alternate screen, which keeps no scrollback for
+  thurbox to move. Scrolling such a session is then the program's
+  own job; Claude Code, vim and htop are all in this class.
 - **Modal scrolling**: while a modal is open the wheel steps its
   selection (one row per notch, like `j`/`k`); overflowing picker
   lists window around the selection and draw a draggable scrollbar
@@ -2472,9 +2492,21 @@ recorded before their pane's whole-rect focus fallback.
   effects (e.g. theme live preview) match keyboard navigation. Pane
   scrollbars beneath an overlay are never grabbable.
 
-Dispatch order on click: modal (scrollbar grab → row act → swallow)
-→ `Ctrl+Click` URL → pane scrollbar grab → global-search swallow →
-click targets → text selection arming.
+Dispatch order on click: modal (swallowing what misses its rows) →
+chrome band button → float (swallowing what misses it) →
+`Ctrl+Click` URL → click targets → text selection arming.
+
+- **Dragging a control**: a node declaring `role = "drag"` takes hold
+  of the pointer for the length of the press — no text selection is
+  armed over it, and every move until release is delivered to it as a
+  further click carrying `dragging`, clamped to the rect it was
+  pressed in (a drag that wanders off a scrollbar is still that
+  scrollbar's). The kernel only routes; what the movement means is the
+  pane's, which is what lets a scrollbar exist at all given four node
+  kinds. The terminal pane's bar is the one in the bundled interface:
+  press the track to jump, drag the thumb to travel, and the thumb is
+  picked up where you grabbed it rather than jumping its own length
+  under the pointer.
 
 The whole subsystem is gated by `[features] mouse` in settings.toml
 (default `true`): when disabled, mouse capture is never enabled, so

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -641,11 +641,16 @@ it:
 ```lua
 on_click = function(hit)
   -- hit.id, hit.class, hit.role, plus hit.x / hit.y inside the node's own rect
+  -- and hit.w / hit.h, its size
   if not hit.id then return false end
   state.cursor = index_of(hit.id)
   return true
 end,
 ```
+
+`hit.w` / `hit.h` are there so a coordinate can be resolved against the shape it
+landed in without the pane keeping geometry from its last render — which a
+`pure` pane cannot do at all, since `render` may not write.
 
 Return `false` and the press falls through, which is what lets the same click
 that focused a terminal also start a drag-selection over it. A pane needs no
@@ -662,6 +667,72 @@ map it necessarily already has. Cells have no per-line identity and do not need 
 thing that decided where every row went is the thing that receives the coordinate. That
 is what lets a side-by-side diff aim a click at the old or the new column with nothing
 added to the node catalog.
+
+### Dragging
+
+A node whose `role` is exactly `drag` takes **hold of the pointer**: the press
+arms no text selection, and every move until the button comes up is delivered to
+that node as a further click with `hit.dragging = true`. That is the whole of
+what a scrollbar, a slider or a splitter needs from four node kinds — the kernel
+only keeps routing the pointer; what the movement *means* stays the pane's.
+
+```lua
+-- the bundled terminal pane's scrollbar, in outline
+on_click = function(hit)
+  if hit.role ~= "drag" then return false end
+  if not hit.dragging then state.grabbed_at = hit.y - thumb_start() end
+  state.offset = offset_for(hit.y - state.grabbed_at, hit.h)
+  return true
+end,
+```
+
+Two things follow from where the grab is held:
+
+- **A drag that wanders off the node is still that node's**, clamped to the rect
+  it was pressed in. Hit-testing every move afresh would hand the gesture to
+  whatever it wandered onto, which is not what any scrollbar does.
+- **Take the grab offset at the press, not at every move.** Without it the thing
+  being dragged jumps so that the point you grabbed becomes its top — very
+  visible on a tall scrollbar thumb.
+
+It is deliberately not one of the click *verbs*: those name something the kernel
+does on the pane's behalf, and here the kernel does nothing but deliver. The
+bare role composes with the `id` a node already carries, so a pane with two
+draggables tells them apart the way it tells two rows apart.
+
+### The wheel
+
+A wheel tick over a pane is offered to that pane — the one under the pointer,
+not the focused one — before it becomes anything else:
+
+```lua
+on_scroll = function(wheel)
+  -- wheel.up, plus wheel.x / wheel.y inside the pane's own rect
+  state.offset = math.max(0, state.offset + (wheel.up and -1 or 1))
+  return true
+end,
+```
+
+Decline it (`false`, or declare no `on_scroll`) and the kernel synthesizes an
+`up`/`down` keystroke for the pane instead, so a pane that already declares
+those keys scrolls by the wheel with nothing added — and the wheel cannot come
+to mean something its arrow keys do not.
+
+The hook exists for the pane that cannot take that fallback: a pane declaring
+`input = "session"` hands every unclaimed key to the agent, so declaring `up`
+there would take the arrow keys away from whatever is running in it. Without a
+tick of its own the wheel did nothing at all over a live terminal.
+
+Two rules follow from where each half sits:
+
+- **`on_scroll` is one report; the keystroke fallback is one notch.** A detent
+  is several reports (three, for ghostty, kitty and xterm) and the fallback
+  folds them into one step, because a pane that moves a *selection* must not
+  walk three rows per flick. A pane that scrolls by lines wants all three, which
+  is also what a tick forwarded to a pty delivers.
+- **A live terminal that asked for the mouse is served before either.** The
+  kernel forwards the tick to the pty instead, since a program on the alternate
+  screen keeps no scrollback for anyone else to scroll.
 
 Everything here is inert when `[features] mouse` is off — the capture escape is
 never sent, so the terminal keeps its own selection and scrolling.

--- a/src/coordinator/boot.rs
+++ b/src/coordinator/boot.rs
@@ -247,6 +247,7 @@ pub(crate) async fn run() -> Result<(), Box<dyn Error>> {
         last_output_painted: std::collections::HashMap::new(),
         last_output_gen: 0,
         grabbed: None,
+        pointer_grab: None,
         runs: thurbox::kernel::runs::RunStore::new(),
         inventory: Vec::new(),
         respawned: std::collections::HashSet::new(),

--- a/src/coordinator/mouse.rs
+++ b/src/coordinator/mouse.rs
@@ -13,8 +13,15 @@ impl App {
             MouseEventKind::Down(MouseButton::Left) => {
                 self.on_click(mouse.column, mouse.row, mouse.modifiers)
             }
-            MouseEventKind::Drag(MouseButton::Left) => self.drag_selection(mouse.column, mouse.row),
+            // A held node comes first: while a scrollbar has the pointer, the
+            // movement is that pane's, not a selection over the text beside it.
+            MouseEventKind::Drag(MouseButton::Left) => {
+                if !self.drag_held(mouse.column, mouse.row) {
+                    self.drag_selection(mouse.column, mouse.row);
+                }
+            }
             MouseEventKind::Up(MouseButton::Left) => {
+                self.pointer_grab = None;
                 if let Some(selection) = &mut self.selection {
                     selection.dragging = false;
                     // A press that never moved is a click, not a selection —
@@ -44,10 +51,13 @@ impl App {
     /// one, so you can spin the wheel over a list without leaving the pane you
     /// are working in.
     ///
-    /// A tick becomes an `up`/`down` keystroke rather than a scroll command of
-    /// its own: every scrollable pane already declares those, so the wheel and
-    /// the arrow keys cannot come to mean different things — the same reasoning
-    /// behind the `key:<chord>` click role.
+    /// The pane is asked first through [`LuaHost::on_scroll`], and only what it
+    /// declines becomes an `up`/`down` keystroke — so a pane that already
+    /// declares those keys keeps scrolling by them and the wheel cannot come to
+    /// mean something its arrow keys do not (the reasoning behind the
+    /// `key:<chord>` click role). The hook exists because the pane that most
+    /// needs the wheel is the one pane that cannot declare `up`: a terminal
+    /// pane hands every unclaimed key to the agent.
     ///
     /// One notch of a wheel is **not** one report, so every leg that steps a
     /// selection asks [`WheelNotch`] first — without it a single detent walked
@@ -87,6 +97,32 @@ impl App {
         }
 
         if let Some(target) = self.target_at(x, y) {
+            // The pane is offered the tick AS a tick before the keystroke
+            // below, because the pane that most needs the wheel is the one that
+            // cannot have those keys: a pane showing a live terminal hands
+            // every unclaimed key to the agent, so declaring `up` there would
+            // take the arrow keys from whatever is running in it. The wheel
+            // therefore did nothing at all over a terminal — unless the program
+            // inside had asked for the mouse, when `forward_wheel` above sends
+            // it the tick instead, which is why it looked like a fault only
+            // some people had.
+            //
+            // No notch: `on_scroll` is one report, exactly as a forwarded tick
+            // is, and the pane that wants a notch declines and takes the
+            // keystroke.
+            let scroll = Scroll {
+                up,
+                x: x.saturating_sub(target.rect.x),
+                y: y.saturating_sub(target.rect.y),
+            };
+            match self.host.on_scroll(target.plugin, &scroll) {
+                Ok(true) => {
+                    self.dirty = true;
+                    return;
+                }
+                Ok(false) => {}
+                Err(e) => self.errors.push(e),
+            }
             if self.wheel_notch.opens(Instant::now(), up) {
                 self.dispatch_key_to(target.plugin, &key);
                 self.dirty = true;
@@ -233,13 +269,18 @@ impl App {
             // this the only such panes you could click were the ones built from
             // `widgets.list`, which is exactly the half that worked.
             None => {
-                let click = Click {
-                    id: target.identity.id.clone(),
-                    classes: target.identity.classes.clone(),
-                    role: target.identity.role.clone(),
-                    x: x.saturating_sub(target.rect.x),
-                    y: y.saturating_sub(target.rect.y),
-                };
+                // A press on a drag handle takes hold of the pointer, so the
+                // moves that follow it reach this pane instead of painting a
+                // selection across the text the pane is about to scroll.
+                if target.identity.is_drag_handle() {
+                    self.selection = None;
+                    self.pointer_grab = Some(PointerGrab {
+                        plugin: target.plugin,
+                        rect: target.rect,
+                        identity: target.identity.clone(),
+                    });
+                }
+                let click = self.click_at(&target, x, y, false);
                 match self.host.on_click(target.plugin, &click) {
                     Ok(handled) => handled,
                     Err(e) => {
@@ -334,6 +375,47 @@ impl App {
             .find(|target| target.identity.is_empty() && target.rect.contains(position))
             .map(|target| target.rect)?;
         PaneBounds::content_at(pane, x, y).map(|bounds| bounds.rect())
+    }
+
+    /// A press or a move, resolved into the node's own coordinate space.
+    fn click_at(&self, target: &ClickTarget, x: u16, y: u16, dragging: bool) -> Click {
+        Click {
+            id: target.identity.id.clone(),
+            classes: target.identity.classes.clone(),
+            role: target.identity.role.clone(),
+            x: x.saturating_sub(target.rect.x),
+            y: y.saturating_sub(target.rect.y),
+            w: target.rect.width,
+            h: target.rect.height,
+            dragging,
+        }
+    }
+
+    /// Deliver a move to the node holding the pointer. `false` when none is.
+    ///
+    /// Clamped to the held node's rect rather than hit-tested afresh: a drag
+    /// that wanders off a scrollbar is still that scrollbar's, which is what
+    /// every scrollbar does and the reason the rect is remembered at press
+    /// time. It is delivered as a further click — the same handler, one place —
+    /// with `dragging` set so a pane that cares can tell the two apart.
+    pub(crate) fn drag_held(&mut self, x: u16, y: u16) -> bool {
+        let Some(grab) = self.pointer_grab.clone() else {
+            return false;
+        };
+        let target = ClickTarget {
+            plugin: grab.plugin,
+            rect: grab.rect,
+            identity: grab.identity,
+        };
+        let bounds = PaneBounds::from_rect(grab.rect);
+        let (x, y) = bounds.clamp(x, y);
+        let click = self.click_at(&target, x, y, true);
+        match self.host.on_click(grab.plugin, &click) {
+            Ok(_) => {}
+            Err(e) => self.errors.push(e),
+        }
+        self.dirty = true;
+        true
     }
 
     /// Arm a drag-to-select over the terminal surface under the point.

--- a/src/kernel/host/mod.rs
+++ b/src/kernel/host/mod.rs
@@ -347,6 +347,40 @@ pub struct Click {
     /// side-by-side diff row, where which half you clicked is the answer.
     pub x: u16,
     pub y: u16,
+    /// The node's own size, so a coordinate can be resolved against the shape
+    /// it landed in without the pane storing geometry from its last render —
+    /// which a `pure` pane cannot do at all, since `render` may not write.
+    pub w: u16,
+    pub h: u16,
+    /// Whether this is the pointer moving under a press it already took, rather
+    /// than the press itself. Set only for a node that declared
+    /// [`super::node::Identity::is_drag_handle`].
+    pub dragging: bool,
+}
+
+/// A wheel tick resolved onto the pane under the pointer.
+///
+/// Its own hook rather than a synthesized `up`/`down` keystroke, because the
+/// one pane that most needs the wheel is the one that cannot have those keys: a
+/// pane showing a live terminal hands every unclaimed key to the agent, so
+/// declaring `up` there would take the arrow keys away from whatever is running
+/// in it. Every pane that *can* declare them still does, and the kernel falls
+/// back to the keystroke when this hook declines — so a list keeps scrolling by
+/// the same code path its arrow keys use.
+///
+/// One report, not one notch. A detent is several reports and each is one line,
+/// which is exactly what the tick means when it is forwarded to a pty instead
+/// ([`super::terminal::Terminals::forward_wheel`]); a pane that steps a
+/// *selection* wants the notch and takes the keystroke fallback, where the
+/// kernel already applies one.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Scroll {
+    /// Which way the wheel turned.
+    pub up: bool,
+    /// Column and row within the scrolled node's own rect, as [`Click`] carries
+    /// them — a pane with more than one scrollable region needs to know which.
+    pub x: u16,
+    pub y: u16,
 }
 
 /// A plugin that is floating this frame, and how much room it wants.
@@ -1640,6 +1674,49 @@ impl LuaHost {
             .map_err(|e| fail(e.to_string()))?;
         table.set("x", click.x).map_err(|e| fail(e.to_string()))?;
         table.set("y", click.y).map_err(|e| fail(e.to_string()))?;
+        table.set("w", click.w).map_err(|e| fail(e.to_string()))?;
+        table.set("h", click.h).map_err(|e| fail(e.to_string()))?;
+        table
+            .set("dragging", click.dragging)
+            .map_err(|e| fail(e.to_string()))?;
+
+        self.enter(plugin);
+        let guard = Budget::arm(&self.lua);
+        let handled: Result<bool, mlua::Error> = handler.call(table);
+        drop(guard);
+
+        handled.map_err(|e| fail(clean_error(&e)))
+    }
+
+    /// Offer a wheel tick to the plugin whose pane is under the pointer.
+    ///
+    /// Declining (`false`, or declaring no `on_scroll` at all) is what puts the
+    /// tick back on the keystroke path, so a pane that already scrolls by
+    /// `up`/`down` needs nothing here. See [`Scroll`].
+    pub fn on_scroll(&self, index: usize, scroll: &Scroll) -> Result<bool, PluginError> {
+        let Some(plugin) = self.plugins.get(index) else {
+            return Ok(false);
+        };
+        let fail = |message: String| PluginError {
+            plugin: plugin.name.clone(),
+            phase: Phase::Key,
+            message,
+        };
+
+        let handler: Value = plugin
+            .def
+            .get("on_scroll")
+            .map_err(|e| fail(e.to_string()))?;
+        let Value::Function(handler) = handler else {
+            return Ok(false);
+        };
+
+        let table = self.lua.create_table().map_err(|e| fail(e.to_string()))?;
+        table
+            .set("up", scroll.up)
+            .map_err(|e| fail(e.to_string()))?;
+        table.set("x", scroll.x).map_err(|e| fail(e.to_string()))?;
+        table.set("y", scroll.y).map_err(|e| fail(e.to_string()))?;
 
         self.enter(plugin);
         let guard = Budget::arm(&self.lua);

--- a/src/kernel/node.rs
+++ b/src/kernel/node.rs
@@ -81,7 +81,25 @@ impl Identity {
     pub fn click_verb(&self) -> Option<ClickVerb> {
         ClickVerb::parse(self.role.as_deref())
     }
+
+    /// Does a press here take hold of the pointer?
+    ///
+    /// A node saying so is handed the drags that follow the press, and no text
+    /// selection is armed over it — which is what makes a scrollbar, a slider or
+    /// a splitter possible from four node kinds. It is not a [`ClickVerb`]: the
+    /// verbs name something the *kernel* does, and here the kernel only keeps
+    /// routing the pointer to the pane, which decides what the movement means.
+    ///
+    /// Spelled as the bare role rather than `drag:<something>` so it composes
+    /// with the `id` a node already carries: a pane with two draggables tells
+    /// them apart the way it tells two rows apart.
+    pub fn is_drag_handle(&self) -> bool {
+        self.role.as_deref() == Some(DRAG_ROLE)
+    }
 }
+
+/// The role a node carries to say a press on it grabs the pointer.
+pub const DRAG_ROLE: &str = "drag";
 
 /// What the kernel itself does when a painted node is clicked.
 ///

--- a/src/kernel/terminal/mod.rs
+++ b/src/kernel/terminal/mod.rs
@@ -146,6 +146,49 @@ const CONTENT_LINE_CAP: usize = 500;
 /// The suffix that addresses a session's companion shell as its own surface.
 const SHELL_SUFFIX: &str = "#shell";
 
+/// One wheel tick, in the encoding the program inside the pane asked for.
+///
+/// Xterm's wheel is buttons 64 (up) and 65 (down), reported as a press with no
+/// release. Two encodings are emitted, because a program that asks for the
+/// mouse at all and is handed nothing is a pane the wheel is dead in: the
+/// alternate screen it is almost certainly on keeps no scrollback, so there is
+/// no local fallback to leave it to.
+///
+/// * `Sgr` (`?1006`) — `CSI < Cb ; Cx ; Cy M`, and the only one with no size
+///   limit.
+/// * `Default` — xterm's original `CSI M` with each field offset by 32, which
+///   caps a coordinate at 223. Past that there is no legal report to send, so
+///   `None`: a truncated one would land the tick on the wrong cell.
+///
+/// `Utf8` (`?1005`) is deliberately not emitted. It is ambiguous by
+/// construction — a receiver cannot tell it from the default encoding without
+/// being told — and no agent asks for it.
+fn wheel_report(
+    encoding: vt100::MouseProtocolEncoding,
+    up: bool,
+    col: u32,
+    row: u32,
+) -> Option<Vec<u8>> {
+    let button = if up { 64 } else { 65 };
+    match encoding {
+        vt100::MouseProtocolEncoding::Sgr => {
+            Some(format!("\x1b[<{button};{col};{row}M").into_bytes())
+        }
+        vt100::MouseProtocolEncoding::Default => {
+            let cell = |n: u32| u8::try_from(n + 32).ok();
+            Some(vec![
+                0x1b,
+                b'[',
+                b'M',
+                cell(button)?,
+                cell(col)?,
+                cell(row)?,
+            ])
+        }
+        _ => None,
+    }
+}
+
 /// A session we have attached to, plus the size we last told it about.
 struct Live {
     session: crate::agent::Session,
@@ -1115,20 +1158,17 @@ impl Terminals {
             return false;
         };
         let parser = live.visible_parser();
-        // Only the SGR encoding is emitted below, so a pane asking for one of
-        // the older ones is left to the local fallback rather than sent bytes it
-        // would misread.
-        let wants = match parser.lock() {
+        let encoding = match parser.lock() {
             Ok(parser) => {
                 let screen = parser.screen();
-                screen.mouse_protocol_mode() != vt100::MouseProtocolMode::None
-                    && screen.mouse_protocol_encoding() == vt100::MouseProtocolEncoding::Sgr
+                (screen.mouse_protocol_mode() != vt100::MouseProtocolMode::None)
+                    .then(|| screen.mouse_protocol_encoding())
             }
-            Err(_) => false,
+            Err(_) => None,
         };
-        if !wants {
+        let Some(encoding) = encoding else {
             return false;
-        }
+        };
 
         // The rect is the surface's own content area — the plugin's frame is
         // outside it — so the offset needs no border adjustment. PTY cells are
@@ -1136,9 +1176,9 @@ impl Terminals {
         let rect = live.rect.get();
         let col = u32::from(x - rect.x) + 1;
         let row = u32::from(y - rect.y) + 1;
-        // Xterm wheel buttons: 64 up, 65 down. SGR press is `CSI < Cb ; Cx ; Cy M`.
-        let button = if up { 64 } else { 65 };
-        let bytes = format!("\x1b[<{button};{col};{row}M").into_bytes();
+        let Some(bytes) = wheel_report(encoding, up, col, row) else {
+            return false;
+        };
         match live.send_visible_input(bytes) {
             Ok(()) => true,
             Err(e) => {
@@ -1548,9 +1588,15 @@ impl SurfaceProvider for Terminals {
                 live.size.set(wanted);
                 live.session.resize(area.height, area.width);
             }
-            let Ok(parser) = shell.parser.lock() else {
+            let Ok(mut parser) = shell.parser.lock() else {
                 return false;
             };
+            // The shell has a scrollback of its own — it is wired up by the same
+            // `wire_up` the agent pane is — so the offset is set here exactly as
+            // it is below. Left out, the pane could hold an offset for the shell
+            // and the wheel could move it, and the screen behind it never went
+            // anywhere.
+            parser.screen_mut().set_scrollback(usize::from(scroll));
             links::clear_uncovered(frame, area, parser.screen());
             frame.render_widget(
                 PseudoTerminal::new(parser.screen()).style(Style::default()),
@@ -1593,6 +1639,32 @@ impl SurfaceProvider for Terminals {
 mod tests {
     use super::*;
     use crate::kernel::snapshot::SessionRow;
+
+    #[test]
+    fn a_wheel_tick_is_encoded_the_way_the_pane_asked_for_it() {
+        use vt100::MouseProtocolEncoding as E;
+        assert_eq!(
+            wheel_report(E::Sgr, true, 12, 3).expect("sgr"),
+            b"\x1b[<64;12;3M".to_vec()
+        );
+        assert_eq!(
+            wheel_report(E::Sgr, false, 12, 3).expect("sgr"),
+            b"\x1b[<65;12;3M".to_vec()
+        );
+        // The original encoding offsets every field by 32. A program that asks
+        // for the mouse without asking for SGR used to be handed nothing, and
+        // its alternate screen leaves no scrollback to fall back on.
+        assert_eq!(
+            wheel_report(E::Default, true, 12, 3).expect("default"),
+            vec![0x1b, b'[', b'M', 96, 44, 35]
+        );
+        // Past 223 there is no legal report, and a truncated one would land the
+        // tick on the wrong cell.
+        assert_eq!(wheel_report(E::Default, true, 224, 3), None);
+        assert!(wheel_report(E::Default, true, 223, 223).is_some());
+        // Ambiguous by construction, and asked for by nothing.
+        assert_eq!(wheel_report(E::Utf8, true, 12, 3), None);
+    }
 
     fn row(id: &str, backend: &str, backend_id: Option<&str>) -> SessionRow {
         SessionRow {

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ use thurbox::agent::input::key_to_bytes;
 use thurbox::kernel::bands::{self, Band, BandState, Level};
 use thurbox::kernel::command::CommandBus;
 use thurbox::kernel::diff::DiffStore;
-use thurbox::kernel::host::{Click, KeyPress, LuaHost, PluginError, RenderContext};
+use thurbox::kernel::host::{Click, KeyPress, LuaHost, PluginError, RenderContext, Scroll};
 use thurbox::kernel::layout::{resolve, SlotMode};
 use thurbox::kernel::metrics::{Metrics, Subject};
 use thurbox::kernel::modals::{ModalKind, Modals};
@@ -163,6 +163,19 @@ async fn main() -> Result<(), Box<dyn Error>> {
 /// recorded before the tree so anything inside it wins.
 #[derive(Debug, Clone)]
 struct ClickTarget {
+    plugin: usize,
+    rect: Rect,
+    identity: Identity,
+}
+
+/// A node that took hold of the pointer, and where it was when it did.
+///
+/// Held rather than re-resolved on every move: a drag that wanders off a
+/// scrollbar is still that scrollbar's, and hit-testing afresh would hand it to
+/// whatever it wandered onto. Released on the button coming up, so nothing
+/// survives the press that made it.
+#[derive(Debug, Clone)]
+struct PointerGrab {
     plugin: usize,
     rect: Rect,
     identity: Identity,
@@ -456,6 +469,8 @@ struct App {
     last_output_gen: u64,
     /// Plugin holding an exclusive key grab this frame, if any.
     grabbed: Option<usize>,
+    /// The node holding the pointer between a press and its release, if any.
+    pointer_grab: Option<PointerGrab>,
     /// Programs plugins asked to be run, and what they printed.
     runs: thurbox::kernel::runs::RunStore,
     /// Every file of the interface, as of the last painted frame.

--- a/tests/mouse.rs
+++ b/tests/mouse.rs
@@ -460,6 +460,9 @@ fn clicking_a_session_row_selects_that_session() {
         role: Some("row".into()),
         x: 0,
         y: 0,
+        w: 40,
+        h: 1,
+        dragging: false,
     };
     assert!(host.on_click(index, &click).expect("click"), "handled");
 

--- a/tests/terminal_pane.rs
+++ b/tests/terminal_pane.rs
@@ -11,8 +11,8 @@ use ratatui::backend::TestBackend;
 use ratatui::buffer::Buffer;
 use ratatui::Terminal;
 
-use thurbox::kernel::host::{KeyPress, LuaHost, Published, RenderContext};
-use thurbox::kernel::node::{ClickVerb, Node};
+use thurbox::kernel::host::{Click, KeyPress, LuaHost, Published, RenderContext, Scroll};
+use thurbox::kernel::node::{ClickVerb, Node, SurfaceSource};
 use thurbox::kernel::paint::{render, render_recording, Hit, PlaceholderSurfaces};
 use thurbox::kernel::registry::Registry;
 use thurbox::kernel::snapshot::{SessionRow, Snapshot};
@@ -168,6 +168,28 @@ fn column_of(line: &str, needle: &str) -> u16 {
         .find(needle)
         .unwrap_or_else(|| panic!("{needle} is not on the border: {line}"));
     u16::try_from(line[..at].chars().count()).expect("a column")
+}
+
+/// How far back the session surface this pane placed is scrolled.
+fn surface_scroll(node: &Node) -> u16 {
+    fn walk(node: &Node) -> Option<u16> {
+        match node {
+            Node::Surface {
+                source: SurfaceSource::Session(_),
+                scroll,
+                ..
+            } => Some(*scroll),
+            Node::Box { children, .. } => children.iter().find_map(walk),
+            _ => None,
+        }
+    }
+    walk(node).expect("the pane places a session surface")
+}
+
+/// One wheel report over the middle of the pane.
+fn wheel(host: &LuaHost, up: bool) -> bool {
+    host.on_scroll(index_of(host, TERMINAL), &Scroll { up, x: 30, y: 5 })
+        .expect("the wheel")
 }
 
 fn session_surface(node: &Node) -> String {
@@ -480,4 +502,252 @@ fn a_chip_is_only_as_wide_as_its_own_label() {
         assert_eq!(hit.rect.y, 0, "the strip is the top border");
         assert!(hit.rect.height == 1 && hit.rect.width < 20, "{hit:?}");
     }
+}
+
+// ── the wheel ─────────────────────────────────────────────────────────────
+
+#[test]
+fn a_wheel_tick_scrolls_the_terminal_under_it() {
+    // The wheel reaches a pane as its own tick, not as a synthesized `up`. This
+    // pane is the reason the hook exists: it hands every unclaimed key to the
+    // agent, so it is the one pane that cannot declare the arrow keys the
+    // keystroke fallback needs — and the wheel therefore did nothing at all
+    // over the only surface with a scrollback worth moving.
+    let host = with_a_selection();
+    assert_eq!(
+        surface_scroll(&tree(&host, 60, 10)),
+        0,
+        "live, at the bottom"
+    );
+
+    assert!(wheel(&host, true), "the pane takes the tick");
+    assert_eq!(
+        surface_scroll(&tree(&host, 60, 10)),
+        1,
+        "one report is one line, as it is when the tick is forwarded to a pty"
+    );
+
+    assert!(wheel(&host, false), "and back down");
+    assert_eq!(surface_scroll(&tree(&host, 60, 10)), 0);
+    assert!(
+        !wheel(&host, false),
+        "at the bottom there is nothing to give, so the tick is declined"
+    );
+}
+
+#[test]
+fn the_wheel_scrolls_the_shell_tab_as_well() {
+    // Scrollback is the pane's policy, and it used to hold one for the agent
+    // view alone: the shell surface is a live terminal with a scrollback of its
+    // own, so refusing to hold an offset for it left the wheel dead there.
+    //
+    // The page keys still decline on this tab (see the test above): a pager or
+    // an editor running in the shell has its own idea of what a page is, and
+    // none of what a wheel means.
+    let host = with_a_selection();
+    let index = index_of(&host, TERMINAL);
+    host.on_action(index, "terminal.shell").expect("select");
+
+    assert!(wheel(&host, true), "the shell takes the tick");
+    let node = tree(&host, 100, 10);
+    assert!(
+        session_surface(&node).ends_with("#shell"),
+        "still the shell's own surface"
+    );
+    assert_eq!(surface_scroll(&node), 1);
+    assert!(
+        painted(&node, 100, 10)[0].contains("1↑"),
+        "and says so on its title: {:?}",
+        painted(&node, 100, 10)[0]
+    );
+}
+
+#[test]
+fn each_tab_keeps_its_own_place_in_its_own_scrollback() {
+    // Two live terminals taking turns in one rect, so one offset between them
+    // would put the shell where the agent was — and the kernel writes the
+    // offset into whichever parser it is drawing.
+    let host = with_a_selection();
+    let index = index_of(&host, TERMINAL);
+    assert!(wheel(&host, true));
+    assert!(wheel(&host, true));
+    assert_eq!(surface_scroll(&tree(&host, 60, 10)), 2);
+
+    host.on_action(index, "terminal.shell").expect("select");
+    assert_eq!(
+        surface_scroll(&tree(&host, 60, 10)),
+        0,
+        "the shell has its own, and has not been scrolled"
+    );
+
+    host.on_action(index, "terminal.agent").expect("back");
+    assert_eq!(
+        surface_scroll(&tree(&host, 60, 10)),
+        2,
+        "the agent kept its"
+    );
+}
+
+#[test]
+fn typing_snaps_the_view_back_to_the_bottom() {
+    // v1's rule: a key forwarded to the pty returns you to the live end of the
+    // stream. Without it a wheel tick leaves you typing into a screen you
+    // cannot see, which is a worse trap now that the wheel actually moves.
+    //
+    // The key is not consumed — the handler declines it — so it still reaches
+    // the agent.
+    let host = with_a_selection();
+    let index = index_of(&host, TERMINAL);
+    assert!(wheel(&host, true));
+    assert_eq!(surface_scroll(&tree(&host, 60, 10)), 1);
+
+    let key = KeyPress {
+        name: "a".into(),
+        ch: Some('a'),
+        ..KeyPress::default()
+    };
+    assert!(
+        !host.on_key(index, &key).expect("key"),
+        "the keystroke belongs to the agent"
+    );
+    assert_eq!(surface_scroll(&tree(&host, 60, 10)), 0);
+}
+
+// ── the scrollbar is a control ────────────────────────────────────────────
+
+/// The pane height every scrollbar case below is rendered at, and the scrollback
+/// they scroll. A 12-row pane leaves 10 inner rows: a cap, eight rows of track,
+/// a cap.
+const BAR_HEIGHT: u16 = 12;
+const BAR_TRACK_TOP: u16 = 1;
+const BAR_TRACK_BOTTOM: u16 = 8;
+const BAR_DEPTH: u16 = 20;
+
+/// The role the pane gives its scrollbar — the kernel's own spelling for "a
+/// press here takes hold of the pointer".
+const DRAG: &str = "drag";
+
+/// A press, or a move under one, on row `row` of the scrollbar column.
+fn bar_press(host: &LuaHost, row: u16, dragging: bool) -> bool {
+    host.on_click(
+        index_of(host, TERMINAL),
+        &Click {
+            id: None,
+            classes: Vec::new(),
+            role: Some(DRAG.into()),
+            x: 0,
+            y: row,
+            w: 1,
+            h: BAR_HEIGHT - 2,
+            dragging,
+        },
+    )
+    .expect("press")
+}
+
+/// A session scrolled back far enough to have a bar to grab.
+fn with_a_scrollback() -> LuaHost {
+    let host = with_a_selection();
+    for _ in 0..BAR_DEPTH {
+        assert!(wheel(&host, true), "scroll back");
+    }
+    assert_eq!(surface_scroll(&tree(&host, 60, BAR_HEIGHT)), BAR_DEPTH);
+    host
+}
+
+#[test]
+fn the_scrollbar_is_a_click_target_only_once_there_is_one() {
+    // The bar is painted into the right border column, which is one node for
+    // the whole column — so it is a target or it is not, and there is no row of
+    // it that can be pressed while the rest cannot.
+    let host = with_a_selection();
+    let roles = |host: &LuaHost| -> Vec<String> {
+        hits(&tree(host, 60, BAR_HEIGHT), 60, BAR_HEIGHT)
+            .iter()
+            .filter_map(|hit| hit.identity.role.clone())
+            .collect()
+    };
+    assert!(
+        !roles(&host).contains(&DRAG.to_string()),
+        "an unscrolled pane draws no bar, so there is nothing to grab"
+    );
+
+    let host = with_a_scrollback();
+    assert!(
+        roles(&host).contains(&DRAG.to_string()),
+        "the bar is grabbable as soon as it is drawn"
+    );
+}
+
+#[test]
+fn the_ends_of_the_track_are_the_ends_of_the_scrollback() {
+    // Both ends have to be reachable, and the bottom one is the one that was
+    // off by a line: the position a scrollbar can express is `0..=depth`, and
+    // counting `depth` of them left the end of the track one line above the
+    // live bottom — so the bar could be dragged all the way down and still
+    // leave you off the stream.
+    let host = with_a_scrollback();
+    assert!(bar_press(&host, BAR_TRACK_BOTTOM, false));
+    assert_eq!(
+        surface_scroll(&tree(&host, 60, BAR_HEIGHT)),
+        0,
+        "the end of the track is the live bottom"
+    );
+
+    assert!(bar_press(&host, BAR_TRACK_TOP, false));
+    assert_eq!(
+        surface_scroll(&tree(&host, 60, BAR_HEIGHT)),
+        BAR_DEPTH,
+        "and the start of it is as far back as we have been"
+    );
+}
+
+#[test]
+fn the_thumb_is_picked_up_where_it_was_grabbed() {
+    // A shallow scrollback makes a tall thumb, and pressing its lower half must
+    // not jerk it up by half its length. The offset within the thumb is taken at
+    // the press and held for the whole gesture, so the row under the pointer
+    // stays the row under the pointer.
+    let host = with_a_scrollback();
+    // Live bottom: the thumb sits at the end of the track, and its last row is
+    // the last row of the track.
+    assert!(bar_press(&host, BAR_TRACK_BOTTOM, false));
+    assert_eq!(surface_scroll(&tree(&host, 60, BAR_HEIGHT)), 0);
+
+    // Pressing that last row again is a grab, not a jump: nothing moves.
+    assert!(bar_press(&host, BAR_TRACK_BOTTOM, false));
+    assert_eq!(
+        surface_scroll(&tree(&host, 60, BAR_HEIGHT)),
+        0,
+        "grabbing the thumb where it already is moves nothing"
+    );
+
+    // And dragging it one row up moves by one row of the track, not by the
+    // whole distance from the track's start.
+    assert!(bar_press(&host, BAR_TRACK_BOTTOM - 1, true));
+    let one_row = surface_scroll(&tree(&host, 60, BAR_HEIGHT));
+    assert!(
+        one_row > 0 && one_row < BAR_DEPTH,
+        "one row of travel, not a jump to the top: {one_row}"
+    );
+}
+
+#[test]
+fn a_press_that_is_not_the_scrollbar_is_declined() {
+    // The pane's other affordances are chips the kernel resolves itself through
+    // a click verb; this handler must not swallow anything else that reaches it.
+    let host = with_a_scrollback();
+    assert!(
+        !host
+            .on_click(
+                index_of(&host, TERMINAL),
+                &Click {
+                    role: Some("row".into()),
+                    h: BAR_HEIGHT - 2,
+                    ..Click::default()
+                },
+            )
+            .expect("press"),
+        "declined, so the press falls through as it always did"
+    );
 }

--- a/tests/tui_e2e.rs
+++ b/tests/tui_e2e.rs
@@ -1030,3 +1030,175 @@ fn a_click_is_not_a_selection_so_ctrl_c_still_interrupts_the_shell() {
     let status = tui.quit();
     assert!(status.success(), "exit must be clean: {status:?}");
 }
+
+// --- the wheel over a live terminal -----------------------------------------
+
+impl Tui {
+    /// `count` wheel reports at a 0-based cell, as the SGR reports the binary
+    /// asked the terminal for (xterm's wheel is buttons 64 up and 65 down).
+    ///
+    /// A notch is several reports and each is one line, so the count is the
+    /// number of lines a real wheel would have travelled.
+    fn wheel(&mut self, (x, y): (u16, u16), up: bool, count: u16) {
+        let (px, py) = (x + 1, y + 1);
+        let button = if up { 64 } else { 65 };
+        for _ in 0..count {
+            self.send(format!("\x1b[<{button};{px};{py}M").as_bytes());
+        }
+        std::thread::sleep(Duration::from_millis(250));
+    }
+}
+
+/// Print `marker` into the focused terminal and then bury it: a hundred
+/// numbered lines, which is more than any pane on a 40-row screen can show.
+///
+/// The marker being off screen is the precondition every scroll assertion
+/// below rests on, so it is waited for rather than assumed.
+fn bury_a_marker(tui: &mut Tui, marker: &str) {
+    tui.send(format!("echo {marker}\r").as_bytes());
+    tui.wait_for(marker);
+    tui.send(b"i=1; while [ $i -le 100 ]; do echo tb-fill-$i; i=$((i+1)); done\r");
+    tui.wait_for("tb-fill-100");
+    tui.wait_gone(marker);
+}
+
+#[test]
+fn the_wheel_scrolls_the_agents_output_back() {
+    // The wheel over a terminal pane has to move that terminal's scrollback.
+    // It reached the pane as a synthesized `up`/`down` keystroke, and the pane
+    // that shows a live terminal is the one pane that cannot declare those —
+    // they belong to the agent — so the tick resolved to nothing and the wheel
+    // did nothing at all. An agent that turns on mouse tracking hid it (the
+    // tick is forwarded to the pty instead), which is why it looked like it
+    // only happened to some people.
+    let Some((_profile, mut tui)) = shell_session() else {
+        return;
+    };
+    bury_a_marker(&mut tui, "tb-scroll-marker");
+
+    let at = tui.find("tb-fill-100");
+    tui.wheel(at, true, 90);
+    tui.wait_for("tb-scroll-marker");
+
+    // And back down again: the wheel is not a one-way trip, and the pane
+    // returns to the live bottom of the stream.
+    tui.wheel(at, false, 90);
+    tui.wait_for("tb-fill-100");
+    tui.wait_gone("tb-scroll-marker");
+
+    let status = tui.quit();
+    assert!(status.success(), "exit must be clean: {status:?}");
+}
+
+#[test]
+fn the_wheel_scrolls_the_companion_shell_too() {
+    // The shell is a second surface over the same primitive, and it was the
+    // half that never honoured a scroll offset: the pane refused to hold one
+    // for it and the kernel never set it on the shell's parser, so the wheel
+    // over an open shell moved nothing.
+    let Some((_profile, mut tui)) = shell_session() else {
+        return;
+    };
+
+    // Ctrl+T opens the companion shell in the same pane. The focus badge names
+    // the view, so it is what tells us the shell is the one on screen.
+    tui.send(b"\x14");
+    tui.wait_until("the shell tab to be the view", |frame| {
+        frame
+            .lines()
+            .last()
+            .is_some_and(|band| band.trim_start().starts_with("Shell"))
+    });
+    // The pane paints before the shell inside it has drawn a prompt, and a
+    // keystroke sent in between is lost.
+    tui.wait_until_quiet();
+    bury_a_marker(&mut tui, "tb-shell-marker");
+
+    let at = tui.find("tb-fill-100");
+    tui.wheel(at, true, 90);
+    tui.wait_for("tb-shell-marker");
+
+    let status = tui.quit();
+    assert!(status.success(), "exit must be clean: {status:?}");
+}
+
+// --- the scrollbar is a control, not a decoration ---------------------------
+
+impl Tui {
+    /// The character painted at a 0-based cell, in cells rather than bytes.
+    fn cell(&self, x: u16, y: u16) -> String {
+        self.row(y)
+            .chars()
+            .nth(usize::from(x))
+            .map(|c| c.to_string())
+            .unwrap_or_default()
+    }
+
+    /// The first and last row a scrollbar occupies in column `x` — its caps.
+    fn track_extent(&self, x: u16) -> (u16, u16) {
+        let rows = self.screen.lock().unwrap().screen().size().0;
+        let painted: Vec<u16> = (0..rows)
+            .filter(|y| matches!(self.cell(x, *y).as_str(), "▲" | "▼" | "║" | "█"))
+            .collect();
+        match (painted.first(), painted.last()) {
+            (Some(top), Some(bottom)) => (*top, *bottom),
+            _ => self.give_up(&format!("a scrollbar in column {x}")),
+        }
+    }
+
+    /// Press at a 0-based cell, drag straight down (or up) to `to_y`, release.
+    fn drag_down(&mut self, (x, y): (u16, u16), to_y: u16) {
+        let px = x + 1;
+        self.send(format!("\x1b[<0;{px};{}M", y + 1).as_bytes());
+        let (from, to) = (y.min(to_y), y.max(to_y));
+        for cy in from..=to {
+            self.send(format!("\x1b[<32;{px};{}M", cy + 1).as_bytes());
+        }
+        self.send(format!("\x1b[<0;{px};{}m", to_y + 1).as_bytes());
+        std::thread::sleep(Duration::from_millis(250));
+    }
+}
+
+#[test]
+fn the_scrollbar_can_be_pressed_and_dragged() {
+    // The bar was drawn and could not be touched: the border column carried no
+    // identity, so a press on it armed a text selection, and a drag only ever
+    // meant "extend the selection" — there was no route from the pointer to the
+    // pane that owns the offset.
+    //
+    // Driven on the SHELL tab, which is where it was reported and the harder of
+    // the two: the shell is a second surface over the same primitive.
+    let Some((_profile, mut tui)) = shell_session() else {
+        return;
+    };
+    tui.send(b"\x14");
+    tui.wait_until("the shell tab to be the view", |frame| {
+        frame
+            .lines()
+            .last()
+            .is_some_and(|band| band.trim_start().starts_with("Shell"))
+    });
+    tui.wait_until_quiet();
+    bury_a_marker(&mut tui, "tb-bar-marker");
+
+    // A wheel scroll is what gives the bar a depth to be scaled against, and
+    // leaves the thumb at the top of its track.
+    let at = tui.find("tb-fill-100");
+    tui.wheel(at, true, 90);
+    tui.wait_for("tb-bar-marker");
+    let (column, _) = tui.find("█");
+    let (top, bottom) = tui.track_extent(column);
+
+    // Drag the thumb down the track: that is a return to the live bottom of the
+    // stream, the same place the wheel would have brought us back to.
+    tui.drag_down((column, top + 1), bottom - 1);
+    tui.wait_for("tb-fill-100");
+    tui.wait_gone("tb-bar-marker");
+
+    // And a press on the track alone is a jump, with no drag behind it.
+    tui.drag_down((column, top + 1), top + 1);
+    tui.wait_for("tb-bar-marker");
+
+    let status = tui.quit();
+    assert!(status.success(), "exit must be clean: {status:?}");
+}

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -95,7 +95,7 @@ pane from being the thing that makes the whole interface feel slow:
 - **Declare `pure = true` unless the render writes.** The kernel then reuses
   your last tree until something you read changes, and skips your Lua on every
   other frame. It is only wrong if `render` writes `store`/`state` or calls
-  `command` — move those into `on_key`/`on_action`/`on_click`/`on_event`. Floats
+  `command` — move those into `on_key`/`on_action`/`on_click`/`on_scroll`/`on_event`. Floats
   especially: a float renders every frame *even while closed*.
 - **Memoize on table identity.** The published groups (`thurbox.sessions`,
   `thurbox.theme`, `thurbox.registry`, `thurbox.bookmarks`, …) keep the *same

--- a/ui/README.md
+++ b/ui/README.md
@@ -155,6 +155,20 @@ the base functions (`pairs`, `ipairs`, `type`, `tostring`, `tonumber`, `select`,
 | `files` | bounded reads the kernel performs for you |
 | `thurbox.platform` | `os` and `arch`, so a plugin shipping several builds can pick one |
 
+**Dragging**: a node with `role = "drag"` takes hold of the pointer — the press
+arms no text selection and every move until release arrives as a further
+`on_click` with `hit.dragging = true`, clamped to the rect it was pressed in.
+That is how the terminal pane's scrollbar is grabbable. `hit.w`/`hit.h` carry
+the node's size, so a `pure` pane can resolve the coordinate without stashing
+geometry in `render`.
+
+**The wheel**: `on_scroll(wheel)` is offered a tick over your pane — `wheel.up`,
+plus `wheel.x`/`wheel.y` inside your rect — before the kernel turns it into an
+`up`/`down` keystroke for you. Decline it and you keep the keystroke, which is
+what a pane that already declares those keys wants. It exists for the pane that
+cannot declare them: one taking `input = "session"` hands every unclaimed key to
+the agent.
+
 **Events**: declare `events = { "session.status", … }` and an `on_event(name,
 payload)` and the kernel calls you once per change, with the same environment a
 render has. `command("emit", { text = "x", … })` reaches every plugin subscribed

--- a/ui/lib/chrome.lua
+++ b/ui/lib/chrome.lua
@@ -168,7 +168,9 @@ end
 ---
 --- opts: width, height, title, title_style, title_align, border_style, square,
 ---       left (runs painted over the top border's left half),
----       right_column (runs, one per inner row), body (node)
+---       right_column (runs, one per inner row),
+---       right_column_role (identity for that column, so it can be clicked),
+---       body (node)
 function chrome.frame(opts)
   local width, height = opts.width or 0, opts.height or 0
   if width < 2 or height < 2 then
@@ -210,12 +212,18 @@ function chrome.frame(opts)
   end
 
   local edge = { text = set.v, style = border }
-  local function column(rows)
+  --- One border column, `inner_h` rows tall.
+  ---
+  --- `role` is what makes it a click target: identity is per node, and this is
+  --- one node for the whole column, so a press arrives with `y` already being
+  --- the row of the bar it landed on and `h` the length of the bar. A column
+  --- with no role is inert chrome, which is what the left edge is.
+  local function column(rows, role)
     local lines = {}
     for row = 1, inner_h do
       lines[row] = { (rows and rows[row]) or edge }
     end
-    return { type = "text", len = 1, text = lines }
+    return { type = "text", len = 1, role = role, text = lines }
   end
 
   return {
@@ -230,7 +238,7 @@ function chrome.frame(opts)
         children = {
           column(nil),
           opts.body,
-          column(opts.right_column),
+          column(opts.right_column, opts.right_column and opts.right_column_role),
         },
       },
       {

--- a/ui/plugins/20_agent.lua
+++ b/ui/plugins/20_agent.lua
@@ -95,45 +95,100 @@ local function set_tab(id, tab)
   state["tab:" .. id] = tab ~= AGENT_TAB and tab or nil
 end
 
---- How far back a session is scrolled, and the deepest it has ever been.
+--- The surface a tab addresses: the session itself, or its `#shell` sibling.
 ---
---- Keyed per session for the same reason the tab is: these are a property of the
---- screen you are looking at, not of the pane looking at it. Shared, selecting
---- another session carried your offset onto it -- and the kernel writes the offset
---- into whichever session's parser it is drawing, so the next session opened
---- scrolled back with no way to tell why.
-local function scroll_of(id)
+--- The same spelling the surface node carries and the kernel resolves, so
+--- anything keyed on it is keyed on the screen the user is actually reading.
+local function surface_of(id, tab)
   if not id then
+    return nil
+  end
+  return tab == SHELL_TAB and (id .. "#shell") or id
+end
+
+--- How far back a surface is scrolled, and the deepest it has ever been.
+---
+--- Keyed per SURFACE, which is both halves of the rule at once. Per session,
+--- because this is a property of the screen you are looking at rather than of
+--- the pane looking at it: shared, selecting another session carried your offset
+--- onto it, and — since the kernel writes the offset into whichever parser it is
+--- drawing — the next session opened scrolled back with no way to tell why. And
+--- per tab within that, because the agent and its companion shell are two live
+--- terminals taking turns in one rect with a scrollback each: one offset between
+--- them put the shell wherever the agent had been left.
+local function scroll_of(surface)
+  if not surface then
     return 0, 0
   end
-  return state["scroll:" .. id] or 0, state["scrollmax:" .. id] or 0
+  return state["scroll:" .. surface] or 0, state["scrollmax:" .. surface] or 0
 end
 
-local function set_scroll(id, scroll, scroll_max)
-  if not id then
+local function set_scroll(surface, scroll, scroll_max)
+  if not surface then
     return
   end
-  state["scroll:" .. id] = scroll ~= 0 and scroll or nil
-  state["scrollmax:" .. id] = scroll_max ~= 0 and scroll_max or nil
+  state["scroll:" .. surface] = scroll ~= 0 and scroll or nil
+  state["scrollmax:" .. surface] = scroll_max ~= 0 and scroll_max or nil
 end
 
---- Move the agent tab's scrollback by `lines`, or decline.
+--- Move a surface's scrollback by `lines`. `true` when it actually moved.
 ---
 --- Scrollback is this pane's policy rather than the kernel's, so a replacement
---- pane can choose differently. Declining on the shell tab is what leaves a page
---- key to the pty, where whatever is running (a pager, an editor) has its own
---- idea of what it means.
-local function scroll_by(id, lines)
-  if not id or tab_of(id) ~= AGENT_TAB then
+--- pane can choose differently. Declining when nothing moved is what lets the
+--- kernel put a wheel tick at the live bottom back on its keystroke fallback
+--- instead of swallowing it.
+local function scroll_surface(surface, lines)
+  if not surface then
     return false
   end
-  local scroll, scroll_max = scroll_of(id)
-  scroll = math.max(0, scroll + lines)
+  local scroll, scroll_max = scroll_of(surface)
+  local moved = math.max(0, scroll + lines)
+  if moved == scroll then
+    return false
+  end
   -- How far back the user has ever gone. The snapshot carries no total
   -- scrollback (v1 probes the vt100 screen for it), so this high-water mark is
   -- what the scrollbar is scaled against — see the report accompanying this
   -- port.
-  set_scroll(id, scroll, math.max(scroll_max, scroll))
+  set_scroll(surface, moved, math.max(scroll_max, moved))
+  return true
+end
+
+--- Move the AGENT tab's scrollback, or decline.
+---
+--- The page keys' half of the policy: declining on the shell tab is what leaves
+--- them to the pty, where whatever is running (a pager, an editor) has its own
+--- idea of what a page is. A wheel tick carries no such meaning, so it scrolls
+--- either tab -- see `on_scroll`.
+local function scroll_by(id, lines)
+  if not id or tab_of(id) ~= AGENT_TAB then
+    return false
+  end
+  scroll_surface(id, lines)
+  -- Claimed even when it did not move: the key is the agent view's, and
+  -- handing a PageDown at the live bottom back to the kernel would offer it to
+  -- the pty this action exists to keep it away from.
+  return true
+end
+
+--- Put the view back at the live bottom of the stream.
+---
+--- v1's rule for every key forwarded to the pty: you type at the end of what
+--- you are typing into. Without it a wheel tick leaves you typing into a screen
+--- you cannot see.
+local function snap_to_bottom(id)
+  local surface = surface_of(id, tab_of(id))
+  if not surface then
+    return false
+  end
+  local scroll, scroll_max = scroll_of(surface)
+  if scroll == 0 then
+    return false
+  end
+  -- The high-water mark stays: it is what the scrollbar is scaled against, and
+  -- the bar reading "you are at the bottom of a stream you have been up" is the
+  -- same thing it says when you scroll back down by hand.
+  set_scroll(surface, 0, scroll_max)
   return true
 end
 
@@ -223,13 +278,15 @@ local function rounding_divide(numerator, denominator)
   return math.floor((numerator + math.floor(denominator / 2)) / denominator)
 end
 
---- One run per row of a vertical scrollbar, mirroring ratatui's
---- `Scrollbar::part_lengths` arithmetic so the thumb lands where v1's does.
+--- Where the thumb sits in a track of `track_length` rows, and how long it is.
 ---
---- Returns nil when there is nothing to draw, and the caller falls back to a
---- plain border column — v1 skips the bar entirely when no scrollback exists.
-local function scrollbar_rows(height, content_len, viewport, position)
-  local track_length = height - 2
+--- Ratatui's `Scrollbar::part_lengths` arithmetic, so the thumb lands where v1's
+--- does. Split out from the drawing because a press on the bar has to answer the
+--- same question the paint does — and answering it twice, differently, is how a
+--- thumb comes to jump out from under the pointer that grabbed it.
+---
+--- `nil` when there is no bar: no content to scroll, or no room for a track.
+local function thumb_geometry(track_length, content_len, viewport, position)
   if content_len <= 0 or track_length <= 0 then
     return nil
   end
@@ -246,6 +303,39 @@ local function scrollbar_rows(height, content_len, viewport, position)
 
   local thumb_start = rounding_divide(start_position * track_length, max_viewport_position)
   thumb_start = math.max(0, math.min(thumb_start, track_length - thumb_length))
+  return thumb_start, thumb_length
+end
+
+--- The position a thumb dropped at `thumb_start` is asking for.
+---
+--- The inverse of `thumb_geometry`, pinned at both ends rather than derived from
+--- the same ratio: the forward map's rounding leaves the last row of travel
+--- short of `max_position`, so a bar dragged all the way down would stop a line
+--- or two above the live bottom and never quite arrive.
+local function position_of_thumb(track_length, content_len, viewport, thumb_start)
+  local max_position = math.max(0, content_len - 1)
+  local _, thumb_length = thumb_geometry(track_length, content_len, viewport, 0)
+  if not thumb_length then
+    return 0
+  end
+  local travel = track_length - thumb_length
+  if travel <= 0 then
+    return max_position
+  end
+  local at = math.max(0, math.min(thumb_start, travel))
+  return math.min(max_position, rounding_divide(at * max_position, travel))
+end
+
+--- One run per row of a vertical scrollbar.
+---
+--- Returns nil when there is nothing to draw, and the caller falls back to a
+--- plain border column — v1 skips the bar entirely when no scrollback exists.
+local function scrollbar_rows(height, content_len, viewport, position)
+  local track_length = height - 2
+  local thumb_start, thumb_length = thumb_geometry(track_length, content_len, viewport, position)
+  if not thumb_start then
+    return nil
+  end
 
   local track_end = track_length - (thumb_start + thumb_length)
 
@@ -266,6 +356,62 @@ local function scrollbar_rows(height, content_len, viewport, position)
   end
   rows[#rows + 1] = { text = SCROLLBAR.end_ }
   return rows
+end
+
+--- The bar's content length for a scrollback `depth` deep.
+---
+--- `depth + 1`, because the places you can be are `0..depth` inclusive and the
+--- live bottom is one of them. Passing `depth` clamps the end of the track to
+--- one line above the live end, so the bar could be dragged all the way down
+--- and still leave you off the bottom of the stream.
+local function bar_content_len(depth)
+  return depth + 1
+end
+
+--- The role the scrollbar column carries.
+---
+--- The kernel's own spelling for "a press here takes hold of the pointer", so
+--- the moves that follow reach this pane instead of painting a text selection
+--- across the terminal the bar is about to scroll. This pane has one draggable,
+--- so the bare role identifies it; a pane with two would tell them apart by `id`.
+local DRAG = "drag"
+
+--- A press or a drag on the scrollbar, mapped back to a scroll offset.
+---
+--- The bar is one node for the whole column, so `hit.y` is already the row of
+--- the bar under the pointer and `hit.h` its length — which is the only reason a
+--- `pure` pane can answer this at all, since `render` may not stash geometry.
+local function scrollbar_grab(id, hit)
+  local surface = surface_of(id, tab_of(id))
+  local scroll, depth = scroll_of(surface)
+  local height = hit.h or 0
+  local track = height - 2
+  local content_len = bar_content_len(depth)
+  local thumb_start, thumb_length = thumb_geometry(track, content_len, height, depth - scroll)
+  if not thumb_start then
+    return false
+  end
+
+  -- Row 0 and the last row are the caps, so the track starts one in. A press on
+  -- a cap clamps onto the end of the track it caps.
+  local row = math.max(0, math.min((hit.y or 0) - 1, track - 1))
+
+  -- Where INSIDE the thumb the press landed, so the thumb is picked up rather
+  -- than centred: grabbing its lower half must not jerk it up by half its
+  -- length, and the thumb here is tall whenever the scrollback is shallow. Held
+  -- for the whole gesture; a press on the bare track jumps the thumb there.
+  if not hit.dragging then
+    local inside = row - thumb_start
+    local held = (inside > 0 and inside < thumb_length) and inside or nil
+    state["grab:" .. surface] = held
+  end
+
+  local position =
+    position_of_thumb(track, content_len, height, row - (state["grab:" .. surface] or 0))
+  -- The bar is inverted, as in v1: the top of the track is the deepest offset
+  -- and the bottom is the live end of the stream.
+  set_scroll(surface, math.max(0, math.min(depth - position, depth)), depth)
+  return true
 end
 
 -- --- the border strip ------------------------------------------------------
@@ -729,11 +875,11 @@ return {
     -- the whole reason the views share one plugin.
     local tab = tab_of(session.id)
     local strip, reserved_left = border_strip(width, border, tab)
-    -- Scrollback belongs to the agent view: the shell surface has none to
-    -- offer (the kernel reads only the agent's parser back), so claiming an
-    -- offset there would put a `[N↑]` marker on a title that cannot move.
-    local session_scroll, session_scroll_max = scroll_of(session.id)
-    local scroll = tab == AGENT_TAB and session_scroll or 0
+    -- Both views are live terminals with a scrollback each, so the offset is
+    -- the one this SURFACE is holding — which is also the one the kernel will
+    -- set on the parser it draws.
+    local surface = surface_of(session.id, tab)
+    local scroll, depth = scroll_of(surface)
     local title = fit_right_title(
       terminal_title(session, { shell = tab == SHELL_TAB, scroll = scroll }),
       width,
@@ -764,11 +910,10 @@ return {
     -- full inner width — v1 draws it into the pane rect inset vertically only.
     -- Its extent is the inner rows exactly, hence `height - 2`.
     local rows = nil
-    local depth = tab == AGENT_TAB and session_scroll_max or 0
     if depth > 0 then
       rows = scrollbar_rows(
         math.max(0, height - 2),
-        depth,
+        bar_content_len(depth),
         math.max(0, height - 2),
         -- Inverted, as in v1: offset 0 (live, at the bottom) puts the thumb at
         -- the end of the track; the deepest offset puts it at the start.
@@ -785,11 +930,12 @@ return {
       border_style = border,
       left = strip,
       right_column = rows,
+      right_column_role = DRAG,
       -- The shell is a second surface over the same primitive, addressed as
       -- `<id>#shell` — no new node kind, and the kernel resolves the suffix.
       body = {
         type = "surface",
-        session = tab == SHELL_TAB and (session.id .. "#shell") or session.id,
+        session = surface,
         scroll = scroll,
         fill = 1,
       },
@@ -804,6 +950,41 @@ return {
     { action = SELECT_AGENT, desc = "show the agent tab" },
     { action = SELECT_SHELL, desc = "show the shell tab" },
   },
+
+  -- A wheel tick, which is NOT the page keys above.
+  --
+  -- This pane hands every unclaimed key to the agent, so it is the one pane
+  -- that cannot declare `up`/`down` -- and the kernel's keystroke fallback for
+  -- the wheel is exactly those. Without this hook the wheel did nothing at all
+  -- over a terminal unless the program inside had turned on mouse tracking, in
+  -- which case the kernel forwards the tick to the pty and the pane never sees
+  -- it: an agent that grabs the mouse and then ignores the wheel is what made
+  -- this look like it only happened to some people.
+  --
+  -- One report, one line. A detent is several reports, which is the count the
+  -- outer terminal means, and it is what a forwarded tick already delivers.
+  on_scroll = function(wheel)
+    local id = store.selected
+    return scroll_surface(surface_of(id, tab_of(id)), wheel.up and 1 or -1)
+  end,
+
+  -- Every key this pane does not claim goes on to the agent, and typing
+  -- belongs at the live end of the stream: the offset is dropped and the key
+  -- is DECLINED, so it still reaches the pty.
+  on_key = function()
+    snap_to_bottom(store.selected)
+    return false
+  end,
+
+  -- The scrollbar, which is the only thing this pane paints that is a control
+  -- rather than a report. Everything else on the border is a chip the kernel
+  -- resolves itself through a click verb.
+  on_click = function(hit)
+    if hit.role ~= DRAG then
+      return false
+    end
+    return scrollbar_grab(store.selected, hit)
+  end,
 
   on_action = function(action)
     local id = store.selected


### PR DESCRIPTION
## Intent

Fix scrolling in the thurbox terminal pane. Two user reports: (1) some macOS users cannot scroll in their Claude session, and (2) the user cannot scroll in the shell pane. A follow-up report: in the shell you cannot click the scrollbar and drag it.

Root causes found and fixed:
- A wheel tick reaches a pane as a synthesized up/down keystroke, and the terminal pane is the one pane that cannot declare those keys (it takes input = "session" and hands every unclaimed key to the agent, so declaring up would steal the agent's arrow keys). It declared nothing and had no on_key, so the wheel resolved to nothing over a terminal. This was masked for agents that turn on mouse tracking, because Terminals::forward_wheel hands those the tick — which is why it looked like a fault only some people had.
- The shell surface never honoured a scroll offset: the pane refused to hold one for it AND render_session never called set_scrollback on the shell's parser.
- The scrollbar was drawn into the right border column as a plain text node with no identity, so it was never a click target, and MouseEventKind::Drag had exactly one destination (drag_selection) — there was no route from a held pointer to a pane at all.

Deliberate decisions the user should not be asked to re-litigate:
- A new kernel hook, on_scroll, rather than making the pane declare up/down: declaring them would break the agent's arrow keys. The keystroke fallback is kept for every pane that already declares up/down so nothing else changes. on_scroll is one report (one line), deliberately NOT notched, matching what a tick forwarded to a pty already delivers; the wheel-notch folding stays on the keystroke path where a pane that steps a selection needs it.
- A drag handle spelled as the bare node role "drag" rather than as a new ClickVerb: the verbs name something the kernel does on the pane's behalf, and here the kernel only keeps routing the pointer. The bare role composes with the id a node already carries. The grab holds the rect from the press so a drag that wanders off the bar is still the bar's, and the grab offset is taken at the press so a tall thumb is not jerked under the pointer.
- Click gains w/h because the pane declares pure = true and therefore cannot stash geometry in render.
- The page keys (PageUp/PageDown) deliberately keep their existing rule: they still decline on the shell tab so the pty keeps them, since a pager or editor there has its own idea of what a page is. Only the wheel scrolls both tabs. An existing test pins this.
- Scroll state was rekeyed per surface (id and id#shell) so the agent and shell each keep their own place; one shared offset put the shell wherever the agent had been left.
- An on_key that snaps back to the live bottom and DECLINES the key, so it still reaches the pty — v1's documented rule, and without it a wheel tick leaves you typing into a screen you cannot see.
- forward_wheel now also emits xterm's original (non-SGR) encoding for a program that asked for mouse reporting without SGR; such a pane used to be handed nothing and has no vt100 scrollback to fall back on. Utf8 (?1005) is deliberately still not emitted, being ambiguous by construction.
- An off-by-one fixed on the way: a scrollbar over a scrollback depth deep has depth + 1 positions (the live bottom is one of them), and counting depth of them left the end of the track one line above the live bottom.

Known and accepted limitation, verified empirically (tmux reports every running Claude Code pane as alternate screen on with SGR any-motion mouse tracking): for a RUNNING Claude Code session the tick is forwarded to Claude Code and thurbox has no substitute, because vt100 allocates the alternate screen with zero scrollback. That case is Claude Code's own wheel handling, not thurbox's, and is documented as such. What this change fixes for those users is every other case — the shell tab, any agent that does not grab the mouse, and Claude Code before its TUI starts.

Tests: three end-to-end tests in tests/tui_e2e.rs drive the real binary on a pty with SGR mouse reports (wheel over the agent tab, wheel over the shell tab, press-and-drag the scrollbar on the shell tab). Each was confirmed to fail on the unfixed code and to fail for the right reason, and each half of the fix was confirmed load-bearing by disabling it individually. Plus eight pane-level tests in tests/terminal_pane.rs and a unit test for the wheel encoder. Docs updated in docs/FEATURES.md (whose click dispatch order was still v1's), docs/PLUGINS.md, ui/README.md and ui/AGENTS.md, as the repo requires when behaviour moves.

## What Changed

- Added a new kernel hook, `on_scroll`, and routed wheel ticks through it for the terminal pane (which can't declare up/down keys without stealing the agent's arrow keys); kept the existing keystroke-based wheel fallback for panes that already declare up/down, and made `forward_wheel` also emit xterm's non-SGR mouse encoding for panes that request reporting without SGR.
- Made the shell surface hold and honor a scroll offset (rekeyed per surface as `id`/`id#shell` so agent and shell keep independent positions), wired `render_session` to call `set_scrollback` for the shell parser, kept `PageUp`/`PageDown` declining on the shell tab so a pty-side pager keeps them, and fixed an off-by-one in the scrollbar track math.
- Gave the scrollbar thumb a real node identity (bare `drag` role) so it's a click target, added a `MouseEventKind::Drag` route from a held pointer to the owning pane with grab-rect/offset tracking taken at press time, and gave `Click` w/h since the pane is `pure = true` and can't stash geometry from render.
- Updated `docs/FEATURES.md`, `docs/PLUGINS.md`, `ui/README.md`, and `ui/AGENTS.md` to reflect the new click dispatch order and scroll/drag behavior, and added corresponding coverage in `tests/tui_e2e.rs`, `tests/terminal_pane.rs`, and `tests/mouse.rs`.

## Risk Assessment

✅ Low: The change is well-scoped to the stated root causes (on_scroll hook, shell scrollback wiring, drag-handle routing, off-by-one fix), traced through Rust and Lua call sites without finding a reachable incorrect-result path; every deliberate design decision named in the intent (per-surface scroll keys, non-notched on_scroll, bare "drag" role, w/h on Click, PageUp/PageDown still declining on the shell tab, xterm default-encoding wheel forwarding, the +1 scrollbar content length) is verifiably present and consistent with call sites; new behavior is covered by real pty-driven e2e tests and pane-level LuaHost tests rather than source-text assertions, and docs (FEATURES.md/PLUGINS.md/ui READMEs) were updated to match the new hooks and the already-drifted click dispatch order.

## Testing

Baseline `cargo nextest run --all` already passed. On top of that I ran the targeted regression suite named in the intent: the wheel-encoder unit test, all 8 new terminal_pane.rs pane-level tests plus the updated mouse.rs test (30 tests, all pass), and — as the strongest product-level evidence — the 3 real-pty tui_e2e tests that drive the actual thurbox binary with SGR mouse reports to scroll the agent tab, scroll the companion shell tab, and press-and-drag the scrollbar thumb on the shell tab; all 3 pass on the target commit. I also independently reproduced the regression by running those same 3 tests against the pre-fix (base) source with only the new test file applied, and confirmed all 3 fail with the exact expected symptom (a marker scrolled out of view never reappears), validating they are genuine end-to-end regression tests rather than incidental passes. Worktree was restored to the clean target commit afterward.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"7a9157ecd65cd8a8b49d8084f4c1d3ae97dcb477","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `cargo nextest run --all`
- `cargo nextest run --lib a_wheel_tick_is_encoded_the_way_the_pane_asked_for_it`
- `cargo nextest run --test terminal_pane --test mouse`
- `cargo nextest run --test tui_e2e -E 'test(the_wheel_scrolls_the_agents_output_back) or test(the_wheel_scrolls_the_companion_shell_too) or test(the_scrollbar_can_be_pressed_and_dragged)' on target commit e50e725 (real tmux pty, all 3 pass)`
- `Same 3 tui_e2e tests re-run against base commit 7f57764 source with only tests/tui_e2e.rs taken from target — all 3 fail on timeout waiting for the buried marker to scroll into view, confirming they are genuine regression tests for the reported scrolling bug`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
