### PR TITLE
ci: let a fork's pull request past the SonarQube gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -420,7 +420,17 @@ jobs:
   sonarqube:
     name: SonarQube
     needs: changes
-    if: needs.changes.outputs.rust == 'true'
+    # Skipped for a pull request from a fork. GitHub never hands a repository
+    # secret to a `pull_request` run whose head is another repository, so
+    # `SONAR_TOKEN` arrives empty, the scan step fails, and it takes
+    # `all-checks` down with it — the required gate would refuse every outside
+    # contribution on a credential the contributor cannot be given. A skipped
+    # job's result is `skipped`, not `failure`, so `all-checks` passes without
+    # it. The trade is real and deliberate: a fork's code is not analysed
+    # before it lands, since this workflow only ever runs on `pull_request`.
+    if: >-
+      needs.changes.outputs.rust == 'true' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7


### PR DESCRIPTION
A public repository never hands a secret to a `pull_request` run whose head is
another repository, so `SONAR_TOKEN` reaches the scan empty and the step fails.
`sonarqube` is in `all-checks.needs` and `All Checks` is required on main, so the
gate refused every fork PR outright — on a credential the contributor could not
have been given. #1042 is the first outside contribution to hit it; there is no
commit it could push that would make the check pass.

Skip the job for a fork's PR. A skipped job's result is `skipped`, not `failure`,
so `all-checks` passes without it, and a PR from a branch of this repository is
analysed exactly as before.

The trade is deliberate and worth stating: a fork's code lands without a Sonar
scan, because this workflow only ever runs on `pull_request`. The alternative —
sending secrets to fork runs — is not on offer for a public repository, and would
mean the token is readable by anyone who opens a PR.

Verified by reading the failing run: `SONAR_TOKEN:` empty, followed by
`Running this GitHub Action without SONAR_TOKEN is not recommended`
(run 33657979643, job 100341588894).

https://claude.ai/code/session_01P2VZUmdf9qRbF9q5yzbSDZ
