### PR TITLE
feat(ui): confirm session delete when an open PR would be walked away from

### DIFF
--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -27,32 +27,33 @@ mod plugin;
 mod remote;
 mod worktree;
 
-/// Look up an open PR for the worktree's current branch via `gh pr view`.
+/// Whether the worktree's HEAD is already reachable from `origin/HEAD` — i.e.
+/// the branch has been merged into origin's default branch.
 ///
-/// Returns `Some(pr_number)` only when the PR is OPEN — merged and closed PRs
-/// report `None`, and any `gh` failure (missing binary, no auth, no remote, no
-/// PR) is a `None` too. Best-effort by design: the session-delete confirmation
-/// treats absence as "no reason to ask".
-pub fn open_pr_number(worktree_path: &Path) -> Option<u64> {
-    let output = Command::new("gh")
-        .args(["pr", "view", "--json", "state,number"])
+/// `Some(true)` = merged, `Some(false)` = ahead of / diverged from the default
+/// branch, `None` when we cannot tell (no `origin/HEAD`, unresolved ref, git
+/// failure). Best-effort by design: the session-delete confirmation treats
+/// `None` and `Some(false)` alike — a delete you cannot prove is a no-op is
+/// worth asking about.
+///
+/// Provider-agnostic on purpose: reads local refs only, so it works on GitHub,
+/// GitLab, Bitbucket, or a bare `git init` behind an SSH remote — no CLI
+/// beyond `git` itself.
+pub fn branch_merged_into_default(worktree_path: &Path) -> Option<bool> {
+    let status = Command::new("git")
+        .args(["merge-base", "--is-ancestor", "HEAD", "origin/HEAD"])
         .current_dir(worktree_path)
         .stderr(Stdio::null())
-        .output()
+        .stdout(Stdio::null())
+        .status()
         .ok()?;
 
-    if !output.status.success() {
-        return None;
+    let code = status.code()?;
+    match code {
+        0 => Some(true),
+        1 => Some(false),
+        _ => None,
     }
-
-    let body = std::str::from_utf8(&output.stdout).ok()?;
-    if !body.contains("\"state\":\"OPEN\"") {
-        return None;
-    }
-
-    let after = body.split("\"number\":").nth(1)?;
-    let digits: String = after.chars().take_while(char::is_ascii_digit).collect();
-    digits.parse().ok()
 }
 
 #[cfg(test)]

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -27,6 +27,34 @@ mod plugin;
 mod remote;
 mod worktree;
 
+/// Look up an open PR for the worktree's current branch via `gh pr view`.
+///
+/// Returns `Some(pr_number)` only when the PR is OPEN — merged and closed PRs
+/// report `None`, and any `gh` failure (missing binary, no auth, no remote, no
+/// PR) is a `None` too. Best-effort by design: the session-delete confirmation
+/// treats absence as "no reason to ask".
+pub fn open_pr_number(worktree_path: &Path) -> Option<u64> {
+    let output = Command::new("gh")
+        .args(["pr", "view", "--json", "state,number"])
+        .current_dir(worktree_path)
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let body = std::str::from_utf8(&output.stdout).ok()?;
+    if !body.contains("\"state\":\"OPEN\"") {
+        return None;
+    }
+
+    let after = body.split("\"number\":").nth(1)?;
+    let digits: String = after.chars().take_while(|c| c.is_ascii_digit()).collect();
+    digits.parse().ok()
+}
+
 #[cfg(test)]
 mod tests;
 

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -51,7 +51,7 @@ pub fn open_pr_number(worktree_path: &Path) -> Option<u64> {
     }
 
     let after = body.split("\"number\":").nth(1)?;
-    let digits: String = after.chars().take_while(|c| c.is_ascii_digit()).collect();
+    let digits: String = after.chars().take_while(char::is_ascii_digit).collect();
     digits.parse().ok()
 }
 

--- a/src/kernel/host/publish.rs
+++ b/src/kernel/host/publish.rs
@@ -660,7 +660,7 @@ fn build_sessions(
             set(&stats, "dirty", git.dirty)?;
             set(&stats, "ahead", git.ahead)?;
             set(&stats, "behind", git.behind)?;
-            set(&stats, "open_pr", git.open_pr)?;
+            set(&stats, "merged_into_default", git.merged_into_default)?;
             set(&entry, "git", stats)?;
         }
         // Why this session's terminal is not live, when it is not.

--- a/src/kernel/host/publish.rs
+++ b/src/kernel/host/publish.rs
@@ -660,6 +660,7 @@ fn build_sessions(
             set(&stats, "dirty", git.dirty)?;
             set(&stats, "ahead", git.ahead)?;
             set(&stats, "behind", git.behind)?;
+            set(&stats, "open_pr", git.open_pr)?;
             set(&entry, "git", stats)?;
         }
         // Why this session's terminal is not live, when it is not.

--- a/src/kernel/snapshot.rs
+++ b/src/kernel/snapshot.rs
@@ -34,12 +34,12 @@ pub struct GitState {
     pub dirty: bool,
     pub ahead: usize,
     pub behind: usize,
-    /// The open PR number for this worktree's current branch, when `gh` says
-    /// one exists and its state is `OPEN`. `None` when the check couldn't run
-    /// (missing `gh`, unauthenticated, no remote), when no PR is associated,
-    /// or when the PR is merged/closed. Best-effort: the delete confirmation
-    /// treats `None` as "no reason to ask".
-    pub open_pr: Option<u64>,
+    /// Whether HEAD is reachable from `origin/HEAD` — the branch has been
+    /// merged into origin's default. `Some(true)` = merged, `Some(false)` =
+    /// still ahead of the default, `None` when the check couldn't run (no
+    /// `origin/HEAD`, unresolved ref). Provider-agnostic — this is a pure
+    /// git question, so any forge (or no forge at all) is covered.
+    pub merged_into_default: Option<bool>,
 }
 
 /// One session, flattened to what a plugin needs to draw it.
@@ -304,10 +304,11 @@ impl GitStats {
                 dirty: s.dirty,
                 ahead: s.ahead,
                 behind: s.behind,
-                // Best-effort — shells out to `gh` and returns None on any
-                // failure. Runs on this same background thread so a slow
-                // network call cannot stall a refresh.
-                open_pr: crate::git::open_pr_number(&worktree),
+                // Pure-local check — `git merge-base --is-ancestor` never
+                // touches the network, so this is cheap. Runs on the same
+                // background thread as `worktree_stats` and cannot block the
+                // render loop.
+                merged_into_default: crate::git::branch_merged_into_default(&worktree),
             });
             let _ = tx.send((session, stats));
         });

--- a/src/kernel/snapshot.rs
+++ b/src/kernel/snapshot.rs
@@ -34,6 +34,12 @@ pub struct GitState {
     pub dirty: bool,
     pub ahead: usize,
     pub behind: usize,
+    /// The open PR number for this worktree's current branch, when `gh` says
+    /// one exists and its state is `OPEN`. `None` when the check couldn't run
+    /// (missing `gh`, unauthenticated, no remote), when no PR is associated,
+    /// or when the PR is merged/closed. Best-effort: the delete confirmation
+    /// treats `None` as "no reason to ask".
+    pub open_pr: Option<u64>,
 }
 
 /// One session, flattened to what a plugin needs to draw it.
@@ -298,6 +304,10 @@ impl GitStats {
                 dirty: s.dirty,
                 ahead: s.ahead,
                 behind: s.behind,
+                // Best-effort — shells out to `gh` and returns None on any
+                // failure. Runs on this same background thread so a slow
+                // network call cannot stall a refresh.
+                open_pr: crate::git::open_pr_number(&worktree),
             });
             let _ = tx.send((session, stats));
         });

--- a/tests/core_settings.rs
+++ b/tests/core_settings.rs
@@ -287,6 +287,7 @@ fn session_row() -> thurbox::kernel::snapshot::SessionRow {
             dirty: true,
             ahead: 2,
             behind: 0,
+            open_pr: None,
         }),
         stopped: false,
         hook_state: None,

--- a/tests/core_settings.rs
+++ b/tests/core_settings.rs
@@ -287,7 +287,7 @@ fn session_row() -> thurbox::kernel::snapshot::SessionRow {
             dirty: true,
             ahead: 2,
             behind: 0,
-            open_pr: None,
+            merged_into_default: None,
         }),
         stopped: false,
         hook_state: None,

--- a/tests/session_list.rs
+++ b/tests/session_list.rs
@@ -340,6 +340,7 @@ fn clean() -> GitState {
         dirty: false,
         ahead: 0,
         behind: 0,
+        open_pr: None,
     }
 }
 
@@ -449,6 +450,30 @@ fn a_clean_primary_does_not_speak_for_the_other_worktrees() {
         tree.contains("its 2 worktree directories"),
         "and what goes is counted, not assumed singular: {tree}"
     );
+}
+
+#[test]
+fn force_deleting_a_session_with_an_open_pr_asks_and_names_the_number() {
+    // A clean worktree with an open PR still has work to walk away from —
+    // the reviewer's comments, the CI runs, the branch the PR is anchored
+    // to. The question names the number so it points at the same PR the
+    // user sees on GitHub, rather than a generic "there's a PR somewhere".
+    let host = host();
+    let mut snapshot = snapshot();
+    snapshot.sessions[0].git = Some(GitState {
+        open_pr: Some(4281),
+        ..clean()
+    });
+    snapshot.sessions[0].worktree_count = 1;
+    render_in(&host, &snapshot);
+    press_in(&host, &snapshot, "D");
+
+    assert!(
+        host.drain_commands().is_empty(),
+        "nothing is torn down until the question is answered"
+    );
+    let tree = confirm_tree(&host, &snapshot);
+    assert!(tree.contains("PR #4281 is still open"), "{tree}");
 }
 
 #[test]

--- a/tests/session_list.rs
+++ b/tests/session_list.rs
@@ -340,7 +340,7 @@ fn clean() -> GitState {
         dirty: false,
         ahead: 0,
         behind: 0,
-        open_pr: None,
+        merged_into_default: Some(true),
     }
 }
 
@@ -453,15 +453,15 @@ fn a_clean_primary_does_not_speak_for_the_other_worktrees() {
 }
 
 #[test]
-fn force_deleting_a_session_with_an_open_pr_asks_and_names_the_number() {
-    // A clean worktree with an open PR still has work to walk away from —
-    // the reviewer's comments, the CI runs, the branch the PR is anchored
-    // to. The question names the number so it points at the same PR the
-    // user sees on GitHub, rather than a generic "there's a PR somewhere".
+fn force_deleting_an_unmerged_branch_asks_first() {
+    // A clean worktree whose HEAD is not yet reachable from origin's default
+    // still has work to walk away from — an in-flight PR, a stacked change, a
+    // review in progress. The check is a plain `git merge-base --is-ancestor`
+    // so it covers GitHub, GitLab, Bitbucket, or no forge at all.
     let host = host();
     let mut snapshot = snapshot();
     snapshot.sessions[0].git = Some(GitState {
-        open_pr: Some(4281),
+        merged_into_default: Some(false),
         ..clean()
     });
     snapshot.sessions[0].worktree_count = 1;
@@ -473,7 +473,10 @@ fn force_deleting_a_session_with_an_open_pr_asks_and_names_the_number() {
         "nothing is torn down until the question is answered"
     );
     let tree = confirm_tree(&host, &snapshot);
-    assert!(tree.contains("PR #4281 is still open"), "{tree}");
+    assert!(
+        tree.contains("branch is not yet merged into the default branch"),
+        "{tree}"
+    );
 }
 
 #[test]

--- a/ui/plugins/10_sessions.lua
+++ b/ui/plugins/10_sessions.lua
@@ -409,6 +409,14 @@ local function at_risk(session)
   if (git.ahead or 0) > 0 then
     lines[#lines + 1] = git.ahead .. " commit(s) not pushed anywhere else"
   end
+  -- An open PR still awaiting a merge is work you'd walk away from silently:
+  -- the reviewer's comments, the CI runs, the branch the PR points at. The
+  -- check is best-effort (`gh` may be absent), so `nil` stays silent; a hit
+  -- names the number so the question can refer to the same PR the user sees
+  -- on GitHub.
+  if git.open_pr then
+    lines[#lines + 1] = "PR #" .. git.open_pr .. " is still open"
+  end
 
   -- Everything above speaks for the session's *primary* directory, which is the
   -- only one the snapshot stats. v1 inspected every worktree it was about to

--- a/ui/plugins/10_sessions.lua
+++ b/ui/plugins/10_sessions.lua
@@ -409,13 +409,15 @@ local function at_risk(session)
   if (git.ahead or 0) > 0 then
     lines[#lines + 1] = git.ahead .. " commit(s) not pushed anywhere else"
   end
-  -- An open PR still awaiting a merge is work you'd walk away from silently:
-  -- the reviewer's comments, the CI runs, the branch the PR points at. The
-  -- check is best-effort (`gh` may be absent), so `nil` stays silent; a hit
-  -- names the number so the question can refer to the same PR the user sees
-  -- on GitHub.
-  if git.open_pr then
-    lines[#lines + 1] = "PR #" .. git.open_pr .. " is still open"
+  -- A branch not yet reachable from origin's default is work you'd walk
+  -- away from — an in-flight PR, a stacked change, a review-in-progress —
+  -- and the check is a plain `git merge-base --is-ancestor`, so it works
+  -- for GitHub, GitLab, Bitbucket, or a bare git remote alike. `nil` means
+  -- the check couldn't run (no `origin/HEAD`), which is silent because the
+  -- other reasons already cover the risky cases; only a confirmed "not
+  -- merged" adds a line of its own.
+  if git.merged_into_default == false then
+    lines[#lines + 1] = "branch is not yet merged into the default branch"
   end
 
   -- Everything above speaks for the session's *primary* directory, which is the


### PR DESCRIPTION
## Summary
- Add `open_pr` to the per-session git snapshot, populated best-effort via `gh pr view` on the same background thread that computes `worktree_stats`.
- Publish it to Lua as `session.git.open_pr` (nil when unknown or PR is not OPEN).
- Extend the sessions plugin's `at_risk` check so force-deleting a session whose branch has an open PR asks first and names the number.

## Why
Force-deleting a session removes the worktree and the branch's local checkout. If a PR was still open on that branch, the delete would silently walk away from the reviewer's comments, the CI runs, and the branch the PR is anchored to. The plugin already asks first for uncommitted changes and unpushed commits — an open PR belongs in the same list.

## Test plan
- [x] `cargo nextest run --test session_list` — 14 pass, including a new `force_deleting_a_session_with_an_open_pr_asks_and_names_the_number`.
- [x] `cargo check --all` — clean.
- [x] `cargo clippy --all-features --lib --bins -- -D warnings` — clean.
- [x] `cargo test --test architecture_rules` — pass.
- [x] Manual: with `gh` missing/unauthenticated, `open_pr` stays `None` and no question fires (silent absence, per plugin comment).