### PR TITLE
ci: retire the merge queue's workflow support and pin Renovate titles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,20 +3,13 @@ name: CI
 on:
   pull_request:
     branches: [main]
-  # The merge queue re-runs the full suite against the temporary
-  # `gh-readonly-queue/*` branch (PR rebased onto main). Without this trigger the
-  # required "All Checks" gate never reports on a queued PR and it stalls until
-  # the queue's check timeout, so the queue *needs* this to merge anything.
-  merge_group:
 
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 
 # Cancel a superseded run when a new commit is pushed to the same PR, so rapid
-# re-pushes don't pile up parallel runs of the (heavy) Rust matrix. Each merge
-# queue entry gets a distinct `github.ref`, so queued runs never cancel each
-# other.
+# re-pushes don't pile up parallel runs of the (heavy) Rust matrix.
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -31,25 +24,17 @@ jobs:
     name: Detect changes
     runs-on: ubuntu-latest
     outputs:
-      rust: ${{ steps.filter.outputs.rust || steps.all.outputs.all }}
-      shell: ${{ steps.filter.outputs.shell || steps.all.outputs.all }}
-      markdown: ${{ steps.filter.outputs.markdown || steps.all.outputs.all }}
-      lua: ${{ steps.filter.outputs.lua || steps.all.outputs.all }}
-      website: ${{ steps.filter.outputs.website || steps.all.outputs.all }}
-      install_sh: ${{ steps.filter.outputs.install_sh || steps.all.outputs.all }}
-      install_ps: ${{ steps.filter.outputs.install_ps || steps.all.outputs.all }}
+      rust: ${{ steps.filter.outputs.rust }}
+      shell: ${{ steps.filter.outputs.shell }}
+      markdown: ${{ steps.filter.outputs.markdown }}
+      lua: ${{ steps.filter.outputs.lua }}
+      website: ${{ steps.filter.outputs.website }}
+      install_sh: ${{ steps.filter.outputs.install_sh }}
+      install_ps: ${{ steps.filter.outputs.install_ps }}
     steps:
-      # A merge queue entry already contains exactly the PR's changes; validate
-      # the whole suite against it rather than diffing (paths-filter has no PR
-      # base on a `merge_group` event). Every filter output falls back to this.
-      - id: all
-        if: github.event_name == 'merge_group'
-        run: echo "all=true" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        if: github.event_name == 'pull_request'
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
-        if: github.event_name == 'pull_request'
         with:
           # Every filter includes `.github/workflows/ci.yml` so editing the
           # workflow re-runs all jobs — any job's definition may have changed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,6 +207,12 @@ Pull requests land by **squash merge**, so the commit that reaches `main` is not
 any commit from your branch: GitHub builds it from the pull request title plus
 its own `(#N)` suffix.
 
+There is no merge queue: at this repository's merge cadence it batched nothing
+and merged one pull request at a time behind a second full CI run. Reintroducing
+one would need a `merge_group:` trigger back in `ci.yml` — without it the
+required `All Checks` gate never reports on a queued pull request and the queue
+stalls until its own check timeout.
+
 ```text
 fix(core): keep the caret where the frame put it
   ↓ squash merge

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,11 @@
   ],
   "labels": ["dependencies"],
   "automerge": true,
+  // Pinned rather than left to the "auto" default, which infers semantic
+  // commits from history. The PR title is the commit squash merge lands and
+  // the required PR Title check rejects a non-conventional one, so a failed
+  // inference would block every Renovate PR.
+  "semanticCommits": "enabled",
   "semanticCommitType": "fix",
   "semanticCommitScope": "deps",
   "minimumReleaseAge": "7 days",


### PR DESCRIPTION
## Intent

Follow-up to the squash migration completed earlier in this session. The user asked for two things in one PR: fix ci.yml's now-false merge-queue references, and pin Renovate's semanticCommits. This is a reattach to a rerun after the previous run failed on an agent-side exit, not a code failure: the suite passed 2247/2247 and the test step's evidence-gathering turn then exited status 1.

Context the diff does not show. Earlier today main moved to squash-only merging: the protect-main-branch ruleset (id 12778606) had its merge_queue rule removed, allowed_merge_methods set to ['squash'], and a new required 'PR Title' check added; the repo now has allow_squash_merge=true with squash_merge_commit_title=PR_TITLE and squash_merge_commit_message=PR_BODY. GitHub now builds main's commit from the PR title plus its own ' (#N)' suffix. This PR is expected to be the FIRST squash merge.

Why the queue went, which is what the ci.yml half follows from: at this repository's cadence (median gap between merges about 1.5 hours, min_entries_to_merge 1) it batched nothing and merged one PR at a time behind a second full CI run. It had also stopped merging entirely - three consecutive merge_group runs failed on SonarQube, because a merge_group run carries no PR number, so the scan analyses as the MAIN PROJECT and evaluates the project quality gate (ERROR on new_security_rating=3, needs 1) rather than the PR's, which passes. That project finding is pre-existing and is NOT addressed here.

With no queue the merge_group event can never fire, so ci.yml's support for it is unreachable: the trigger, the 'all' step that substituted for paths-filter when there was no PR base, the seven output fallbacks to that step, and the two 'if: github.event_name == pull_request' guards that existed only to exclude the other event. All removed, plus the concurrency comment's false claim about queue entries. Verified zero merge-queue references remain, ci.yml still parses, and actionlint reports nothing new.

Deliberate decision on what NOT to delete: the concurrency group expression keeps its '|| github.ref' fallback - a harmless idiomatic default, unlike unreachable code carrying a comment about something that no longer exists.

Deliberate decision on knowledge migration: CONTRIBUTING.md now records that there is no merge queue and that reintroducing one needs the merge_group trigger back in ci.yml, without which the required All Checks gate never reports on a queued PR and the queue stalls until its own check timeout. That was the one non-obvious fact the deleted comment carried.

The Renovate half: semanticCommits was unset, so it defaulted to 'auto', inferring semantic commits from history. That inference is why Renovate's titles have always been 'fix(deps): ...'. Under squash the PR title IS the commit and the required PR Title check rejects a non-conventional one, so a failed inference would block every Renovate PR. Pinned to 'enabled'. semanticCommitType 'fix' and semanticCommitScope 'deps' were already set and are unchanged.

Known and deliberately OUT OF SCOPE, do not fix here: actionlint reports that ci.yml references needs.changes.outputs.extension_scripts, which the changes job does not declare. This is pre-existing and means the 'Extension Script Tests' job's if: is always false, so that job has never run - it reported 'skipping' on PR #1045. It is a real CI coverage gap violating the invariant CLAUDE.md states, that each bats pre-commit hook has a CI twin. It is being reported to the user as a separate follow-up because enabling a job that has never executed does not belong in a change meant to be a clean first squash merge.

The PR title you write becomes main's commit verbatim plus ' (#N)', and the required PR Title check will validate it. It must be a conventional commit per cog.toml: a valid type, and either no scope or one of api, cli, ui, git, core, docs, deps, config, mcp. 'ci:' with no scope is right - this ships no binary bytes and must not cut a release.

## What Changed

- Removed the now-unreachable `merge_group` trigger from `.github/workflows/ci.yml`, along with the `all` fallback step, the seven `|| steps.all.outputs.all` output fallbacks, and the two `if: github.event_name == 'pull_request'` guards that existed only to distinguish it from `pull_request` runs; also dropped the stale comments describing merge-queue behavior (the concurrency group's `|| github.ref` fallback is kept).
- Added a note to `CONTRIBUTING.md` recording that there is no merge queue and that reintroducing one requires restoring the `merge_group:` trigger in `ci.yml`, since without it the required `All Checks` gate never reports on a queued PR and the queue stalls until its own check timeout.
- Pinned `semanticCommits` to `"enabled"` in `renovate.json` (previously unset, defaulting to `"auto"`), with a comment explaining why: an inference failure under squash-merge titles would block Renovate PRs against the required PR Title check.

## Risk Assessment

✅ Low: The change is a well-bounded, mechanical removal of now-unreachable merge_group support plus a scoped Renovate config pin; both halves are internally consistent, match the stated intent point-for-point (verified zero remaining merge-queue references, correct semanticCommits pin, accurate CONTRIBUTING.md knowledge migration), and the one leftover vacuous conditional found is harmless and pre-existing in spirit.

## Testing

Baseline `cargo nextest run --all` already passed 2247/2247 before this phase, and this change touches only declarative CI config (ci.yml, renovate.json) plus a docs file (CONTRIBUTING.md), none of which any Rust test references. I wrote a Python script that loads ci.yml with a real YAML parser and asserts on the resulting semantic model — no merge_group trigger, no steps.all fallback on any of the 7 changes-job outputs, no leftover conditional `if:` guards or `all` step, and the concurrency group's `|| github.ref` fallback intact — matching every merge-queue-support removal claimed in the intent. A repo-wide grep confirms the only remaining 'merge_group' mention is the deliberate CONTRIBUTING.md documentation. For renovate.json I ran Renovate's own `renovate-config-validator` (the real consumer, via npx), which reports the file validates successfully, confirming `semanticCommits: enabled` is accepted by Renovate's actual schema. All checks passed; no findings.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"15f396e033c1ba569ddb1f659dc573e695ff12f0","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `.github/workflows/ci.yml:258` - The `conventional-commits` job&#39;s `if: github.event_name == &#39;pull_request&#39;` guard (ci.yml:258) is now always true, since `pull_request` is the workflow&#39;s only trigger after `merge_group` was removed — it existed to exclude merge_group runs just like the two guards removed from the `changes` job. Harmless (unlike the deleted comment, it makes no false claim), so not a blocker for this PR; worth trimming in a follow-up cleanup.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `cargo nextest run --all`
- `cargo nextest run --all (baseline, already passed 2247/2247 prior to this phase)`
- <code>python3 semantic check of .github/workflows/ci.yml via yaml.safe_load: asserts on: contains only pull_request (no merge_group), concurrency.group retains its `|| github.ref` fallback, all 7 `changes` job outputs are bare `steps.filter.outputs.X` with no `steps.all` fallback, the `changes` job has exactly 2 steps (checkout + paths-filter) with no leftover `all` step and no `if:` guards, and no leaf string value anywhere in the parsed workflow contains &#39;merge_group&#39;</code>
- `grep -rn 'merge_group|merge-queue|mergequeue|gh-readonly-queue' across *.yml/*.yaml/*.md/*.toml — confirms the only surviving reference is the intentional CONTRIBUTING.md knowledge-migration note`
- <code>npx -p renovate renovate-config-validator (Renovate&#39;s real config validator) against renovate.json — &#39;Config validated successfully&#39;, confirming the pinned `semanticCommits: enabled` is a schema-valid value accepted by the actual consumer</code>
- `git status --porcelain — confirmed no transient artifacts left in the worktree after testing`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
