### PR TITLE
fix(ui): drop the bare `d` shortcut for deleting a session

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ cannot drift from what is running.
 | `Enter` | Open the session | `10_sessions.lua` |
 | `Shift+J` / `Shift+K` | Move it down / up | `10_sessions.lua` |
 | `Shift+S` | Sort by name within each repo group | `10_sessions.lua` |
-| `d` / `Ctrl+D` | Delete (reversible) | `10_sessions.lua` |
+| `Ctrl+D` | Delete (reversible) | `10_sessions.lua` |
 | `Shift+D` | Delete it *and* its worktree, confirming if work is at risk | `10_sessions.lua` |
 | `Ctrl+Z` | Undo the last delete | `10_sessions.lua` |
 | `Ctrl+U` | Restore a deleted session | `80_restore.lua` |

--- a/tests/core_settings.rs
+++ b/tests/core_settings.rs
@@ -411,7 +411,7 @@ fn deleting_with_soft_delete_on_is_reversible_and_asks_nothing() {
     let host = host();
     let settings = with_soft_delete(true);
     publish_with(&host, &settings);
-    press(&host, "sessions", "d");
+    press(&host, "sessions", "ctrl+d");
 
     assert_eq!(
         host.drain_commands(),
@@ -429,7 +429,7 @@ fn deleting_with_soft_delete_off_confirms_and_itemises_the_loss() {
     let host = host();
     let settings = with_soft_delete(false);
     publish_with(&host, &settings);
-    press(&host, "sessions", "d");
+    press(&host, "sessions", "ctrl+d");
 
     assert!(
         host.drain_commands().is_empty(),
@@ -466,7 +466,7 @@ fn declining_the_confirmation_deletes_nothing() {
     let host = host();
     let settings = with_soft_delete(false);
     publish_with(&host, &settings);
-    press(&host, "sessions", "d");
+    press(&host, "sessions", "ctrl+d");
     assert!(confirmation(&host, &settings).is_some());
 
     press(&host, "confirm", "esc");

--- a/tests/kernel_mvp.rs
+++ b/tests/kernel_mvp.rs
@@ -844,10 +844,20 @@ use thurbox::kernel::command::{Command, InFlight, Phase};
 /// Press a key and route it exactly as the binary does: registry first
 /// (declared actions), then raw `on_key`. Returns whatever commands it issued.
 fn press_key(host: &LuaHost, plugin: &str, ch: char) {
+    press_chord(host, plugin, ch, false);
+}
+
+/// The same, with Ctrl held.
+fn press_ctrl_key(host: &LuaHost, plugin: &str, ch: char) {
+    press_chord(host, plugin, ch, true);
+}
+
+fn press_chord(host: &LuaHost, plugin: &str, ch: char, ctrl: bool) {
     let registry = registry(host);
     let key = KeyPress {
         name: ch.to_lowercase().to_string(),
         ch: Some(ch),
+        ctrl,
         ..KeyPress::default()
     };
     if let Some(binding) = registry.resolve(&key, Some(plugin)) {
@@ -865,6 +875,11 @@ fn keys_to_commands(host: &LuaHost, plugin: &str, ch: char) -> Vec<Command> {
     host.drain_commands()
 }
 
+fn ctrl_keys_to_commands(host: &LuaHost, plugin: &str, ch: char) -> Vec<Command> {
+    press_ctrl_key(host, plugin, ch);
+    host.drain_commands()
+}
+
 #[test]
 fn deleting_from_the_session_list_issues_a_command() {
     let host = host();
@@ -872,7 +887,7 @@ fn deleting_from_the_session_list_issues_a_command() {
     host.render(index_of(&host, "sessions"), ctx(40, 12, true))
         .expect("render");
 
-    let issued = keys_to_commands(&host, "sessions", 'd');
+    let issued = ctrl_keys_to_commands(&host, "sessions", 'd');
     assert_eq!(issued.len(), 1, "{issued:?}");
     assert_eq!(issued[0].kind(), "delete");
     assert!(

--- a/tests/keymap.rs
+++ b/tests/keymap.rs
@@ -542,3 +542,47 @@ fn the_agent_panes_page_keys_are_declared_rather_than_hidden_in_on_key() {
         );
     }
 }
+
+#[test]
+fn a_bare_d_deletes_nothing_in_the_session_list() {
+    // Deleting is the one destructive thing a focused list can do, and `d` is a
+    // single unmodified keystroke away from `j`/`k`. `Ctrl+D` (and `Shift+D` for
+    // the worktree with it) are the only ways in.
+    let host = host();
+    let snapshot = Snapshot {
+        sessions: vec![row("fix-osc52")],
+        ..Snapshot::default()
+    };
+    publish(&host, &snapshot);
+    host.render(
+        index_of(&host, "sessions"),
+        RenderContext {
+            width: 40,
+            height: 12,
+            focused: true,
+            elapsed: 1.0,
+            frame: 1,
+        },
+    )
+    .expect("render the list");
+    host.drain_commands();
+
+    assert!(
+        registry(&host)
+            .resolve(&press("d"), Some("sessions"))
+            .is_none(),
+        "`d` must not be bound with the session list focused"
+    );
+    host.on_key(index_of(&host, "sessions"), &press("d"))
+        .expect("key");
+    assert!(
+        host.drain_commands().is_empty(),
+        "and the pane must not delete on it either"
+    );
+
+    // The chord that does still deletes.
+    fire(&host, "ctrl+d");
+    let issued = host.drain_commands();
+    assert_eq!(issued.len(), 1, "{issued:?}");
+    assert_eq!(issued[0].kind(), "delete");
+}

--- a/tests/palette.rs
+++ b/tests/palette.rs
@@ -136,10 +136,12 @@ fn every_kind_of_action_is_a_row() {
 
     // A key-bound action, with its chord beside it.
     let delete = find("sessions.delete").expect("a plugin's key is a row");
-    // Its alternates joined as help joins them: the pane-scoped `d` and the
-    // global `ctrl+d` are one action.
-    assert_eq!(delete.chords.as_deref(), Some("d / ctrl+d"));
+    assert_eq!(delete.chords.as_deref(), Some("ctrl+d"));
     assert_eq!(delete.plugin, "sessions");
+    // Alternates joined as help joins them: the pane-scoped keys and the global
+    // `ctrl+j` are one action.
+    let next = find("sessions.next").expect("a plugin's key is a row");
+    assert_eq!(next.chords.as_deref(), Some("j / down / ctrl+j"));
     // A chord-less command, with none.
     let export = find("mine.export").expect("a chord-less command is a row");
     assert_eq!(export.chords, None);

--- a/ui/plugins/10_sessions.lua
+++ b/ui/plugins/10_sessions.lua
@@ -534,7 +534,9 @@ return {
     -- v1's `Enter` on a session row: go to what you selected. The row is already
     -- selected by the time this fires, so opening is only a focus change.
     { key = "enter", action = "sessions.open", desc = "open the session", group = "Navigation" },
-    { key = "d", action = "sessions.delete", desc = "delete session", group = "Sessions" },
+    -- Delete has no unmodified chord on purpose: `d` sits next to `j`/`k`, and
+    -- a stray keystroke on a focused list should not tear a session down.
+    -- `ctrl+d` below is the way in; `D` takes the worktree with it.
     {
       key = "D",
       action = "sessions.force_delete",

--- a/website/docs/keybindings.html
+++ b/website/docs/keybindings.html
@@ -69,7 +69,7 @@ breadcrumb: 'Keybindings'
     <tr><td><kbd>Enter</kbd></td><td>Open it &mdash; focus its agent</td></tr>
     <tr><td><kbd>Shift</kbd>+<kbd>J</kbd> / <kbd>Shift</kbd>+<kbd>K</kbd></td><td>Move it down / up. A parent drags its children; a whole group moves past a group edge</td></tr>
     <tr><td><kbd>Shift</kbd>+<kbd>S</kbd></td><td>Sort by name within each repository group</td></tr>
-    <tr><td><kbd>d</kbd> or <kbd>Ctrl</kbd>+<kbd>D</kbd></td><td>Delete &mdash; reversible, with an undo window</td></tr>
+    <tr><td><kbd>Ctrl</kbd>+<kbd>D</kbd></td><td>Delete &mdash; reversible, with an undo window</td></tr>
     <tr><td><kbd>Shift</kbd>+<kbd>D</kbd></td><td>Delete it <em>and its worktree</em>. Confirms first, itemising what would be lost</td></tr>
     <tr><td><kbd>Ctrl</kbd>+<kbd>Z</kbd></td><td>Undo the last delete</td></tr>
     <tr><td><kbd>r</kbd> or <kbd>Ctrl</kbd>+<kbd>R</kbd></td><td>Restart the agent, resuming the conversation where the agent supports it</td></tr>


### PR DESCRIPTION
## Intent

Remove the bare 'd' keyboard shortcut for deleting a session in the thurbox TUI: the user asked that 'd' no longer delete a session and that only Ctrl+D remain. Implementation decisions made while doing the work: (1) the pane-scoped { key = "d", action = "sessions.delete" } binding was deleted from ui/plugins/10_sessions.lua, leaving the global passthrough ctrl+d as the only delete chord; (2) Shift+D (sessions.force_delete, delete session AND its worktree) was deliberately KEPT — the user only asked about the bare 'd', and Shift+D is a modified chord like Ctrl+D, so it is not a footgun; (3) per the user's standing rule, a failing end-to-end test was written first: tests/keymap.rs::a_bare_d_deletes_nothing_in_the_session_list, which asserts 'd' resolves to no binding with the session list focused, that the pane issues no command on the raw key either, and that ctrl+d still issues a delete — it failed on the real binding before the fix; (4) dependent tests were updated rather than deleted: tests/core_settings.rs presses ctrl+d for the three soft/hard-delete cases, tests/kernel_mvp.rs gained press_chord/press_ctrl_key helpers so its delete test can hold Ctrl, and tests/palette.rs moved its 'alternates joined with /' assertion from sessions.delete (now a single chord) to sessions.next (j / down / ctrl+j) while still asserting sessions.delete shows ctrl+d; (5) docs were updated in the same commit as the repo rule requires — README.md's keybinding table row and website/docs/keybindings.html now list Ctrl+D only. Other 'd' bindings in the interface are unrelated and untouched: 'd' forgets a remembered repo in 70_new_session.lua, and 'd' resets/removes in the help, settings and Interface modals. Full cargo nextest run --all passes 2282/2282 plus clippy, selene, stylua, rumdl and all 20 pre-commit hooks.

## What Changed

- Removed the pane-scoped `{ key = "d", action = "sessions.delete" }` binding from `ui/plugins/10_sessions.lua`, leaving `Ctrl+D` as the sole delete chord (`Shift+D`, which also removes the worktree, is unchanged).
- Updated `README.md` and `website/docs/keybindings.html` keybinding tables to list `Ctrl+D` only for delete.
- Added `tests/keymap.rs::a_bare_d_deletes_nothing_in_the_session_list`, which asserts `d` resolves to no binding and issues no command with the session list focused, while `Ctrl+D` still issues a delete.
- Updated dependent tests to hold `Ctrl` when exercising delete: `tests/core_settings.rs` now presses `ctrl+d` for its soft/hard-delete cases, `tests/kernel_mvp.rs` gained `press_chord`/`press_ctrl_key` helpers, and `tests/palette.rs` moved its "alternates joined with /" assertion to `sessions.next` while asserting `sessions.delete` shows `ctrl+d`.

## Risk Assessment

✅ Low: A single well-scoped commit removes the pane-scoped `d` binding from ui/plugins/10_sessions.lua while keeping the global ctrl+d passthrough and Shift+D force-delete, exactly matching the stated intent; the new keymap.rs test exercises real registry resolution and on_key/drain_commands behavior rather than grepping source, and all dependent tests (core_settings.rs, kernel_mvp.rs, palette.rs) plus README.md and website/docs/keybindings.html were updated consistently in the same commit with no stale references to the removed shortcut found elsewhere.

## Testing

Ran the four targeted test files touched by this change (158 tests) covering keymap resolution, kernel-level key routing, settings delete flows, and the command palette's chord display — all passed, including the new end-to-end regression test proving `d` no longer deletes a session while `ctrl+d` still does; docs were manually diffed and confirmed to match the intent.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"9853378db8ed11d22640e195b3246d4abc776d67","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `cargo nextest run --all`
- `cargo nextest run --test keymap --test kernel_mvp --test core_settings --test palette`
- `git diff d0458d1b652ae99cbe4cd0487118c1e1bac2541d 9853378 -- README.md website/docs/keybindings.html (manual doc verification)`
- <code>git show d0458d1:ui/plugins/10_sessions.lua confirms the bare `d` binding existed pre-fix, validating the new test as a real regression check</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
