### PR TITLE
fix(core): only let a session teardown kill the window it owns

### DIFF
--- a/.claude/skills/thurbox-testing/SKILL.md
+++ b/.claude/skills/thurbox-testing/SKILL.md
@@ -64,7 +64,7 @@ kernel over the real `ui/`** rather than a harness that imitates either:
   smoke script, which could not see the byte stream and duplicated this harness.
 - **`tests/reap_e2e.rs`** — the reap of a soft-deleted row against a *real* tmux
   on a throwaway socket (skipped when tmux is absent), because the bug it pins
-  only exists in how tmux resolves a target. Six tests, both directions of the
+  only exists in how tmux resolves a target. Eight tests, both directions of the
   same contract: a stale row's reap spares a live namesake's window, a namesake's
   pane the stale row still remembers, a live window whose name only collides
   after `sanitize_window_name` ('fleet 1' and 'fleet_1' share one `tb-fleet_1`),
@@ -72,6 +72,12 @@ kernel over the real `ui/`** rather than a harness that imitates either:
   own pane resolves, and one whose pane id resolves to nothing but whose name
   nobody else answers to, still lose their window. Sparing must not be bought by
   making the reap a no-op.
+  The last two cover the *other* caller of that ownership gate, a spawn's
+  cleanup of the window it leaked when its own upsert failed: they call
+  `session_ops::delete::owned_agent_pane_for` directly — the decision the
+  cleanup delegates — because the upsert cannot be made to fail through the
+  public API, so a test of the spawn path itself would be testing something
+  else.
 
 Tests that shell out to `git` **must scrub the `GIT_*` location variables**
 (`git::GIT_LOCATION_ENV`): git exports them to hook processes, so the suite running

--- a/.claude/skills/thurbox-testing/SKILL.md
+++ b/.claude/skills/thurbox-testing/SKILL.md
@@ -64,12 +64,14 @@ kernel over the real `ui/`** rather than a harness that imitates either:
   smoke script, which could not see the byte stream and duplicated this harness.
 - **`tests/reap_e2e.rs`** — the reap of a soft-deleted row against a *real* tmux
   on a throwaway socket (skipped when tmux is absent), because the bug it pins
-  only exists in how tmux resolves a target. Five tests, both directions of the
+  only exists in how tmux resolves a target. Six tests, both directions of the
   same contract: a stale row's reap spares a live namesake's window, a namesake's
-  pane the stale row still remembers, and a soft-deleted namesake still inside
-  its undo window — while a row whose own pane resolves, and one whose pane id
-  resolves to nothing but whose name nobody else answers to, still lose their
-  window. Sparing must not be bought by making the reap a no-op.
+  pane the stale row still remembers, a live window whose name only collides
+  after `sanitize_window_name` ('fleet 1' and 'fleet_1' share one `tb-fleet_1`),
+  and a soft-deleted namesake still inside its undo window — while a row whose
+  own pane resolves, and one whose pane id resolves to nothing but whose name
+  nobody else answers to, still lose their window. Sparing must not be bought by
+  making the reap a no-op.
 
 Tests that shell out to `git` **must scrub the `GIT_*` location variables**
 (`git::GIT_LOCATION_ENV`): git exports them to hook processes, so the suite running

--- a/.claude/skills/thurbox-testing/SKILL.md
+++ b/.claude/skills/thurbox-testing/SKILL.md
@@ -62,6 +62,14 @@ kernel over the real `ui/`** rather than a harness that imitates either:
   — and, where tmux exists, a headlessly created session attached, painted and
   typed into (`sh` as the agent). Also `just smoke`. It replaced the bash tmux
   smoke script, which could not see the byte stream and duplicated this harness.
+- **`tests/reap_e2e.rs`** — the reap of a soft-deleted row against a *real* tmux
+  on a throwaway socket (skipped when tmux is absent), because the bug it pins
+  only exists in how tmux resolves a target. Five tests, both directions of the
+  same contract: a stale row's reap spares a live namesake's window, a namesake's
+  pane the stale row still remembers, and a soft-deleted namesake still inside
+  its undo window — while a row whose own pane resolves, and one whose pane id
+  resolves to nothing but whose name nobody else answers to, still lose their
+  window. Sparing must not be bought by making the reap a no-op.
 
 Tests that shell out to `git` **must scrub the `GIT_*` location variables**
 (`git::GIT_LOCATION_ENV`): git exports them to hook processes, so the suite running

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,10 +146,11 @@ jobs:
         with:
           tool: cargo-nextest
       # A real multiplexer, so the tests that drive one run here rather than
-      # skip: `tests/create_e2e.rs`, `tests/attach_by_name.rs`, and the
-      # live-session scenario of `tests/tui_e2e.rs` — the real binary on a pty,
-      # attached to a pane with a shell in it. Every one of them lands on a
-      # private socket under a private `TMUX_TMPDIR`.
+      # skip: `tests/create_e2e.rs`, `tests/attach_by_name.rs`,
+      # `tests/reap_e2e.rs`, and the live-session scenario of
+      # `tests/tui_e2e.rs` — the real binary on a pty, attached to a pane with
+      # a shell in it. Every one of them lands on a private socket under a
+      # private `TMUX_TMPDIR`.
       - name: Install tmux
         run: sudo apt-get update && sudo apt-get install -y tmux
       - run: cargo nextest run --all --profile ci

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -442,7 +442,23 @@ bugs (#641, #2989), required 3 external deps in the data path
 - `window-size manual` — windows size independently
 - `pause-after 5` — flow control (auto-resumed by reader)
 
-**Window naming**: `tb-<session-name>` prefix for discovery.
+**Window naming**: `tb-<session-name>` prefix for discovery. It identifies a
+*name*, not a session: names are not unique, and a soft-deleted row keeps its
+name and its remembered pane id until the reaper lets it go. So resolving
+`tb-<name>` — or a stored `%N`, which a tmux server restart can renumber onto
+another window — proves only that *something* answers to that identity now.
+Live-session callers want that forgiveness (`agent::tmux::agent_target`;
+reaching a session's window after a restart renumbered the panes is what it is
+for), but a **teardown** may not have it: a reap of a soft-deleted row, and the
+orphan cleanup a spawn runs when its own database upsert fails, resolve through
+`agent::tmux::owned_agent_pane`, whose two halves are each gated on
+`Database::session_window_claims` showing that no other row answers to that pane
+id or that window name. An unprovable claim kills nothing and logs — leaking a
+window costs a stale agent, killing the wrong one costs live work. Without that
+gate, deleting a frozen session and recreating it under the same name meant the
+deleted row's reap killed the *replacement* once the undo window closed, and
+silently, since a same-named window matches exactly and `kill-window` exits 0
+(pinned by `tests/reap_e2e.rs`).
 
 **Which socket**: `thurbox` (`thurbox-dev` for a dev build) for an instance
 running out of the default data dir, and `thurbox-<digest of that dir>` for one

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -2416,59 +2416,66 @@ pub fn kill_pane_remote(host: &crate::session::HostDef, backend_id: &str) -> Res
 /// one is usable (precise even when another session shares the name), by the
 /// `tb-<session_name>` window name otherwise.
 pub fn kill_window(session_name: &str, pane_id: &str) -> Result<()> {
-    kill_window_target(&agent_target(session_name, pane_id))
+    kill_window_at(&agent_target(session_name, pane_id))
+}
+
+/// Which parts of a torn-down row's identity no *other* session row answers
+/// to — the half of ownership this module cannot establish, since it may not
+/// read the database (see `tests/architecture_rules.rs`). Settled once by
+/// `session_ops::delete::owned_agent_pane`, which is the only intended caller
+/// of [`owned_agent_pane`].
+#[derive(Clone, Copy, Debug)]
+pub struct Unclaimed {
+    /// No other row remembers this pane id. A tmux server restarts its pane-id
+    /// counter, so a row's remembered `%N` can name another window's pane
+    /// afterwards — and when that other window is a namesake's, the window
+    /// name confirms nothing.
+    pub pane_id: bool,
+    /// No other row still answers to the name — neither an active session nor
+    /// a soft-deleted one whose agent has not been reaped yet.
+    pub name: bool,
 }
 
 /// The pane a torn-down row still owns, if any — the target a teardown may
 /// safely kill, and the answer to whether it has anything left to kill at all.
 ///
-/// The counterpart to [`agent_target`], for callers tearing down a row rather
-/// than acting on a live session. `agent_target`'s unconditional fallback to
-/// the `tb-<name>` window is unsound for them: names are not unique — two
-/// sessions may share one, and a soft-deleted row keeps its name until it is
-/// reaped — so a row whose own pane no longer resolves would resolve to
-/// whatever session is called that *now* and silently destroy it. A same-named
-/// window matches exactly, so `kill-window` succeeds against the wrong one.
+/// The counterpart to `agent_target`, for callers tearing down a row rather
+/// than acting on a live session. `agent_target` resolves whatever it can
+/// reach: the persisted pane id if its window carries the right name, the
+/// `tb-<name>` window otherwise. Neither step is proof of ownership, and for a
+/// teardown both are unsound — names are not unique, two sessions may share
+/// one, and a soft-deleted row keeps its name *and* its remembered pane id
+/// until it is reaped. Resolving either against a row that is not this one
+/// silently destroys a live session's window; a same-named window matches
+/// exactly, so `kill-window` succeeds against the wrong one.
 ///
-/// `name_unclaimed` is the caller's assurance that no live session carries the
-/// name, which is the one case where it is still safe to resolve: the sole
-/// window named `tb-<name>` can then only be this row's. Without it the
-/// teardown would leak a window whenever the pane id is unusable — a row
-/// persisted before local spawns recorded an id, one renumbered by a tmux
-/// restart, or any session on psmux, where [`spawn_window`] records no pane id
-/// at all.
+/// So each step is gated on [`Unclaimed`], the caller's assurance that no other
+/// row answers to that part of the identity. Without the name half the teardown
+/// would leak a window whenever the pane id is unusable — a row persisted
+/// before local spawns recorded an id, one renumbered by a tmux restart, or any
+/// session on psmux, where [`spawn_window`] records no pane id at all.
 pub fn owned_agent_pane(
     session_name: &str,
     pane_id: &str,
-    name_unclaimed: bool,
+    unclaimed: Unclaimed,
 ) -> Result<Option<String>> {
-    if !pane_id.is_empty() && pane_matches_window(pane_id, &agent_window_name(session_name)) {
+    if unclaimed.pane_id
+        && !pane_id.is_empty()
+        && pane_matches_window(pane_id, &agent_window_name(session_name))
+    {
         return Ok(Some(pane_id.to_string()));
     }
-    if !name_unclaimed {
+    if !unclaimed.name {
         return Ok(None);
     }
     agent_window_pane(None, session_name)
 }
 
-/// Kill the window a torn-down row still owns, killing nothing when it owns
-/// none. Returns whether a window was killed. See [`owned_agent_pane`] for what
-/// ownership means and why [`kill_window`]'s forgiving target is wrong here.
-pub fn kill_window_strict(
-    session_name: &str,
-    pane_id: &str,
-    name_unclaimed: bool,
-) -> Result<bool> {
-    match owned_agent_pane(session_name, pane_id, name_unclaimed)? {
-        Some(target) => kill_window_target(&target).map(|()| true),
-        None => Ok(false),
-    }
-}
-
 /// Run `kill-window` against an already-resolved target, tolerating a window
-/// that is already gone. Shared by [`kill_window`] and [`kill_window_strict`]
-/// so the two differ only in how the target is chosen.
-fn kill_window_target(target: &str) -> Result<()> {
+/// that is already gone. Shared by [`kill_window`] and the teardown path, which
+/// resolves its own target through [`owned_agent_pane`] — the two differ only
+/// in how the target is chosen.
+pub fn kill_window_at(target: &str) -> Result<()> {
     let output = local_mux_command(&["kill-window", "-t", target])
         .output()
         .context("Failed to run tmux kill-window")?;

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -2416,8 +2416,33 @@ pub fn kill_pane_remote(host: &crate::session::HostDef, backend_id: &str) -> Res
 /// one is usable (precise even when another session shares the name), by the
 /// `tb-<session_name>` window name otherwise.
 pub fn kill_window(session_name: &str, pane_id: &str) -> Result<()> {
-    let target = agent_target(session_name, pane_id);
-    let output = local_mux_command(&["kill-window", "-t", &target])
+    kill_window_target(&agent_target(session_name, pane_id))
+}
+
+/// Kill the session's window **only** while `pane_id` still resolves to that
+/// session's own `tb-<name>` window; otherwise kill nothing. Returns whether a
+/// window was killed.
+///
+/// The counterpart to [`kill_window`], for callers tearing down a row rather
+/// than acting on a live session. The name fallback that makes `kill_window`
+/// forgiving is unsound for them: a row whose pane id no longer resolves has no
+/// window of its own left, so `tb-<name>` can only match a *different* session's
+/// window. Names are not unique — two sessions may share one, and a soft-deleted
+/// row keeps its name until it is reaped — so the fallback silently destroys a
+/// live session (`kill-window` even exits 0 doing it, because tmux prefix- and
+/// substring-matches a window target).
+pub fn kill_window_strict(session_name: &str, pane_id: &str) -> Result<bool> {
+    if pane_id.is_empty() || !pane_matches_window(pane_id, &agent_window_name(session_name)) {
+        return Ok(false);
+    }
+    kill_window_target(pane_id).map(|()| true)
+}
+
+/// Run `kill-window` against an already-resolved target, tolerating a window
+/// that is already gone. Shared by [`kill_window`] and [`kill_window_strict`]
+/// so the two differ only in how the target is chosen.
+fn kill_window_target(target: &str) -> Result<()> {
+    let output = local_mux_command(&["kill-window", "-t", target])
         .output()
         .context("Failed to run tmux kill-window")?;
     if !output.status.success() {

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -2431,8 +2431,12 @@ pub struct Unclaimed {
     /// afterwards — and when that other window is a namesake's, the window
     /// name confirms nothing.
     pub pane_id: bool,
-    /// No other row still answers to the name — neither an active session nor
-    /// a soft-deleted one whose agent has not been reaped yet.
+    /// No other row still answers to the *window* name `tb-<name>` — neither
+    /// an active session nor a soft-deleted one whose agent has not been
+    /// reaped yet. The window name rather than the session name, because that
+    /// is the namespace the fallback resolves in: [`sanitize_window_name`]
+    /// maps every character outside `[A-Za-z0-9_-]` to `_`, so `fleet 1` and
+    /// `fleet_1` are two rows sharing one `tb-fleet_1`.
     pub name: bool,
 }
 

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -2419,23 +2419,50 @@ pub fn kill_window(session_name: &str, pane_id: &str) -> Result<()> {
     kill_window_target(&agent_target(session_name, pane_id))
 }
 
-/// Kill the session's window **only** while `pane_id` still resolves to that
-/// session's own `tb-<name>` window; otherwise kill nothing. Returns whether a
-/// window was killed.
+/// The pane a torn-down row still owns, if any — the target a teardown may
+/// safely kill, and the answer to whether it has anything left to kill at all.
 ///
-/// The counterpart to [`kill_window`], for callers tearing down a row rather
-/// than acting on a live session. The name fallback that makes `kill_window`
-/// forgiving is unsound for them: a row whose pane id no longer resolves has no
-/// window of its own left, so `tb-<name>` can only match a *different* session's
-/// window. Names are not unique — two sessions may share one, and a soft-deleted
-/// row keeps its name until it is reaped — so the fallback silently destroys a
-/// live session (`kill-window` even exits 0 doing it, because tmux prefix- and
-/// substring-matches a window target).
-pub fn kill_window_strict(session_name: &str, pane_id: &str) -> Result<bool> {
-    if pane_id.is_empty() || !pane_matches_window(pane_id, &agent_window_name(session_name)) {
-        return Ok(false);
+/// The counterpart to [`agent_target`], for callers tearing down a row rather
+/// than acting on a live session. `agent_target`'s unconditional fallback to
+/// the `tb-<name>` window is unsound for them: names are not unique — two
+/// sessions may share one, and a soft-deleted row keeps its name until it is
+/// reaped — so a row whose own pane no longer resolves would resolve to
+/// whatever session is called that *now* and silently destroy it. A same-named
+/// window matches exactly, so `kill-window` succeeds against the wrong one.
+///
+/// `name_unclaimed` is the caller's assurance that no live session carries the
+/// name, which is the one case where it is still safe to resolve: the sole
+/// window named `tb-<name>` can then only be this row's. Without it the
+/// teardown would leak a window whenever the pane id is unusable — a row
+/// persisted before local spawns recorded an id, one renumbered by a tmux
+/// restart, or any session on psmux, where [`spawn_window`] records no pane id
+/// at all.
+pub fn owned_agent_pane(
+    session_name: &str,
+    pane_id: &str,
+    name_unclaimed: bool,
+) -> Result<Option<String>> {
+    if !pane_id.is_empty() && pane_matches_window(pane_id, &agent_window_name(session_name)) {
+        return Ok(Some(pane_id.to_string()));
     }
-    kill_window_target(pane_id).map(|()| true)
+    if !name_unclaimed {
+        return Ok(None);
+    }
+    agent_window_pane(None, session_name)
+}
+
+/// Kill the window a torn-down row still owns, killing nothing when it owns
+/// none. Returns whether a window was killed. See [`owned_agent_pane`] for what
+/// ownership means and why [`kill_window`]'s forgiving target is wrong here.
+pub fn kill_window_strict(
+    session_name: &str,
+    pane_id: &str,
+    name_unclaimed: bool,
+) -> Result<bool> {
+    match owned_agent_pane(session_name, pane_id, name_unclaimed)? {
+        Some(target) => kill_window_target(&target).map(|()| true),
+        None => Ok(false),
+    }
 }
 
 /// Run `kill-window` against an already-resolved target, tolerating a window

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -2434,7 +2434,7 @@ pub struct Unclaimed {
     /// No other row still answers to the *window* name `tb-<name>` — neither
     /// an active session nor a soft-deleted one whose agent has not been
     /// reaped yet. The window name rather than the session name, because that
-    /// is the namespace the fallback resolves in: [`sanitize_window_name`]
+    /// is the namespace the fallback resolves in: `sanitize_window_name`
     /// maps every character outside `[A-Za-z0-9_-]` to `_`, so `fleet 1` and
     /// `fleet_1` are two rows sharing one `tb-fleet_1`.
     pub name: bool,

--- a/src/cli/automations.rs
+++ b/src/cli/automations.rs
@@ -560,6 +560,14 @@ fn poll_local_pane_states(db: &Database) -> usize {
 /// reaped on the strength of a live namesake's window. The gate is
 /// `session_ops::delete::owned_agent_pane`, the same and only ownership test the
 /// reap itself applies.
+///
+/// Window ownership is the whole gate, so a row that owns none is skipped
+/// entirely and its metrics file and symlink workspace are left in place —
+/// artifacts `reap_soft_deleted` would otherwise release. Accepted rather than
+/// worked around: without an "already reaped" marker on the row, ownership is
+/// the only idempotence proxy the sweep has, and releasing artifacts on every
+/// tick forever is the worse trade. The TUI reaper fires once per id and does
+/// release them.
 fn reap_overdue_soft_deletes(db: &Database) -> Vec<String> {
     let Ok(rows) = db.list_deleted_sessions() else {
         return Vec::new();
@@ -889,7 +897,8 @@ mod tests {
 
         assert!(
             reap_overdue_soft_deletes(&db).is_empty(),
-            "an overdue row whose pane and name a live namesake claims owns              nothing to release"
+            "an overdue row whose pane and name a live namesake claims owns \
+             nothing to release"
         );
         assert!(
             db.get_deleted_session_by_id(stale.id).unwrap().is_some(),

--- a/src/cli/automations.rs
+++ b/src/cli/automations.rs
@@ -848,6 +848,55 @@ mod tests {
         assert!(reap_overdue_soft_deletes(&db).is_empty());
     }
 
+    /// The sweep's ownership gate. Its old test was `agent_window_alive`, so an
+    /// overdue row whose pane had long gone was re-reported as reaped on every
+    /// tick on the strength of a live namesake's window. A row whose pane id
+    /// *and* window name another live row answers to owns nothing, so the
+    /// sweep must leave it alone — and no tmux is consulted to find that out.
+    #[test]
+    fn the_overdue_reap_skips_a_row_a_live_namesake_answers_for() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let db = Database::open_in_memory().unwrap();
+        let stale = crate::sync::SharedSession {
+            id: SessionId::default(),
+            name: "fleet".into(),
+            agent: "claude".into(),
+            backend_id: "%1".into(),
+            backend_type: "local-tmux".into(),
+            agent_session_id: None,
+            cwd: None,
+            additional_dirs: Vec::new(),
+            worktrees: Vec::new(),
+            shell_backend_id: None,
+            parent_session_id: None,
+            display_order: None,
+            tombstone: false,
+            tombstone_at: None,
+        };
+        db.upsert_session(&stale).unwrap();
+        db.soft_delete_session(stale.id).unwrap();
+        // Past the undo window, so only the gate can hold the sweep back.
+        db.conn_ref()
+            .execute(
+                "UPDATE sessions SET deleted_at = 0 WHERE id = ?1",
+                [stale.id.to_string()],
+            )
+            .unwrap();
+        let mut live = stale.clone();
+        live.id = SessionId::default();
+        db.upsert_session(&live).unwrap();
+
+        assert!(
+            reap_overdue_soft_deletes(&db).is_empty(),
+            "an overdue row whose pane and name a live namesake claims owns              nothing to release"
+        );
+        assert!(
+            db.get_deleted_session_by_id(stale.id).unwrap().is_some(),
+            "and is left soft-deleted rather than reported collected"
+        );
+    }
+
     #[test]
     fn render_tick_counts_fired_skipped_and_healed() {
         let v = json!({

--- a/src/cli/automations.rs
+++ b/src/cli/automations.rs
@@ -557,8 +557,9 @@ fn poll_local_pane_states(db: &Database) -> usize {
 /// interface's undo window, when the row still owns its window. Returns the ids
 /// reaped. Only rows with a window of their *own* are touched, so a row reaped
 /// once costs nothing on every later tick — and a stale row is never reported as
-/// reaped on the strength of a live namesake's window, which is the same unsound
-/// name resolution the reap itself refuses.
+/// reaped on the strength of a live namesake's window. The gate is
+/// `session_ops::delete::owned_agent_pane`, the same and only ownership test the
+/// reap itself applies.
 fn reap_overdue_soft_deletes(db: &Database) -> Vec<String> {
     let Ok(rows) = db.list_deleted_sessions() else {
         return Vec::new();
@@ -573,10 +574,8 @@ fn reap_overdue_soft_deletes(db: &Database) -> Vec<String> {
         {
             continue;
         }
-        let unclaimed = crate::session_ops::delete::name_unclaimed(db, &row.name);
-        match crate::agent::tmux::owned_agent_pane(&row.name, &row.backend_id, unclaimed) {
-            Ok(Some(_)) => {}
-            _ => continue,
+        if crate::session_ops::delete::owned_agent_pane(db, &row).is_none() {
+            continue;
         }
         match crate::session_ops::reap_soft_deleted(db, row.id) {
             Ok(true) => reaped.push(row.id.to_string()),

--- a/src/cli/automations.rs
+++ b/src/cli/automations.rs
@@ -554,9 +554,11 @@ fn poll_local_pane_states(db: &Database) -> usize {
 }
 
 /// Let go of the agents of local sessions soft-deleted longer ago than the
-/// interface's undo window, when their window is still up. Returns the ids
-/// reaped. Only rows with a live window are touched, so a row reaped once
-/// costs nothing on every later tick.
+/// interface's undo window, when the row still owns its window. Returns the ids
+/// reaped. Only rows with a window of their *own* are touched, so a row reaped
+/// once costs nothing on every later tick — and a stale row is never reported as
+/// reaped on the strength of a live namesake's window, which is the same unsound
+/// name resolution the reap itself refuses.
 fn reap_overdue_soft_deletes(db: &Database) -> Vec<String> {
     let Ok(rows) = db.list_deleted_sessions() else {
         return Vec::new();
@@ -571,8 +573,9 @@ fn reap_overdue_soft_deletes(db: &Database) -> Vec<String> {
         {
             continue;
         }
-        match crate::agent::tmux::agent_window_alive(None, &row.name) {
-            Ok(true) => {}
+        let unclaimed = crate::session_ops::delete::name_unclaimed(db, &row.name);
+        match crate::agent::tmux::owned_agent_pane(&row.name, &row.backend_id, unclaimed) {
+            Ok(Some(_)) => {}
             _ => continue,
         }
         match crate::session_ops::reap_soft_deleted(db, row.id) {

--- a/src/session_ops/delete.rs
+++ b/src/session_ops/delete.rs
@@ -282,7 +282,12 @@ pub fn owned_agent_pane(db: &Database, row: &DeletedSessionInfo) -> Option<Strin
         pane_id: !claims
             .iter()
             .any(|(_, pane)| !pane.is_empty() && *pane == row.backend_id),
-        name: !claims.iter().any(|(name, _)| *name == row.name),
+        name: {
+            let own = crate::agent::tmux::agent_window_name(&row.name);
+            !claims
+                .iter()
+                .any(|(name, _)| crate::agent::tmux::agent_window_name(name) == own)
+        },
     };
     crate::agent::tmux::owned_agent_pane(&row.name, &row.backend_id, unclaimed)
         .ok()

--- a/src/session_ops/delete.rs
+++ b/src/session_ops/delete.rs
@@ -224,10 +224,25 @@ pub fn reap_soft_deleted(db: &Database, id: SessionId) -> Result<bool, String> {
         return Ok(false);
     }
 
-    if let Err(e) = crate::agent::tmux::kill_window(&row.name, &row.backend_id) {
+    // Strict: kill this row's window only while its own pane id still resolves
+    // to it. A reap must never fall back to the `tb-<name>` target — by the time
+    // the pane is unresolvable there is nothing of this row's left to kill, and
+    // the name matches whatever session is called that *now*. That is how
+    // deleting a frozen session came to kill its replacement 30-60s later, and
+    // why each delete-and-recreate made the next one die sooner.
+    match crate::agent::tmux::kill_window_strict(&row.name, &row.backend_id) {
+        Ok(true) => {}
         // The window may already be gone — the agent exited, or a previous reap
-        // got there first. Not worth failing a cleanup over.
-        tracing::debug!("kill_window({}) during reap: {e}", row.name);
+        // got there first. Logged rather than silent: an unresolvable pane is
+        // also the shape a misdirected kill used to take.
+        Ok(false) => tracing::debug!(
+            "reap of '{}': pane {:?} no longer resolves to its own window; \
+             leaving any same-named window alone",
+            row.name,
+            row.backend_id
+        ),
+        // Not worth failing a cleanup over.
+        Err(e) => tracing::debug!("kill_window_strict({}) during reap: {e}", row.name),
     }
 
     // Derived per-session artifacts, both rebuilt on restore.

--- a/src/session_ops/delete.rs
+++ b/src/session_ops/delete.rs
@@ -196,9 +196,11 @@ pub fn teardown_runtime_resources(
 ///
 /// Worktrees are deliberately untouched: they are what makes the undo lossless.
 ///
-/// Returns whether anything was reaped — `false` when the row came back (the
-/// user undid it) or was force-deleted (already torn down), both of which are
-/// ordinary races rather than failures.
+/// Returns whether the row was processed — `false` when it came back (the user
+/// undid it) or was force-deleted (already torn down), both of which are
+/// ordinary races rather than failures. It is not a claim that a window came
+/// down: a row that owns none (see [`owned_agent_pane`]) still releases its
+/// derived artifacts and reports `true`.
 pub fn reap_soft_deleted(db: &Database, id: SessionId) -> Result<bool, String> {
     let Some(row) = db
         .get_deleted_session_by_id(id)

--- a/src/session_ops/delete.rs
+++ b/src/session_ops/delete.rs
@@ -224,19 +224,21 @@ pub fn reap_soft_deleted(db: &Database, id: SessionId) -> Result<bool, String> {
         return Ok(false);
     }
 
-    // Strict: kill this row's window only while its own pane id still resolves
-    // to it. A reap must never fall back to the `tb-<name>` target — by the time
-    // the pane is unresolvable there is nothing of this row's left to kill, and
-    // the name matches whatever session is called that *now*. That is how
-    // deleting a frozen session came to kill its replacement 30-60s later, and
-    // why each delete-and-recreate made the next one die sooner.
-    match crate::agent::tmux::kill_window_strict(&row.name, &row.backend_id) {
+    // Strict: kill only the window this row still owns. A reap must not fall
+    // back to the `tb-<name>` target while a live session answers to the name —
+    // that is how deleting a frozen session came to kill its replacement 30-60s
+    // later, and why each delete-and-recreate made the next one die sooner.
+    match crate::agent::tmux::kill_window_strict(
+        &row.name,
+        &row.backend_id,
+        name_unclaimed(db, &row.name),
+    ) {
         Ok(true) => {}
         // The window may already be gone — the agent exited, or a previous reap
         // got there first. Logged rather than silent: an unresolvable pane is
         // also the shape a misdirected kill used to take.
         Ok(false) => tracing::debug!(
-            "reap of '{}': pane {:?} no longer resolves to its own window; \
+            "reap of '{}': pane {:?} owns no window it may kill; \
              leaving any same-named window alone",
             row.name,
             row.backend_id
@@ -255,6 +257,15 @@ pub fn reap_soft_deleted(db: &Database, id: SessionId) -> Result<bool, String> {
         }
     }
     Ok(true)
+}
+
+/// Whether no live session answers to `name`, so a `tb-<name>` window can only
+/// belong to the row being torn down — the assurance
+/// [`tmux::owned_agent_pane`](crate::agent::tmux::owned_agent_pane) needs before
+/// it will resolve a name. Conservatively `false` if the read fails: leaking a
+/// window costs a stale agent, killing the wrong one costs live work.
+pub fn name_unclaimed(db: &Database, name: &str) -> bool {
+    matches!(db.find_sessions_by_name(name), Ok(rows) if rows.is_empty())
 }
 
 /// Kill the session's window on the local tmux server, reaping the pane's child

--- a/src/session_ops/delete.rs
+++ b/src/session_ops/delete.rs
@@ -273,7 +273,23 @@ pub fn reap_soft_deleted(db: &Database, id: SessionId) -> Result<bool, String> {
 /// Conservatively owns nothing when the read fails: leaking a window costs a
 /// stale agent, killing the wrong one costs live work.
 pub fn owned_agent_pane(db: &Database, row: &DeletedSessionInfo) -> Option<String> {
-    let Ok(claims) = db.session_window_claims(row.id) else {
+    owned_agent_pane_for(db, row.id, &row.name, &row.backend_id)
+}
+
+/// [`owned_agent_pane`] for a window whose row is not a `DeletedSessionInfo`:
+/// the one a spawn leaked when its own upsert failed, which owns a name and a
+/// pane id but never became a row at all. Same decision, same reason — a
+/// teardown may only kill what nothing else answers to.
+///
+/// `session_id` is excluded from the claims, so a row that *is* this window's
+/// does not read as somebody else's claim on it.
+pub fn owned_agent_pane_for(
+    db: &Database,
+    session_id: SessionId,
+    name: &str,
+    backend_id: &str,
+) -> Option<String> {
+    let Ok(claims) = db.session_window_claims(session_id) else {
         return None;
     };
     let unclaimed = crate::agent::tmux::Unclaimed {
@@ -281,15 +297,15 @@ pub fn owned_agent_pane(db: &Database, row: &DeletedSessionInfo) -> Option<Strin
         // `owned_agent_pane` declines to resolve it regardless.
         pane_id: !claims
             .iter()
-            .any(|(_, pane)| !pane.is_empty() && *pane == row.backend_id),
+            .any(|(_, pane)| !pane.is_empty() && pane == backend_id),
         name: {
-            let own = crate::agent::tmux::agent_window_name(&row.name);
+            let own = crate::agent::tmux::agent_window_name(name);
             !claims
                 .iter()
-                .any(|(name, _)| crate::agent::tmux::agent_window_name(name) == own)
+                .any(|(claimed, _)| crate::agent::tmux::agent_window_name(claimed) == own)
         },
     };
-    crate::agent::tmux::owned_agent_pane(&row.name, &row.backend_id, unclaimed)
+    crate::agent::tmux::owned_agent_pane(name, backend_id, unclaimed)
         .ok()
         .flatten()
 }

--- a/src/session_ops/delete.rs
+++ b/src/session_ops/delete.rs
@@ -4,7 +4,7 @@
 //! running to observe the deletion.
 
 use crate::session::SessionId;
-use crate::storage::Database;
+use crate::storage::{Database, DeletedSessionInfo};
 
 /// Outcome of a force-delete, reported to callers for their JSON payload.
 #[derive(Debug, Clone, Default)]
@@ -224,27 +224,26 @@ pub fn reap_soft_deleted(db: &Database, id: SessionId) -> Result<bool, String> {
         return Ok(false);
     }
 
-    // Strict: kill only the window this row still owns. A reap must not fall
-    // back to the `tb-<name>` target while a live session answers to the name —
-    // that is how deleting a frozen session came to kill its replacement 30-60s
-    // later, and why each delete-and-recreate made the next one die sooner.
-    match crate::agent::tmux::kill_window_strict(
-        &row.name,
-        &row.backend_id,
-        name_unclaimed(db, &row.name),
-    ) {
-        Ok(true) => {}
+    // Strict: kill only the window this row still owns. A reap must not resolve
+    // a pane id or a `tb-<name>` target another row answers to — that is how
+    // deleting a frozen session came to kill its replacement 30-60s later, and
+    // why each delete-and-recreate made the next one die sooner.
+    match owned_agent_pane(db, &row) {
+        // Not worth failing a cleanup over if the window went away underneath.
+        Some(target) => {
+            if let Err(e) = crate::agent::tmux::kill_window_at(&target) {
+                tracing::debug!("kill_window_at({target}) during reap: {e}");
+            }
+        }
         // The window may already be gone — the agent exited, or a previous reap
-        // got there first. Logged rather than silent: an unresolvable pane is
-        // also the shape a misdirected kill used to take.
-        Ok(false) => tracing::debug!(
+        // got there first. Logged rather than silent: owning nothing is also
+        // the shape a misdirected kill used to take.
+        None => tracing::debug!(
             "reap of '{}': pane {:?} owns no window it may kill; \
              leaving any same-named window alone",
             row.name,
             row.backend_id
         ),
-        // Not worth failing a cleanup over.
-        Err(e) => tracing::debug!("kill_window_strict({}) during reap: {e}", row.name),
     }
 
     // Derived per-session artifacts, both rebuilt on restore.
@@ -259,13 +258,33 @@ pub fn reap_soft_deleted(db: &Database, id: SessionId) -> Result<bool, String> {
     Ok(true)
 }
 
-/// Whether no live session answers to `name`, so a `tb-<name>` window can only
-/// belong to the row being torn down — the assurance
-/// [`tmux::owned_agent_pane`](crate::agent::tmux::owned_agent_pane) needs before
-/// it will resolve a name. Conservatively `false` if the read fails: leaking a
-/// window costs a stale agent, killing the wrong one costs live work.
-pub fn name_unclaimed(db: &Database, name: &str) -> bool {
-    matches!(db.find_sessions_by_name(name), Ok(rows) if rows.is_empty())
+/// The window a soft-deleted row still owns, if any — the sole target its reap
+/// may kill, and the answer to whether it has anything left to release.
+///
+/// The one place ownership is decided, so the reap and the headless sweep that
+/// gates on it cannot drift apart. It is decided here rather than in
+/// [`tmux::owned_agent_pane`](crate::agent::tmux::owned_agent_pane) because
+/// only a `Database` can settle it: a remembered pane id and a name are both
+/// this row's only while no other row answers to them — see
+/// [`session_window_claims`](crate::storage::Database::session_window_claims).
+///
+/// Conservatively owns nothing when the read fails: leaking a window costs a
+/// stale agent, killing the wrong one costs live work.
+pub fn owned_agent_pane(db: &Database, row: &DeletedSessionInfo) -> Option<String> {
+    let Ok(claims) = db.session_window_claims(row.id) else {
+        return None;
+    };
+    let unclaimed = crate::agent::tmux::Unclaimed {
+        // An empty id is claimed by nobody — psmux rows all carry one, and
+        // `owned_agent_pane` declines to resolve it regardless.
+        pane_id: !claims
+            .iter()
+            .any(|(_, pane)| !pane.is_empty() && *pane == row.backend_id),
+        name: !claims.iter().any(|(name, _)| *name == row.name),
+    };
+    crate::agent::tmux::owned_agent_pane(&row.name, &row.backend_id, unclaimed)
+        .ok()
+        .flatten()
 }
 
 /// Kill the session's window on the local tmux server, reaping the pane's child

--- a/src/session_ops/spawn.rs
+++ b/src/session_ops/spawn.rs
@@ -406,15 +406,43 @@ pub fn spawn_session_headless_with_progress(
              tearing down the orphaned window: {e}",
             req.name
         );
+        // Strict, for the same reason the reap is: this tears down a window
+        // that has no row, so it must kill only the window it just spawned.
+        // `kill_window`'s fallback to the `tb-<name>` target would resolve to
+        // whatever session already answers to that name — names are not unique,
+        // and the pane id is unusable exactly where it matters (psmux records
+        // none). Losing the window we leaked is the cheap failure; killing a
+        // live session's is not.
+        // Ownership-gated, for the same reason the reap is: this tears down a
+        // window that never became a row, so it must kill only the one it just
+        // spawned. `kill_window`'s resolution would reach the `tb-<name>`
+        // window when the pane id is unusable — and it is unusable exactly
+        // where it matters, since psmux records none — which on a name two
+        // sessions share destroys a live one. Leaking the window we already
+        // leaked is the cheap failure; killing someone else's is not.
         let cleanup = match host.as_ref() {
-            Some(h) => crate::agent::tmux::kill_pane_remote(h, &backend_id),
-            None => crate::agent::tmux::kill_window(&req.name, &backend_id),
+            Some(h) => crate::agent::tmux::kill_pane_remote(h, &backend_id).map(|()| true),
+            None => {
+                match super::delete::owned_agent_pane_for(db, session_id, &req.name, &backend_id) {
+                    Some(target) => crate::agent::tmux::kill_window_at(&target).map(|()| true),
+                    None => Ok(false),
+                }
+            }
         };
-        if let Err(kill_err) = cleanup {
-            tracing::error!(
+        match cleanup {
+            Ok(true) => {}
+            // Nothing this spawn can prove is its own. The window leaks rather
+            // than taking a live session's down with it.
+            Ok(false) => tracing::error!(
+                "orphaned window for '{}' (pane {:?}) is not provably its own; \
+                 leaving any same-named window alone",
+                req.name,
+                backend_id
+            ),
+            Err(kill_err) => tracing::error!(
                 "failed to tear down orphaned window for '{}': {kill_err}",
                 req.name
-            );
+            ),
         }
         return Err(format!("Failed to persist session: {e}"));
     }

--- a/src/session_ops/spawn.rs
+++ b/src/session_ops/spawn.rs
@@ -406,13 +406,6 @@ pub fn spawn_session_headless_with_progress(
              tearing down the orphaned window: {e}",
             req.name
         );
-        // Strict, for the same reason the reap is: this tears down a window
-        // that has no row, so it must kill only the window it just spawned.
-        // `kill_window`'s fallback to the `tb-<name>` target would resolve to
-        // whatever session already answers to that name — names are not unique,
-        // and the pane id is unusable exactly where it matters (psmux records
-        // none). Losing the window we leaked is the cheap failure; killing a
-        // live session's is not.
         // Ownership-gated, for the same reason the reap is: this tears down a
         // window that never became a row, so it must kill only the one it just
         // spawned. `kill_window`'s resolution would reach the `tb-<name>`

--- a/src/storage/sessions.rs
+++ b/src/storage/sessions.rs
@@ -35,8 +35,10 @@ pub struct DeletedSessionInfo {
     /// a remote session re-spawns against its own host, not the local default.
     pub backend_type: String,
     /// The pane id (`%N`) the session held when it was deleted — what the reap
-    /// kills, so a live session sharing the name is never the one torn down.
-    /// Empty for rows persisted before local spawns recorded an id.
+    /// kills once [`session_window_claims`](Database::session_window_claims)
+    /// confirms no other row answers to it, so a live session sharing the name
+    /// is never the one torn down. Empty for rows persisted before local spawns
+    /// recorded an id.
     pub backend_id: String,
     pub deleted_at: u64,
     /// Whether this row was hard-deleted (tmux window + worktrees torn down). A
@@ -447,6 +449,30 @@ impl Database {
     /// them and lets the caller refuse.
     pub fn find_sessions_by_name(&self, name: &str) -> rusqlite::Result<Vec<SharedSession>> {
         self.query_sessions("s.deleted_at IS NULL AND s.name = ?1", params![name])
+    }
+
+    /// The `(name, backend_id)` of every session other than `exclude` that
+    /// could still own a live agent window — active rows *and* soft-deleted
+    /// rows, which keep their agent until the reaper lets them go.
+    ///
+    /// What a teardown resolves its target against: neither a stored pane id
+    /// nor a `tb-<name>` window proves ownership while another row answers to
+    /// it — names are not unique, and tmux restarts its pane-id counter, so a
+    /// row's remembered `%N` can be another window's pane after a reboot.
+    /// Force-deleted rows are excluded: their window went down with them, and
+    /// counting one would block a namesake's teardown forever (the row is
+    /// kept indefinitely, see schema v37).
+    pub fn session_window_claims(
+        &self,
+        exclude: SessionId,
+    ) -> rusqlite::Result<Vec<(String, String)>> {
+        let mut stmt = self.conn.prepare_cached(
+            "SELECT name, backend_id FROM sessions WHERE force_deleted = 0 AND id != ?1",
+        )?;
+        let rows = stmt.query_map(params![exclude.to_string()], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?;
+        rows.collect()
     }
 
     /// Active sessions whose id **starts with** `prefix`, for addressing a

--- a/src/storage/sessions.rs
+++ b/src/storage/sessions.rs
@@ -452,8 +452,9 @@ impl Database {
     }
 
     /// The `(name, backend_id)` of every session other than `exclude` that
-    /// could still own a live agent window — active rows *and* soft-deleted
-    /// rows, which keep their agent until the reaper lets them go.
+    /// could still own a live agent window **on the local tmux server** —
+    /// active rows *and* soft-deleted rows, which keep their agent until the
+    /// reaper lets them go.
     ///
     /// What a teardown resolves its target against: neither a stored pane id
     /// nor a `tb-<name>` window proves ownership while another row answers to
@@ -461,7 +462,12 @@ impl Database {
     /// row's remembered `%N` can be another window's pane after a reboot.
     /// Force-deleted rows are excluded: their window went down with them, and
     /// counting one would block a namesake's teardown forever (the row is
-    /// kept indefinitely, see schema v37).
+    /// kept indefinitely, see schema v37). Remote (`ssh:` / `wsl:`) rows are
+    /// excluded for the mirror reason: their window is on another tmux server,
+    /// so it can never be what a local teardown resolves, and a name or a `%N`
+    /// it happens to share with a local row is a collision between two
+    /// independent namespaces rather than a claim. Both callers of the
+    /// ownership test already refuse to touch a remote row.
     ///
     /// The name returned is the **raw** session name. A caller comparing it
     /// against a `tb-<name>` target has to sanitize it first — two distinct
@@ -471,12 +477,23 @@ impl Database {
         exclude: SessionId,
     ) -> rusqlite::Result<Vec<(String, String)>> {
         let mut stmt = self.conn.prepare_cached(
-            "SELECT name, backend_id FROM sessions WHERE force_deleted = 0 AND id != ?1",
+            "SELECT name, backend_id, backend_type FROM sessions \
+             WHERE force_deleted = 0 AND id != ?1",
         )?;
         let rows = stmt.query_map(params![exclude.to_string()], |row| {
-            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+            ))
         })?;
-        rows.collect()
+        rows.filter_map(|row| match row {
+            Ok((name, pane, backend_type)) => {
+                (!crate::session::is_remote_backend(&backend_type)).then_some(Ok((name, pane)))
+            }
+            Err(e) => Some(Err(e)),
+        })
+        .collect()
     }
 
     /// Active sessions whose id **starts with** `prefix`, for addressing a
@@ -966,11 +983,38 @@ mod tests {
         );
         assert!(
             !names.contains(&"forced-namesake"),
-            "a force-deleted row's window is gone; counting it would deadlock              every namesake's teardown: {names:?}"
+            "a force-deleted row's window is gone; counting it would deadlock \
+             every namesake's teardown: {names:?}"
         );
         assert!(
             !names.contains(&"fleet"),
             "the excluded row must not claim against itself: {names:?}"
+        );
+    }
+
+    /// A remote row's window is on its host's own tmux server, so it can
+    /// neither be what a local teardown resolves nor a claim against one. Both
+    /// callers of the ownership test skip remote rows outright, so counting one
+    /// here would only deny a local row the window it does own — a name and a
+    /// `%N` are independent counters per server, and low ids collide routinely.
+    #[test]
+    fn window_claims_ignore_remote_rows_that_cannot_own_a_local_window() {
+        let db = Database::open_in_memory().unwrap();
+        let subject = make_session("fleet");
+        let mut ssh = make_session("fleet");
+        ssh.backend_type = "ssh:builder".into();
+        ssh.backend_id = subject.backend_id.clone();
+        let mut wsl = make_session("fleet");
+        wsl.backend_type = "wsl:Ubuntu".into();
+        wsl.backend_id = subject.backend_id.clone();
+        for session in [&subject, &ssh, &wsl] {
+            db.upsert_session(session).unwrap();
+        }
+
+        let claims = db.session_window_claims(subject.id).unwrap();
+        assert!(
+            claims.is_empty(),
+            "a remote namesake sharing the pane id claims nothing locally: {claims:?}"
         );
     }
 

--- a/src/storage/sessions.rs
+++ b/src/storage/sessions.rs
@@ -462,6 +462,10 @@ impl Database {
     /// Force-deleted rows are excluded: their window went down with them, and
     /// counting one would block a namesake's teardown forever (the row is
     /// kept indefinitely, see schema v37).
+    ///
+    /// The name returned is the **raw** session name. A caller comparing it
+    /// against a `tb-<name>` target has to sanitize it first — two distinct
+    /// names collapse onto one window name.
     pub fn session_window_claims(
         &self,
         exclude: SessionId,
@@ -928,6 +932,45 @@ mod tests {
         assert!(
             !bases.contains_key(&without.id),
             "a session with no base must be absent, not empty: {bases:?}"
+        );
+    }
+
+    /// The two exclusions the teardown ownership rule leans on. A soft-deleted
+    /// namesake still claims its window — it keeps its agent until the reaper
+    /// lets it go — while a force-deleted one went down with its window, and
+    /// counting one would block every namesake's teardown forever, since the
+    /// row is never removed (schema v37).
+    #[test]
+    fn window_claims_count_soft_deleted_rows_but_not_force_deleted_ones() {
+        let db = Database::open_in_memory().unwrap();
+        let subject = make_session("fleet");
+        let active = make_session("active-namesake");
+        let soft = make_session("soft-namesake");
+        let forced = make_session("forced-namesake");
+        for session in [&subject, &active, &soft, &forced] {
+            db.upsert_session(session).unwrap();
+        }
+        db.soft_delete_session(soft.id).unwrap();
+        db.soft_delete_session(forced.id).unwrap();
+        db.mark_session_force_deleted(forced.id).unwrap();
+
+        let claims = db.session_window_claims(subject.id).unwrap();
+        let names: Vec<&str> = claims.iter().map(|(name, _)| name.as_str()).collect();
+        assert!(
+            names.contains(&"active-namesake"),
+            "an active row claims its window: {names:?}"
+        );
+        assert!(
+            names.contains(&"soft-namesake"),
+            "a soft-deleted row still owns its agent, so it claims too: {names:?}"
+        );
+        assert!(
+            !names.contains(&"forced-namesake"),
+            "a force-deleted row's window is gone; counting it would deadlock              every namesake's teardown: {names:?}"
+        );
+        assert!(
+            !names.contains(&"fleet"),
+            "the excluded row must not claim against itself: {names:?}"
         );
     }
 

--- a/tests/reap_e2e.rs
+++ b/tests/reap_e2e.rs
@@ -444,3 +444,56 @@ fn reaping_spares_a_soft_deleted_namesake_still_inside_its_undo_window() {
         undoable.backend_id
     );
 }
+
+/// The name a reap resolves is not the session's name but the *window's*, and
+/// `sanitize_window_name` maps every character outside `[A-Za-z0-9_-]` to `_`.
+/// So two legal, distinct session names — 'fleet 1' and 'fleet_1' — share one
+/// `tb-fleet_1`, and an ownership test settled on the raw names would call the
+/// stale row's name unclaimed and hand it its namesake's live window.
+#[test]
+fn reaping_spares_a_live_window_whose_name_only_collides_once_sanitized() {
+    if !have_tmux() {
+        eprintln!("skipping: tmux is not installed");
+        return;
+    }
+
+    let repo = repo();
+    let db = thurbox::storage::Database::open_in_memory().expect("db");
+    let _tmux_dir = isolate_tmux();
+    let home = tempfile::tempdir().expect("tempdir");
+    isolate_paths(home.path());
+
+    let Some(stale) = spawn(&db, repo.path(), "fleet 1") else {
+        return;
+    };
+    thurbox::session_ops::delete_session_headless(&db, stale.session_id, false).expect("delete");
+    // Its agent exits, so the row's pane id resolves to nothing and only the
+    // name is left to go on.
+    let _ = tmux(&["kill-pane", "-t", &stale.backend_id]);
+    assert!(
+        !pane_alive(&stale.backend_id),
+        "the stale row's pane should be gone"
+    );
+
+    // A different name, the same window: `tb-fleet_1`.
+    let Some(live) = spawn(&db, repo.path(), "fleet_1") else {
+        return;
+    };
+    assert_ne!(stale.session_id, live.session_id);
+    assert!(
+        pane_alive(&live.backend_id),
+        "the replacement should be running"
+    );
+
+    let reaped = thurbox::session_ops::reap_soft_deleted(&db, stale.session_id).expect("reap");
+    let survived = pane_alive(&live.backend_id);
+    let windows_after = windows();
+    cleanup();
+
+    assert!(
+        survived,
+        "reaping 'fleet 1' killed the live 'fleet_1' pane {} through the window \
+         name the two share (reaped={reaped}); windows left: {windows_after:?}",
+        live.backend_id
+    );
+}

--- a/tests/reap_e2e.rs
+++ b/tests/reap_e2e.rs
@@ -1,0 +1,270 @@
+//! Reaping a soft-deleted session must not kill a live session's window.
+//!
+//! The reaper resolves its victim through `agent_target`, which falls back from
+//! a stale pane id to the `tb-<name>` window name. That fallback is right for a
+//! *live* session — you still want to reach its window after a tmux restart
+//! renumbered the panes — but for a reap it is unsound: if the deleted row's
+//! pane id no longer resolves, the row has no window of its own left, so the
+//! name can only ever match somebody else's.
+//!
+//! The sequence below is the one that bites in practice. A session freezes, the
+//! operator deletes the row and recreates it, and 30-60s later the reaper for
+//! the *deleted* row closes its undo window and kills the *replacement*. Each
+//! delete-and-recreate arms one more of these, so the session dies faster every
+//! time.
+//!
+//! Scoped to a throwaway socket and temporary directories, and skipped when
+//! tmux is absent, like the other end-to-end tests here.
+
+use std::path::Path;
+use std::process::Command;
+
+/// A throwaway tmux socket, so this never touches the real one.
+const SOCKET: &str = "thurbox-reap-e2e";
+
+fn have_tmux() -> bool {
+    Command::new("tmux")
+        .arg("-V")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn tmux(args: &[&str]) -> std::process::Output {
+    Command::new("tmux")
+        .args(["-L", SOCKET])
+        .args(args)
+        .output()
+        .expect("run tmux")
+}
+
+/// Every window currently on the throwaway server.
+fn windows() -> Vec<String> {
+    let out = tmux(&["list-windows", "-a", "-F", "#{window_name}"]);
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .map(str::to_string)
+        .collect()
+}
+
+/// Whether `pane_id` (`%N`) still exists.
+fn pane_alive(pane_id: &str) -> bool {
+    let out = tmux(&["list-panes", "-a", "-F", "#{pane_id}"]);
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .any(|l| l.trim() == pane_id)
+}
+
+/// The `GIT_*` location variables git exports to hook processes — the list
+/// `git::GIT_LOCATION_ENV` scrubs, which is crate-private. A suite running
+/// under this repository's own pre-commit hook inherits a `GIT_DIR` pointing
+/// at the real repository, so every git process here drops them.
+const GIT_LOCATION_ENV: [&str; 8] = [
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_COMMON_DIR",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_PREFIX",
+    "GIT_NAMESPACE",
+];
+
+fn git(dir: &Path, args: &[&str]) {
+    let mut cmd = Command::new("git");
+    cmd.args(args).current_dir(dir);
+    for var in GIT_LOCATION_ENV {
+        cmd.env_remove(var);
+    }
+    let ok = cmd.output().expect("run git").status.success();
+    assert!(ok, "git {args:?} failed");
+}
+
+/// A repository with one commit, which is the minimum a spawn needs.
+fn repo() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    git(dir.path(), &["init", "-q", "-b", "main"]);
+    git(dir.path(), &["config", "user.email", "t@example.com"]);
+    git(dir.path(), &["config", "user.name", "thurbox-test"]);
+    // Signing would make this depend on a key in the user's agent; the repo is
+    // throwaway, so it is disabled rather than required of the machine.
+    git(dir.path(), &["config", "commit.gpgsign", "false"]);
+    std::fs::write(dir.path().join("README.md"), "# probe\n").expect("write");
+    git(dir.path(), &["add", "."]);
+    git(dir.path(), &["commit", "-qm", "init"]);
+    dir
+}
+
+/// Point the spawn at a private socket in a private directory, so it can never
+/// see — or race — a real server. nextest runs one process per test, so env
+/// mutation is safe. Returns the tempdir so it outlives the test.
+fn isolate_tmux() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::env::set_var("TMUX_TMPDIR", dir.path());
+    std::env::set_var(thurbox::agent::tmux::SOCKET_OVERRIDE_ENV, SOCKET);
+    dir
+}
+
+/// A shell rather than a real agent: the reap path is what is under test, and
+/// launching a coding agent would want credentials and a network.
+fn isolate_paths(home: &Path) {
+    thurbox::paths::set_test_dir(home);
+    let config = thurbox::paths::config_file()
+        .expect("config path")
+        .parent()
+        .expect("config dir")
+        .to_path_buf();
+    std::fs::create_dir_all(&config).expect("mkdir");
+    std::fs::write(
+        config.join("agents.toml"),
+        "default = \"shell\"\n\n[[agents]]\nname = \"shell\"\ncommand = \"sh\"\nargs = []\n",
+    )
+    .expect("write agents.toml");
+}
+
+fn cleanup() {
+    let _ = tmux(&["kill-server"]);
+}
+
+fn spawn(
+    db: &thurbox::storage::Database,
+    repo: &Path,
+    name: &str,
+) -> Option<thurbox::session_ops::SpawnResult> {
+    let result = thurbox::session_ops::spawn_session_headless(
+        db,
+        thurbox::session_ops::SpawnRequest {
+            name: name.into(),
+            repo_path: repo.to_path_buf(),
+            // In place: a worktree is irrelevant to which window a reap targets.
+            worktree_branch: None,
+            base_branch: None,
+            agent: Some("shell".into()),
+            agent_session_id: None,
+            host: None,
+            parent_session_id: None,
+            task_id: None,
+            extra_repos: Vec::new(),
+            fork_session_id: None,
+            inherit_worktrees: Vec::new(),
+        },
+    );
+    match result {
+        Ok(spawned) => Some(spawned),
+        Err(e) => {
+            cleanup();
+            // A tmux server that will not start is an environment problem.
+            assert!(e.contains("tmux"), "spawn failed: {e}");
+            eprintln!("skipping: tmux would not spawn a window: {e}");
+            None
+        }
+    }
+}
+
+#[test]
+fn reaping_a_stale_row_spares_the_live_window_of_the_same_name() {
+    if !have_tmux() {
+        eprintln!("skipping: tmux is not installed");
+        return;
+    }
+
+    let repo = repo();
+    let db = thurbox::storage::Database::open_in_memory().expect("db");
+    let _tmux_dir = isolate_tmux();
+    let home = tempfile::tempdir().expect("tempdir");
+    isolate_paths(home.path());
+
+    // 1. The session that will go stale.
+    let Some(stale) = spawn(&db, repo.path(), "fleet") else {
+        return;
+    };
+
+    // 2. Soft-deleted: the row is kept for undo, the window is left alone.
+    let report = thurbox::session_ops::delete_session_headless(&db, stale.session_id, false)
+        .expect("delete");
+    assert!(
+        !report.killed_window,
+        "a soft delete must leave the window for the undo window"
+    );
+
+    // 3. Its agent exits and the window goes away — the state every frozen
+    //    session ends up in, and what makes the row's pane id unresolvable.
+    let _ = tmux(&["kill-pane", "-t", &stale.backend_id]);
+    assert!(
+        !pane_alive(&stale.backend_id),
+        "the stale row's pane should be gone"
+    );
+
+    // 4. The operator recreates the session under the same name.
+    let Some(live) = spawn(&db, repo.path(), "fleet") else {
+        return;
+    };
+    assert!(
+        pane_alive(&live.backend_id),
+        "the replacement should be running"
+    );
+
+    // 5. The undo window closes and the reaper collects the stale row.
+    let reaped = thurbox::session_ops::reap_soft_deleted(&db, stale.session_id).expect("reap");
+
+    // The reap has nothing of its own left to kill, so it must not have reached
+    // for the name — the replacement is the only `tb-fleet` there is.
+    let survived = pane_alive(&live.backend_id);
+    let windows_after = windows();
+    cleanup();
+
+    assert!(
+        survived,
+        "reaping the stale 'fleet' row killed the live one's pane {} \
+         (reaped={reaped}); windows left: {windows_after:?}",
+        live.backend_id
+    );
+    assert!(
+        db.get_session_by_id(live.session_id)
+            .expect("query")
+            .is_some(),
+        "the live row must survive its namesake's reap"
+    );
+}
+
+/// The other half of the contract. Sparing a same-named window must not have
+/// been bought by making the reap a no-op: while the row's *own* pane still
+/// resolves, reaping it has to take the window down, or a soft-deleted session
+/// keeps its agent running and writing forever — the thing the reaper exists
+/// to prevent.
+#[test]
+fn reaping_still_kills_the_row_its_own_window() {
+    if !have_tmux() {
+        eprintln!("skipping: tmux is not installed");
+        return;
+    }
+
+    let repo = repo();
+    let db = thurbox::storage::Database::open_in_memory().expect("db");
+    let _tmux_dir = isolate_tmux();
+    let home = tempfile::tempdir().expect("tempdir");
+    isolate_paths(home.path());
+
+    let Some(session) = spawn(&db, repo.path(), "solo") else {
+        return;
+    };
+    assert!(
+        pane_alive(&session.backend_id),
+        "the spawn should be running"
+    );
+
+    thurbox::session_ops::delete_session_headless(&db, session.session_id, false).expect("delete");
+
+    // The undo window closes with the pane still there: this row owns it, so it
+    // is exactly what the reap should collect.
+    let reaped = thurbox::session_ops::reap_soft_deleted(&db, session.session_id).expect("reap");
+    let still_there = pane_alive(&session.backend_id);
+    cleanup();
+
+    assert!(reaped, "a soft-deleted row with a live pane must be reaped");
+    assert!(
+        !still_there,
+        "the reap must kill the row's own window (pane {} survived)",
+        session.backend_id
+    );
+}

--- a/tests/reap_e2e.rs
+++ b/tests/reap_e2e.rs
@@ -540,7 +540,10 @@ fn a_spawns_orphan_cleanup_owns_nothing_a_live_namesake_claims() {
          nothing (resolved {owned:?}, live pane {})",
         live.backend_id
     );
-    assert!(survived, "the ownership test must not touch the live window");
+    assert!(
+        survived,
+        "the ownership test must not touch the live window"
+    );
 }
 
 /// And the strictness is not a blanket refusal: with nothing else answering to

--- a/tests/reap_e2e.rs
+++ b/tests/reap_e2e.rs
@@ -309,11 +309,138 @@ fn reaping_collects_its_window_when_the_pane_id_resolves_to_nothing() {
     let windows_after = windows();
     cleanup();
 
-    assert!(reaped, "a soft-deleted row with a live window must be reaped");
+    assert!(
+        reaped,
+        "a soft-deleted row with a live window must be reaped"
+    );
     assert!(
         !still_there,
         "the reap must collect the row's own window with no pane id to go on \
          (pane {} survived); windows left: {windows_after:?}",
         session.backend_id
+    );
+}
+
+/// A remembered pane id is not proof of ownership either. tmux restarts its
+/// pane-id counter with the server, so after a reboot the id a soft-deleted row
+/// still remembers can be the pane of a *replacement* window — and the window
+/// name, the check that normally catches a reused id, confirms nothing when the
+/// two sessions share a name. A test cannot make a server restart renumber a
+/// pane onto a chosen `%N`, so the row state a restart leaves behind is written
+/// through the storage API instead: a soft-deleted row remembering the pane id
+/// its live namesake now holds.
+#[test]
+fn reaping_spares_a_namesakes_pane_the_stale_row_remembers() {
+    if !have_tmux() {
+        eprintln!("skipping: tmux is not installed");
+        return;
+    }
+
+    let repo = repo();
+    let db = thurbox::storage::Database::open_in_memory().expect("db");
+    let _tmux_dir = isolate_tmux();
+    let home = tempfile::tempdir().expect("tempdir");
+    isolate_paths(home.path());
+
+    let Some(stale) = spawn(&db, repo.path(), "fleet") else {
+        return;
+    };
+    thurbox::session_ops::delete_session_headless(&db, stale.session_id, false).expect("delete");
+    let _ = tmux(&["kill-pane", "-t", &stale.backend_id]);
+
+    let Some(live) = spawn(&db, repo.path(), "fleet") else {
+        return;
+    };
+
+    // Post-restart: the stale row's remembered pane id is now the live
+    // namesake's pane, in a window that carries the very name it expects.
+    // `set_backend_id` only touches live rows, so the row is revived for the
+    // write and deleted again — the persisted state, not the route to it, is
+    // what the reap sees.
+    db.restore_session(stale.session_id).expect("revive");
+    assert!(
+        db.set_backend_id(stale.session_id, &live.backend_id)
+            .expect("renumber the stale row's pane"),
+        "the stale row should be there to update"
+    );
+    db.soft_delete_session(stale.session_id)
+        .expect("soft-delete again");
+
+    let reaped = thurbox::session_ops::reap_soft_deleted(&db, stale.session_id).expect("reap");
+    let survived = pane_alive(&live.backend_id);
+    let windows_after = windows();
+    cleanup();
+
+    assert!(
+        survived,
+        "reaping the stale 'fleet' row killed the live one's pane {} through a \
+         renumbered id (reaped={reaped}); windows left: {windows_after:?}",
+        live.backend_id
+    );
+}
+
+/// A name is claimed by soft-deleted rows too, not just live ones. A row keeps
+/// its agent until the reaper lets it go — that is what makes an undo restore a
+/// session rather than respawn it — so while one soft-deleted 'fleet' is inside
+/// its undo window, an *older* 'fleet' row's reap must not resolve `tb-fleet`
+/// and destroy the work the undo would have brought back. The older row's reap
+/// still has to collect its own window, which the second half asserts.
+#[test]
+fn reaping_spares_a_soft_deleted_namesake_still_inside_its_undo_window() {
+    if !have_tmux() {
+        eprintln!("skipping: tmux is not installed");
+        return;
+    }
+
+    let repo = repo();
+    let db = thurbox::storage::Database::open_in_memory().expect("db");
+    let _tmux_dir = isolate_tmux();
+    let home = tempfile::tempdir().expect("tempdir");
+    isolate_paths(home.path());
+
+    let Some(stale) = spawn(&db, repo.path(), "fleet") else {
+        return;
+    };
+    thurbox::session_ops::delete_session_headless(&db, stale.session_id, false).expect("delete");
+    let _ = tmux(&["kill-pane", "-t", &stale.backend_id]);
+
+    // The undoable one: soft-deleted, its agent and window still up, so no
+    // *active* session answers to 'fleet' any more.
+    let Some(undoable) = spawn(&db, repo.path(), "fleet") else {
+        return;
+    };
+    thurbox::session_ops::delete_session_headless(&db, undoable.session_id, false).expect("delete");
+    assert!(
+        pane_alive(&undoable.backend_id),
+        "a soft delete must leave the window for the undo window"
+    );
+
+    let stale_reaped =
+        thurbox::session_ops::reap_soft_deleted(&db, stale.session_id).expect("reap stale");
+    let survived = pane_alive(&undoable.backend_id);
+
+    // And the strictness is not a leak: the undoable row's own reap, when its
+    // turn comes, takes its window down.
+    let own_reaped =
+        thurbox::session_ops::reap_soft_deleted(&db, undoable.session_id).expect("reap own");
+    let released = !pane_alive(&undoable.backend_id);
+    let windows_after = windows();
+    cleanup();
+
+    assert!(
+        survived,
+        "reaping the stale 'fleet' row killed the pane {} of a namesake still \
+         inside its undo window (reaped={stale_reaped}); windows left: \
+         {windows_after:?}",
+        undoable.backend_id
+    );
+    assert!(
+        own_reaped,
+        "a soft-deleted row with a live pane must be reaped"
+    );
+    assert!(
+        released,
+        "the undoable row's own reap must collect its window (pane {} survived)",
+        undoable.backend_id
     );
 }

--- a/tests/reap_e2e.rs
+++ b/tests/reap_e2e.rs
@@ -1,11 +1,11 @@
 //! Reaping a soft-deleted session must not kill a live session's window.
 //!
-//! The reaper resolves its victim through `agent_target`, which falls back from
-//! a stale pane id to the `tb-<name>` window name. That fallback is right for a
-//! *live* session — you still want to reach its window after a tmux restart
-//! renumbered the panes — but for a reap it is unsound: if the deleted row's
-//! pane id no longer resolves, the row has no window of its own left, so the
-//! name can only ever match somebody else's.
+//! The reaper resolved its victim through `agent_target`, which falls back from
+//! a stale pane id to the `tb-<name>` window name unconditionally. That fallback
+//! is right for a *live* session — you still want to reach its window after a
+//! tmux restart renumbered the panes — but a reap must first know that nobody
+//! else answers to the name: once the deleted row's pane no longer resolves, a
+//! `tb-<name>` window is its own only while no live session shares the name.
 //!
 //! The sequence below is the one that bites in practice. A session freezes, the
 //! operator deletes the row and recreates it, and 30-60s later the reaper for
@@ -140,6 +140,10 @@ fn spawn(
             worktree_branch: None,
             base_branch: None,
             agent: Some("shell".into()),
+            command: None,
+            args: Vec::new(),
+            env: Default::default(),
+            resume_session_id: None,
             agent_session_id: None,
             host: None,
             parent_session_id: None,
@@ -265,6 +269,51 @@ fn reaping_still_kills_the_row_its_own_window() {
     assert!(
         !still_there,
         "the reap must kill the row's own window (pane {} survived)",
+        session.backend_id
+    );
+}
+
+/// The pane id is not always there to be strict about. A row persisted before
+/// local spawns recorded one, a pane renumbered by a tmux server restart, and
+/// every session on psmux (where `spawn_window` records no id at all) all reach
+/// the reap with an id that resolves to nothing. Strictness must not turn those
+/// into a permanent no-op: while no live session answers to the name, the sole
+/// `tb-<name>` window can only be this row's, and leaving it up means the
+/// soft-deleted agent keeps running and writing forever.
+#[test]
+fn reaping_collects_its_window_when_the_pane_id_resolves_to_nothing() {
+    if !have_tmux() {
+        eprintln!("skipping: tmux is not installed");
+        return;
+    }
+
+    let repo = repo();
+    let db = thurbox::storage::Database::open_in_memory().expect("db");
+    let _tmux_dir = isolate_tmux();
+    let home = tempfile::tempdir().expect("tempdir");
+    isolate_paths(home.path());
+
+    let Some(session) = spawn(&db, repo.path(), "orphan") else {
+        return;
+    };
+    // The psmux shape: the window is up, the row remembers no pane for it.
+    assert!(
+        db.set_backend_id(session.session_id, "")
+            .expect("clear the pane id"),
+        "the spawned row should be there to update"
+    );
+    thurbox::session_ops::delete_session_headless(&db, session.session_id, false).expect("delete");
+
+    let reaped = thurbox::session_ops::reap_soft_deleted(&db, session.session_id).expect("reap");
+    let still_there = pane_alive(&session.backend_id);
+    let windows_after = windows();
+    cleanup();
+
+    assert!(reaped, "a soft-deleted row with a live window must be reaped");
+    assert!(
+        !still_there,
+        "the reap must collect the row's own window with no pane id to go on \
+         (pane {} survived); windows left: {windows_after:?}",
         session.backend_id
     );
 }

--- a/tests/reap_e2e.rs
+++ b/tests/reap_e2e.rs
@@ -498,3 +498,90 @@ fn reaping_spares_a_live_window_whose_name_only_collides_once_sanitized() {
         live.backend_id
     );
 }
+
+/// The decision the spawn's orphan cleanup delegates. When a spawn's DB upsert
+/// fails the tmux window is already up, and tearing it down through
+/// `kill_window` would reach `tb-<name>` whenever the pane id is unusable —
+/// always, on psmux. `owned_agent_pane_for` is that teardown's gate, reachable
+/// directly, so what the cleanup would do is asserted without having to make an
+/// upsert fail: a window whose name a live session claims is not provably the
+/// spawn's, so it leaks rather than taking the live one down.
+#[test]
+fn a_spawns_orphan_cleanup_owns_nothing_a_live_namesake_claims() {
+    if !have_tmux() {
+        eprintln!("skipping: tmux is not installed");
+        return;
+    }
+
+    let repo = repo();
+    let db = thurbox::storage::Database::open_in_memory().expect("db");
+    let _tmux_dir = isolate_tmux();
+    let home = tempfile::tempdir().expect("tempdir");
+    isolate_paths(home.path());
+
+    let Some(live) = spawn(&db, repo.path(), "fleet") else {
+        return;
+    };
+
+    // The failed spawn: a window named 'fleet' that never became a row, so no
+    // id of its own excludes anything, and psmux's shape — no pane id at all.
+    let owned = thurbox::session_ops::delete::owned_agent_pane_for(
+        &db,
+        thurbox::session::SessionId::default(),
+        "fleet",
+        "",
+    );
+    let survived = pane_alive(&live.backend_id);
+    cleanup();
+
+    assert_eq!(
+        owned, None,
+        "a live 'fleet' claims the window name, so the orphan cleanup owns \
+         nothing (resolved {owned:?}, live pane {})",
+        live.backend_id
+    );
+    assert!(survived, "the ownership test must not touch the live window");
+}
+
+/// And the strictness is not a blanket refusal: with nothing else answering to
+/// the name or the pane id, the orphan cleanup resolves the window it just
+/// leaked, so a failed spawn still cleans up after itself.
+#[test]
+fn a_spawns_orphan_cleanup_owns_the_window_nothing_else_answers_for() {
+    if !have_tmux() {
+        eprintln!("skipping: tmux is not installed");
+        return;
+    }
+
+    let repo = repo();
+    let db = thurbox::storage::Database::open_in_memory().expect("db");
+    let _tmux_dir = isolate_tmux();
+    let home = tempfile::tempdir().expect("tempdir");
+    isolate_paths(home.path());
+
+    let Some(session) = spawn(&db, repo.path(), "solo") else {
+        return;
+    };
+    // The upsert that never landed: the window is up with no row behind it.
+    // Force-deleting is how a row stops claiming its window, which is the state
+    // a failed upsert leaves the server in.
+    db.soft_delete_session(session.session_id).expect("delete");
+    db.mark_session_force_deleted(session.session_id)
+        .expect("force-delete");
+
+    let owned = thurbox::session_ops::delete::owned_agent_pane_for(
+        &db,
+        thurbox::session::SessionId::default(),
+        "solo",
+        &session.backend_id,
+    );
+    cleanup();
+
+    assert_eq!(
+        owned,
+        Some(session.backend_id.clone()),
+        "with no other claim on the name or the pane, the cleanup owns the \
+         window it leaked (pane {})",
+        session.backend_id
+    );
+}

--- a/tests/reap_e2e.rs
+++ b/tests/reap_e2e.rs
@@ -151,6 +151,7 @@ fn spawn(
             extra_repos: Vec::new(),
             fork_session_id: None,
             inherit_worktrees: Vec::new(),
+            existing_worktree: None,
         },
     );
     match result {


### PR DESCRIPTION
## Intent

Fix thurbox sessions freezing — the operator's fleet orchestrator session in particular, which was dying within 6-60 seconds of every revival, all day, for days. This branch already has an open draft PR, https://github.com/Thurbeen/thurbox/pull/1056, opened outside the gate at the operator's request; the gate run now needs to validate the branch and bring that PR up to date.

Root cause established by experiment, not inspection. A soft-deleted session row is reaped once its undo window closes; reap_soft_deleted resolved its victim through agent_target, which resolves whatever it can reach — the persisted pane id, else the tb-<name> window. Neither is proof of ownership. For a live session that is right, but for a teardown it is unsound: names are not unique, and a soft-deleted row keeps its name and its remembered pane id until it is reaped, so the teardown resolved to whatever session answers to that identity now. Deleting a frozen session and recreating it meant the reaper for the deleted row killed the replacement 30-60s later, and each delete-and-recreate armed one more pending reap. tmux made it silent — a same-named window matches exactly and kill-window exits 0.

Isolated causally with a throwaway session identical in agent and cwd, varying only the number of soft-deleted rows sharing its name: 0 rows survived 105+ seconds, 1 row died within 30. On the operator's machine 'fleet' had 18 such rows and nothing outside that shape had ever frozen. After disarming those rows the session stayed up 15+ minutes.

The operator asked for the failing test first. tests/reap_e2e.rs reproduces the production sequence end to end against real tmux on a throwaway socket — spawn 'fleet', soft-delete, kill its pane, respawn 'fleet', reap the stale row — and failed before the fix with the live pane destroyed and only the base window left. Six reap tests now cover the regression, the leak case, sanitized-name collisions, a namesake's pane the stale row remembers, a soft-deleted namesake still inside its undo window, and one asserting a reap still collects its own window so the fix cannot degenerate into a no-op.

The design that earlier gate rounds settled on, and why: owned_agent_pane(session_name, pane_id, Unclaimed) resolves only what a teardown can prove is its own, each half of the identity gated on the caller's assurance that no other row claims it. session_ops::delete::owned_agent_pane decides that from the Database, because only a Database can settle it. Gating purely on "does the pane id resolve" was the first version and was wrong: it made the reap a permanent no-op on Windows/psmux, where spawn_window records no pane id by design, leaking soft-deleted agents forever. Ownership is conservatively denied when the DB read fails — leaking a window costs a stale agent, killing the wrong one costs live work.

New in this run, and the reason for it: the same defect existed at a second call site, session_ops/spawn.rs. When a spawn's DB upsert fails, it tears down the tmux window it just created so the window is not orphaned; that teardown went through kill_window, which reaches the tb-<name> window whenever the pane id is unusable — which on psmux is always. On a name two sessions share, the cleanup destroyed a live session's window instead of the one it had just leaked. It now resolves through owned_agent_pane_for, which is owned_agent_pane for a window that never became a row, extracted so the two callers cannot drift apart. An unprovable claim logs and leaves the window alone.

That spawn change carries no new test of its own, deliberately: the upsert-failure path has no seam to drive it from an integration test (upsert_session cannot be made to fail through the public API), so a test claiming to cover it would be testing something else. The ownership gate it now shares with the reap is covered by tests/reap_e2e.rs. This is stated plainly rather than papered over — if the reviewer sees a way to drive that path, it is worth adding.

kill_window keeps its forgiving resolution because its live-session callers (restart.rs, force-delete) need it — reaching a session's window after a tmux restart renumbered the panes is exactly what it is for. The strictness is added alongside rather than replacing it, so the difference is explicit at each call site.

tests/reap_e2e.rs also gained `existing_worktree: None` in its SpawnRequest, a field main added under this branch.

Verification on this head: all 6 reap tests and all 11 create_e2e tests pass. They must be run serially or under nextest — threaded `cargo test` races them on a shared tmux socket, which is why two create_e2e tests fail under `cargo test` and pass under `--test-threads=1`; CI uses nextest, one process per test.

Run history, for context on why this branch has an unusual number of gate-fix commits: six earlier runs each died at a different infrastructure point — the review step's 30-minute agent cap, a GitHub token missing workflow scope, a transient DNS fault, a daemon shutdown, a corrupted intent, and 1Password commit signing being locked — and none on the change itself. Review, test, document and lint have all passed on the reap content in earlier runs; push, PR and CI were never reached, which is why the draft PR was opened by hand.

## What Changed

- Session teardowns no longer resolve their tmux target through `agent_target`, which reaches the persisted pane id or the `tb-<name>` window without proving either belongs to the row being torn down. A new `agent::tmux::owned_agent_pane` gates each half of that identity on an `Unclaimed` assurance from the caller, and `session_ops::delete::owned_agent_pane` settles it from the database via a new `Database::session_window_claims` (active *and* soft-deleted local rows, excluding force-deleted and remote ones). Ownership is denied when the read fails, so an unprovable claim logs and leaves the window standing. `kill_window` keeps its forgiving resolution for its live-session callers; `kill_window_at` runs the kill against an already-resolved target.
- Both teardown call sites now go through that gate: `reap_soft_deleted` (which previously killed whatever answered to the stale row's name or remembered pane id — how deleting and recreating a session under one name let the deleted row's reaper kill the replacement once the undo window closed) and the orphan cleanup in `session_ops/spawn.rs`, which tore down the window it just created after a failed DB upsert and could reach a live namesake's instead. The headless `reap_overdue_soft_deletes` sweep swaps its `agent_window_alive` check for the same ownership test, so a stale row is no longer re-reported as reaped on the strength of a namesake's live window.
- Added `tests/reap_e2e.rs`: 8 tests against a real tmux on a throwaway socket covering the regression, sanitized-name collisions, a namesake's remembered pane, a soft-deleted namesake inside its undo window, both spawn-cleanup ownership directions, and two asserting a reap still collects its own window. Unit tests cover the claims query's soft/force-deleted and remote exclusions plus the sweep's gate; the spawn path itself has no new test because `upsert_session` cannot be made to fail through the public API. CI's tmux comment and `docs/ARCHITECTURE.md`'s window-naming section document the rule.

## Risk Assessment

✅ Low: Every prior-round finding is genuinely fixed at this head, the ownership gate traces correctly through the concrete failing sequences (including the gate-ordering case that keeps the undoable row's own reap from becoming a no-op, and the remote-claim filter which I confirmed cannot drop a claim on a real local window), and the only issues left are two comment/doc accuracy slips; the one accepted behavior tradeoff — the headless sweep withholding metrics and workspace artifacts for rows that own no window — is now stated in the sweep's doc comment rather than remedied, which is the narrower option the earlier round offered.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 2 runs (1m14s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"a93bcc1b77e459214b563a9e793fcf576c678aaa","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ⚠️ `src/storage/sessions.rs:474` - `session_window_claims` selects every non-force-deleted row regardless of `backend_type` (`SELECT name, backend_id FROM sessions WHERE force_deleted = 0 AND id != ?1`), so a remote (`ssh:&lt;host&gt;` / `wsl:&lt;distro&gt;`) row claims a name and a pane id in the **local** tmux server&#39;s namespace, where it can own nothing. Both callers of the ownership test already draw that line — `reap_soft_deleted` returns early with &#34;its remote window is left running&#34; for `is_remote_backend(row.backend_type)` (src/session_ops/delete.rs:198), and `reap_overdue_soft_deletes` filters remote rows at src/cli/automations.rs:571 — so the claim set contradicts both of its own callers.

Concrete trace, the precise-pane-id path: an active session on host `wsl:Ubuntu` (row R, backend_type &#34;wsl:Ubuntu&#34;) happens to remember pane `%4` inside WSL&#39;s own tmux server. A local session &#39;solo&#39; (row L, backend_type &#34;local-tmux&#34;, pane `%4`, window `tb-solo`) is soft-deleted with its window and agent still up — exactly the state `reaping_still_kills_the_row_its_own_window` pins. Reap L -&gt; `session_window_claims(L)` returns R -&gt; `unclaimed.pane_id` = `!(any claim&#39;s pane == &#34;%4&#34;)` = **false** -&gt; the fast path is skipped -&gt; `unclaimed.name` is true (no namesake) -&gt; `agent_window_pane(None, &#34;solo&#34;)` resolves L&#39;s own live pane, so this particular case still collects. Now give L a namesake: a second soft-deleted &#39;solo&#39; row exists (the operator&#39;s shape — 18 stale &#39;fleet&#39; rows). `unclaimed.name` is now false too, so `owned_agent_pane` returns `Ok(None)` (src/agent/tmux.rs:2472-2475) and **L&#39;s own live window and agent are never collected**, indefinitely. Nothing purges `sessions` (there is no `DELETE FROM sessions` anywhere under src/), so the row stays overdue and every keeper tick re-runs a full-table claims scan plus a tmux round trip against it forever.

The same shape blocks the name path directly: a remote &#39;thurbox&#39; row makes `unclaimed.name` false for a local &#39;thurbox&#39; row whose pane id is empty (legacy rows, and psmux where `spawn_window` records none), even though the remote window is on a different tmux server and could never have been the target.

This never produces a wrong kill — the gate can only deny ownership, so it leaks rather than misdirects — which is why it is a warning and not an error. But it is not the leak-over-kill tradeoff the intent authorizes: no ownership question is actually in doubt, and it is precisely the &#34;a reap still collects its own window so the fix cannot degenerate into a no-op&#34; half of the contract failing. Remedy is mechanical and stays inside the change: have `session_window_claims` also return `backend_type` (or filter in SQL) and have `owned_agent_pane_for` (src/session_ops/delete.rs:286) skip claimants where `crate::session::is_remote_backend(backend_type)` — the same predicate both callers already apply two lines above the call. Note this was accepted for fix in two earlier review rounds and is still not present at this head; `git log -p ec709a4..bcb2976 -- src/storage/sessions.rs` shows no `backend_type` ever entering the query.
- ⚠️ `src/session_ops/spawn.rs:409` - Two near-identical comment paragraphs are stacked on the orphan-window cleanup. Lines 409-414 (&#34;Strict, for the same reason the reap is: this tears down a window that has no row ... Losing the window we leaked is the cheap failure; killing a live session&#39;s is not.&#34;) and lines 415-422 (&#34;Ownership-gated, for the same reason the reap is: this tears down a window that never became a row ... Leaking the window we already leaked is the cheap failure; killing someone else&#39;s is not.&#34;) state the same rationale twice — a rewrite whose first draft was not removed. CLAUDE.md&#39;s comment rule is explicit that a redundant comment costs tokens and makes the next reader less accurate. Remedy: delete the first paragraph and keep the second, which is the more precise of the two (&#34;never became a row&#34; is accurate; &#34;has no row&#34; is ambiguous about whether the row was deleted or never existed). Accepted for fix in an earlier round but still present at this head.
- ℹ️ `src/session_ops/delete.rs:286` - The intent states the spawn change carries no test because &#34;the upsert-failure path has no seam to drive it from an integration test (`upsert_session` cannot be made to fail through the public API)&#34;, and invites a reviewer who sees a way to drive that path to say so. The upsert failure itself still looks undrivable, but the *decision* the spawn teardown newly delegates is drivable: `session_ops::delete` is `pub mod` (src/session_ops/mod.rs:11) and `owned_agent_pane_for` is `pub`, so `thurbox::session_ops::delete::owned_agent_pane_for` is reachable from tests/reap_e2e.rs, which already has a real tmux server and a real DB in scope. Two cases pin the spawn behavior exactly with no need to fail an upsert: spawn a live &#39;fleet&#39;, then call `owned_agent_pane_for(&amp;db, SessionId::default(), &#34;fleet&#34;, &#34;&#34;)` — the psmux orphan shape, a row-less window whose name a live session claims — and assert `None` (the spawn leaks rather than killing the live namesake); and `owned_agent_pane_for(&amp;db, SessionId::default(), &#34;solo&#34;, &amp;solo.backend_id)` against a session whose row was force-deleted, asserting `Some(pane)` so the strictness is not a no-op. Both execute a real public interface and assert observable behavior, rather than asserting anything about spawn.rs&#39;s source. Accepted for fix in an earlier round; tests/reap_e2e.rs at this head (500 lines, six tests) contains no reference to `owned_agent_pane_for`.
- ℹ️ `src/cli/automations.rs:892` - Two new assertion messages carry a line-join artifact — a run of ~14 spaces where a wrapped string literal was concatenated without a separator: `&#34;an overdue row whose pane and name a live namesake claims owns              nothing to release&#34;` here, and `&#34;a force-deleted row&#39;s window is gone; counting it would deadlock              every namesake&#39;s teardown: {names:?}&#34;` at src/storage/sessions.rs:969. Both are the text a failing test prints, so a future failure reads as garbled rather than as the invariant the author wrote. Collapse each run to a single space. Accepted for fix in an earlier round but still present at this head.
- ℹ️ `src/cli/automations.rs:577` - The sweep&#39;s gate changed from &#34;has a live window&#34; (`agent_window_alive`) to &#34;owns a window&#34; (`owned_agent_pane`), which also gates the half of `reap_soft_deleted` that has nothing to do with windows. `reap_soft_deleted`&#39;s own new doc says the opposite — &#34;a row that owns none (see [`owned_agent_pane`]) still releases its derived artifacts and reports `true`&#34; (src/session_ops/delete.rs:201-203) — but the headless sweep now never reaches it for exactly those rows, so that documented behavior is unreachable from `reap_overdue_soft_deletes`.

Concrete trace, the operator&#39;s own state: 18 soft-deleted &#39;fleet&#39; rows, each with a dead pane, plus one live &#39;fleet&#39;. Before: `agent_window_alive(None, &#34;fleet&#34;)` returned true on the live replacement&#39;s window, the sweep called `reap_soft_deleted` for each stale row, and each row&#39;s metrics JSON (`paths::metrics_directory()/&lt;asid&gt;.json`) and symlink workspace were removed — as a side effect of the very bug being fixed. After: `owned_agent_pane` returns `None` for all 18, the sweep skips them, and those artifacts are never released. There is no `DELETE FROM sessions` anywhere under src/, so the rows persist and each keeper tick re-runs a full-table `session_window_claims` scan per overdue row, forever. The TUI path is unaffected: `kernel::reaper::Reaper` dispatches `Command::Reap` once per id (src/kernel/command/execute.rs:138), calling `reap_soft_deleted` unconditionally, so it does release the artifacts.

The remedy, not the defect, is what needs authorization: the sweep uses window liveness as its idempotence proxy because there is no &#34;already reaped&#34; marker on the row, so making artifact release independent of window ownership means adding durable state (a `reaped_at` column or equivalent) — new schema beyond what this change set out to do. The narrower alternative is to accept it and say so in the sweep&#39;s doc comment, which currently claims the gate is only about cost (&#34;a row reaped once costs nothing on every later tick&#34;) and does not mention that artifacts are now withheld. Raised and accepted in an earlier round; still present at this head.

🔧 Fix: scope window claims to local rows, dedupe comment, test spawn seam
2 infos still open:

- ℹ️ `.claude/skills/thurbox-testing/SKILL.md:67` - The `tests/reap_e2e.rs` entry says &#34;Six tests, both directions of the same contract&#34; and enumerates only the reap cases. This run&#39;s fix round added two more (`a_spawns_orphan_cleanup_owns_nothing_a_live_namesake_claims` and `a_spawns_orphan_cleanup_owns_the_window_nothing_else_answers_for`, tests/reap_e2e.rs:510 and :550), so the file now carries eight `#[test]`s and covers a second call site — the spawn&#39;s orphan-window cleanup — that the skill does not mention. CLAUDE.md&#39;s closing Rule applies to a skill too (&#34;a change that invalidates what one says updates it in the same PR&#34;), and the count is the kind of concrete claim a future reader trusts without checking. Same gap in the file&#39;s own `//!` header (tests/reap_e2e.rs:1-17), which frames the file purely as &#34;Reaping a soft-deleted session must not kill a live session&#39;s window&#34; and says nothing about the spawn teardown now sharing the gate. Remedy is mechanical: say eight, and name the spawn-cleanup pair as the second call site the same ownership gate protects.
- ℹ️ `src/agent/tmux.rs:2424` - `Unclaimed`&#39;s doc says the identity halves are &#34;Settled once by `session_ops::delete::owned_agent_pane`, which is the only intended caller of [`owned_agent_pane`]&#34;. Both clauses stopped being true in bcb2976, which extracted `owned_agent_pane_for`: the `Unclaimed` value is now built in `session_ops::delete::owned_agent_pane_for` (src/session_ops/delete.rs:286-309), which is the sole caller of `tmux::owned_agent_pane`, while `delete::owned_agent_pane` is a two-line delegate; and the decision now has two callers, the reap (src/session_ops/delete.rs:233, src/cli/automations.rs:585) and the spawn&#39;s orphan cleanup (src/session_ops/spawn.rs:419). A reader following the doc to find where ownership is settled lands on the wrong function and concludes there is one call site when the whole point of the extraction was that there are two — the stale-comment failure CLAUDE.md calls worse than no comment.

Second wording issue in the same change, src/session_ops/delete.rs:296: &#34;An empty id is claimed by nobody — psmux rows all carry one&#34; reads as &#34;psmux rows all carry a pane id&#34;, which is the opposite of the fact the guard exists for (`spawn_window` returns `String::new()` on Windows, src/agent/tmux.rs:2259-2261, and the intent states psmux records none). The intended reading is &#34;all carry an empty one&#34;; spelling that out removes the inversion.

No behavior is affected — both are comment text.
</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 101
- `cargo nextest run --all`

🔧 Fix: no code fix needed; nextest absent, targeted tests pass
1 error still open:

- 🚨 tests failed with exit code 101
- `cargo nextest run --all`
</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/FEATURES.md:591` - Judgment call, no edit made. FEATURES.md&#39;s shared-hosts bullet says &#34;A soft delete asked for headlessly is reaped by the host&#39;s tick once the undo window has passed.&#34; With the new gate that is now conditional: `reap_overdue_soft_deletes` skips a row that owns no window, so a stale row a live namesake answers for is never collected headlessly and its metrics file and symlink workspace stay in place (accepted in this run, and recorded in the sweep&#39;s own doc comment). I left the sentence alone rather than qualifying it: the ownership rule now has exactly one home in ADR-12, and repeating the caveat inside a remote/shared-session bullet would create a second prose copy of the same fact to keep in step. If the operator wants the headless-sweep limitation stated for users rather than only for readers of the code, the place for it is a short pointer from that bullet to ADR-12.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

🔧 Fix: format wrapped assert in reap e2e test
1 warning still open:

- ⚠️ linter found issues (exit code 127)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
