### PR TITLE
fix(cli): repair driver-facing contracts for session state, exec env, and agent introspection

### DIFF
--- a/.claude/skills/thurbox-cli/SKILL.md
+++ b/.claude/skills/thurbox-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: thurbox-cli
-description: The thurbox-cli binary: every subcommand group (session, automation, task, message, editor, config, extension, version, update, notify, perf, plugin), soft vs force delete and restore, session lifecycle hooks (hooks.toml), parent lead/worker sessions, manual session ordering, the inter-session message mailbox, Exec automations and the heartbeat keeper, plus tasks/todos. Use when changing or driving thurbox headlessly, or working on any of those subsystems.
+description: The thurbox-cli binary: every subcommand group (agent, session, automation, task, message, editor, config, extension, version, update, notify, perf, plugin), soft vs force delete and restore, session lifecycle hooks (hooks.toml), parent lead/worker sessions, manual session ordering, the inter-session message mailbox, Exec automations and the heartbeat keeper, plus tasks/todos. Use when changing or driving thurbox headlessly, or working on any of those subsystems.
 ---
 
 # thurbox-cli, automations, tasks and messages
@@ -34,7 +34,7 @@ thurbox-cli session list --json | jq           # machine output for scripts
 thurbox-cli session list --parent <lead-uuid> --json | jq  # direct children only
 ```
 
-Subcommands: `session` (create/list [`--deleted`]/get/delete/restore/restart
+Subcommands: `agent` (launch-args — see below), `session` (create/list [`--deleted`]/get/delete/restore/restart
 [`--if-missing`]/stop/start/fork/exec/meta/send [`--no-enter`]/key/capture/focus/signal/doctor/sync/register —
 `sync`/`register` and the flags serve session sharing, ADR-24), `watch` (stream
 session changes as newline-delimited JSON), `runtime` (status/stop — what
@@ -144,6 +144,15 @@ session that has no pane on sight — the interface's respawn of surveyed rows, 
 peer's `restart --if-missing` after a reboot, and extension self-heal. All three
 skip a stopped row; `session start` is the only caller that clears the mark.
 
+The mark is **reported by the read verbs**, not only by `watch`: a parked
+session stays in `session list` and carries `stopped: true` with
+`state: "stopped"` on `get` and `list` — the same key and type the stream uses.
+`state` is `stopped` rather than the agent's latched last word or one of the two
+silences, because all three describe a session that is running. `backend_id`
+keeps naming the window it had (that is what the row records; `session start`
+replaces it), and `send`/`key`/`capture` refuse a parked session by name instead
+of reaching for the window that is gone.
+
 ### `session exec` — run something in a session's context
 
 ```bash
@@ -151,8 +160,13 @@ thurbox-cli session exec worker -- git status --porcelain
 ```
 
 A separate process in the session's directory, on the machine the session lives
-on — **not** typed into the pane, which belongs to the agent and would interleave
-with whatever it is doing. The command's exit code is always in the output;
+on, **under the session's own environment** — its recorded `--env` plus the
+`THURBOX_*` identity its pane carries, with the *caller's* `THURBOX_*` scrubbed
+so a driver running inside one session cannot lend the child that session's
+identity (a `session signal` through `exec` used to record for the caller, with
+exit 0). The environment used is in the result's `env`. Deliberately **not**
+typed into the pane, which belongs to the agent and would interleave with
+whatever it is doing. The command's exit code is always in the output;
 `--exit-passthrough` additionally makes it this invocation's own — a command
 exiting 2 is *that command's* 2, not a usage error, which is the distinction
 Gas City's `proc.exec` capability is defined by. `exit_code` is `null` when the
@@ -162,10 +176,36 @@ the generic failure code, since there is no code to carry.
 Arguments to `--command` may start with a dash (`--arg -c`): passing a switch is
 the usual reason to pass an argument at all.
 
+### `agent launch-args` — the hook wiring, for a driver that launches its own agent
+
+```bash
+thurbox-cli agent launch-args claude                      # command + args + env
+thurbox-cli agent launch-args claude --session <ref>      # …resolved for one session
+```
+
+Status hooks are **arguments**: the `hooks` extension installs them by appending
+to an agent's `args` in `agents.toml` (`--settings <hooks>.json` for claude), so
+they reach the process only when thurbox builds the command line. A driver that
+launches the agent itself — `session create --command`, or typing into a shell
+session — therefore got no hooks, so `state` never populated and `watch` never
+mentioned that session. This prints what thurbox would run; pass the args
+through and the hooks are there.
+
+`--session <ref>` resolves it for one session: the conversation id is pinned to
+that row's, the host adapts the args (a remote session's hook configs are
+shipped there), and the env carries the `THURBOX_SESSION` the agent's
+`session signal` will report under. Without it the env names only this instance
+(config dir, data dir, socket). Always a **fresh** launch — continuing a
+conversation is `session start`/`restart`.
+
 ### `session meta` — the driver's key/value space
 
 `set`/`get`/`list`/`unset`, namespaced by convention (`fm.*`, `gc.*`), never
-interpreted by thurbox. Without it a driver's identity ends up encoded in the
+interpreted by thurbox. `get` answers with the **bare value** in every format
+but JSON — being captured into a shell variable is what makes stdout a pipe, so
+the piped default would otherwise hand back the record in exactly the case the
+command exists for. An unset key produces nothing; `--json` returns the record,
+and is the only form that tells a `null` value from a key that was never set. Without it a driver's identity ends up encoded in the
 session *name*, which then has to be parsed and kept unique and inside the
 64-character limit. `set` reads the value from stdin when it is not an argument.
 
@@ -232,7 +272,11 @@ The shape that follows from that:
   quietly.
 - **Errors are structured on stdout, never stderr**, and the exit code says
   which kind: `0` success, `1` the command ran and failed, `2` the invocation
-  was wrong. Each carries a `suggestion` and a runnable `help[]` line. stdout
+  was wrong. The trap that follows is worth naming to integrators:
+  `thurbox-cli … --json | jq -r .field` exits **0 with empty output** on a
+  failure, because `jq` parsed the error object and the pipeline carries `jq`'s
+  status (`pipefail` does not help — `jq` succeeded). Capture, branch on the
+  status, then parse. Each carries a `suggestion` and a runnable `help[]` line. stdout
   carries **exactly one** document, so a command that renders its report and
   *then* asks for a non-zero exit (`session doctor` on a broken session,
   `config validate` on an invalid file) comes back as `cli::Outcome::Failed`:

--- a/.claude/skills/thurbox-cli/SKILL.md
+++ b/.claude/skills/thurbox-cli/SKILL.md
@@ -201,13 +201,16 @@ conversation is `session start`/`restart`.
 ### `session meta` — the driver's key/value space
 
 `set`/`get`/`list`/`unset`, namespaced by convention (`fm.*`, `gc.*`), never
-interpreted by thurbox. `get` answers with the **bare value** in every format
-but JSON — being captured into a shell variable is what makes stdout a pipe, so
-the piped default would otherwise hand back the record in exactly the case the
-command exists for. An unset key produces nothing; `--json` returns the record,
-and is the only form that tells a `null` value from a key that was never set. Without it a driver's identity ends up encoded in the
+interpreted by thurbox. Without it a driver's identity ends up encoded in the
 session *name*, which then has to be parsed and kept unique and inside the
-64-character limit. `set` reads the value from stdin when it is not an argument.
+64-character limit. `set` reads the value from stdin when it is not an
+argument.
+
+`get` answers with the **bare value** in every format but JSON — being
+captured into a shell variable is what makes stdout a pipe, so the piped
+default would otherwise hand back the record in exactly the case the command
+exists for. An unset key produces nothing; `--json` returns the record, and is
+the only form that tells a `null` value from a key that was never set.
 
 ### `thurbox-cli watch` — nothing has to poll
 

--- a/.claude/skills/thurbox-cli/SKILL.md
+++ b/.claude/skills/thurbox-cli/SKILL.md
@@ -119,11 +119,13 @@ thurbox-cli session create --name build --repo-path . \
     --command npm --arg run --arg watch --env NODE_ENV=development
 ```
 
-A `--command` session persists its **launch recipe** (command, args, env) on its
-row, because there is no registry entry to re-resolve; `session restart` replays
-it verbatim. A registry agent deliberately stores nothing, so it is resolved by
+A `--command` session persists its **launch recipe** (command, args) on its row,
+because there is no registry entry to re-resolve; `session restart` replays it
+verbatim. A registry agent deliberately stores no recipe, so it is resolved by
 name at every launch and editing `agents.toml` then restarting still takes
-effect.
+effect. `--env` is the exception both kinds store: it is the *caller's*, not
+the registry's, so a registry agent's row carries it too — replayed on restart
+and reproduced by `session exec`.
 
 What a command session does **not** have is a conversation. `resume_args` and
 `fork_args` are what address one, and only an agent definition declares them —

--- a/README.md
+++ b/README.md
@@ -625,13 +625,14 @@ takes to judge it:
 | `hook_blocked_is_heuristic` | whether its `blocked` is a text match on a notification body |
 | `hook_corroboration` / `hook_state_contradicted` | what actually holds the pane, and whether it agrees |
 | `state` / `state_source` | the best answer available, and whether it came from a hook or from the pane |
+| `stopped` | whether the session is parked (`session stop`) — no process at all |
 
 `state` is always a word, never null: a session nothing has reported for reads
-`unreported`, and one whose agent is wired to report nothing at all reads
-`uncovered`. Neither is a state an agent can signal, so neither can be mistaken
-for one, and `state_source` is null for both. It is also the column the piped
-(TOON) `session list` shows, so an agent and a person reading the same call see
-the same word.
+`unreported`, one whose agent is wired to report nothing at all reads
+`uncovered`, and a parked session reads `stopped`. None of the three is a state
+an agent can signal, so none can be mistaken for one, and `state_source` is
+null for all of them. It is also the column the piped (TOON) `session list`
+shows, so an agent and a person reading the same call see the same word.
 
 There is deliberately **no staleness timeout**: a turn may run for an hour, so a
 guessed bound would report live work as finished. The age is published and the
@@ -664,7 +665,11 @@ signal that never lands is otherwise invisible. It exits non-zero when a
 session's wiring is broken — something that must work for state to reach thurbox
 does not. An agent thurbox ships no hooks for but which is signalling anyway
 (your driver calling `session signal`) is a *warning*, not a failure: state is
-demonstrably arriving.
+demonstrably arriving. A parked session reports its missing pane as by design
+rather than as a fault, and `send`/`key`/`capture` refuse a parked session by
+name rather than reaching for a window that is deliberately gone (see
+[FEATURES.md](docs/FEATURES.md#stopping-is-not-deleting) for the full
+contract).
 
 **Deleting.** `session delete <uuid>` is a soft-delete: it only marks the
 database row. A running TUI kills the tmux window once the 10-second undo
@@ -679,6 +684,19 @@ Teardown is best-effort: individual failures are recorded in the JSON report
 (`killed_window`, `removed_worktrees`, `worktree_errors`,
 `disabled_automations`) but never abort the delete, and the row is always
 soft-deleted last.
+
+### Agents
+
+```bash
+thurbox-cli agent launch-args claude                  # command + args + env
+thurbox-cli agent launch-args claude --session <uuid>  # ...resolved for one session
+```
+
+Status hooks are installed by appending to an agent's `args` in `agents.toml`,
+so a driver that launches the agent itself — `session create --command`, or
+typing into a shell session — gets none unless it passes these through.
+`--session` pins the conversation id to that session's and carries the
+`THURBOX_SESSION` its `session signal` will report under.
 
 ### Automations (alias `auto`)
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1846,6 +1846,12 @@ distinction matters at restart, not at spawn:
   (command, args, env) is persisted on its row and replayed verbatim. Without
   that it would restart into nothing and lose its `--env` on the first respawn.
 
+`--env` is the exception that belongs to both: it is the *caller's*, never the
+registry's, so there is nowhere to re-resolve it from either way. It is recorded
+on every session's row — command or registry agent — replayed on restart, and
+reproduced by `session exec`, which runs in the session's environment as well as
+its directory and on its machine.
+
 A ready-made form ships as the `shell` built-in, whose `command` is the
 platform's own interactive shell (see [AGENTS.md](AGENTS.md)).
 
@@ -1896,6 +1902,18 @@ the interface's respawn of surveyed rows, a peer's `restart --if-missing` after
 a reboot, and extension self-heal. All three skip a marked row, and `start` is
 the only caller that clears the mark. Without the exemptions the interface would
 undo every stop within a tick of it happening.
+
+The mark is also **readable**, which is the half that makes the verb usable
+headlessly. A parked session stays in `session list` and reports `stopped: true`
+and `state: "stopped"` on `get` and `list` alike — the same key and type `watch`
+publishes, so a driver polling the read verbs and one reading the stream learn
+the same fact. `state` is `stopped` rather than the agent's last word or one of
+the two silences: all three describe a session that is *running*, and this one
+has no process at all. Its `backend_id` still names the window it had, because
+that is what the row records and `session start` replaces it with the new pane's
+id. `send`, `key` and `capture` refuse a parked session by name rather than
+reporting whatever the multiplexer says about a window that is deliberately
+gone.
 
 ## Session Persistence
 

--- a/docs/ORCHESTRATION.md
+++ b/docs/ORCHESTRATION.md
@@ -178,7 +178,7 @@ system, and the whole point of the run log is that there is one.
 
 ## Constraints worth stating
 
-Three facts shape any headless orchestration built on thurbox. Each
+Five facts shape any headless orchestration built on thurbox. Each
 costs real time to rediscover.
 
 ### The status field is not a completion signal
@@ -206,11 +206,22 @@ gone — and each one comes with what it takes to judge it:
 | `hook_blocked_is_heuristic` | whether its `blocked` is a text match on a notification body |
 | `hook_corroboration`, `hook_state_contradicted` | what actually holds the pane, and whether it agrees |
 | `state`, `state_source` | the best answer available, and where it came from |
+| `stopped` | whether the session is parked — `session stop`, no pane |
 
 `state` is always a word: `unreported` when nothing has reported for
-this session and `uncovered` when its agent is wired to report nothing.
-Neither is a state an agent can signal, and `state_source` is null for
-both. The piped (TOON) `session list` shows this column.
+this session, `uncovered` when its agent is wired to report nothing, and
+`stopped` when the session is parked. None of the three is a state an
+agent can signal, and `state_source` is null for all of them. The piped
+(TOON) `session list` shows this column.
+
+A **parked** session (`session stop`: pane killed, row and checkout
+kept) stays in `session list` and is told apart there — `stopped: true`
+and `state: "stopped"` on both read verbs, so a liveness check is the
+poll you were already doing rather than a pane probe or a one-second
+`watch --initial`. Its `backend_id` still names the window it had: that
+is what the row records, and `session start` replaces it with the new
+pane's id. `send`, `key` and `capture` refuse a parked session by name
+instead of reaching for the window that is gone.
 
 There is deliberately **no staleness timeout**. A turn may legitimately
 run for an hour, so any bound thurbox picked would report live work as
@@ -239,15 +250,26 @@ thurbox for a bare interactive shell and starting the agent inside that
 pane — therefore gets no hooks, and its sessions would read as never
 having reported anything.
 
-Two things close that, and both are **stable contract**:
+Three things close that, and all are **stable contract**:
 
+- **`thurbox-cli agent launch-args <name>` reports what to launch.**
+  The hooks are *arguments* — the `hooks` extension installs them by
+  appending to the agent's `args` in `agents.toml` (`--settings
+  <hooks>.json` for claude) — so an agent started any other way simply
+  has none. This prints the `command`, `args` and `env` thurbox itself
+  would use; pass the args through and the hooks are there. With
+  `--session <ref>` it resolves for that session: the conversation id is
+  pinned to the row's, the host adapts the args, and the environment
+  carries the `THURBOX_SESSION` its `session signal` will report under.
 - **`THURBOX_SESSION` is in the pane's environment**, and every child
   process inherits it. So anything running in the pane — the driver, the
   agent, one of the agent's own hooks — can call
   `thurbox-cli session signal --state <working|blocked|done|idle>` with
   **no arguments**: identity resolves from the environment. From outside
   the pane, pass `--session <uuid>`. This is the supported way to report
-  state for an agent thurbox did not launch.
+  state for an agent thurbox did not launch. `session exec` carries the
+  *target* session's identity, not the calling driver's, so a signal run
+  through it lands on the session it names.
 - **Failing that, the pane is read anyway.** A session that never
   signalled but whose pane's foreground process is an agent the registry
   knows reports `state: "running"` with `state_source: "process"` and
@@ -255,6 +277,43 @@ Two things close that, and both are **stable contract**:
   design — process inspection can say an agent is there, never what it
   is doing — but it is the difference between a session that reads as
   empty and one that reads as alive.
+
+### Read the exit status before parsing the output
+
+Errors are **structured documents on stdout**, not lines on stderr —
+AXI principle 6, because an agent reads one stream and a message on
+stderr is one it has to be told to capture. The exit code carries the
+verdict: `0` success, `1` the command ran and failed, `2` the invocation
+was wrong.
+
+The consequence is a trap worth naming. `thurbox-cli … --json | jq -r
+'.field'` exits **0 with empty output** when the command failed: `jq`
+parsed the error object perfectly well, found no such field, and the
+pipeline reports `jq`'s status rather than thurbox's. Capture first and
+branch on the status, or read `.error`:
+
+```bash
+out=$(thurbox-cli session get "$ref" --json) || {
+  printf 'thurbox: %s\n' "$(jq -r .error <<<"$out")" >&2
+  exit 1
+}
+id=$(jq -r .id <<<"$out")
+```
+
+`set -o pipefail` does not help here — the failing command exits 1 but
+`jq` succeeds, so the pipeline's status is `jq`'s either way.
+
+### The environment `session exec` runs under
+
+`session exec <ref> -- <cmd>` runs in the session's directory, on the
+machine it lives on, and under the session's own environment: whatever
+`session create --env` recorded for it, plus the `THURBOX_*` identity
+its pane carries. The calling process's own `THURBOX_*` variables are
+**scrubbed** — a driver running inside one session must not lend the
+child that session's identity, which is what made
+`session exec <worker> -- thurbox-cli session signal --state done`
+record for the *driver* and exit 0. The environment actually used is in
+the result's `env`.
 
 ### Fast-forward the base branch before creating a worktree
 

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -1504,11 +1504,11 @@ pub fn send_text_now(session_name: &str, pane_id: &str, text: &str, submit: bool
     }
     let paste = paste_prompt_args(&target, text, DEFAULT_MUX == "psmux");
     let paste_argv: Vec<&str> = paste.iter().map(String::as_str).collect();
-    let status = local_mux_command(&paste_argv)
-        .status()
+    let out = local_mux_command(&paste_argv)
+        .output()
         .context("Failed to paste prompt text into the session pane")?;
-    if !status.success() {
-        bail!("{DEFAULT_MUX} {} exited with status {status}", paste[0]);
+    if !out.status.success() {
+        bail!("{DEFAULT_MUX} {} {}", paste[0], mux_failure(&out));
     }
 
     if !submit {
@@ -1517,13 +1517,31 @@ pub fn send_text_now(session_name: &str, pane_id: &str, text: &str, submit: bool
 
     std::thread::sleep(SEND_KEYS_ENTER_DELAY);
 
-    let status = local_mux_command(&["send-keys", "-t", &target, "Enter"])
-        .status()
+    let out = local_mux_command(&["send-keys", "-t", &target, "Enter"])
+        .output()
         .context("Failed to send Enter to the session pane")?;
-    if !status.success() {
-        bail!("{DEFAULT_MUX} send-keys (Enter) exited with status {status}");
+    if !out.status.success() {
+        bail!("{DEFAULT_MUX} send-keys (Enter) {}", mux_failure(&out));
     }
     Ok(())
+}
+
+/// How a failed one-shot multiplexer command reads inside an error.
+///
+/// `output()` rather than `status()` at every call site above is the point: a
+/// `status()` child inherits this process's stderr, so tmux's own `can't find
+/// window: tb-<name>` lands there directly — a second, unstructured stream
+/// beside the error document the CLI puts on stdout (AXI principle 6, "an
+/// agent reads one stream"). Captured, the same sentence becomes part of the
+/// one answer. tmux says nothing at all for some failures, hence the fallback
+/// to the bare status.
+fn mux_failure(out: &std::process::Output) -> String {
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let detail = stderr.trim();
+    if detail.is_empty() {
+        return format!("exited with status {}", out.status);
+    }
+    detail.to_string()
 }
 
 /// The special keys [`send_key_now`] can deliver, as
@@ -1628,11 +1646,11 @@ pub fn send_key_now(session_name: &str, pane_id: &str, tmux_key: &str) -> Result
     if pane_is_dead(&target) {
         bail!("session '{session_name}' has exited; its pane accepts no input");
     }
-    let status = local_mux_command(&["send-keys", "-t", &target, tmux_key])
-        .status()
+    let out = local_mux_command(&["send-keys", "-t", &target, tmux_key])
+        .output()
         .context("Failed to send a key to the session pane")?;
-    if !status.success() {
-        bail!("{DEFAULT_MUX} send-keys ({tmux_key}) exited with status {status}");
+    if !out.status.success() {
+        bail!("{DEFAULT_MUX} send-keys ({tmux_key}) {}", mux_failure(&out));
     }
     Ok(())
 }
@@ -1687,11 +1705,11 @@ pub fn send_prompt_after_delay(
 ) -> Result<()> {
     let target = agent_target(session_name, pane_id);
     let script = deferred_prompt_script(&target, text);
-    let status = local_mux_command(&["run-shell", "-b", "-d", &delay_secs.to_string(), &script])
-        .status()
+    let out = local_mux_command(&["run-shell", "-b", "-d", &delay_secs.to_string(), &script])
+        .output()
         .context("Failed to schedule tmux run-shell for deferred prompt")?;
-    if !status.success() {
-        bail!("tmux run-shell (deferred prompt) exited with status {status}");
+    if !out.status.success() {
+        bail!("tmux run-shell (deferred prompt) {}", mux_failure(&out));
     }
     Ok(())
 }
@@ -1781,7 +1799,7 @@ pub fn ensure_automation_heartbeat(cli_path: &Path) -> Result<()> {
         return Ok(());
     }
     let loop_cmd = heartbeat_loop_command(cli_path);
-    let status = local_mux_command(&[
+    let out = local_mux_command(&[
         "new-window",
         "-d",
         "-t",
@@ -1790,10 +1808,10 @@ pub fn ensure_automation_heartbeat(cli_path: &Path) -> Result<()> {
         HEARTBEAT_WINDOW,
         &loop_cmd,
     ])
-    .status()
+    .output()
     .context("Failed to create automation heartbeat window")?;
-    if !status.success() {
-        bail!("tmux new-window (heartbeat) exited with status {status}");
+    if !out.status.success() {
+        bail!("tmux new-window (heartbeat) {}", mux_failure(&out));
     }
     debug!("Armed automation heartbeat keeper window");
     Ok(())

--- a/src/cli/agents.rs
+++ b/src/cli/agents.rs
@@ -1,0 +1,165 @@
+//! `thurbox-cli agent` — read the registry a session's launch is resolved from.
+//!
+//! Read-only, and one verb: what thurbox would run to start a registered agent.
+//!
+//! It exists because the status hooks that make `state` and `watch` work are
+//! *arguments*. The `hooks` extension installs them by appending to an agent's
+//! `args` in `agents.toml` (`--settings <hooks>.json` for claude), so they only
+//! reach the process when thurbox builds the command line. A driver that
+//! launches the agent itself — through `session create --command`, or by typing
+//! into a shell session — had no way to obtain them, so its sessions reported
+//! nothing and `watch` never mentioned them. That is exactly the integrator
+//! `session signal`'s help invites in ("a driver that launches its own agent
+//! there"), and this is the missing half of the invitation.
+
+use clap::Subcommand;
+use serde_json::json;
+
+use crate::cli::output::CommandOutput;
+use crate::storage::Database;
+
+#[derive(Subcommand, Debug)]
+pub enum Action {
+    /// Print how thurbox would launch a registered agent: `command`, `args`,
+    /// `env`.
+    ///
+    /// Pass the args through and the agent's status hooks fire, so the session
+    /// reports `state` and appears in `watch` — which is the whole reason to
+    /// ask. Without `--session` the environment names this thurbox instance
+    /// (config dir, data dir, multiplexer socket) and nothing more; with it,
+    /// the agent's conversation id is pinned to that session's and the
+    /// `THURBOX_*` identity its `session signal` needs is included.
+    ///
+    /// This is a fresh launch, never a resume: continuing an existing
+    /// conversation is `session start` / `session restart`.
+    LaunchArgs {
+        /// Agent name from `agents.toml` (e.g. `claude`, `codex`).
+        agent: String,
+        /// Resolve for this session — name, UUID, or unique id prefix.
+        #[arg(long)]
+        session: Option<String>,
+    },
+}
+
+pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
+    match action {
+        Action::LaunchArgs { agent, session } => {
+            let session = session
+                .as_deref()
+                .map(|reference| super::sessions::resolve(db, reference))
+                .transpose()?;
+            let plan = crate::session_ops::agent_launch_plan(db, &agent, session.as_ref())?;
+            let mut human = format!("{} {}", plan.command, plan.args.join(" "));
+            for (key, value) in &plan.env {
+                human.push_str(&format!("\n  {key}={value}"));
+            }
+            if !plan.hooks_enabled {
+                human.push_str(
+                    "\n  ! the hooks extension is not active, so these args carry no status \
+                     wiring",
+                );
+            }
+            if let Some(note) = &plan.degraded {
+                human.push_str(&format!("\n  ! {note}"));
+            }
+            // The registry's own account of what this agent could report, so an
+            // empty `args` is readable: an uninstrumented agent has none to
+            // give, an instrumented one with the extension off has them
+            // uninstalled, and the two look identical in the args alone.
+            let coverage =
+                crate::session::coverage_for(&crate::agent::agent_config::load_or_seed(), &agent);
+            Ok(CommandOutput::new(
+                json!({
+                    "agent": plan.agent,
+                    "command": plan.command,
+                    "args": plan.args,
+                    "env": plan.env,
+                    "session_id": session.as_ref().map(|s| s.id.to_string()),
+                    "hooks_enabled": plan.hooks_enabled,
+                    "hook_coverage": crate::session::Coverage::of(coverage.map(|(c, _)| c)).as_str(),
+                    "hook_states_reportable": coverage.map(|(c, _)| c.states).unwrap_or(&[]),
+                    "degraded": plan.degraded,
+                }),
+                human,
+            )
+            .help([
+                "thurbox-cli agent launch-args <name> --session <ref>   with that session's identity",
+                "thurbox-cli session create --name x --repo-path . --command <command> --arg <arg>   run it as a session",
+                "thurbox-cli session doctor <ref>   whether its reports are arriving",
+            ]))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// An `agents.toml` carrying the shape the hooks extension leaves behind:
+    /// the status wiring is an appended argument, which is the thing a driver
+    /// cannot otherwise obtain.
+    const AGENTS_TOML: &str = r#"
+config_version = 1
+default = "claude"
+
+[[agents]]
+name = "claude"
+command = "claude"
+args = ["--settings", "/opt/hooks/claude.json"]
+new_session_args = ["--session-id", "{id}"]
+
+[[agents]]
+name = "shell"
+command = "bash"
+args = ["-i"]
+"#;
+
+    fn isolated(dir: &std::path::Path) -> crate::paths::TestPathGuard {
+        let guard = crate::paths::TestPathGuard::new(dir);
+        let path = crate::agent::agent_config::agents_config_path().expect("agents path");
+        std::fs::create_dir_all(path.parent().expect("config dir")).expect("mkdir");
+        std::fs::write(&path, AGENTS_TOML).expect("write agents.toml");
+        guard
+    }
+
+    #[test]
+    fn launch_args_reports_the_hook_wiring() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = isolated(temp.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let out = run(
+            Action::LaunchArgs {
+                agent: "claude".into(),
+                session: None,
+            },
+            &db,
+        )
+        .expect("launch-args");
+
+        assert_eq!(out["command"], json!("claude"));
+        assert_eq!(out["args"], json!(["--settings", "/opt/hooks/claude.json"]));
+        // No session, so no identity to lend — and saying nothing is right:
+        // an empty THURBOX_SESSION would report for no session at all.
+        assert!(out["env"]["THURBOX_SESSION"].is_null());
+        assert!(out["session_id"].is_null());
+    }
+
+    #[test]
+    fn an_unknown_agent_names_the_ones_there_are() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = isolated(temp.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let err = run(
+            Action::LaunchArgs {
+                agent: "nope".into(),
+                session: None,
+            },
+            &db,
+        )
+        .expect_err("unknown agent");
+        assert!(err.contains("claude"), "got {err}");
+        assert!(err.contains("shell"), "got {err}");
+    }
+}

--- a/src/cli/home.rs
+++ b/src/cli/home.rs
@@ -32,6 +32,7 @@ pub fn run(db: &Database) -> Result<CommandOutput, String> {
         .list_active_sessions()
         .map_err(|e| format!("list_active_sessions: {e}"))?;
     let states = db.load_hook_states().unwrap_or_default();
+    let parked = db.load_stopped_sessions().unwrap_or_default();
     let registry = crate::agent::agent_config::load_or_seed();
 
     // The rows are trimmed to the four fields that let an agent decide what to
@@ -48,7 +49,7 @@ pub fn run(db: &Database) -> Result<CommandOutput, String> {
     let rows: Vec<Value> = sessions
         .iter()
         .map(|s| {
-            let hook = crate::cli::sessions::assess(&registry, s, &states, false);
+            let hook = crate::cli::sessions::assess(&registry, s, &states, &parked, false);
             json!({
                 "name": s.name,
                 "agent": s.agent,
@@ -71,6 +72,7 @@ pub fn run(db: &Database) -> Result<CommandOutput, String> {
         crate::session::STATE_RUNNING,
         crate::session::STATE_UNCOVERED,
         crate::session::STATE_UNREPORTED,
+        crate::session::STATE_STOPPED,
     ] {
         let n = rows.iter().filter(|r| r["state"] == json!(state)).count();
         if n > 0 {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -35,6 +35,7 @@ use crate::storage::Database;
 mod tests;
 
 pub mod action;
+pub mod agents;
 pub mod automations;
 pub mod config;
 pub mod editor;
@@ -123,6 +124,7 @@ Examples:
   thurbox-cli session list                     every session, with status and branch
   thurbox-cli session create --name fix-ci --repo-path . --worktree-branch fix/ci
   thurbox-cli session capture <id> --lines 50  what an agent's pane is showing
+  thurbox-cli agent launch-args claude          what to run so its hooks report
   thurbox-cli message send --to <id> --kind result --body 'done'
   thurbox-cli session list --json | jq         full records for a script
 
@@ -135,6 +137,11 @@ pub enum Command {
     Editor {
         #[command(subcommand)]
         action: editor::Action,
+    },
+    /// The agent registry: how thurbox would launch a registered agent.
+    Agent {
+        #[command(subcommand)]
+        action: agents::Action,
     },
     /// Manage sessions.
     Session {
@@ -322,6 +329,7 @@ fn parse_fields(spec: &str) -> Vec<String> {
 fn dispatch(command: Command, db: &Database) -> Result<CommandOutput, String> {
     match command {
         Command::Editor { action } => editor::run(action, db),
+        Command::Agent { action } => agents::run(action, db),
         Command::Session { action } => sessions::run(action, db),
         Command::Automation { action } => automations::run(action, db),
         Command::Task { action } => tasks::run(action, db),

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -82,6 +82,9 @@ pub struct AgentView {
     /// than every other answer of the session put together. `--json` is never
     /// capped: a script asking for the record wants the record.
     pub max_text: Option<usize>,
+    /// This answer **is** one value, so every non-JSON rendering is that value
+    /// and nothing else. See [`CommandOutput::scalar`].
+    pub scalar: bool,
 }
 
 impl CommandOutput {
@@ -137,6 +140,25 @@ impl CommandOutput {
     /// the escape hatch named in place. `--full` lifts it.
     pub fn truncate(mut self, chars: usize) -> Self {
         self.agent.max_text = Some(chars);
+        self
+    }
+
+    /// Declare that this answer is a **single value**, so the piped rendering
+    /// is that value alone rather than the record around it.
+    ///
+    /// The TOON default exists because the reader of a pipe is usually an
+    /// agent reading a *record*. A getter that returns one scalar has the
+    /// opposite reader: its output is routinely captured into a shell variable
+    /// (`v=$(thurbox-cli session meta get <ref> <key>)`), and capturing is
+    /// precisely what makes stdout not a terminal — so the format meant for a
+    /// pipe replaced the value with `id: …\nkey: …\nvalue: …` in exactly the
+    /// case the command exists for. A caller that wants the record asks for it
+    /// with `--json`, which is unchanged.
+    ///
+    /// The human rendering *is* the value, so `--text` and the piped form
+    /// agree, and an absent value renders as nothing at all.
+    pub fn scalar(mut self) -> Self {
+        self.agent.scalar = true;
         self
     }
 
@@ -268,6 +290,12 @@ impl Format {
 /// saves. The two are separated by a blank line so a reader can see where the
 /// document ends.
 fn render_toon(out: &CommandOutput) -> String {
+    // A single-value answer renders as that value in every format but JSON —
+    // see `CommandOutput::scalar`. Ahead of everything else here, because the
+    // whole point is that nothing is wrapped around it.
+    if out.agent.scalar {
+        return out.human.clone();
+    }
     let mut blocks: Vec<String> = Vec::new();
 
     let capped;

--- a/src/cli/session_doctor.rs
+++ b/src/cli/session_doctor.rs
@@ -304,7 +304,8 @@ fn diagnose(
         findings.push(Finding {
             key: "pane",
             level: Level::Ok,
-            detail: "this session is stopped (`session stop`), so it has no pane by design —                      `session start` puts one back"
+            detail: "stopped by `session stop`, so it has no pane by design — `session start` \
+                      puts one back"
                 .into(),
         });
     } else if let Some(corroboration) = hook.corroboration {

--- a/src/cli/session_doctor.rs
+++ b/src/cli/session_doctor.rs
@@ -66,6 +66,7 @@ pub fn run(db: &Database, uuid: Option<&str>) -> Result<CommandOutput, String> {
             .map_err(|e| format!("list_active_sessions: {e}"))?,
     };
     let states = db.load_hook_states().unwrap_or_default();
+    let parked = db.load_stopped_sessions().unwrap_or_default();
     let registry = crate::agent::agent_config::load_or_seed();
     let hooks_active = crate::session_ops::builtin_hooks::hooks_enabled(db);
     // Resolved once: the same answer for every session, and each probe is a
@@ -74,7 +75,7 @@ pub fn run(db: &Database, uuid: Option<&str>) -> Result<CommandOutput, String> {
 
     let mut reports = Vec::new();
     for session in &sessions {
-        let hook = super::sessions::assess(&registry, session, &states, true);
+        let hook = super::sessions::assess(&registry, session, &states, &parked, true);
         reports.push(diagnose(
             session,
             &hook,
@@ -280,6 +281,14 @@ fn diagnose(
             level: Level::Ok,
             detail: format!("{state}, {} ago", output::duration_short(age)),
         },
+        // A parked session reports nothing because there is nothing running to
+        // report — `stop` clears the state for exactly that reason. Warning
+        // about the silence would be warning about the operator's own request.
+        _ if hook.stopped => Finding {
+            key: "last-signal",
+            level: Level::Ok,
+            detail: "stopped, so nothing is reporting".into(),
+        },
         _ => Finding {
             key: "last-signal",
             level: Level::Warn,
@@ -287,7 +296,18 @@ fn diagnose(
         },
     });
 
-    if let Some(corroboration) = hook.corroboration {
+    // A parked session has no pane on purpose, and nothing has signalled since
+    // `stop` cleared the state. Said plainly it is a clean report; left to the
+    // pane check below it would be one more "could not be checked" warning
+    // about the very thing the operator asked for.
+    if hook.stopped {
+        findings.push(Finding {
+            key: "pane",
+            level: Level::Ok,
+            detail: "this session is stopped (`session stop`), so it has no pane by design —                      `session start` puts one back"
+                .into(),
+        });
+    } else if let Some(corroboration) = hook.corroboration {
         let process = hook.foreground_process.as_deref().unwrap_or("nothing");
         findings.push(if hook.contradicted == Some(true) {
             Finding {

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -25,8 +25,11 @@ pub enum Action {
     /// Each row carries the session's reported agent state plus how old that
     /// report is and what its agent is able to report at all (`hook_state`,
     /// `hook_state_age_secs`, `hook_coverage`, `hook_states_reportable`).
-    /// `state` is the one word to read: an agent's own report, or `unreported`
-    /// / `uncovered` when there is none.
+    /// `state` is the one word to read: an agent's own report, `unreported`
+    /// / `uncovered` when there is none, or `stopped` for a session parked by
+    /// `session stop`. A parked session stays in this list and carries
+    /// `stopped: true`, so a driver can tell one from a running session
+    /// without probing its pane.
     List {
         /// Only list children of this parent session UUID.
         #[arg(long)]
@@ -53,6 +56,11 @@ pub enum Action {
     /// coverage of its agent's hooks, and — for a local session — what the
     /// pane's foreground process says about it (`hook_corroboration`,
     /// `hook_state_contradicted`). Pass `--no-verify` to skip the pane probe.
+    ///
+    /// A session parked by `session stop` reports `stopped: true` and
+    /// `state: "stopped"`, and its pane is not probed — there is none.
+    /// `backend_id` still names the window it had: it is what the row records,
+    /// and `session start` replaces it with the new pane's id.
     Get {
         /// Session UUID.
         uuid: String,
@@ -274,6 +282,10 @@ pub enum Action {
     /// A stopped session costs no process and no terminal, and `session start`
     /// puts it back where it was — nothing else reclaims its pane in the
     /// meantime, which is what separates this from a window that merely died.
+    ///
+    /// It stays in `session list`, reporting `stopped: true` and
+    /// `state: "stopped"` on both read verbs, and `send`/`key`/`capture`
+    /// refuse it by name rather than reaching for the window that is gone.
     Stop {
         /// Session name, UUID, or unique id prefix.
         session: String,
@@ -303,6 +315,18 @@ pub enum Action {
     /// with its output returned. What "check the state of that session's work"
     /// needs, without a driver having to reconstruct the cwd and the host
     /// itself.
+    ///
+    /// "The session's context" is three things, and the third is the one worth
+    /// spelling out. The child runs in the session's **directory**, on the
+    /// **machine** the session lives on, and under the session's own
+    /// **environment**: whatever `session create --env` recorded, plus the
+    /// `THURBOX_*` identity variables the session's pane carries — so
+    /// `session exec <ref> -- thurbox-cli session signal --state done` reports
+    /// for `<ref>`. What is *not* carried is this invocation's own environment
+    /// in the `THURBOX_*` namespace: it is scrubbed, because a driver calling
+    /// from inside another session would otherwise lend the child that
+    /// session's identity. Everything else is inherited as usual. The
+    /// environment actually used is in the result's `env`.
     Exec {
         /// Session name, UUID, or unique id prefix.
         session: String,
@@ -338,7 +362,8 @@ pub enum Action {
     /// process in it, so a driver that launches its own agent there — and that
     /// agent's own hooks — can report state with no arguments at all. From
     /// outside the pane, pass `--session <uuid>`. `session doctor` says whether
-    /// the reports are arriving.
+    /// the reports are arriving, and `agent launch-args <name>` says what to
+    /// launch the agent with so that its hooks exist to do the reporting.
     Signal {
         /// The reported state. `idle` = agent ready/at-rest (e.g. a fresh
         /// session boot); `done` = a turn just finished (shows until you look).
@@ -400,6 +425,12 @@ pub enum MetaAction {
         value: Option<String>,
     },
     /// Print one key's value, or nothing when it is unset.
+    ///
+    /// The bare value, on a terminal and down a pipe alike — this is the getter
+    /// whose output is captured into a shell variable, and being captured is
+    /// what makes stdout a pipe. `--json` returns the whole record, which is
+    /// also the only form that tells a value of `null` from a key that was
+    /// never set.
     Get {
         /// Session name, UUID, or unique id prefix.
         session: String,
@@ -475,11 +506,12 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
                 .filter(|s| parent_id.is_none() || s.parent_session_id == parent_id)
                 .collect();
             let states = db.load_hook_states().unwrap_or_default();
+            let parked = db.load_stopped_sessions().unwrap_or_default();
             let bases = db.load_base_branches().unwrap_or_default();
             let registry = crate::agent::agent_config::load_or_seed();
             let assessments: Vec<crate::session::Assessment> = sessions
                 .iter()
-                .map(|s| assess(&registry, s, &states, verify))
+                .map(|s| assess(&registry, s, &states, &parked, verify))
                 .collect();
             let json = Value::Array(
                 sessions
@@ -519,9 +551,10 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
         Action::Get { uuid, no_verify } => {
             let session = resolve(db, &uuid)?;
             let states = db.load_hook_states().unwrap_or_default();
+            let parked = db.load_stopped_sessions().unwrap_or_default();
             let bases = db.load_base_branches().unwrap_or_default();
             let registry = crate::agent::agent_config::load_or_seed();
-            let hook = assess(&registry, &session, &states, !no_verify);
+            let hook = assess(&registry, &session, &states, &parked, !no_verify);
             Ok(CommandOutput::new(
                 crate::session_ops::mirror::session_to_json_assessed(
                     &session,
@@ -638,6 +671,7 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
             if text.trim().is_empty() {
                 return Err("text must not be empty".into());
             }
+            refuse_if_parked(db, &session)?;
             let id = session.id.to_string();
             let mut args = vec!["session", "send", &id, &text];
             if no_enter {
@@ -668,6 +702,7 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
             let session = resolve(db, &uuid)?;
             let resolved =
                 crate::agent::tmux::resolve_key(&key).ok_or_else(|| unknown_key(&key))?;
+            refuse_if_parked(db, &session)?;
             let id = session.id.to_string();
             if let Some(remote) =
                 delegate_to_host(&session, &["session", "key", &id, &resolved.name])?
@@ -845,6 +880,7 @@ fn capture_pane(
     ansi: bool,
 ) -> Result<CommandOutput, String> {
     let session = resolve(db, uuid)?;
+    refuse_if_parked(db, &session)?;
     let id = session.id.to_string();
     let line_count = lines.to_string();
     let mut args = vec!["session", "capture", &id, "--lines", &line_count];
@@ -1146,6 +1182,15 @@ fn coverage_line(hook: &crate::session::Assessment) -> String {
 ///
 /// Host-transparent: a session created with `--host` runs this over that host's
 /// launcher rather than refusing, so `exec` means the same thing everywhere.
+///
+/// "In the session's context" is the directory, the machine **and** the
+/// environment: the child gets the session's own recorded `--env` and the
+/// identity variables its pane carries, and every `THURBOX_*` variable of this
+/// process is dropped before they go on
+/// ([`crate::session_ops::session_process_env`]). Without the scrub a driver
+/// reaching into a session from inside another one handed the child the
+/// *caller's* `THURBOX_SESSION`, so a `session signal` run through here
+/// recorded state for the wrong session and exited 0.
 fn exec_in_session(
     db: &Database,
     reference: &str,
@@ -1176,7 +1221,8 @@ fn exec_in_session(
     } else {
         None
     };
-    let output = crate::session_ops::exec_in_dir(host.as_ref(), &cwd, program, rest)
+    let env = crate::session_ops::session_process_env(db, &session);
+    let output = crate::session_ops::exec_in_dir(host.as_ref(), &cwd, program, rest, &env)
         .map_err(|e| format!("could not run '{program}' in {}: {e}", cwd.display()))?;
 
     // `None` when the process was terminated without exiting — killed by a
@@ -1201,6 +1247,9 @@ fn exec_in_session(
         "id": session.id.to_string(),
         "name": session.name,
         "cwd": cwd.display().to_string(),
+        // What the child actually ran under, so a caller debugging "why did my
+        // command not see FOO" reads the answer instead of guessing at it.
+        "env": env,
         "exit_code": code,
         "stdout": stdout,
         "stderr": stderr,
@@ -1262,9 +1311,14 @@ fn run_meta(action: MetaAction, db: &Database) -> Result<CommandOutput, String> 
             Ok(CommandOutput::new(
                 json!({ "id": target.id.to_string(), "key": key, "value": value }),
                 // Bare value on stdout: this is the one command whose output is
-                // routinely captured into a shell variable.
+                // routinely captured into a shell variable. `.scalar()` is what
+                // makes that survive the capture — being captured is what makes
+                // stdout a pipe, and the piped default would otherwise answer
+                // with the whole record. A key that is not set renders as
+                // nothing; `--json` still tells a null value from an unset key.
                 value.unwrap_or_default(),
-            ))
+            )
+            .scalar())
         }
         MetaAction::List { session } => {
             let target = resolve(db, &session)?;
@@ -1421,6 +1475,28 @@ fn existing_session_output(session: &SharedSession) -> CommandOutput {
     .help(["thurbox-cli session get <id>   what it is doing now"])
 }
 
+/// Refuse a pane verb pointed at a **parked** session, naming the fix.
+///
+/// `session stop` killed the window on purpose, so `send`, `key` and `capture`
+/// have nothing to reach. Without this they reach for it anyway and report
+/// whatever the multiplexer says about a window that is not there — `can't find
+/// window: tb-<name>`, which describes a crash rather than the deliberate state
+/// the caller itself asked for. One database read, on verbs that already do
+/// several.
+fn refuse_if_parked(db: &Database, session: &SharedSession) -> Result<(), String> {
+    let parked = db
+        .session_stopped_at(session.id)
+        .map_err(|e| format!("session_stopped_at: {e}"))?
+        .is_some();
+    if !parked {
+        return Ok(());
+    }
+    Err(format!(
+        "session '{}' is stopped: it has no pane. `thurbox-cli session start {}` puts one back",
+        session.name, session.name
+    ))
+}
+
 /// Resolve the session a command was pointed at — a name, a UUID or an id
 /// prefix, all equally. See [`super::session_ref`] for why one resolver.
 pub(crate) fn resolve(db: &Database, reference: &str) -> Result<SharedSession, String> {
@@ -1500,10 +1576,16 @@ fn unknown_key(key: &str) -> String {
 /// get` does it for one session and `session list` only on `--verify`. A
 /// **remote** session is never probed: its pane lives on its own host's
 /// multiplexer, so the answer is `unavailable` rather than a guess.
+///
+/// `parked` is the set `session stop` marked. It short-circuits everything
+/// else: a parked session has no pane to probe and no agent to have reported,
+/// so probing one would ask tmux about a window that was deliberately killed
+/// and read the answer as if it meant something.
 pub(crate) fn assess(
     registry: &crate::session::AgentRegistry,
     s: &SharedSession,
     states: &std::collections::HashMap<crate::session::SessionId, crate::storage::HookRow>,
+    parked: &std::collections::HashSet<crate::session::SessionId>,
     probe: bool,
 ) -> crate::session::Assessment {
     let row = states.get(&s.id);
@@ -1514,6 +1596,9 @@ pub(crate) fn assess(
         row.and_then(|r| r.state_at),
         crate::sync::current_time_millis() as i64,
     );
+    if parked.contains(&s.id) {
+        return hook.parked();
+    }
     if !probe {
         return hook;
     }

--- a/src/session/hook_status.rs
+++ b/src/session/hook_status.rs
@@ -453,6 +453,15 @@ pub const STATE_UNCOVERED: &str = "uncovered";
 /// The word for a session whose agent *can* report and has not yet.
 pub const STATE_UNREPORTED: &str = "unreported";
 
+/// The word for a session that was deliberately parked (`session stop`).
+///
+/// Outside [`HOOK_STATES`] like the three above, and for the sharpest version
+/// of the same reason: a parked session has no process at all, so *every* other
+/// word here would describe an agent that is not running. It is the one state
+/// thurbox knows first-hand rather than infers — the mark `session stop` wrote
+/// — which is why it outranks anything the hook columns still hold.
+pub const STATE_STOPPED: &str = "stopped";
+
 /// The best answer available for a session, and where it came from.
 ///
 /// The hook state wins whenever there is one — it is the agent's own report,
@@ -511,6 +520,10 @@ pub struct Assessment {
     /// The best answer available, and where it came from — see [`best_state`].
     pub state: Option<String>,
     pub state_source: Option<StateSource>,
+    /// Parked by `session stop`: the row and its checkout stand, the pane does
+    /// not. Set by [`Self::parked`], and the one fact here that is thurbox's
+    /// own rather than the agent's or the pane's.
+    pub stopped: bool,
 }
 
 impl Assessment {
@@ -522,12 +535,17 @@ impl Assessment {
     /// [`STATE_UNCOVERED`] (this agent is wired to report nothing, so silence
     /// means nothing) and [`STATE_UNREPORTED`] (it can report and has not).
     /// Neither is in [`crate::session::HOOK_STATES`], so neither can be read
-    /// as an agent's own report.
+    /// as an agent's own report. A session [`parked`](Self::parked) by `session
+    /// stop` answers [`STATE_STOPPED`] ahead of all three: it has no process,
+    /// so nothing the hook columns still hold describes it.
     ///
     /// Every rendering goes through here — the human table, the agent-facing
     /// TOON view and the home view — so no surface can invent a third answer
     /// for the same row.
     pub fn state_word(&self) -> &str {
+        if self.stopped {
+            return STATE_STOPPED;
+        }
         match self.state.as_deref() {
             Some(state) => state,
             None if self.coverage == Coverage::None => STATE_UNCOVERED,
@@ -585,6 +603,7 @@ impl Assessment {
             contradicted: None,
             state: state.as_ref().map(|(s, _)| s.clone()),
             state_source: state.map(|(_, source)| source),
+            stopped: false,
         }
     }
 
@@ -619,6 +638,21 @@ impl Assessment {
     /// leaving the corroboration unset, which means nobody tried.
     pub fn pane_unavailable(mut self) -> Self {
         self.corroboration = Some(Corroboration::Unavailable);
+        self
+    }
+
+    /// Record that the session is parked — `session stop` killed its pane and
+    /// kept everything else.
+    ///
+    /// [`Self::state`] and its source are dropped rather than kept: they are
+    /// "the best answer available" for a session that is *running*, and a
+    /// parked one is not. `hook_state` stays exactly as stored, because a
+    /// consumer reading that column reads the agent's last word verbatim and
+    /// nothing here may launder thurbox's own fact into it.
+    pub fn parked(mut self) -> Self {
+        self.stopped = true;
+        self.state = None;
+        self.state_source = None;
         self
     }
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -27,7 +27,7 @@ pub use hook_def::{
 pub use hook_status::{
     age_secs, best_state, classify_foreground, contradicts, coverage_for, AgentHookCoverage,
     Assessment, Corroboration, Coverage, CoverageSource, HookDelivery, StateSource,
-    AGENT_HOOK_COVERAGE, STATE_RUNNING, STATE_UNCOVERED, STATE_UNREPORTED,
+    AGENT_HOOK_COVERAGE, STATE_RUNNING, STATE_STOPPED, STATE_UNCOVERED, STATE_UNREPORTED,
 };
 pub use host_def::{
     is_remote_backend, is_ssh_backend, is_wsl_backend, HostDef, HostKind, HostRegistry,

--- a/src/session_ops/mirror.rs
+++ b/src/session_ops/mirror.rs
@@ -158,6 +158,11 @@ pub fn session_to_json_assessed(
     // null for both, which is what tells them from an agent's own report.
     put("state", json!(hook.state_word()));
     put("state_source", json!(hook.state_source.map(|s| s.as_str())));
+    // The parked mark, under the same name and type `thurbox-cli watch`
+    // already publishes it — so a driver polling `get`/`list` and one reading
+    // the stream learn the same fact from the same key. Without it the two
+    // verbs describe a parked session exactly as they describe a running one.
+    put("stopped", json!(hook.stopped));
     value
 }
 

--- a/src/session_ops/mod.rs
+++ b/src/session_ops/mod.rs
@@ -34,7 +34,7 @@ pub use restart::{restart_session_headless, RestartReport};
 pub use restore::{restore_session_headless, RestoreReport};
 pub use spawn::{spawn_session_headless, SpawnRequest, SpawnResult};
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use crate::session::agent_def::ID_PLACEHOLDER;
 use crate::session::{AutomationRunStatus, SessionConfig};
@@ -257,37 +257,192 @@ pub fn host_launcher(host: &crate::session::HostDef) -> crate::shell::HostLaunch
     }
 }
 
-/// Run a command in `cwd`, on `host` when the session lives off this machine.
+/// Run a command in `cwd`, on `host` when the session lives off this machine,
+/// under `env`.
 ///
 /// The remote form is one `sh -c` because `cd` and the command have to share a
 /// shell, and every word is POSIX-quoted so the host's login shell re-splitting
 /// cannot reinterpret an argument containing a space. Lives here rather than in
 /// `cli` because knowing how to reach a host — and how to quote for one — is
 /// `session_ops`' job; `cli` may not reach into `shell` at all.
+///
+/// `env` is layered onto the inherited environment, and every inherited
+/// `THURBOX_*` variable is dropped first. That scrub is the substance, not
+/// hygiene: this runs *in a session's context*, and the caller invoking it is
+/// itself usually inside a different session, whose `THURBOX_SESSION` the child
+/// would otherwise inherit — so a `thurbox-cli session signal` run through here
+/// would record state against the caller, silently and with exit 0. Anything
+/// the target session should carry is in `env`, which is passed explicitly for
+/// exactly this reason. Nothing crosses an SSH connection, so the remote form
+/// has nothing to scrub and only has to set: `env` there is one `env K=V …`
+/// prefix, whose arguments carry names a shell assignment prefix could not.
 pub fn exec_in_dir(
     host: Option<&crate::session::HostDef>,
     cwd: &std::path::Path,
     program: &str,
     args: &[String],
+    env: &BTreeMap<String, String>,
 ) -> std::io::Result<std::process::Output> {
     match host {
-        None => std::process::Command::new(program)
-            .args(args)
-            .current_dir(cwd)
-            .output(),
+        None => {
+            let mut cmd = std::process::Command::new(program);
+            cmd.args(args).current_dir(cwd);
+            for key in std::env::vars_os()
+                .map(|(k, _)| k)
+                .filter(|k| k.to_string_lossy().starts_with(THURBOX_ENV_PREFIX))
+            {
+                cmd.env_remove(key);
+            }
+            cmd.envs(env).output()
+        }
         Some(host) => {
+            let assignments = env
+                .iter()
+                .map(|(k, v)| crate::shell::posix_quote(&format!("{k}={v}")));
             let script = format!(
-                "cd {} && exec {}",
+                "cd {} && exec env {}",
                 crate::shell::posix_quote(&cwd.to_string_lossy()),
-                std::iter::once(program)
-                    .chain(args.iter().map(String::as_str))
-                    .map(crate::shell::posix_quote)
+                assignments
+                    .chain(
+                        std::iter::once(program)
+                            .chain(args.iter().map(String::as_str))
+                            .map(crate::shell::posix_quote)
+                    )
                     .collect::<Vec<_>>()
                     .join(" ")
             );
             host_launcher(host).shell_c(&script).output()
         }
     }
+}
+
+/// The prefix every variable thurbox injects into a session's processes shares.
+const THURBOX_ENV_PREFIX: &str = "THURBOX_";
+
+/// How thurbox would launch a registered agent: the executable, its arguments,
+/// and the environment around them.
+///
+/// The point of reporting it is the arguments. An agent's status hooks are
+/// installed by *appending to its `args`* in `agents.toml` (claude's
+/// `--settings <hooks>.json`), so they only fire when thurbox builds the
+/// command line. A driver that launches the agent itself — the documented
+/// `--command` path, or typing into a shell session — got no hooks, and so an
+/// empty `state` and a `watch` stream that never mentioned that session.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LaunchPlan {
+    /// The registry name the plan was resolved from.
+    pub agent: String,
+    /// The executable, resolved on `PATH` at launch exactly as thurbox leaves
+    /// it to the multiplexer.
+    pub command: String,
+    pub args: Vec<String>,
+    /// The environment to launch under. Without a session this is only the
+    /// pointers to *this* thurbox instance (config dir, data dir, multiplexer
+    /// socket); with one it also carries that session's identity, which is what
+    /// makes the agent's `session signal` land on the right row.
+    pub env: BTreeMap<String, String>,
+    /// Why hooks-driven status will be degraded or absent on this host, when it
+    /// will be. `None` means nothing is known to be wrong.
+    pub degraded: Option<String>,
+    /// Whether the built-in `hooks` extension is active. It is what puts the
+    /// status wiring into an agent's `args` in the first place, so with it off
+    /// these args are simply the agent's own — and an empty `args` is then an
+    /// answer rather than a surprise.
+    pub hooks_enabled: bool,
+}
+
+/// Resolve the [`LaunchPlan`] for a registered agent, optionally in the context
+/// of an existing session.
+///
+/// With `session`, the plan is the one that session's *next fresh launch* would
+/// use: its `agent_session_id` pins the conversation, its host adapts the args,
+/// and its identity is in the environment. Resuming an existing conversation is
+/// `session start`/`restart`'s job and deliberately not offered here — a driver
+/// asking what to run is starting something, not continuing it.
+pub fn agent_launch_plan(
+    db: &crate::storage::Database,
+    agent: &str,
+    session: Option<&crate::sync::SharedSession>,
+) -> Result<LaunchPlan, String> {
+    let registry = crate::agent::agent_config::load_or_seed();
+    let def = registry.get(agent).cloned().ok_or_else(|| {
+        let known: Vec<&str> = registry.agents.iter().map(|a| a.name.as_str()).collect();
+        format!(
+            "no agent named '{agent}' in agents.toml; known agents: {}",
+            known.join(", ")
+        )
+    })?;
+    let host = match session {
+        Some(s) => resolve_host(&s.backend_type).ok_or_else(|| {
+            format!(
+                "session '{}' runs on backend '{}', which is not in hosts.toml",
+                s.name, s.backend_type
+            )
+        })?,
+        None => None,
+    };
+    let mut config = SessionConfig {
+        session_id: session.map(|s| s.id),
+        agent_session_id: session.and_then(|s| s.agent_session_id.clone()),
+        agent: def.name.clone(),
+        cwd: session.and_then(|s| s.cwd.clone()),
+        backend: session.map(|s| s.backend_type.clone()),
+        ..SessionConfig::default()
+    };
+    match session {
+        Some(s) => config.env.extend(session_process_env(db, s)),
+        // No session to take an identity from, but the instance is still
+        // knowable — and a child `thurbox-cli` that resolves a different data
+        // dir or socket would report into a database nothing here reads.
+        None => config.env.extend(thurbox_env_overrides()),
+    }
+    let hooks = hooks_enabled(db);
+    let (def, degraded) = spawn::adapt_def_for_launch(def, host.as_ref(), hooks);
+    let (command, args) = build_agent_invocation(&def, &config);
+    Ok(LaunchPlan {
+        agent: def.name,
+        command,
+        args,
+        env: config.env.into_iter().collect(),
+        degraded,
+        hooks_enabled: hooks,
+    })
+}
+
+/// The environment a process run **in a session's context** must carry: the
+/// session's own recorded `--env`, then the identity variables its pane has.
+///
+/// The order is the spawn's, and for the same reason: thurbox's identity wins,
+/// so a session cannot rename its own `THURBOX_SESSION` and report another
+/// session's state. Built from `inject_thurbox_env` rather than beside it, so
+/// what `session exec` hands a child and what the pane holds cannot drift —
+/// the surprise this exists to remove is precisely that the two disagreed.
+///
+/// A session with no `agent_session_id` gets no `THURBOX_SESSION_ID`: an empty
+/// one would read as a conversation id rather than as the absence of one.
+pub fn session_process_env(
+    db: &crate::storage::Database,
+    session: &crate::sync::SharedSession,
+) -> BTreeMap<String, String> {
+    let mut config = SessionConfig {
+        session_id: Some(session.id),
+        agent_session_id: session.agent_session_id.clone(),
+        agent: session.agent.clone(),
+        backend: Some(session.backend_type.clone()),
+        ..SessionConfig::default()
+    };
+    config
+        .env
+        .extend(db.load_launch_env(session.id).unwrap_or_default());
+    inject_thurbox_env(
+        &mut config,
+        session.agent_session_id.as_deref().unwrap_or_default(),
+        None,
+    );
+    if session.agent_session_id.is_none() {
+        config.env.remove("THURBOX_SESSION_ID");
+    }
+    config.env.into_iter().collect()
 }
 
 /// Fork a session: a new one beside it, on the same directory and branch, with
@@ -456,7 +611,7 @@ pub(crate) fn expand_home_in_def(def: &mut crate::session::AgentDef, home: &str)
 /// Centralised here so headless spawn and restart agree on the args, and so the
 /// `AgentDef` is resolved exactly once per operation (callers pass the def they
 /// already resolved rather than re-running [`resolve_agent_def`]).
-fn build_agent_invocation(
+pub(crate) fn build_agent_invocation(
     def: &crate::session::AgentDef,
     config: &SessionConfig,
 ) -> (String, Vec<String>) {

--- a/src/session_ops/mod.rs
+++ b/src/session_ops/mod.rs
@@ -491,6 +491,10 @@ pub fn fork_session_headless(
     // recipe rather than the agent name — otherwise it would look up an agent
     // called `bash` and find nothing.
     let recipe = db.load_launch_recipe(id).unwrap_or_default();
+    // Read separately from the recipe: a registry-agent session has no
+    // recipe at all, but its `--env` is still recorded in the same column and
+    // there is nowhere else to re-resolve it from for the fork.
+    let env = db.load_launch_env(id).unwrap_or_default();
 
     let request = spawn::SpawnRequest {
         name,
@@ -500,7 +504,7 @@ pub fn fork_session_headless(
         agent: recipe.is_none().then(|| source.agent.clone()),
         command: recipe.as_ref().map(|r| r.command.clone()),
         args: recipe.as_ref().map(|r| r.args.clone()).unwrap_or_default(),
-        env: recipe.map(|r| r.env).unwrap_or_default(),
+        env,
         // A fork of a remote session belongs on that session's host, or it would
         // silently become a local session pointed at a path that is not here.
         host: resolve_host(&source.backend_type)

--- a/src/session_ops/restart.rs
+++ b/src/session_ops/restart.rs
@@ -28,15 +28,16 @@ pub(crate) struct RestartPlan {
 }
 
 /// Build the [`RestartPlan`] for a persisted session: keep its identity stable,
-/// inject the standard `THURBOX_*` env, decide the resume trigger from the
-/// agent definition, and resolve the process cwd (the symlink workspace for a
-/// multi-repo session, else the primary repo — mirroring the TUI's
-/// `App::resolve_process_cwd`).
+/// replay the session's recorded `--env`, inject the standard `THURBOX_*` env,
+/// decide the resume trigger from the agent definition, and resolve the process
+/// cwd (the symlink workspace for a multi-repo session, else the primary repo —
+/// mirroring the TUI's `App::resolve_process_cwd`).
 pub(crate) fn build_restart_plan(
     session: &SharedSession,
     host: Option<&crate::session::HostDef>,
     hooks_enabled: bool,
     recipe: Option<&crate::session::LaunchRecipe>,
+    env: &std::collections::BTreeMap<String, String>,
 ) -> Result<RestartPlan, String> {
     let agent_session_id = session.agent_session_id.clone().ok_or_else(|| {
         format!(
@@ -56,13 +57,14 @@ pub(crate) fn build_restart_plan(
         backend: Some(session.backend_type.clone()),
         ..SessionConfig::default()
     };
-    // A command session's own env is part of what it *is*, so it goes on before
+    // The session's own env is part of what it *is*, so it goes on before
     // thurbox's identity vars — which must still win — exactly as at spawn.
-    if let Some(r) = recipe {
-        config
-            .env
-            .extend(r.env.iter().map(|(k, v)| (k.clone(), v.clone())));
-    }
+    // Recorded for a registry agent as much as for a command session: `--env`
+    // is the caller's, not the registry's, and there is nowhere else to
+    // re-resolve it from.
+    config
+        .env
+        .extend(env.iter().map(|(k, v)| (k.clone(), v.clone())));
     super::inject_thurbox_env(&mut config, &agent_session_id, None);
     // Where a restart gets what to run. A registry agent is resolved by name
     // *now* rather than replayed, so an `agents.toml` edit takes effect on the
@@ -260,7 +262,14 @@ pub fn restart_session_headless_with(
 
     let hooks_enabled = super::hooks_enabled(db);
     let recipe = db.load_launch_recipe(session_id).unwrap_or_default();
-    let plan = build_restart_plan(&session, host.as_ref(), hooks_enabled, recipe.as_ref())?;
+    let env = db.load_launch_env(session_id).unwrap_or_default();
+    let plan = build_restart_plan(
+        &session,
+        host.as_ref(),
+        hooks_enabled,
+        recipe.as_ref(),
+        &env,
+    )?;
 
     // The user's say, with the plan built and nothing yet killed: a refusal
     // leaves the running window running.
@@ -370,7 +379,8 @@ mod tests {
     fn restart_plan_requires_agent_session_id() {
         let temp = tempfile::TempDir::new().unwrap();
         let _guard = crate::paths::TestPathGuard::new(temp.path());
-        let err = build_restart_plan(&session(None, None), None, true, None).unwrap_err();
+        let err = build_restart_plan(&session(None, None), None, true, None, &Default::default())
+            .unwrap_err();
         assert!(err.contains("agent_session_id"), "got: {err}");
     }
 
@@ -379,7 +389,7 @@ mod tests {
         let temp = tempfile::TempDir::new().unwrap();
         let _guard = crate::paths::TestPathGuard::new(temp.path());
         let sess = session(Some("agent-conv-uuid"), Some(PathBuf::from("/tmp/repo")));
-        let plan = build_restart_plan(&sess, None, true, None).unwrap();
+        let plan = build_restart_plan(&sess, None, true, None, &Default::default()).unwrap();
 
         // The thurbox session key and the agent conversation id are both present
         // and distinct, exactly as a fresh spawn would inject them.
@@ -401,6 +411,7 @@ mod tests {
             None,
             true,
             None,
+            &Default::default(),
         )
         .unwrap();
         assert_eq!(plan.cwd, Some(primary));
@@ -418,7 +429,7 @@ mod tests {
         let mut sess = session(Some("sid-multi"), Some(primary.clone()));
         sess.additional_dirs = vec![extra];
 
-        let plan = build_restart_plan(&sess, None, true, None).unwrap();
+        let plan = build_restart_plan(&sess, None, true, None, &Default::default()).unwrap();
         // ≥2 members → the symlink workspace, not the primary repo itself.
         assert_ne!(plan.cwd.as_deref(), Some(primary.as_path()));
         assert!(plan.cwd.is_some());
@@ -449,7 +460,7 @@ mod tests {
         let mut sess = session(Some("agent-conv-uuid"), Some(PathBuf::from("/srv/repo")));
         sess.backend_type = "ssh:devbox".into();
 
-        let plan = build_restart_plan(&sess, None, true, None).unwrap();
+        let plan = build_restart_plan(&sess, None, true, None, &Default::default()).unwrap();
         assert_eq!(plan.env.get("THURBOX_SESSION"), Some(&sess.id.to_string()));
         assert!(!plan.env.contains_key(crate::paths::CONFIG_DIR_OVERRIDE_ENV));
         assert!(!plan.env.contains_key("THURBOX_METRICS_DIR"));

--- a/src/session_ops/restore.rs
+++ b/src/session_ops/restore.rs
@@ -211,7 +211,9 @@ fn respawn(db: &Database, id: SessionId) -> Result<(), String> {
     }
     let hooks_enabled = super::hooks_enabled(db);
     let recipe = db.load_launch_recipe(session.id).unwrap_or_default();
-    let plan = super::restart::build_restart_plan(&session, None, hooks_enabled, recipe.as_ref())?;
+    let env = db.load_launch_env(session.id).unwrap_or_default();
+    let plan =
+        super::restart::build_restart_plan(&session, None, hooks_enabled, recipe.as_ref(), &env)?;
     let pane = crate::agent::tmux::spawn_window(
         &plan.window_name,
         &plan.command,

--- a/src/session_ops/spawn.rs
+++ b/src/session_ops/spawn.rs
@@ -412,12 +412,18 @@ pub fn spawn_session_headless_with_progress(
 
     // A command session's recipe is the only record of how to start it again:
     // there is no registry entry to re-resolve at restart, so the row carries
-    // it. Registry agents deliberately store nothing here and stay resolved by
-    // name, so editing `agents.toml` and restarting still takes effect.
-    if let Some(r) = &recipe {
-        if let Err(e) = db.set_launch_recipe(session_id, r) {
-            tracing::warn!("Failed to record launch recipe: {e}");
-        }
+    // it. Registry agents deliberately store no *command* here and stay
+    // resolved by name, so editing `agents.toml` and restarting still takes
+    // effect — but their `--env` is recorded all the same. It is not a
+    // launch recipe, it is what the session's processes live in: a restart has
+    // to replay it, and `session exec` has to reproduce it.
+    let recorded = match &recipe {
+        Some(r) => db.set_launch_recipe(session_id, r),
+        None if !req.env.is_empty() => db.set_launch_env(session_id, &req.env),
+        None => Ok(()),
+    };
+    if let Err(e) = recorded {
+        tracing::warn!("Failed to record the session's launch environment: {e}");
     }
 
     // Record the worktree's fork point so the code-review view can scope its

--- a/src/storage/sessions.rs
+++ b/src/storage/sessions.rs
@@ -271,6 +271,50 @@ impl Database {
         Ok(())
     }
 
+    /// Persist the extra environment a session was created with (`--env`),
+    /// whatever it launches.
+    ///
+    /// Separate from [`set_launch_recipe`](Self::set_launch_recipe) because the
+    /// two answer different questions. A recipe says *what to run* and is only
+    /// meaningful for a command session — persisting one for a registry agent
+    /// would freeze it at creation time. An environment says what the session's
+    /// processes live in, and that is equally true of both: `--env FOO=1` on an
+    /// `--agent` session used to be applied at spawn and then forgotten, so the
+    /// first restart silently dropped it and nothing could report it back.
+    pub fn set_launch_env(
+        &self,
+        id: SessionId,
+        env: &std::collections::BTreeMap<String, String>,
+    ) -> rusqlite::Result<()> {
+        let json = serde_json::to_string(env).unwrap_or_else(|_| "{}".into());
+        self.conn.execute(
+            "UPDATE sessions SET launch_env = ?1 WHERE id = ?2",
+            params![json, id.to_string()],
+        )?;
+        Ok(())
+    }
+
+    /// The extra environment a session was created with — empty when it was
+    /// created with none, or when the row predates the column being written for
+    /// registry agents.
+    pub fn load_launch_env(
+        &self,
+        id: SessionId,
+    ) -> rusqlite::Result<std::collections::BTreeMap<String, String>> {
+        let stored: Option<Option<String>> = self
+            .conn
+            .query_row(
+                "SELECT launch_env FROM sessions WHERE id = ?1",
+                params![id.to_string()],
+                |row| row.get(0),
+            )
+            .optional()?;
+        Ok(stored
+            .flatten()
+            .and_then(|e| serde_json::from_str(&e).ok())
+            .unwrap_or_default())
+    }
+
     /// The persisted launch recipe, or `None` for a registry agent.
     ///
     /// `None` is the discriminant the restart path reads: no recipe means the

--- a/tests/cli_driver_contracts.rs
+++ b/tests/cli_driver_contracts.rs
@@ -1,0 +1,285 @@
+//! The contracts an external driver reads off `thurbox-cli`'s streams.
+//!
+//! Each test here asserts something that is only observable from *outside* the
+//! process: what a child of `session exec` inherits, what a `$(…)` capture
+//! actually receives, and which stream a failure lands on. Driven through the
+//! real binary for that reason — the answers are a matter of the process's own
+//! environment and of stdout not being a terminal, and nothing below `main` can
+//! see either.
+
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+use serde_json::Value;
+use thurbox::session::SessionId;
+use thurbox::sync::SharedSession;
+
+/// A throwaway thurbox instance: its own config, data, home and multiplexer
+/// socket, so no test here reads or writes the operator's.
+struct Env {
+    root: tempfile::TempDir,
+}
+
+impl Env {
+    fn new() -> Self {
+        let root = tempfile::TempDir::new().expect("tempdir");
+        for sub in ["home", "config", "data", "work"] {
+            std::fs::create_dir_all(root.path().join(sub)).expect("mkdir");
+        }
+        Self { root }
+    }
+
+    fn path(&self, sub: &str) -> PathBuf {
+        self.root.path().join(sub)
+    }
+
+    fn db(&self) -> thurbox::storage::Database {
+        thurbox::storage::Database::open(&self.path("data").join("thurbox.db"))
+            .expect("open the instance database")
+    }
+
+    /// Run the CLI with stdout and stderr as pipes — which is what a driver
+    /// capturing output gives it, and what makes the piped format apply.
+    fn run(&self, args: &[&str]) -> Output {
+        self.command(args).output().expect("run thurbox-cli")
+    }
+
+    fn command(&self, args: &[&str]) -> Command {
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_thurbox-cli"));
+        cmd.args(args);
+        cmd.env("HOME", self.path("home"));
+        cmd.env("USERPROFILE", self.path("home"));
+        cmd.env("THURBOX_CONFIG_DIR", self.path("config"));
+        cmd.env("THURBOX_DATA_DIR", self.path("data"));
+        // Named outright: a relocated data dir derives a socket of its own, and
+        // the pane verbs must never reach the operator's server.
+        cmd.env("THURBOX_SOCKET", "thurbox-driver-contract-test");
+        cmd.env_remove("THURBOX_SESSION");
+        cmd.env_remove("THURBOX_SESSION_ID");
+        cmd
+    }
+
+    /// Seed a session row directly, optionally with a working directory and an
+    /// agent conversation id. Written through `storage::Database` because these
+    /// tests need a *row*, never a pane: `session create` would spawn one.
+    fn seed(&self, name: &str, cwd: Option<&std::path::Path>) -> SessionId {
+        let row = SharedSession {
+            id: SessionId::default(),
+            name: name.into(),
+            agent: "shell".into(),
+            backend_id: String::new(),
+            backend_type: "local-tmux".into(),
+            agent_session_id: Some("conversation-1".into()),
+            cwd: cwd.map(std::path::Path::to_path_buf),
+            additional_dirs: Vec::new(),
+            worktrees: Vec::new(),
+            shell_backend_id: None,
+            parent_session_id: None,
+            display_order: None,
+            tombstone: false,
+            tombstone_at: None,
+        };
+        self.db().upsert_session(&row).expect("persist");
+        row.id
+    }
+}
+
+fn stdout_of(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+fn stderr_of(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stderr).to_string()
+}
+
+/// `session exec` runs "in the session's context", and the environment is part
+/// of that context.
+///
+/// The failure this pins is not that the session's own `--env` was missing —
+/// it is that the **caller's** `THURBOX_SESSION` was inherited by the child. A
+/// driver reaching into a session from inside another one would then have
+/// `thurbox-cli session signal` record state for the *calling* session,
+/// silently and with exit 0, which is the one outcome that cannot be correct.
+#[cfg(unix)]
+#[test]
+fn exec_carries_the_targets_identity_and_environment_not_the_callers() {
+    let env = Env::new();
+    let work = env.path("work");
+    let target = env.seed("target", Some(&work));
+    env.db()
+        .set_launch_env(
+            target,
+            &[("FM_PROBE".to_string(), "1".to_string())]
+                .into_iter()
+                .collect(),
+        )
+        .expect("record the session's --env");
+
+    let caller = SessionId::default();
+    let mut cmd = env.command(&[
+        "session",
+        "exec",
+        &target.to_string(),
+        "--json",
+        "--",
+        "sh",
+        "-c",
+        "printf '%s|%s' \"$THURBOX_SESSION\" \"$FM_PROBE\"",
+    ]);
+    // The calling driver is itself inside a session, which is the ordinary
+    // case and the one that used to leak.
+    cmd.env("THURBOX_SESSION", caller.to_string());
+    let out = cmd.output().expect("run thurbox-cli");
+
+    let doc: Value = serde_json::from_slice(&out.stdout)
+        .unwrap_or_else(|e| panic!("stdout is JSON ({e}): {}", stdout_of(&out)));
+    let printed = doc["stdout"].as_str().expect("the child's stdout");
+    let (session, probe) = printed.split_once('|').expect("both values");
+
+    assert_eq!(
+        session,
+        target.to_string(),
+        "the child must carry the target session's identity, not the caller's \
+         ({caller}): {printed}"
+    );
+    assert_eq!(
+        probe, "1",
+        "the session's own --env must be there: {printed}"
+    );
+}
+
+/// `session meta get`'s answer is one value, and being captured into a shell
+/// variable is exactly what makes stdout not a terminal.
+///
+/// The piped default is TOON because the reader of a pipe is usually an agent
+/// reading a record — but this getter's reader is `v=$(…)`, so the format meant
+/// for a pipe replaced the value with the record in precisely the case the
+/// command exists for.
+#[test]
+fn meta_get_answers_with_the_bare_value_when_piped() {
+    let env = Env::new();
+    let id = env.seed("probe", None).to_string();
+    env.run(&["session", "meta", "set", &id, "fm.state", "plain-value"]);
+
+    let out = env.run(&["session", "meta", "get", &id, "fm.state"]);
+    assert_eq!(
+        stdout_of(&out).trim_end_matches('\n'),
+        "plain-value",
+        "the value and nothing else: {}",
+        stdout_of(&out)
+    );
+
+    // An unset key is nothing at all, matching the help — not the string
+    // `value: null`, which no caller can tell from a value.
+    let unset = env.run(&["session", "meta", "get", &id, "fm.never-set"]);
+    assert!(
+        stdout_of(&unset).trim().is_empty(),
+        "an unset key produces nothing: {:?}",
+        stdout_of(&unset)
+    );
+
+    // …and the record is still one flag away, which is where a caller that
+    // needs to tell a null value from an unset key goes.
+    let json = env.run(&["session", "meta", "get", &id, "fm.state", "--json"]);
+    let doc: Value = serde_json::from_slice(&json.stdout).expect("a record");
+    assert_eq!(doc["key"], Value::String("fm.state".into()));
+    assert_eq!(doc["value"], Value::String("plain-value".into()));
+}
+
+/// A failing `session send` keeps its output on one stream.
+///
+/// `send` used to write tmux's own `can't find window: tb-<name>` to stderr in
+/// addition to the structured error on stdout, while `capture` in the same
+/// situation did not — one error contract, two behaviours. An agent reads one
+/// stream (AXI principle 6), so the multiplexer's sentence belongs inside the
+/// document, not beside it.
+#[test]
+fn send_to_a_session_with_no_pane_keeps_its_error_on_stdout() {
+    let env = Env::new();
+    let id = env.seed("gone", None).to_string();
+    env.run(&["session", "stop", &id]);
+
+    for verb in [
+        vec!["session", "send", &id, "hello", "--json"],
+        vec!["session", "capture", &id, "--json"],
+    ] {
+        let out = env.run(&verb);
+        assert_eq!(out.status.code(), Some(1), "{verb:?} ran and failed");
+        assert!(
+            stderr_of(&out).trim().is_empty(),
+            "{verb:?} put something on stderr: {:?}",
+            stderr_of(&out)
+        );
+        let doc: Value = serde_json::from_slice(&out.stdout)
+            .unwrap_or_else(|e| panic!("{verb:?} stdout is JSON ({e}): {}", stdout_of(&out)));
+        assert!(
+            doc["error"].as_str().is_some_and(|e| e.contains("stopped")),
+            "{verb:?} says what is actually wrong: {doc}"
+        );
+    }
+}
+
+/// The same rule where the window is merely gone rather than parked.
+///
+/// This is the path that actually reached the multiplexer: the one-shot helpers
+/// ran `tmux` with `status()`, so the child inherited this process's stderr and
+/// wrote its own diagnosis straight onto it. Captured, the same sentence is
+/// part of the one document instead of a second stream beside it.
+#[test]
+fn a_pane_verb_on_a_missing_window_says_so_on_stdout_alone() {
+    let env = Env::new();
+    // Not stopped: nothing knows the window is absent until the multiplexer is
+    // asked, which is exactly the case that leaked.
+    let id = env.seed("vanished", None).to_string();
+
+    for verb in [
+        vec!["session", "send", &id, "hello", "--json"],
+        vec!["session", "key", &id, "enter", "--json"],
+    ] {
+        let out = env.run(&verb);
+        assert_eq!(out.status.code(), Some(1), "{verb:?} ran and failed");
+        assert!(
+            stderr_of(&out).trim().is_empty(),
+            "{verb:?} put the multiplexer's own message on stderr: {:?}",
+            stderr_of(&out)
+        );
+        let doc: Value = serde_json::from_slice(&out.stdout)
+            .unwrap_or_else(|e| panic!("{verb:?} stdout is JSON ({e}): {}", stdout_of(&out)));
+        assert!(
+            !doc["error"].as_str().unwrap_or_default().is_empty(),
+            "{verb:?} still says what went wrong: {doc}"
+        );
+    }
+}
+
+/// A driver that launches its own agent can obtain the hook wiring.
+///
+/// Status hooks are installed by appending to an agent's `args`, so they only
+/// reach the process when thurbox builds the command line. Without a verb that
+/// reports those args, a driver launching the agent itself got no hooks — and
+/// so an empty `state` and a `watch` stream that never mentioned the session.
+#[test]
+fn agent_launch_args_reports_what_to_run() {
+    let env = Env::new();
+    std::fs::write(
+        env.path("config").join("agents.toml"),
+        "config_version = 1\ndefault = \"driver\"\n\n\
+         [[agents]]\nname = \"driver\"\ncommand = \"driver-cli\"\n\
+         args = [\"--settings\", \"/opt/hooks/driver.json\"]\n",
+    )
+    .expect("write agents.toml");
+    let id = env.seed("wired", None).to_string();
+
+    let out = env.run(&["agent", "launch-args", "driver", "--session", &id, "--json"]);
+    assert_eq!(out.status.code(), Some(0), "{}", stdout_of(&out));
+    let doc: Value = serde_json::from_slice(&out.stdout).expect("a record");
+
+    assert_eq!(doc["command"], Value::String("driver-cli".into()), "{doc}");
+    assert_eq!(
+        doc["args"],
+        serde_json::json!(["--settings", "/opt/hooks/driver.json"]),
+        "the hook wiring is the answer: {doc}"
+    );
+    // And the identity the agent's own `session signal` will report under.
+    assert_eq!(doc["env"]["THURBOX_SESSION"], Value::String(id), "{doc}");
+}

--- a/tests/cli_session_hook_state.rs
+++ b/tests/cli_session_hook_state.rs
@@ -602,3 +602,109 @@ fn doctor_fails_a_session_whose_hook_command_cannot_find_the_binary_it_names() {
     assert_eq!(check(&out, "cli")["level"], Value::String("ok".into()));
     assert!(out.failure.is_none(), "{out}");
 }
+
+/// A session parked by `session stop` must be tellable from a running one by
+/// the two verbs a driver polls.
+///
+/// It used to be readable only through `watch`, which reports the flag — so the
+/// alternative was probing the pane and inferring, or paying a one-second
+/// `watch --initial` per liveness check. `get` and `list` answered *identically*
+/// for a parked and a running session, down to a `backend_id` naming a window
+/// that no longer existed.
+#[test]
+fn a_parked_session_says_so_on_get_and_on_list() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let _guard = isolated_config(dir.path());
+    let db = Database::open_in_memory().expect("db");
+    let row = session_row("parked", "claude", "local-tmux");
+    db.upsert_session(&row).expect("persist");
+    db.set_hook_state(row.id, "working").expect("signal");
+
+    // Running: the agent's own last word, and not stopped.
+    let before = get(&db, row.id, false);
+    assert_eq!(before["state"], Value::String("working".into()));
+    assert_eq!(before["stopped"], Value::Bool(false));
+
+    run(
+        Action::Stop {
+            session: row.id.to_string(),
+        },
+        &db,
+    )
+    .expect("session stop");
+
+    let after = get(&db, row.id, false);
+    assert_eq!(after["stopped"], Value::Bool(true), "{after}");
+    // Not `working`, and not `uncovered` either: it is parked, which is a fact
+    // thurbox knows first-hand rather than one inferred from an agent's
+    // silence. Both of the other answers describe a session that is running.
+    assert_eq!(after["state"], Value::String("stopped".into()), "{after}");
+    assert!(
+        after["state_source"].is_null(),
+        "nothing reported this; thurbox recorded it: {after}"
+    );
+
+    // And the same fact under the same key on the list, which is the verb a
+    // driver actually polls.
+    let listed = run(
+        Action::List {
+            parent: None,
+            deleted: false,
+            verify: false,
+        },
+        &db,
+    )
+    .expect("session list");
+    let rows = listed.json.as_array().expect("rows");
+    let found = rows
+        .iter()
+        .find(|r| r["id"] == Value::String(row.id.to_string()))
+        .expect("a parked session stays in the list");
+    assert_eq!(found["stopped"], Value::Bool(true), "{found}");
+    assert_eq!(found["state"], Value::String("stopped".into()), "{found}");
+}
+
+/// The pane verbs refuse a parked session by name.
+///
+/// `session stop` killed the window on purpose, so reaching for it and
+/// reporting what the multiplexer says about a window that is not there
+/// describes a crash rather than the state the caller itself asked for.
+#[test]
+fn the_pane_verbs_refuse_a_parked_session_by_name() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let _guard = isolated_config(dir.path());
+    let db = Database::open_in_memory().expect("db");
+    let row = session_row("no-pane", "claude", "local-tmux");
+    db.upsert_session(&row).expect("persist");
+    run(
+        Action::Stop {
+            session: row.id.to_string(),
+        },
+        &db,
+    )
+    .expect("session stop");
+
+    for action in [
+        Action::Send {
+            uuid: row.id.to_string(),
+            text: "hello".into(),
+            no_enter: false,
+        },
+        Action::Key {
+            uuid: row.id.to_string(),
+            key: "enter".into(),
+        },
+        Action::Capture {
+            uuid: row.id.to_string(),
+            lines: 10,
+            ansi: false,
+        },
+    ] {
+        let err = run(action, &db).expect_err("a parked session has no pane");
+        assert!(err.contains("stopped"), "got {err}");
+        assert!(
+            err.contains("session start"),
+            "the refusal names the fix: {err}"
+        );
+    }
+}

--- a/tests/cli_session_hook_state.rs
+++ b/tests/cli_session_hook_state.rs
@@ -708,3 +708,61 @@ fn the_pane_verbs_refuse_a_parked_session_by_name() {
         );
     }
 }
+
+/// `session doctor` on a parked session is a clean report, not a warning about
+/// silence it was told to cause.
+///
+/// `aider` only ever reports `blocked` (`Coverage::Partial`, and no
+/// `hook_file`), so its coverage and payload checks stay put across the stop —
+/// the only thing that moves is what the doctor makes of a session it knows was
+/// asked to go silent. Before `stop`, a session that has never signalled gets a
+/// `warn` on `last-signal` — the honest "nothing has ever signalled" case. Once
+/// `stop` parks it, the same absence of a signal is expected and reported
+/// `ok`, and the pane check — which would otherwise warn that nothing could be
+/// resolved — says plainly that there is no pane by design.
+#[test]
+fn a_parked_sessions_doctor_report_is_clean_not_a_warning() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let _guard = isolated_config(dir.path());
+    let _path = PathGuard::only(&dir.path().join("path"), true);
+    let db = Database::open_in_memory().expect("db");
+    let row = session_row("parked-doctor", "aider", "local-tmux");
+    db.upsert_session(&row).expect("persist");
+
+    let before = doctor(&db, row.id);
+    assert_eq!(
+        check(&before, "last-signal")["level"],
+        Value::String("warn".into()),
+        "{before}"
+    );
+
+    run(
+        Action::Stop {
+            session: row.id.to_string(),
+        },
+        &db,
+    )
+    .expect("session stop");
+
+    let after = doctor(&db, row.id);
+    let last_signal = check(&after, "last-signal");
+    assert_eq!(
+        last_signal["level"],
+        Value::String("ok".into()),
+        "{last_signal}"
+    );
+
+    let pane = check(&after, "pane");
+    assert_eq!(pane["level"], Value::String("ok".into()), "{pane}");
+    assert!(
+        pane["detail"]
+            .as_str()
+            .is_some_and(|d| d.contains("stopped") && d.contains("session start")),
+        "the report must say why there is no pane and how to get one back: {pane}"
+    );
+
+    assert!(
+        after.failure.is_none(),
+        "a parked session is not broken wiring: {after}"
+    );
+}

--- a/tests/create_e2e.rs
+++ b/tests/create_e2e.rs
@@ -860,3 +860,113 @@ fn a_command_session_survives_restart_and_can_be_parked() {
 
     cleanup();
 }
+
+/// Forking a registry-agent session must carry over its recorded `--env`.
+///
+/// A registry agent has no [`LaunchRecipe`](thurbox::session::LaunchRecipe) —
+/// only a command session does — so a fork that read its env from the recipe
+/// would always find one and silently produce a fork with no env at all,
+/// unlike a command session's fork, which keeps its env via the recipe. Both
+/// now read the same `launch_env` column instead.
+#[test]
+#[cfg(not(windows))]
+fn a_forked_registry_agent_session_keeps_its_recorded_env() {
+    if !have_tmux() {
+        eprintln!("skipping: tmux is not installed");
+        return;
+    }
+
+    let repo = repo();
+    let db = thurbox::storage::Database::open_in_memory().expect("db");
+    let _tmux_dir = isolate_tmux();
+    let home = tempfile::tempdir().expect("tempdir");
+    thurbox::paths::set_test_dir(home.path());
+    let config = thurbox::paths::config_file()
+        .expect("config path")
+        .parent()
+        .expect("config dir")
+        .to_path_buf();
+    std::fs::create_dir_all(&config).expect("mkdir");
+    std::fs::write(
+        config.join("agents.toml"),
+        "default = \"shell\"\n\n[[agents]]\nname = \"shell\"\ncommand = \"sh\"\nargs = []\n",
+    )
+    .expect("write agents.toml");
+
+    let result = thurbox::session_ops::spawn::spawn_session_headless(
+        &db,
+        thurbox::session_ops::spawn::SpawnRequest {
+            name: "env-probe".into(),
+            repo_path: repo.path().to_path_buf(),
+            worktree_branch: None,
+            base_branch: None,
+            agent: Some("shell".into()),
+            command: None,
+            args: Vec::new(),
+            env: [("FM_PROBE".to_string(), "1".to_string())]
+                .into_iter()
+                .collect(),
+            resume_session_id: None,
+            agent_session_id: None,
+            host: None,
+            parent_session_id: None,
+            task_id: None,
+            extra_repos: Vec::new(),
+            fork_session_id: None,
+            inherit_worktrees: Vec::new(),
+        },
+    );
+    let spawned = match result {
+        Ok(spawned) => spawned,
+        Err(e) => {
+            cleanup();
+            if e.contains("tmux") {
+                eprintln!("skipping: tmux would not spawn a window: {e}");
+                return;
+            }
+            panic!("creation failed: {e}");
+        }
+    };
+
+    // A registry agent carries no recipe — its `--env` lives only in the
+    // shared `launch_env` column.
+    assert!(db
+        .load_launch_recipe(spawned.session_id)
+        .expect("query")
+        .is_none());
+    assert_eq!(
+        db.load_launch_env(spawned.session_id)
+            .expect("query")
+            .get("FM_PROBE")
+            .map(String::as_str),
+        Some("1"),
+        "the spawn recorded its own --env"
+    );
+
+    let fork = match thurbox::session_ops::fork_session_headless(
+        &db,
+        spawned.session_id,
+        "env-probe-fork",
+    ) {
+        Ok(fork) => fork,
+        Err(e) => {
+            cleanup();
+            if e.contains("tmux") {
+                eprintln!("skipping: tmux would not spawn a window: {e}");
+                return;
+            }
+            panic!("fork failed: {e}");
+        }
+    };
+
+    assert_eq!(
+        db.load_launch_env(fork.session_id)
+            .expect("query")
+            .get("FM_PROBE")
+            .map(String::as_str),
+        Some("1"),
+        "a fork of a registry-agent session must keep the env its parent recorded"
+    );
+
+    cleanup();
+}

--- a/website/docs/features.html
+++ b/website/docs/features.html
@@ -1140,6 +1140,7 @@ thurbox-cli session stop reviewer                            # park it: pane gon
 thurbox-cli session start reviewer                           # and put it back
 thurbox-cli session exec reviewer -- git status --porcelain  # run in its dir, not in its pane
 thurbox-cli session meta set reviewer fm.task_id T-1043      # your own key/value space
+thurbox-cli agent launch-args claude                         # what to run so its hooks report
 thurbox-cli watch --initial                                  # one JSON line per change
 thurbox-cli message send --to flow --kind questions --task 5 --body "scope?"
 thurbox-cli message inbox --for flow --claim</code></pre>
@@ -1268,13 +1269,64 @@ thurbox-cli message inbox --for flow --claim</code></pre>
             <li>
               <strong>session exec</strong>
               &mdash; runs a command in the session's directory, on the machine
-              it lives on. Deliberately
+              it lives on, and under the session's own environment (whatever
+              <code>session create --env</code>
+              recorded, plus the
+              <code>THURBOX_*</code>
+              identity its pane carries &mdash; the
+              <em>caller's</em>
+              <code>THURBOX_*</code>
+              is scrubbed, so a driver inside one session cannot lend the child
+              that session's identity). Deliberately
               <em>not</em>
               typed into the pane: the pane belongs to the agent, and borrowing
               it would interleave with whatever it is doing and leave the answer
               in its scrollback. The command's exit code is always in the output;
               <code>--exit-passthrough</code>
               additionally makes it this invocation's own.
+            </li>
+            <li>
+              <strong>agent launch-args</strong>
+              &mdash; prints the
+              <code>command</code>
+              ,
+              <code>args</code>
+              and
+              <code>env</code>
+              thurbox would launch a registered agent with. Status hooks are
+              <em>arguments</em>
+              &mdash; the hooks extension installs them by appending to the
+              agent's
+              <code>args</code>
+              in
+              <code>agents.toml</code>
+              &mdash; so an agent a driver launches itself has none, and its
+              session reports no state. Pass these through and the hooks are
+              there;
+              <code>--session &lt;ref&gt;</code>
+              resolves it for one session, pinning the conversation id and
+              carrying the identity its
+              <code>session signal</code>
+              will report under.
+            </li>
+            <li>
+              <strong>session stop / start</strong>
+              &mdash; park a session and put it back: the pane goes, the row,
+              the checkout and the conversation stay. A parked session stays in
+              <code>session list</code>
+              and is told apart there &mdash;
+              <code>stopped: true</code>
+              and
+              <code>state: "stopped"</code>
+              on both read verbs, the same key
+              <code>watch</code>
+              publishes &mdash; so a liveness check needs no pane probe.
+              <code>send</code>
+              ,
+              <code>key</code>
+              and
+              <code>capture</code>
+              refuse a parked session by name.
             </li>
             <li>
               <strong>watch</strong>
@@ -1376,6 +1428,8 @@ thurbox-cli message inbox --for flow --claim</code></pre>
               <code>state</code>
               /
               <code>state_source</code>
+              , and
+              <code>stopped</code>
               . There is deliberately no staleness timeout: a turn may run for
               an hour, so a guessed bound would report live work as finished.
               The decisive check is the pane instead &mdash;

--- a/website/docs/orchestration.html
+++ b/website/docs/orchestration.html
@@ -348,8 +348,59 @@ thurbox-cli session list --parent "$LEAD" --json</code></pre>
   <code>session signal</code>
   itself &mdash;
   <code>THURBOX_SESSION</code>
-  is already in the pane's environment, so the call needs no arguments.
+  is already in the pane's environment, so the call needs no arguments. To get the real hooks
+  rather than the coarse pane reading, ask for the wiring:
+  <code>thurbox-cli agent launch-args &lt;name&gt;</code>
+  prints the
+  <code>command</code>
+  ,
+  <code>args</code>
+  and
+  <code>env</code>
+  Thurbox itself would launch with &mdash; the status hooks
+  <em>are</em>
+  arguments, so an agent started any other way has none.
 </p>
+<p>
+  A session parked with
+  <code>session stop</code>
+  is equally readable:
+  <code>stopped: true</code>
+  and
+  <code>state: "stopped"</code>
+  on
+  <code>session get</code>
+  and
+  <code>list</code>
+  alike, so a liveness check is the poll you were already doing.
+</p>
+<h3>Read the exit status before parsing</h3>
+<p>
+  Errors are structured documents on
+  <strong>stdout</strong>
+  , not lines on stderr &mdash; an agent reads one stream. The exit code carries the verdict (
+  <code>0</code>
+  ok,
+  <code>1</code>
+  ran and failed,
+  <code>2</code>
+  bad invocation), and the trap that follows is worth naming:
+  <code>thurbox-cli &hellip; --json | jq -r '.field'</code>
+  exits
+  <strong>0 with empty output</strong>
+  when the command failed, because
+  <code>jq</code>
+  parsed the error object and the pipeline carries
+  <code>jq</code>
+  's status.
+  <code>set -o pipefail</code>
+  does not help. Capture first, branch on the status, then parse.
+</p>
+<pre><code class="language-bash">out=$(thurbox-cli session get "$ref" --json) || {
+  printf 'thurbox: %s\n' "$(jq -r .error &lt;&lt;&lt;"$out")" &gt;&amp;2
+  exit 1
+}
+id=$(jq -r .id &lt;&lt;&lt;"$out")</code></pre>
 
 <h3>Fast-forward the base branch first</h3>
 <p>


### PR DESCRIPTION
## Intent

An external driver (Firstmate) was built against `thurbox-cli` 2.11 as a runtime
backend and got wrong answers from five of the contracts it reads. Each was
reproduced against the real binary; none is speculative.

- A **parked session** (`session stop`) was reported by `session get`/`list`
  identically to a running one — same `state`, same `backend_id` naming a window
  that no longer exists, no `stopped` field at all. Only `watch` carried the
  flag, so a liveness check meant probing the pane or paying a one-second
  `watch --initial`.
- **`session exec`** carried the *caller's* `THURBOX_SESSION` into the child, so
  `session exec <worker> -- thurbox-cli session signal --state done` recorded
  state for the calling driver, silently, with exit 0. The session's own
  `--env` was absent too.
- **`session meta get`** carried a comment promising a bare value for shell
  capture. Capturing is what makes stdout a pipe, and the piped default answered
  with the whole record.
- A driver launching its **own agent** could not obtain the hook wiring, so
  `state` never populated and `watch` never mentioned that session.
- **`session send`** wrote tmux's `can't find window` to stderr beside the
  structured error on stdout; `capture` in the same situation did not.

## What Changed

`stopped` is now on `get` and `list`, under the name and type `watch` already
uses, and `state` answers a new word `stopped`. `send`/`key`/`capture` refuse a
parked session by name, and `doctor` reports it has no pane by design rather
than warning about the silence.

`session exec` composes the child's environment explicitly instead of inheriting
whatever the caller had:

```mermaid
flowchart LR
  A["caller's env<br/>(incl. its own THURBOX_*)"] -->|THURBOX_* scrubbed| D["exec'd child"]
  B["session row<br/>launch_env"] --> D
  C["target identity<br/>THURBOX_SESSION, THURBOX_SESSION_ID"] --> D
```

`CommandOutput::scalar()` makes a single-value answer render as that value in
every format but JSON. `thurbox-cli agent launch-args <name> [--session <ref>]`
reports the `command`, `args` and `env` thurbox would launch with, plus the
agent's hook coverage. The one-shot multiplexer helpers capture tmux's output
and fold it into the structured error.

## Decisions a reviewer cannot see in the diff

**Errors stay on stdout.** This was filed as a sixth defect and it is not one —
`error_output` puts the structured error on stdout deliberately (AXI principle
6, "an agent reads one stream"). The trap it creates is real: `--json | jq -r
.field` exits 0 with empty output when the command failed, because `jq` parsed
the error object and the pipeline carries `jq`'s status (`pipefail` does not
help). That is addressed with a documentation note telling integrators to check
the exit status before parsing, not by moving the stream.

**`state: "stopped"` is a new word in a field consumers read.** It joins
`running`/`uncovered`/`unreported`, already outside `HOOK_STATES`, so a consumer
matching only the four hook states will see it. The alternative — leaving
`state` reporting the agent's latched last word — tells a driver something
untrue about a session with no process.

**`backend_id` still names the dead window.** It is what the row records,
`session start` replaces it, and the mirror wire shape (ADR-24) round-trips it.
The `stopped` boolean is the honest discriminator; nulling `backend_id` would
buy nothing and break peer sync.

**`--env` is now recorded for registry agents, not just command sessions.**
Wider than the reported defect. `--env` is the caller's, not the registry's, so
there is nowhere to re-resolve it from — it was applied at spawn and then lost
on the first restart. Restart, restore and fork now replay it. The launch
*recipe* stays command-session-only, so editing `agents.toml` and restarting
still takes effect. The fork half of this was missed on the first pass and
caught in review.

**A verb rather than `session create --agent --command`.** clap already refuses
that combination (`conflicts_with`), and a verb also serves the driver that
types into a shell session or launches outside thurbox entirely.

**Left alone:** `watch`'s `state` still carries the raw `hook_state` while
`get`/`list`'s `state` is the assessed word. The two disagree, but changing the
stream's meaning would break its existing readers, and it is outside what was
reported.

## Testing

`tests/cli_driver_contracts.rs` drives the real binary for the exec leak, the
piped `meta get`, the stderr contract and the new verb — those are only
observable outside the process, from the child's environment and from stdout not
being a terminal. `tests/cli_session_hook_state.rs` covers the parked state and
the doctor findings in-process; the fork env inheritance is covered in
`tests/create_e2e.rs`. Full `cargo nextest run --all` and `just lint` pass, and
the transcripts below are from driving the real binary against a throwaway
instance.

Docs updated in `docs/FEATURES.md`, `docs/ORCHESTRATION.md`, the two website
pages and the `thurbox-cli` skill, per the repo's rule that a change
invalidating a documented decision updates it in the same PR.

<details>
<summary>Evidence: Parked session (item 1) and agent launch-args (item 4) CLI transcript</summary>

```text
=== session get (running, before stop) ===
{"additional_dirs":[],"agent":"shell","agent_session_id":"00000000-0000-4000-8000-000000000001","backend_id":"%1","backend_type":"local-tmux","base_branch":null,"cwd":"/tmp/tbx-manual/work","display_order":null,"foreground_command":"sh","foreground_process":"sh","hook_blocked_is_heuristic":false,"hook_corroboration":"shell","hook_coverage":"none","hook_coverage_source":null,"hook_delivery":null,"hook_reported":false,"hook_state":null,"hook_state_age_secs":null,"hook_state_at":null,"hook_state_contradicted":false,"hook_states_reportable":[],"id":"00000000-0000-4000-8000-000000000002","name":"manual-probe","parent_session_id":null,"state":"uncovered","state_source":null,"stopped":false,"worktrees":[]}

=== session stop ===
{"id":"00000000-0000-4000-8000-000000000002","killed_window":true,"name":"manual-probe","stopped":true}

=== session get (after stop, parked) ===
{"additional_dirs":[],"agent":"shell","agent_session_id":"00000000-0000-4000-8000-000000000001","backend_id":"%1","backend_type":"local-tmux","base_branch":null,"cwd":"/tmp/tbx-manual/work","display_order":null,"foreground_command":null,"foreground_process":null,"hook_blocked_is_heuristic":false,"hook_corroboration":null,"hook_coverage":"none","hook_coverage_source":null,"hook_delivery":null,"hook_reported":false,"hook_state":null,"hook_state_age_secs":null,"hook_state_at":null,"hook_state_contradicted":null,"hook_states_reportable":[],"id":"00000000-0000-4000-8000-000000000002","name":"manual-probe","parent_session_id":null,"state":"stopped","state_source":null,"stopped":true,"worktrees":[]}

=== session list (shows stopped:true) ===
[{"additional_dirs":[],"agent":"shell","agent_session_id":"00000000-0000-4000-8000-000000000001","backend_id":"%1","backend_type":"local-tmux","base_branch":null,"cwd":"/tmp/tbx-manual/work","display_order":null,"foreground_command":null,"foreground_process":null,"hook_blocked_is_heuristic":false,"hook_corroboration":null,"hook_coverage":"none","hook_coverage_source":null,"hook_delivery":null,"hook_reported":false,"hook_state":null,"hook_state_age_secs":null,"hook_state_at":null,"hook_state_contradicted":null,"hook_states_reportable":[],"id":"00000000-0000-4000-8000-000000000002","name":"manual-probe","parent_session_id":null,"state":"stopped","state_source":null,"stopped":true,"worktrees":[]}]

=== session doctor (stopped session, should be clean 'ok', not warn) ===
[{"agent":"shell","checks":[{"check":"extension","detail":"the built-in hooks extension is active","level":"ok"},{"check":"coverage","detail":"thurbox ships no status hooks for agent 'shell' — set `hook_schema` in agents.toml if it speaks a built-in's hook format, or have your driver call `thurbox-cli session signal --state <s>` (identity comes from the injected $THURBOX_SESSION, so it needs no arguments)","level":"fail"},{"check":"cli","detail":"hook commands resolve `thurbox-cli` to ~/.local/bin/thurbox-cli","level":"ok"},{"check":"last-signal","detail":"stopped, so nothing is reporting","level":"ok"},{"check":"pane","detail":"stopped by `session stop`, so it has no pane by design — `session start` puts one back","level":"ok"}],"hook_corroboration":null,"hook_coverage":"none","hook_reported":false,"hook_state":null,"hook_state_age_secs":null,"hook_state_contradicted":null,"hook_states_reportable":[],"session_id":"00000000-0000-4000-8000-000000000002","session_name":"manual-probe","verdict":"fail"}]
hook wiring is broken for: manual-probe — see the FAIL checks above

=== session send refuses parked session (exit code + stderr check) ===
{"error":"session 'manual-probe' is stopped: it has no pane. `thurbox-cli session start manual-probe` puts one back","suggestion":"the command ran and failed; the message says what went wrong — `thurbox-cli` prints the state it was working against"}
exit=1

=== agent launch-args (item 4) ===
{"agent":"shell","args":[],"command":"sh","degraded":null,"env":{"FOO":"bar","THURBOX_CONFIG_DIR":"/tmp/tbx-manual/config","THURBOX_DATA_DIR":"/tmp/tbx-manual/data","THURBOX_METRICS_DIR":"/tmp/tbx-manual/data/metrics","THURBOX_SESSION":"00000000-0000-4000-8000-000000000002","THURBOX_SESSION_ID":"00000000-0000-4000-8000-000000000001","THURBOX_SOCKET":"thurbox-manual-verify","THURBOX_SOCKET_FOR":"/tmp/tbx-manual/data"},"hook_coverage":"none","hook_states_reportable":[],"hooks_enabled":true,"session_id":"00000000-0000-4000-8000-000000000002"}
```
</details>
<details>
<summary>Evidence: session exec env injection/scrubbing (item 2) CLI transcript</summary>

```text
=== session exec: target's env injected, caller's THURBOX_SESSION scrubbed ===
{"cwd":"/tmp/tbx-manual/work","env":{"FOO":"bar","THURBOX_CONFIG_DIR":"/tmp/tbx-manual/config","THURBOX_DATA_DIR":"/tmp/tbx-manual/data","THURBOX_METRICS_DIR":"/tmp/tbx-manual/data/metrics","THURBOX_SESSION":"00000000-0000-4000-8000-000000000002","THURBOX_SESSION_ID":"00000000-0000-4000-8000-000000000001","THURBOX_SOCKET":"thurbox-manual-verify","THURBOX_SOCKET_FOR":"/tmp/tbx-manual/data"},"exit_code":0,"id":"00000000-0000-4000-8000-000000000002","name":"manual-probe","stderr":"","stdout":"THURBOX_SESSION=00000000-0000-4000-8000-000000000002 FOO=bar\n"}
```
</details>
<details>
<summary>Evidence: session meta bare-value get (item 3) CLI transcript</summary>

```text
=== session meta set ===
{"id":"00000000-0000-4000-8000-000000000002","key":"fm.state","value":"plain-value"}

=== session meta get, piped (captured like a shell $(...)) ===
captured value: [plain-value]

=== session meta get --json (full record, tells null from unset) ===
{"id":"00000000-0000-4000-8000-000000000002","key":"fm.state","value":"plain-value"}

=== session meta get on an unset key (piped): ===
[]
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"fbff919d6c7f51c71b7b0c7451fd66cf942aada7","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (3) ✅</summary>

- ⚠️ `src/cli/session_doctor.rs:307` - The new &#39;pane&#39; finding text for a stopped session contains a stray run of ~22 spaces between the em-dash and the backtick-quoted `session start`: &#34;...has no pane by design —                      `session start` puts one back&#34;. This is user/agent-facing output text (rendered verbatim in `session doctor`&#39;s human and TOON views), not a comment, so it isn&#39;t something rustfmt or a formatter would normalize.

🔧 Fix: fix(cli): remove stray whitespace in doctor pane finding text
2 issues (1 warning, 1 info) still open:

- ℹ️ `.claude/skills/thurbox-cli/SKILL.md:208` - In the `session meta` section, the new sentence about `--json` telling a null value from an unset key runs directly into the pre-existing, unrelated sentence &#34;Without it a driver&#39;s identity ends up encoded in the session *name*...&#34; with no paragraph break, so &#39;it&#39; now dangles without its original antecedent (`session meta` existing at all) right after a sentence about `--json`. Purely a documentation coherence issue introduced by inserting the new text mid-paragraph.
- ⚠️ `src/cli/session_doctor.rs:288` - The new `last-signal`/`pane` findings for a parked (`stopped`) session — reporting `Ok` with &#34;stopped, so nothing is reporting&#34; and &#34;stopped by `session stop`, so it has no pane by design …&#34; — have no test coverage anywhere in the diff. `tests/cli_session_hook_state.rs` covers item 1&#39;s `get`/`list`/pane-verb-refusal behavior but never calls `session doctor` on a stopped session, so this new branch (part of item 1&#39;s stated scope: &#34;session doctor reports it has no pane by design instead of warning about the silence&#34;) could regress silently, contrary to the repo&#39;s test-driven convention.

🔧 Fix: fix(docs,cli): mend meta paragraph flow, test parked doctor report
1 warning still open:

- ⚠️ `src/session_ops/mod.rs:493` - `fork_session_headless` builds the new session&#39;s `env` from `recipe.map(|r| r.env).unwrap_or_default()` (session_ops/mod.rs:493,503), where `recipe` is `db.load_launch_recipe(id)` — which is `None` for any registry-agent session (its discriminant is a non-empty `launch_command`, per storage/sessions.rs:318-340). Item 2&#39;s stated fix records a session&#39;s `--env` for registry agents too specifically because it &#39;was previously applied at spawn and then lost, including on restart&#39; and &#39;there is nowhere to re-resolve it from&#39; — and `restart.rs`/`restore.rs` were both updated in this diff to also call `db.load_launch_env(id)` alongside `load_launch_recipe` (restart.rs:265, restore.rs:214). `fork_session_headless` is the one remaining relaunch-shaped sibling path that was not: it still reads only `recipe.env`, so forking a registry-agent session created with `--env FOO=bar` silently produces a fork with no `FOO` in its environment — no error, no warning, just a session that behaves differently from the one it was forked from. Concrete repro: `session create --agent claude --env FOO=bar` (persists via the new `set_launch_env`), then `session fork &lt;id&gt; new-name` — the new session&#39;s env is `{}`. Since `db.load_launch_env` reads the exact same `launch_env` column `load_launch_recipe` already draws its `env` field from, swapping `recipe.map(|r| r.env).unwrap_or_default()` for `db.load_launch_env(id).unwrap_or_default()` is a value-preserving fix for command sessions and closes the gap for registry agents.

🔧 Fix: fix(cli): keep registry-agent env when forking a session
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `cargo nextest run --all`
- `cargo nextest run -E 'binary(cli_driver_contracts) or binary(cli_session_hook_state) or test(a_forked_registry_agent_session_keeps_its_recorded_env)' (19 tests, all pass) — covers items 1,2,3,5, the agent launch-args verb (item 4), the parked-session doctor/get/list behavior, the pane-verb refusal, and the fork env-inheritance fix`
- `Manual end-to-end CLI transcript: session create --env FOO=bar → session get (running, stopped:false) → session stop → session get (stopped:true, state:"stopped") → session list (stopped:true) → session doctor (pane check is level:ok with clean single-spaced wording) → session send (refused with exit 1, structured stopped error) → agent launch-args (reports command/args/env/hook coverage)`
- `Manual end-to-end CLI transcript: session exec on a target session while THURBOX_SESSION=some-other-caller-id was set in the calling environment — child process reported the target's own session id and its recorded FOO=bar, confirming the caller's identity was scrubbed and the target's env was injected (item 2)`
- `Manual end-to-end CLI transcript: session meta set/get — piped capture returns the bare value only, an unset key returns empty output, and --json still returns the full {key,value} record (item 3)`
- <code>Rust snippet compiled and run to confirm the doctor &#39;pane&#39; finding string literal (backslash-newline continuation) produces a single space between `session start` and &#39;puts one back&#39;, with no stray run of spaces</code>
- `Read tests/create_e2e.rs:864-972 (a_forked_registry_agent_session_keeps_its_recorded_env) confirming it asserts fork_session_headless carries over a registry agent's recorded --env via the shared launch_env column`
- `Read .claude/skills/thurbox-cli/SKILL.md session-meta section confirming the 'Without it a driver's identity...' sentence is restored to its original antecedent and the --json/bare-value material is in its own paragraph`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

