### PR TITLE
ci: require the PR title to be the conventional commit that lands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,6 +287,11 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y bats
       - name: Test the commit checker
         run: bats scripts/ci/check-conventional-commits.bats
+      # The PR-title checker's suite runs here rather than in pr-title.yml:
+      # bats and cog are already installed in this job, and that workflow
+      # re-runs on every edit of the title box, so it stays lean.
+      - name: Test the PR title checker
+        run: bats scripts/ci/check-pr-title.bats
       - name: Check conventional commits
         run: scripts/ci/check-conventional-commits.sh
 

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,43 @@
+# The pull request title is the commit squash merge lands on main, so it is
+# validated on its own trigger rather than inside CI.
+#
+# `ci.yml` declares no `types:` for its `pull_request` trigger, which means the
+# GitHub default `[opened, synchronize, reopened]` — `edited` is absent. A title
+# corrected (or broken) after checks went green would never be revalidated, and
+# the squash would use the edited one. Adding `edited` to `ci.yml` would re-run
+# the whole Rust matrix on every touch of the title box, so the check lives here
+# with a trigger of its own and is required alongside `All Checks`.
+name: PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-title-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  pr-title:
+    name: PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      # Provides the `cog` binary; the checker reads this repository's cog.toml
+      # for the commit-type and scope allowlists.
+      - name: Install cocogitto
+        uses: cocogitto/cocogitto-action@52d0023b4396897f1815648e553db2ab8d782f3a # v4.2.0
+        with:
+          install-only: true
+      # The title reaches the script through the environment, never through
+      # `${{ }}` interpolation into the shell: it is attacker-controlled text on
+      # a public repository, and interpolation would run it.
+      - name: Check the PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: scripts/ci/check-pr-title.sh "$PR_TITLE" "$PR_NUMBER"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,7 +188,8 @@ cog commit fix "avoid panic on empty worktree" git
 ```
 
 Commit type drives releases: `feat` → minor bump, `fix` / `perf` → patch bump;
-`docs`, `chore`, `ci`, `style` and `test` produce no release.
+`docs`, `chore`, `ci`, `style` and `test` produce no release. On `main` the type
+that counts is the **pull request title's** — see below.
 
 The history check that the `pre-push` hook and CI's `Conventional Commits` job
 run is [`scripts/ci/check-conventional-commits.sh`](scripts/ci/check-conventional-commits.sh)
@@ -199,6 +200,37 @@ authors (`no-mistakes: apply CI fixes` and `no-mistakes: apply agent fixes`).
 `.no-mistakes.yaml`'s `commit.fix_message` retemplates the gate's per-step
 auto-fix commits, but those two are not templatable, and `cog check` cannot
 exempt a commit — so the fix the gate pushed for this job used to fail it.
+
+### The pull request title is the commit
+
+Pull requests land by **squash merge**, so the commit that reaches `main` is not
+any commit from your branch: GitHub builds it from the pull request title plus
+its own `(#N)` suffix.
+
+```text
+fix(core): keep the caret where the frame put it
+  ↓ squash merge
+fix(core): keep the caret where the frame put it (#1044)
+```
+
+That single string is what `cog bump --auto` reads for the release decision,
+what the changelog quotes, and what the history check above then holds `main`
+to. So the type and scope allowlists apply to the **title**, and it is the
+title's type that decides the release — a branch whose every commit is `fix`
+still ships nothing if its pull request is titled `docs:`. Keep a pull request
+to one purpose and title it after its most significant change.
+
+Declare a breaking change in the title (`feat(core)!: …`) or as a
+`BREAKING CHANGE:` footer in the pull request **body**. The squash commit's body
+comes from the body box, so a footer left behind in a branch commit is
+discarded.
+
+[`scripts/ci/check-pr-title.sh`](scripts/ci/check-pr-title.sh) enforces this as
+the required `PR Title` check. It validates the title in the exact form that
+lands, suffix included, and rejects one that already ends in a `(#N)` of its own
+— squash would append a second. It runs from its own workflow rather than from
+CI because `ci.yml` does not listen for `edited`, so a title changed after
+checks went green would otherwise never be revalidated.
 
 ## Documentation
 

--- a/scripts/ci/check-pr-title.bats
+++ b/scripts/ci/check-pr-title.bats
@@ -1,0 +1,94 @@
+#!/usr/bin/env bats
+#
+# Drives check-pr-title.sh: what a pull request title must be for squash merge
+# to land a commit `cog` can still parse, and the mistakes it exists to catch.
+
+setup() {
+  CHECKER="${BATS_TEST_DIRNAME}/check-pr-title.sh"
+  if ! command -v cog >/dev/null 2>&1; then
+    skip "cocogitto (cog) is not installed"
+  fi
+
+  # git exports these to hook processes, so a suite running under this
+  # project's own pre-commit hook would otherwise read the real repository
+  # instead of the temporary one below.
+  unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_COMMON_DIR \
+    GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_PREFIX \
+    GIT_NAMESPACE
+
+  REPO="${BATS_TEST_TMPDIR}/repo"
+  mkdir -p "$REPO"
+  cd "$REPO" || exit 1
+  git init -q -b main .
+  git config user.name tester
+  git config user.email tester@example.invalid
+  # cog.toml is read by `cog verify` from the working directory, so the scope
+  # allowlist a repository declares is part of what the checker enforces.
+  printf 'scopes = ["core", "cli"]\n' >cog.toml
+}
+
+@test "accepts a conventional title" {
+  run "$CHECKER" "fix(core): keep the caret where the frame put it" 1044
+  [ "$status" -eq 0 ]
+}
+
+@test "validates the title in the form squash merge lands, suffix included" {
+  run "$CHECKER" "fix(core): keep the caret where the frame put it" 1044
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"(#1044)"* ]]
+}
+
+@test "rejects a title that is not a conventional commit" {
+  run "$CHECKER" "Fix the caret" 1044
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"not a conventional commit"* ]]
+}
+
+@test "rejects a commit type cog.toml does not declare" {
+  run "$CHECKER" "wibble(core): keep the caret where the frame put it" 1044
+  [ "$status" -eq 1 ]
+}
+
+@test "rejects a scope outside the allowlist" {
+  run "$CHECKER" "fix(lint): keep the caret where the frame put it" 1044
+  [ "$status" -eq 1 ]
+}
+
+@test "accepts a breaking change declared in the title" {
+  run "$CHECKER" "feat(core)!: drop the v1 pane API" 1050
+  [ "$status" -eq 0 ]
+}
+
+@test "rejects a title that already ends in its own (#N)" {
+  run "$CHECKER" "fix(core): keep the caret where the frame put it (#1044)" 1044
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"already ends in"* ]]
+}
+
+@test "accepts a title citing another pull request mid-sentence" {
+  run "$CHECKER" "fix(core): finish what (#900) started for the caret" 1044
+  [ "$status" -eq 0 ]
+}
+
+@test "rejects an empty title" {
+  run "$CHECKER" "" 1044
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"empty"* ]]
+}
+
+@test "reports a usage error when the pr number is missing" {
+  run "$CHECKER" "fix(core): keep the caret where the frame put it"
+  [ "$status" -eq 2 ]
+}
+
+@test "works in a checkout that has configured no git identity" {
+  # `cog verify` resolves the current author before parsing and panics when
+  # user.name is unset, which is every fresh CI checkout. The checker lends one
+  # through a throwaway HOME; without that this call aborts.
+  git config --unset user.name
+  git config --unset user.email
+  HOME="${BATS_TEST_TMPDIR}/empty-home"
+  mkdir -p "$HOME"
+  run env HOME="$HOME" "$CHECKER" "fix(core): keep the caret" 1044
+  [ "$status" -eq 0 ]
+}

--- a/scripts/ci/check-pr-title.sh
+++ b/scripts/ci/check-pr-title.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# Verify a pull request title is the conventional commit squash merge will land.
+#
+# Under squash merge the commit on main is built by GitHub from the PR title
+# plus its own " (#N)" suffix. That string — not any commit on the branch — is
+# what `cog bump --auto` reads for the release decision, what the changelog
+# quotes, and what check-conventional-commits.sh then holds the history to.
+# Nothing else validates it: that sibling script walks *branch* commits, and
+# squash discards exactly those. This is the only gate between a typo in a title
+# box and a main whose history no longer parses.
+#
+# The title is checked in its final form, suffix included, because that is the
+# artifact — not the bare title the author typed.
+#
+# Usage: check-pr-title.sh <title> <pr-number>
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+    printf 'usage: %s <title> <pr-number>\n' "${0##*/}" >&2
+    exit 2
+fi
+
+title="$1"
+number="$2"
+
+if [ -z "$title" ]; then
+    printf 'The pull request title is empty.\n' >&2
+    exit 1
+fi
+
+# GitHub appends " (#N)" itself, so a title that already ends in one lands as
+# "… (#12) (#34)". Only a *trailing* reference is rejected: a title that cites
+# another pull request mid-sentence is a different thing and still passes.
+if printf '%s' "$title" | grep -qE '[[:space:]]\(#[0-9]+\)[[:space:]]*$'; then
+    printf 'The pull request title already ends in a (#N) reference:\n\n' >&2
+    printf '  %s\n\n' "$title" >&2
+    printf 'Squash merge appends " (#%s)" on its own — drop the one in the title.\n' \
+        "$number" >&2
+    exit 1
+fi
+
+# `cog verify` resolves the current git author before it parses anything and
+# panics when user.name is unset — which is every fresh CI checkout, where
+# nothing commits and so nothing configures an identity. The author is only
+# printed back, never part of the verdict, so lend one through a throwaway HOME
+# (libgit2 reads $HOME/.gitconfig) rather than writing into the repository being
+# checked. Same reasoning, and same fix, as check-conventional-commits.sh.
+if ! git config --get user.name >/dev/null 2>&1 ||
+    ! git config --get user.email >/dev/null 2>&1; then
+    borrowed_home=$(mktemp -d)
+    trap 'rm -rf "$borrowed_home"' EXIT
+    printf '[user]\n\tname = pr title checker\n\temail = checker@invalid\n' \
+        >"$borrowed_home/.gitconfig"
+    export HOME="$borrowed_home"
+fi
+
+# cog.toml is read from the working directory, so the commit-type and scope
+# allowlists this repository declares are part of what is enforced here.
+subject="$title (#$number)"
+
+if ! report=$(printf '%s\n' "$subject" | cog verify --file - 2>&1); then
+    printf 'The pull request title is not a conventional commit.\n\n' >&2
+    printf '  title:    %s\n' "$title" >&2
+    printf '  lands as: %s\n\n' "$subject" >&2
+    printf '%s\n\n' "$report" >&2
+    printf 'Valid types and scopes are declared in cog.toml.\n' >&2
+    exit 1
+fi
+
+printf 'Pull request title lands as a conventional commit: %s\n' "$subject"


### PR DESCRIPTION
## Intent

The user is moving this repository from rebase merge to squash merge, with the '<conventional commit> (#PR NUMBER)' naming convention on main, and asked to ensure a PR title ALWAYS matches a cog conventional commit.

This PR is deliberately only STEP 1 of that move: the required check. The sequencing is load-bearing and must not be collapsed. Under squash, the commit that lands on main is built by GitHub from the PR title plus its own ' (#N)' suffix, and nothing in this repository has ever validated a PR title (I grepped .github/ and scripts/ - zero hits). scripts/ci/check-conventional-commits.sh walks BRANCH commits, which squash discards. If squash were enabled before this check is required, the first bad title lands on main and permanently fails that script for every future PR, because it defaults to every commit reachable from HEAD and history cannot be rewritten. So the GitHub ruleset and repo merge settings are deliberately NOT touched in this PR - they are flipped by hand after this merges. Do not propose adding them here.

What the change contains: scripts/ci/check-pr-title.sh, its bats suite, a pr-title.yml workflow, one added step in ci.yml, and a CONTRIBUTING.md section.

Decisions made, each verified by running the tool rather than assumed:
- The checker validates the title in the exact form that LANDS - '<title> (#N)' - not the bare title the author typed, because the composed string is the artifact cog bump --auto and the changelog read. Verified that GitHub's ' (#1044)' suffix and a breaking 'feat(core)!:' both pass cog verify against this repo's cog.toml.
- It rejects a title that already ends in its own '(#N)', because squash would append a second and land '... (#12) (#34)'. Only a TRAILING reference is rejected, so a title citing another PR mid-sentence still passes - that distinction is deliberate and is covered by two separate tests.
- It lives in its own workflow rather than in ci.yml because ci.yml declares no 'types:' for its pull_request trigger, which means the GitHub default [opened, synchronize, reopened] - 'edited' is absent. A title corrected or broken after checks went green would never be revalidated and the squash would use the edited one. Adding 'edited' to ci.yml would re-run the entire Rust matrix on every touch of the title box, which is why it is a separate lean workflow.
- The bats suite runs in ci.yml's existing 'Conventional Commits' job, where bats and cog are already installed, rather than in pr-title.yml which re-runs on every title edit.
- The PR title reaches the script through an env: var, never through ${{ }} interpolation into the shell. It is attacker-controlled text on a public repository and interpolation would execute it. This is a security property of the change, not a style choice.
- The checker borrows a throwaway HOME when no git identity is configured, mirroring check-conventional-commits.sh: cog verify resolves the current author before parsing and panics when user.name is unset, which is every fresh CI checkout. There is a test for exactly that.
- Validated the new rule against the last 25 merged PRs, including Renovate's: 0 of 25 would fail. This codifies existing practice rather than changing it.

Known and deliberately out of scope: actionlint reports 'property extension_scripts is not defined' in ci.yml. I verified this is PRE-EXISTING on origin/main (same finding before my diff, at the line my 5 added lines shifted) and that this repository runs no actionlint gate. Do not fix it here.

One thing to be aware of while running: pr-title.yml is new on this branch, so it will execute against THIS pull request. The PR title you write must itself be a conventional commit per cog.toml - a valid type, and either no scope or one of api, cli, ui, git, core, docs, deps, config, mcp - or this PR's own new check will fail it. 'ci:' with no scope is appropriate for this change.

Note on working tree: two unrelated untracked draft files (medium-article-orchestrating-agents.html/.md) were stashed before this run. They are not part of this change. They also block any markdown-touching commit locally, because the rumdl prek hook runs 'rumdl check .' over the whole tree rather than over changed files.

## What Changed

- Add `scripts/ci/check-pr-title.sh`, which validates a pull request title in its exact landed form (`<title> (#N)`) against this repo's cog.toml, rejects a title already ending in its own `(#N)`, and borrows a throwaway `HOME` when no git identity is configured for `cog verify`.
- Add `.github/workflows/pr-title.yml`, a dedicated workflow triggered on `opened`/`edited`/`synchronize`/`reopened` that installs cocogitto and runs the checker, passing the title through an `env:` var rather than shell interpolation.
- Add `scripts/ci/check-pr-title.bats` covering the checker, wire its execution into `ci.yml`'s existing `Conventional Commits` job (`Test the PR title checker` step), and add a CONTRIBUTING.md section explaining that the PR title, not branch commits, is what squash merge lands and what drives the release/changelog.

## Risk Assessment

✅ Low: Self-contained, well-tested addition (new script + bats suite + isolated workflow) that matches the stated intent exactly: title passed via env var (no shell interpolation of attacker-controlled text), trailing-(#N) rejection correctly scoped to avoid false positives on mid-sentence references, HOME-borrowing correctly mirrors the sibling script, and no GitHub ruleset/merge-strategy changes were made as explicitly required.

## Testing

<code>Baseline `cargo nextest run --all` already passed. Targeted validation here confirms the PR-title checker itself: the bats suite (11 cases, executing the real script binary end-to-end) all pass, and manual runs of check-pr-title.sh against this repo&#39;s actual cog.toml validate the intent&#39;s specific claims — the landed form `&lt;title&gt; (#N)` is what&#39;s checked, a self-referencing trailing `(#N)` is rejected while a mid-sentence reference is not, breaking-change and Renovate-style titles pass, and the workflow YAML genuinely passes the title through an env var rather than shell interpolation, with `edited` present in its trigger types. No findings; the change behaves exactly as described in the intent.</code>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"612e8cb2a256bffeb166af3a8e2e3add079ac518","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `cargo nextest run --all`
- <code>`bats scripts/ci/check-pr-title.bats` — all 11 cases pass, including the double-suffix rejection, mid-sentence-reference acceptance, empty-title rejection, and the no-git-identity fallback</code>
- <code>`scripts/ci/check-pr-title.sh &#34;&lt;this PR&#39;s own title&gt;&#34; 9999` against the repo&#39;s real cog.toml — accepts, landing as `... (#9999)`</code>
- <code>`scripts/ci/check-pr-title.sh &#34;&lt;title&gt; (#9999)&#34; 9999` — rejected as already ending in its own (#N)</code>
- <code>`scripts/ci/check-pr-title.sh &#34;feat(core)!: drop the v1 pane API&#34; 1050` — accepted (breaking change form)</code>
- <code>`scripts/ci/check-pr-title.sh &#34;chore(deps): update taiki-e/install-action action to v2.86.6&#34; 5678` — accepted (Renovate-style)</code>
- <code>Parsed `.github/workflows/pr-title.yml` with PyYAML into a semantic model to confirm `types: [opened, edited, synchronize, reopened]` and that the title reaches the shell only via `env: PR_TITLE` (no `${{ }}` in the `run:` line)</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
