### PR TITLE
test(cli): make the socket tests immune to the developer's own thurbox env

### DIFF
--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -2769,6 +2769,14 @@ mod tests {
     fn local_socket_honors_env_override() {
         // nextest runs one process per test, so env mutation can't race other
         // tests reading `local_socket()`.
+        //
+        // The owner tag has to go first. `cargo test` runs inside a live
+        // thurbox session on any developer machine, and that session injects
+        // the pair — so an inherited `THURBOX_SOCKET_FOR` naming the operator's
+        // data dir would make the override below read as inherited rather than
+        // typed, and `local_socket()` would derive a socket instead of
+        // honouring it.
+        std::env::remove_var(SOCKET_OWNER_ENV);
         std::env::set_var(SOCKET_OVERRIDE_ENV, "thurbox-lab-test");
         assert_eq!(local_socket(), "thurbox-lab-test");
         assert_eq!(TmuxBackend::local().socket, "thurbox-lab-test");

--- a/tests/cli_socket_isolation.rs
+++ b/tests/cli_socket_isolation.rs
@@ -51,10 +51,19 @@ impl Env {
         cmd.env("APPDATA", self.path("config"));
         cmd.env("LOCALAPPDATA", self.path("data"));
         // Inherited from the developer's own session, and the subject of the
-        // test — never leave them to chance.
-        cmd.env_remove("THURBOX_CONFIG_DIR");
-        cmd.env_remove("THURBOX_DATA_DIR");
-        cmd.env_remove("THURBOX_SOCKET");
+        // test — never leave them to chance. Scrubbed as a namespace rather
+        // than a list: `cargo test` runs inside a live thurbox session on any
+        // developer machine, and a list has to be extended every time thurbox
+        // injects one more var. It was not. `THURBOX_SOCKET_FOR` — the tag that
+        // tells an inherited socket from an operator's own — leaked in and made
+        // `an_explicit_socket_still_wins` fail, because the ambient tag named a
+        // data dir that was not the test's and the override was correctly ruled
+        // inherited.
+        for (key, _) in std::env::vars_os() {
+            if key.to_string_lossy().starts_with("THURBOX_") {
+                cmd.env_remove(&key);
+            }
+        }
         for (key, value) in vars {
             cmd.env(key, value);
         }


### PR DESCRIPTION
Two socket tests fail for anyone running `cargo test` inside a live thurbox
session — which is this repo's normal dev loop, and how CLAUDE.md describes the
dev shell. They pass in CI, so the breakage only ever lands on a developer.

Both fail for one reason. A session injects `THURBOX_SOCKET` together with
`THURBOX_SOCKET_FOR`, the tag naming the data dir that socket belongs to.
Neither test cleared the tag, so the child inherited one naming the operator's
data dir rather than the test's — and `socket_for` then correctly ruled the
test's own override "inherited" and derived a socket instead of honouring it.
The pairing did exactly what it exists to do; the tests just did not know about
it.

```mermaid
flowchart LR
    A["developer's session injects<br/>THURBOX_SOCKET + THURBOX_SOCKET_FOR"] --> B["test sets THURBOX_SOCKET<br/>clears 3 of 4 vars"]
    B --> C["child sees the operator's tag"]
    C --> D["socket_for: tag names another dir<br/>→ inherited, not typed"]
    D --> E["derives thurbox-dev-&lt;digest&gt;<br/>test expected thurbox-named-lab"]
```

## What changed

- `tests/cli_socket_isolation.rs` scrubbed `THURBOX_CONFIG_DIR`,
  `THURBOX_DATA_DIR` and `THURBOX_SOCKET` but not `THURBOX_SOCKET_FOR`, so
  `an_explicit_socket_still_wins` got a derived socket. It now scrubs the whole
  `THURBOX_` namespace. A hand-maintained list has to be extended every time
  thurbox injects one more var, and this is what happens when it is not — the
  missing var was added by the same change that added the test.
- `agent::tmux::tests::local_socket_honors_env_override` reads the process env
  in-process and set only the override. It now clears the tag first.

No production code changed. The pairing semantics are already pinned by
`an_inherited_socket_loses_to_a_relocation`, which sets both vars explicitly, so
this does not weaken what is under test — it stops the developer's environment
standing in for it.

## Verified

Reproduced on `main` at 5f7032a6 with a thurbox session's env present:
`an_explicit_socket_still_wins` fails, `left: "thurbox-dev-0c9e164c"`,
`right: "thurbox-named-lab"`. After the change all 4 in that binary and all 12
matching `test(socket)` pass with the same env still set — not unset for the
run, which is the point. Full `cargo nextest run --all` passed through the
pre-commit hooks: 2281 tests, 0 failures.
