### PR TITLE
feat(cli): make watch stream exact via an append-only session_events log

### DIFF
--- a/.claude/skills/thurbox-cli/SKILL.md
+++ b/.claude/skills/thurbox-cli/SKILL.md
@@ -372,8 +372,11 @@ the worktrees **thurbox created** + the symlink workspace, disables `send`
 automations targeting the session, and clears its `session meta` key/value space
 (the row is unrestorable, so the meta would otherwise outlive it) — for headless
 cleanup with no TUI running. Teardown is best-effort
-(failures land in the JSON report); the row is always soft-deleted last. A
-worktree the session merely **opened** (`created_by_thurbox = 0`, schema v42) is
+(failures land in the JSON report); the row is always marked deleted last, in
+one write — a force delete stamps `deleted_at` and `force_deleted` together
+rather than soft-deleting first, so a watcher of `session_events` never sees an
+intermediate state that reads as restorable. A worktree the session merely
+**opened** (`created_by_thurbox = 0`, schema v42) is
 left on disk and listed in the report's `kept_worktrees`: `git worktree remove
 --force` would take the uncommitted work in it too, which is thurbox's to discard
 only for a directory it made.

--- a/.claude/skills/thurbox-cli/SKILL.md
+++ b/.claude/skills/thurbox-cli/SKILL.md
@@ -37,7 +37,7 @@ thurbox-cli session list --parent <lead-uuid> --json | jq  # direct children onl
 Subcommands: `agent` (launch-args — see below), `session` (create/list [`--deleted`]/get/delete/restore/restart
 [`--if-missing`]/stop/start/fork/exec/meta/send [`--no-enter`]/key/capture/focus/signal/doctor/sync/register —
 `sync`/`register` and the flags serve session sharing, ADR-24), `watch` (stream
-session changes as newline-delimited JSON), `runtime` (status/stop — what
+the session event log, one event per line), `runtime` (status/stop — what
 thurbox runs that is not a session), `automation` (alias `auto`:
 create/list/show/edit/remove/run/runs/tick), `task` (alias `todo`:
 create/list/show/edit/remove/run), `message` (alias `msg`:
@@ -189,8 +189,8 @@ Status hooks are **arguments**: the `hooks` extension installs them by appending
 to an agent's `args` in `agents.toml` (`--settings <hooks>.json` for claude), so
 they reach the process only when thurbox builds the command line. A driver that
 launches the agent itself — `session create --command`, or typing into a shell
-session — therefore got no hooks, so `state` never populated and `watch` never
-mentioned that session. This prints what thurbox would run; pass the args
+session — therefore got no hooks, so `state` never populated and `watch` reports
+no state transition for that session. This prints what thurbox would run; pass the args
 through and the hooks are there.
 
 `--session <ref>` resolves it for one session: the conversation id is pinned to
@@ -217,16 +217,58 @@ the only form that tells a `null` value from a key that was never set.
 ### `thurbox-cli watch` — nothing has to poll
 
 ```bash
-thurbox-cli watch --initial | while read -r line; do …; done
+thurbox-cli watch --json --initial | while read -r line; do …; done
 ```
 
-One JSON object per line as sessions appear, change state, or go —
-`{"event":"changed","session":"…","name":"…","state":"working",…}`. The
-mechanism is the `PRAGMA data_version` gate the sync worker already uses, so it
-works with no interface running and costs a pragma per tick rather than a query.
-`--session` narrows it to one, `--for-secs` bounds it, `--initial` emits the
-current state first so a starting driver gets its baseline and every change
-after it in one stream.
+One event per line as sessions appear, change state, or go —
+`{"seq":41,"event":"changed","reason":"state","session":"…","name":"…",
+"from_state":"working","to_state":"blocked","state":"blocked",…}`. It works
+with no interface running, because everything worth waking on is already in the
+database.
+
+**It streams a log, not a diff.** Every writer that changes what a watcher
+reports appends a row to `session_events` (schema v43) in the same transaction
+as the change — `set_hook_state`, the park/un-park mark, the delete and restore
+verbs, the spawn upsert, both pane-option polls and the mirror pass. `watch`
+tails that table by `seq`, still waking on the `PRAGMA data_version` gate the
+sync worker uses, so it costs a pragma per tick rather than a query. The
+previous implementation sampled every session every 250 ms and diffed the
+samples, which collapsed any two transitions inside one sample: `working →
+blocked → working` around an auto-answered permission arrived as *nothing at
+all*, and the driver never learned the permission had been asked. A log written
+by the writer cannot lose a transition.
+
+Each line carries:
+
+| field | what it says |
+|---|---|
+| `seq` | monotonic, never reused — what `--since` resumes from |
+| `event` | `present` (baseline) / `created` / `changed` / `gone` |
+| `reason` | `spawned`, `registered`, `restored` · `state`, `stopped`, `started`, `updated` · `soft_deleted`, `force_deleted` |
+| `from_state`, `to_state` | the transition itself, for a `changed`/`state` event |
+| `state`, `hook_state`, `state_source`, `hook_coverage`, `hook_blocked_is_heuristic`, `hook_state_contradicted` | the same gating fields `session get` publishes, so reacting to a `blocked` needs no follow-up call |
+
+`reason` is what a bare event name could not say: a `gone` used to mean both
+deletes, and only one of them is restorable. `hook_state_contradicted` is
+`null` — *not checked* — unless you pass `--verify`, which costs a multiplexer
+query and a `ps` per event, the same trade `session list --verify` makes.
+
+`--session` narrows it to one (the log is filtered, not the output),
+`--for-secs` bounds it, `--initial` emits the current state as `present` rows
+first, and `--since <seq>` resumes from the last event a driver handled — the
+gap a stream otherwise has across a restart. The stream exits as soon as its
+reader closes the pipe rather than sitting out its `--for-secs`.
+
+**A parked session takes no hook state at all.** `session stop` killed the
+pane, so a heartbeat's pane-option poll or a mirror pass carrying a host's last
+word would otherwise write a turn onto a session with no process to be in one —
+and every watcher would see a transition that did not happen. `session signal`
+against a parked session fails, saying to `session start` it first.
+
+The format follows the CLI-wide rule: human in a terminal, TOON down a pipe
+(one `events{…}:` header, then a row per event — a stream has no length for the
+header to declare), `--json` for one JSON object per line. `--pretty` is
+`--json` here: a stream's frame is the line.
 
 ### Remote sessions are driven, not refused
 

--- a/.claude/skills/thurbox-session-status/SKILL.md
+++ b/.claude/skills/thurbox-session-status/SKILL.md
@@ -113,6 +113,19 @@ one invalidated every `pure` pane on every idle frame (ADR-P16). The filled `●
   fresh spawn seeds **nothing** — a never-reported session is `Idle`, and the
   agent's hooks drive it from there (so an idle, just-booted agent doesn't look
   stuck working).
+- **A parked session takes no state.** `set_hook_state` returns `false` for a
+  row with `stopped_at` set, and `set_session_stopped(true)` clears the hook
+  columns in the same transaction as the mark. `session stop` killed the pane,
+  so a heartbeat's pane-option poll or a mirror pass carrying a host's last word
+  would be writing a turn onto a session with no process to be in one — and
+  `thurbox-cli watch` would publish a transition that did not happen. The
+  callers treat `Ok(false)` as "not written", never as a failure; `session
+  signal` reports it, saying to `session start` first.
+- **Transitions are logged.** Each write that moves the state appends to
+  `session_events` (schema **v43**) inside the same transaction, carrying
+  `from_state` → `to_state`. That log is what `thurbox-cli watch` streams —
+  see the `thurbox-cli` skill — and it exists because sampling the columns
+  collapses two transitions that land between two samples.
 - **Derivation.** The snapshot carries each session's `hook_state` and folds
   attach state into the published status — a *remote* session with no live pane
   → `Unreachable` (`with_reachability`); a `working` one gone quiet → `Idle`

--- a/README.md
+++ b/README.md
@@ -683,7 +683,7 @@ workspace if any, and disables `send` automations targeting the session.
 Teardown is best-effort: individual failures are recorded in the JSON report
 (`killed_window`, `removed_worktrees`, `worktree_errors`,
 `disabled_automations`) but never abort the delete, and the row is always
-soft-deleted last.
+marked deleted last, in one write.
 
 ### Agents
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -329,7 +329,7 @@ all commented so defaults still apply out of the box.
 | `scrollback_lines` | `1000` | terminal scrollback kept per session |
 | `two_panel_min_cols` | `80` | width below which only the terminal renders |
 | `three_panel_min_cols` | `120` | width unlocking the optional third column |
-| `audit_retention_days` | `90` | audit-log history kept (pruned on startup) |
+| `audit_retention_days` | `90` | audit + session-event history kept (pruned on startup) |
 
 A complete `settings.toml` showing every knob at its default — copy
 this, uncomment what you want to change, and restart:
@@ -341,7 +341,7 @@ config_version = 1
 scrollback_lines      = 1000   # terminal scrollback kept per session
 two_panel_min_cols    = 80     # width below which only the terminal renders
 three_panel_min_cols  = 120    # accepted and ignored (v1's third column)
-audit_retention_days  = 90     # audit-log history kept (pruned on startup)
+audit_retention_days  = 90     # audit + session-event history kept (pruned on startup)
 
 [features]
 shell_pane    = true

--- a/docs/ORCHESTRATION.md
+++ b/docs/ORCHESTRATION.md
@@ -152,6 +152,39 @@ that matters:
 `--kind` is a free-form tag, so a run can distinguish `result` from
 `questions` or `plan` without the lead parsing prose.
 
+### `watch`, for everything that is not a report
+
+The mailbox is how a worker says it finished. `thurbox-cli watch` is how a
+driver learns everything the worker was never going to mail — that it went
+blocked on a permission, that its pane died, that somebody deleted it:
+
+```sh
+thurbox-cli watch --json --initial | while read -r line; do …; done
+```
+
+It streams an **append-only log**, not a sampled diff. Every writer that
+changes what a watcher reports appends its event in the same transaction as the
+change, so two transitions in the same instant are two events. That is not a
+detail: `working → blocked → working` is what an auto-answered permission looks
+like, and a sampler that reads the row every 250 ms sees neither edge.
+
+Each line carries a `seq` (monotonic, never reused), the `event`
+(`present`/`created`/`changed`/`gone`), a `reason` saying which kind it was —
+`spawned`/`registered`/`restored`, `state`/`stopped`/`started`/`updated`,
+`soft_deleted`/`force_deleted` — the `from_state` → `to_state` of the
+transition, and the same gating fields the table above lists, so acting on a
+`blocked` needs no follow-up `session get`. `hook_state_contradicted` is `null`
+(not checked) unless you pass `--verify`.
+
+A driver that persists the last `seq` it handled restarts with
+`--since <seq>` and gets exactly what it missed. `--session` narrows the stream
+to one session, `--for-secs` bounds it, and it exits the moment its reader
+closes the pipe.
+
+`gone` used to be one word for both deletes. It is now two, and the difference
+is the one that matters to a driver: `soft_deleted` can be restored,
+`force_deleted` had its worktrees and window torn down.
+
 ### `--parent`
 
 Spawn workers with `--parent "$THURBOX_SESSION"` and the lead/worker
@@ -217,11 +250,18 @@ agent can signal, and `state_source` is null for all of them. The piped
 A **parked** session (`session stop`: pane killed, row and checkout
 kept) stays in `session list` and is told apart there — `stopped: true`
 and `state: "stopped"` on both read verbs, so a liveness check is the
-poll you were already doing rather than a pane probe or a one-second
-`watch --initial`. Its `backend_id` still names the window it had: that
-is what the row records, and `session start` replaces it with the new
-pane's id. `send`, `key` and `capture` refuse a parked session by name
-instead of reaching for the window that is gone.
+poll you were already doing rather than a pane probe. Its `backend_id`
+still names the window it had: that is what the row records, and
+`session start` replaces it with the new pane's id. `send`, `key` and
+`capture` refuse a parked session by name instead of reaching for the
+window that is gone.
+
+Parking also **clears the latched state and refuses a new one**. A parked
+session has no process, so a heartbeat's pane-option poll or a mirror pass
+carrying a host's last word would be reporting a turn on a session that cannot
+be in one — and every watcher of that row would see a transition that did not
+happen. `session signal` against a parked session fails rather than silently
+doing nothing, and says to `session start` it first.
 
 There is deliberately **no staleness timeout**. A turn may legitimately
 run for an hour, so any bound thurbox picked would report live work as

--- a/src/agent/settings_config.rs
+++ b/src/agent/settings_config.rs
@@ -32,7 +32,7 @@ config_version = 1
 # Kept so an existing settings.toml still loads.
 # three_panel_min_cols = 120
 
-# Days of audit-log history kept (pruned on startup).
+# Days of audit-log and session-event history kept (pruned on startup).
 # audit_retention_days = 90
 
 # Feature flags: turn whole TUI features off. All default to true.

--- a/src/cli/automations.rs
+++ b/src/cli/automations.rs
@@ -546,7 +546,9 @@ fn poll_local_pane_states(db: &Database) -> usize {
         if hook_rows.get(&session.id).and_then(|r| r.state.as_deref()) == Some(state.as_str()) {
             continue;
         }
-        if db.set_hook_state(session.id, &state).is_ok() {
+        // `Ok(false)` is a parked session refusing a state it has no process
+        // to be in — not a write that failed, and not one that happened.
+        if matches!(db.set_hook_state(session.id, &state), Ok(true)) {
             written += 1;
         }
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -186,8 +186,14 @@ pub enum Command {
     /// Print the perf snapshot a running TUI publishes (THURBOX_PERF_LOG or
     /// the perf HUD must be active in that TUI).
     Perf,
-    /// Stream session changes as newline-delimited JSON — one object per
-    /// transition, so nothing driving thurbox has to poll.
+    /// Stream the session event log — one line per transition, so nothing
+    /// driving thurbox has to poll.
+    ///
+    /// Every writer appends its event in the same transaction as the change, so
+    /// two transitions in the same instant are two events. Each carries a
+    /// monotonic `seq` (`--since` resumes from it), a `reason`, the
+    /// `from_state` → `to_state`, and the gating fields `session get`
+    /// publishes. `--json` for one JSON object per line.
     Watch(watch::WatchArgs),
     /// What thurbox runs besides sessions (the automation heartbeat keeper).
     Runtime {
@@ -278,7 +284,7 @@ pub fn run(cli: Cli, db: &Database) -> Result<Outcome, String> {
     // writes a line per change for as long as it runs, so the one-document rule
     // below (and the renderer it exists for) does not apply to it.
     if let Some(Command::Watch(args)) = cli.command {
-        watch::run(db, args)?;
+        watch::run(db, args, format)?;
         return Ok(Outcome::Ok);
     }
 

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -843,8 +843,16 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
         Action::Doctor { uuid } => super::session_doctor::run(db, uuid.as_deref()),
         Action::Signal { state, session } => {
             let target = resolve_signal_target(db, session.as_deref())?;
-            db.set_hook_state(target.id, &state)
-                .map_err(|e| format!("set_hook_state: {e}"))?;
+            if !db
+                .set_hook_state(target.id, &state)
+                .map_err(|e| format!("set_hook_state: {e}"))?
+            {
+                return Err(format!(
+                    "'{}' is parked, so it has no turn to report; \
+                     thurbox-cli session start {} first",
+                    target.name, target.id
+                ));
+            }
             // The same state on the pane, for a peer's live subscription:
             // best-effort, and nothing at all outside tmux.
             if let Err(e) = crate::agent::tmux::set_own_pane_state(&state) {
@@ -1713,7 +1721,7 @@ fn register_running_session(
             )
         })?;
     session.backend_id = pane;
-    db.upsert_session(&session)
+    db.upsert_session_as(&session, crate::storage::EventReason::Registered)
         .map_err(|e| format!("upsert_session: {e}"))?;
     if let Some(state) = row.hook_state.as_deref() {
         let _ = db.set_hook_state(session.id, state);

--- a/src/cli/toon.rs
+++ b/src/cli/toon.rs
@@ -360,7 +360,11 @@ fn collect_cells<'a>(value: &'a Value, fields: &[Field], out: &mut Vec<&'a Value
 }
 
 /// Encode one primitive token, quoting per §7.2 against `delim`.
-fn scalar(value: &Value, delim: char) -> String {
+///
+/// `pub(crate)`: [`crate::cli::watch`]'s streamed TOON rows share this rather
+/// than hand-rolling their own quoting, since a session name is free-form and
+/// can carry the delimiter, a colon, or anything else §7.2 requires quoted.
+pub(crate) fn scalar(value: &Value, delim: char) -> String {
     match value {
         Value::Null => "null".to_string(),
         Value::Bool(b) => b.to_string(),

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -98,8 +98,17 @@ pub fn run(db: &Database, args: WatchArgs, format: Format) -> Result<(), String>
             .map_err(|e| tracing::warn!("could not read the event log head: {e}"))
             .unwrap_or_default()
     });
+    // Seeds the per-session park state that `drain` advances from here: an
+    // event's own `stopped`/`started` reason updates it, everything else reads
+    // it as of the last event *for that session*, never a later batch's
+    // snapshot (see `drain`'s doc comment).
+    let seed_facts = db.load_session_facts().unwrap_or_default();
+    let mut stopped_state: HashMap<SessionId, bool> = seed_facts
+        .iter()
+        .map(|(id, facts)| (*id, facts.stopped))
+        .collect();
     if args.initial {
-        let facts = db.load_session_facts().unwrap_or_default();
+        let facts = &seed_facts;
         let states = db.load_hook_states().unwrap_or_default();
         for session in db.list_active_sessions().unwrap_or_default() {
             if filter.is_some_and(|only| only != session.id) {
@@ -130,7 +139,15 @@ pub fn run(db: &Database, args: WatchArgs, format: Format) -> Result<(), String>
     // moved `data_version`, so the gate below would sit on it until somebody
     // else committed again.
     let mut version = db.data_version().unwrap_or_default();
-    if !drain(db, &registry, filter, &mut seq, &args, &mut out) {
+    if !drain(
+        db,
+        &registry,
+        filter,
+        &mut seq,
+        &args,
+        &mut stopped_state,
+        &mut out,
+    ) {
         return Ok(());
     }
 
@@ -148,7 +165,15 @@ pub fn run(db: &Database, args: WatchArgs, format: Format) -> Result<(), String>
         }
         version = current;
 
-        if !drain(db, &registry, filter, &mut seq, &args, &mut out) {
+        if !drain(
+            db,
+            &registry,
+            filter,
+            &mut seq,
+            &args,
+            &mut stopped_state,
+            &mut out,
+        ) {
             return Ok(());
         }
     }
@@ -170,12 +195,19 @@ fn remaining(deadline: Option<Instant>) -> Option<Duration> {
 
 /// Emit every event after `seq`, advancing it. `false` means the reader is gone
 /// and the stream is over.
+///
+/// `stopped_state` carries each session's park state forward event by event,
+/// rather than reading it once per batch: the naming facts (`facts`, below)
+/// are the row *as of after the whole batch*, so two events for the same
+/// session sharing a batch — a `state` transition followed by a park, say —
+/// would otherwise both read the park state that only the second one earned.
 fn drain(
     db: &Database,
     registry: &crate::session::AgentRegistry,
     filter: Option<SessionId>,
     seq: &mut i64,
     args: &WatchArgs,
+    stopped_state: &mut HashMap<SessionId, bool>,
     out: &mut Stream,
 ) -> bool {
     loop {
@@ -190,11 +222,22 @@ fn drain(
             return true;
         }
         // One read of the naming facts per batch: an event names a session, and
-        // the row it names is the same row for every event in the batch.
+        // the row it names is the same row for every event in the batch. Only
+        // `stopped` needs point-in-time tracking; the rest doesn't change
+        // mid-batch the way a park does.
         let facts = db.load_session_facts().unwrap_or_default();
         for event in &events {
             *seq = event.seq;
-            if !out.write(&line(db, registry, &facts, event, args.verify)) {
+            let stopped = match event.reason.as_str() {
+                "stopped" => true,
+                "started" => false,
+                _ => stopped_state
+                    .get(&event.session_id)
+                    .copied()
+                    .unwrap_or(false),
+            };
+            stopped_state.insert(event.session_id, stopped);
+            if !out.write(&line(db, registry, &facts, event, stopped, args.verify)) {
                 return false;
             }
         }
@@ -208,12 +251,15 @@ fn drain(
 ///
 /// The state is assessed from the event's **own** `to_state` rather than the
 /// row's current one: two transitions inside one wake-up are two events, and
-/// re-reading the row would report the later one twice.
+/// re-reading the row would report the later one twice. `stopped` is likewise
+/// the mark as of *this* event ([`drain`]'s `stopped_state`), not the row's
+/// current one.
 fn line(
     db: &Database,
     registry: &crate::session::AgentRegistry,
     facts: &HashMap<SessionId, SessionFacts>,
     event: &SessionEventRow,
+    stopped: bool,
     verify: bool,
 ) -> Value {
     let unknown = SessionFacts {
@@ -223,13 +269,6 @@ fn line(
         stopped: false,
     };
     let facts = facts.get(&event.session_id).unwrap_or(&unknown);
-    // The mark as of *this* event, not as of now: a park and an un-park inside
-    // one wake-up would otherwise both read as whichever landed last.
-    let stopped = match event.reason.as_str() {
-        "stopped" => true,
-        "started" => false,
-        _ => facts.stopped,
-    };
     // Only the pane probe needs the backend, and only a live row has a pane to
     // probe — so the lookup is paid for exactly where it is used.
     let probe = verify && event.event != "gone";
@@ -412,15 +451,13 @@ impl Stream {
     }
 }
 
-/// One TOON row: the [`COLUMNS`] cells of this event, comma-delimited.
+/// One TOON row: the [`COLUMNS`] cells of this event, comma-delimited and
+/// quoted per §7.2 by the same encoder every other TOON surface uses — a
+/// session name is free-form and can otherwise carry the delimiter itself.
 fn row(event: &Value) -> String {
     COLUMNS
         .iter()
-        .map(|column| match event.get(*column) {
-            Some(Value::String(s)) => s.clone(),
-            Some(Value::Null) | None => String::new(),
-            Some(other) => other.to_string(),
-        })
+        .map(|column| crate::cli::toon::scalar(event.get(*column).unwrap_or(&Value::Null), ','))
         .collect::<Vec<_>>()
         .join(",")
 }

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -5,33 +5,45 @@
 //! integration, each with its own interval, each wrong in one direction or the
 //! other — too slow to react, or spending a query a second to react to nothing.
 //!
-//! The mechanism is the one the interface's own sync worker already uses:
-//! SQLite's `PRAGMA data_version` changes when *another* connection commits, so
-//! a reader can sit on a cheap pragma and re-read only when there is something
-//! to re-read (see [`crate::sync`]). This is that gate in the CLI, turning
-//! what it finds into one JSON object per line.
+//! The stream is the `session_events` log ([`crate::storage::session_events`]),
+//! not a sampled diff of the session table. That distinction is the whole
+//! command: a diff every 250 ms collapses any two transitions inside one
+//! sample, so `working → blocked → working` around an auto-answered permission
+//! arrived as *nothing at all* and the driver never learned the permission had
+//! been asked. Each writer appends its own event in its own transaction, so the
+//! stream is what happened rather than what a sample could still see.
+//!
+//! The wake-up is still the gate the interface's own sync worker uses: SQLite's
+//! `PRAGMA data_version` changes when *another* connection commits, so a reader
+//! sits on a cheap pragma and reads the log's tail only when there is a tail to
+//! read (see [`crate::sync`]).
 //!
 //! Deliberately not the kernel's event bus. That would need an IPC channel out
 //! of a running interface, and would then only work while one is running —
-//! whereas everything a driver needs to be woken by (a status transition, a
-//! session appearing or going) is already in the database, written by whoever
-//! made the change, interface or not. A richer transport can replace what is
-//! behind this command later without the command itself changing.
+//! whereas everything a driver needs to be woken by is already in the database,
+//! written by whoever made the change, interface or not. A richer transport can
+//! replace what is behind this command later without the command itself
+//! changing.
 
 use std::collections::HashMap;
-use std::io::Write;
+use std::io::{ErrorKind, Write};
 use std::time::{Duration, Instant};
 
 use clap::Args;
-use serde_json::json;
+use serde_json::{json, Value};
 
-use crate::session::SessionId;
-use crate::storage::Database;
+use crate::cli::output::Format;
+use crate::session::{Assessment, SessionId};
+use crate::storage::{Database, SessionEventRow, SessionFacts};
 
 /// How often the change gate is checked. A `PRAGMA data_version` on an open
 /// connection is a memory read, not a query — this is a latency choice, not a
 /// cost one.
 const POLL: Duration = Duration::from_millis(250);
+
+/// How many events one wake-up reads. A backlog larger than this is drained
+/// over consecutive reads rather than in one allocation.
+const BATCH: usize = 512;
 
 #[derive(Args, Debug)]
 pub struct WatchArgs {
@@ -47,23 +59,25 @@ pub struct WatchArgs {
     /// in one stream, with no separate `session list` first.
     #[arg(long)]
     pub initial: bool,
+    /// Resume after this sequence number instead of from now.
+    ///
+    /// Every event carries a `seq`. A driver that persists the last one it
+    /// handled restarts with `--since <seq>` and receives exactly what it
+    /// missed — the gap a stream otherwise has across a restart.
+    #[arg(long, value_name = "SEQ")]
+    pub since: Option<i64>,
+    /// Also check each event's session against its pane, filling
+    /// `hook_state_contradicted`.
+    ///
+    /// Off by default for the same reason `session list --verify` is: it costs
+    /// a multiplexer query and a `ps` per event.
+    #[arg(long)]
+    pub verify: bool,
 }
 
-/// One session's watched state — everything a transition can be reported from.
-///
-/// Compared as a whole rather than field by field, so adding a field here is
-/// all it takes for a change in it to become an event.
-#[derive(PartialEq, Clone)]
-struct Watched {
-    name: String,
-    state: Option<String>,
-    backend_id: String,
-    stopped: bool,
-}
-
-/// Stream session changes until the deadline (or forever) — one JSON object per
-/// line, flushed as it is written so a reader blocked on the pipe wakes on it.
-pub fn run(db: &Database, args: WatchArgs) -> Result<(), String> {
+/// Stream session changes until the deadline (or forever) — one event per line,
+/// flushed as it is written so a reader blocked on the pipe wakes on it.
+pub fn run(db: &Database, args: WatchArgs, format: Format) -> Result<(), String> {
     let filter = args
         .session
         .as_deref()
@@ -73,81 +87,370 @@ pub fn run(db: &Database, args: WatchArgs) -> Result<(), String> {
     let deadline = args
         .for_secs
         .map(|secs| Instant::now() + Duration::from_secs(secs));
-    let mut previous = read(db, filter);
+    let registry = crate::agent::agent_config::load_or_seed();
+    let mut out = Stream::new(format);
+
+    // The head is taken *before* the baseline rows, so a session created
+    // between the two is announced twice rather than not at all: a driver can
+    // reconcile a repeated `created`, and cannot invent one it never saw.
+    let mut seq = args.since.unwrap_or_else(|| {
+        db.latest_session_event_seq()
+            .map_err(|e| tracing::warn!("could not read the event log head: {e}"))
+            .unwrap_or_default()
+    });
     if args.initial {
-        for (id, row) in &previous {
-            emit("present", id, row);
+        let facts = db.load_session_facts().unwrap_or_default();
+        let states = db.load_hook_states().unwrap_or_default();
+        for session in db.list_active_sessions().unwrap_or_default() {
+            if filter.is_some_and(|only| only != session.id) {
+                continue;
+            }
+            let Some(facts) = facts.get(&session.id) else {
+                continue;
+            };
+            let row = states.get(&session.id);
+            let hook = assess(
+                &registry,
+                facts,
+                row.and_then(|r| r.state.as_deref()),
+                row.and_then(|r| r.state_at),
+                facts.stopped,
+                args.verify,
+                &session.backend_type,
+            );
+            let line = present(seq, session.id, facts, &hook);
+            if !out.write(&line) {
+                return Ok(());
+            }
         }
     }
+    // Drain once before entering the gate, for two reasons that are the same
+    // reason: `--since` is a resume, so what was missed is already waiting; and
+    // a commit that landed while the baseline was being read has *already*
+    // moved `data_version`, so the gate below would sit on it until somebody
+    // else committed again.
     let mut version = db.data_version().unwrap_or_default();
+    if !drain(db, &registry, filter, &mut seq, &args, &mut out) {
+        return Ok(());
+    }
 
     loop {
-        if deadline.is_some_and(|end| Instant::now() >= end) {
+        let Some(nap) = remaining(deadline) else {
             return Ok(());
-        }
-        std::thread::sleep(POLL);
+        };
+        std::thread::sleep(nap);
 
         // The gate: unchanged means no other connection has committed, so
-        // nothing can have happened and the rows need not be read at all.
+        // nothing can have happened and the log need not be read at all.
         let current = db.data_version().unwrap_or(version);
         if current == version {
             continue;
         }
         version = current;
 
-        let now = read(db, filter);
-        for (id, row) in &now {
-            match previous.get(id) {
-                None => emit("created", id, row),
-                Some(before) if before != row => emit("changed", id, row),
-                Some(_) => {}
-            }
+        if !drain(db, &registry, filter, &mut seq, &args, &mut out) {
+            return Ok(());
         }
-        for (id, row) in &previous {
-            if !now.contains_key(id) {
-                emit("gone", id, row);
-            }
-        }
-        previous = now;
     }
 }
 
-/// The watched state of every session (or the one asked for).
-fn read(db: &Database, only: Option<SessionId>) -> HashMap<SessionId, Watched> {
-    let states = db.load_hook_states().unwrap_or_default();
-    let stopped = db.load_stopped_sessions().unwrap_or_default();
-    db.list_active_sessions()
-        .unwrap_or_default()
-        .into_iter()
-        .filter(|s| only.is_none() || only == Some(s.id))
-        .map(|s| {
-            let state = states.get(&s.id).and_then(|h| h.state.clone());
-            (
-                s.id,
-                Watched {
-                    name: s.name,
-                    state,
-                    backend_id: s.backend_id,
-                    stopped: stopped.contains(&s.id),
-                },
-            )
-        })
-        .collect()
+/// How long to sleep before the next gate check: a whole [`POLL`] normally, the
+/// time left when the deadline is nearer, and `None` once it has passed.
+///
+/// Sleeping past the deadline is what made `--for-secs 1` take a second and a
+/// quarter; the caller's bound is a bound.
+fn remaining(deadline: Option<Instant>) -> Option<Duration> {
+    match deadline {
+        None => Some(POLL),
+        Some(end) => end
+            .checked_duration_since(Instant::now())
+            .map(|left| left.min(POLL)),
+    }
 }
 
-/// One event. Written with an explicit flush: a stream whose reader is blocked
-/// on the next line must not have that line sitting in a buffer.
-fn emit(event: &str, id: &SessionId, row: &Watched) {
-    let line = json!({
-        "event": event,
+/// Emit every event after `seq`, advancing it. `false` means the reader is gone
+/// and the stream is over.
+fn drain(
+    db: &Database,
+    registry: &crate::session::AgentRegistry,
+    filter: Option<SessionId>,
+    seq: &mut i64,
+    args: &WatchArgs,
+    out: &mut Stream,
+) -> bool {
+    loop {
+        let events = match db.session_events_since(*seq, filter, BATCH) {
+            Ok(events) => events,
+            Err(e) => {
+                tracing::warn!("could not read the event log: {e}");
+                return true;
+            }
+        };
+        if events.is_empty() {
+            return true;
+        }
+        // One read of the naming facts per batch: an event names a session, and
+        // the row it names is the same row for every event in the batch.
+        let facts = db.load_session_facts().unwrap_or_default();
+        for event in &events {
+            *seq = event.seq;
+            if !out.write(&line(db, registry, &facts, event, args.verify)) {
+                return false;
+            }
+        }
+        if events.len() < BATCH {
+            return true;
+        }
+    }
+}
+
+/// One event, as the fields a driver decides on.
+///
+/// The state is assessed from the event's **own** `to_state` rather than the
+/// row's current one: two transitions inside one wake-up are two events, and
+/// re-reading the row would report the later one twice.
+fn line(
+    db: &Database,
+    registry: &crate::session::AgentRegistry,
+    facts: &HashMap<SessionId, SessionFacts>,
+    event: &SessionEventRow,
+    verify: bool,
+) -> Value {
+    let unknown = SessionFacts {
+        name: String::new(),
+        agent: String::new(),
+        backend_id: String::new(),
+        stopped: false,
+    };
+    let facts = facts.get(&event.session_id).unwrap_or(&unknown);
+    // The mark as of *this* event, not as of now: a park and an un-park inside
+    // one wake-up would otherwise both read as whichever landed last.
+    let stopped = match event.reason.as_str() {
+        "stopped" => true,
+        "started" => false,
+        _ => facts.stopped,
+    };
+    // Only the pane probe needs the backend, and only a live row has a pane to
+    // probe — so the lookup is paid for exactly where it is used.
+    let probe = verify && event.event != "gone";
+    let backend_type = probe
+        .then(|| db.get_session_by_id(event.session_id).ok().flatten())
+        .flatten()
+        .map(|s| s.backend_type)
+        .unwrap_or_default();
+    let hook = assess(
+        registry,
+        facts,
+        event.to_state.as_deref(),
+        Some(event.at_ms),
+        stopped,
+        probe,
+        &backend_type,
+    );
+    let mut line = base(event.session_id, facts, &hook);
+    line["seq"] = json!(event.seq);
+    line["event"] = json!(event.event);
+    line["reason"] = json!(event.reason);
+    line["from_state"] = json!(event.from_state);
+    line["to_state"] = json!(event.to_state);
+    line["stopped"] = json!(stopped);
+    line["at"] = json!(event.at_ms);
+    line
+}
+
+/// The baseline `--initial` emits: the same shape as an event, with no
+/// transition to report.
+fn present(seq: i64, id: SessionId, facts: &SessionFacts, hook: &Assessment) -> Value {
+    let mut line = base(id, facts, hook);
+    line["seq"] = json!(seq);
+    line["event"] = json!("present");
+    line["reason"] = Value::Null;
+    line["from_state"] = Value::Null;
+    line["to_state"] = json!(hook.hook_state);
+    line["stopped"] = json!(facts.stopped);
+    line["at"] = json!(crate::sync::current_time_millis());
+    line
+}
+
+/// The fields every line carries whatever produced it.
+///
+/// `state` is [`Assessment::state_word`] — the same one word `session get` and
+/// `session list` answer with, so a driver never has to reconcile two
+/// vocabularies — and the gating fields beside it are what say how much that
+/// word is worth. They are on the line rather than a `session get` away
+/// precisely because a driver reacting to a `blocked` needs to know whether
+/// this agent's `blocked` is a text match on a notification body before it
+/// acts on one.
+fn base(id: SessionId, facts: &SessionFacts, hook: &Assessment) -> Value {
+    json!({
         "session": id.to_string(),
-        "name": row.name,
-        "state": row.state,
-        "backend_id": row.backend_id,
-        "stopped": row.stopped,
-        "at": crate::sync::current_time_millis(),
-    });
-    let mut out = std::io::stdout().lock();
-    let _ = writeln!(out, "{line}");
-    let _ = out.flush();
+        "name": facts.name,
+        "agent": facts.agent,
+        "backend_id": facts.backend_id,
+        "state": hook.state_word(),
+        "hook_state": hook.hook_state,
+        "state_source": hook.state_source.map(|source| source.as_str()),
+        "hook_coverage": hook.coverage.as_str(),
+        "hook_blocked_is_heuristic": hook.blocked_is_heuristic(),
+        "hook_state_contradicted": hook.contradicted,
+    })
+}
+
+/// What the stored columns — and, with `--verify`, the pane — say about a
+/// session at the moment an event describes.
+///
+/// Reuses [`Assessment`] rather than re-deriving coverage here, so the words
+/// this stream uses are the words every other surface uses.
+fn assess(
+    registry: &crate::session::AgentRegistry,
+    facts: &SessionFacts,
+    state: Option<&str>,
+    state_at: Option<i64>,
+    stopped: bool,
+    verify: bool,
+    backend_type: &str,
+) -> Assessment {
+    let hook = Assessment::from_hooks(
+        registry,
+        &facts.agent,
+        state,
+        state_at,
+        crate::sync::current_time_millis() as i64,
+    );
+    if stopped {
+        return hook.parked();
+    }
+    if !verify {
+        return hook;
+    }
+    if crate::session::is_remote_backend(backend_type) {
+        return hook.pane_unavailable();
+    }
+    // The agent *binary*, not the agent name: `antigravity` runs `agy`, and the
+    // pane's foreground process is spelled the way it was invoked.
+    let command = registry
+        .get(&facts.agent)
+        .map(|d| d.command.clone())
+        .unwrap_or_else(|| facts.agent.clone());
+    let known: Vec<String> = registry.agents.iter().map(|a| a.command.clone()).collect();
+    let pane = crate::agent::tmux::pane_state(&facts.name, &facts.backend_id);
+    hook.with_pane(
+        &command,
+        &known,
+        pane.foreground_process.as_deref(),
+        pane.foreground_command.as_deref(),
+        pane.dead,
+    )
+}
+
+/// The columns the non-JSON renderings show, in the order they answer "what
+/// happened, to what, and how sure are we".
+const COLUMNS: &[&str] = &[
+    "seq",
+    "event",
+    "reason",
+    "name",
+    "state",
+    "from_state",
+    "to_state",
+    "session",
+];
+
+/// stdout as a line-framed stream, in the format the caller asked for.
+///
+/// A stream's unit is the line, which is what every format here is bent to:
+/// `--pretty` would otherwise put one document across many lines and leave a
+/// `read -r` loop parsing a brace. TOON declares its field list once and then
+/// writes rows, which is exactly the shape of a stream — with the length the
+/// header would carry left off, because a stream has none.
+struct Stream {
+    format: Format,
+    header: bool,
+}
+
+impl Stream {
+    fn new(format: Format) -> Self {
+        Self {
+            format,
+            header: false,
+        }
+    }
+
+    /// Write one event. `false` means the reader closed the pipe — the stream
+    /// is over and nothing further should be written to it.
+    fn write(&mut self, event: &Value) -> bool {
+        let mut lines = Vec::new();
+        match self.format {
+            Format::Human => lines.push(human(event)),
+            Format::Toon => {
+                if !self.header {
+                    self.header = true;
+                    lines.push(format!("events{{{}}}:", COLUMNS.join(",")));
+                }
+                lines.push(format!("  {}", row(event)));
+            }
+            // `--pretty` frames a document, and this is a stream of them.
+            Format::Json | Format::JsonPretty => {
+                lines.push(serde_json::to_string(event).unwrap_or_default());
+            }
+        }
+        let mut out = std::io::stdout().lock();
+        for line in lines {
+            match writeln!(out, "{line}").and_then(|()| out.flush()) {
+                Ok(()) => {}
+                // The reader is gone. Exiting now is the difference between a
+                // `watch | head -1` that ends and one that sits out the whole
+                // of its `--for-secs`.
+                Err(e) if e.kind() == ErrorKind::BrokenPipe => return false,
+                Err(e) => {
+                    tracing::warn!("watch stream write failed: {e}");
+                    return false;
+                }
+            }
+        }
+        true
+    }
+}
+
+/// One TOON row: the [`COLUMNS`] cells of this event, comma-delimited.
+fn row(event: &Value) -> String {
+    COLUMNS
+        .iter()
+        .map(|column| match event.get(*column) {
+            Some(Value::String(s)) => s.clone(),
+            Some(Value::Null) | None => String::new(),
+            Some(other) => other.to_string(),
+        })
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+/// One human line: what happened, to which session, and the transition.
+fn human(event: &Value) -> String {
+    let field = |key: &str| {
+        event
+            .get(key)
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string()
+    };
+    let seq = event.get("seq").and_then(Value::as_i64).unwrap_or_default();
+    let reason = match field("reason").as_str() {
+        "" => String::new(),
+        reason => format!(" ({reason})"),
+    };
+    let transition = match (field("from_state").as_str(), field("to_state").as_str()) {
+        ("", "") => String::new(),
+        (from, to) => format!(
+            "  {} → {}",
+            if from.is_empty() { "-" } else { from },
+            if to.is_empty() { "-" } else { to }
+        ),
+    };
+    format!(
+        "{seq:>5}  {:<8}{reason}  {}  [{}]{transition}",
+        field("event"),
+        field("name"),
+        field("state"),
+    )
 }

--- a/src/kernel/modals/settings.rs
+++ b/src/kernel/modals/settings.rs
@@ -253,7 +253,7 @@ const CORE_FIELDS: &[CoreField] = &[
     // fail on an unknown key — it simply has no reader and no UI.
     CoreField {
         id: "audit_retention_days",
-        description: "days of audit history kept",
+        description: "days of audit + event history kept",
         get: |s| Value::Number(s.audit_retention_days as f64),
         set: |s, v| {
             if let Value::Number(n) = v {

--- a/src/session/settings.rs
+++ b/src/session/settings.rs
@@ -31,7 +31,8 @@ pub struct Settings {
     /// tasks / file viewer) becomes available.
     #[serde(default = "default_three_panel_min_cols")]
     pub three_panel_min_cols: u16,
-    /// Days of audit-log history kept (pruned on startup).
+    /// Days of audit-log and session-event history kept (both pruned on
+    /// startup).
     #[serde(default = "default_audit_retention_days")]
     pub audit_retention_days: u64,
     /// Per-feature on/off switches (`[features]` table). Absent table = all

--- a/src/session_ops/delete.rs
+++ b/src/session_ops/delete.rs
@@ -78,14 +78,7 @@ pub fn delete_session_headless(
             report.disabled_automations = db
                 .disable_send_automations_for_session(session_id)
                 .map_err(|e| format!("disable_send_automations_for_session: {e}"))?;
-            db.soft_delete_session(session_id)
-                .map_err(|e| format!("soft_delete_session: {e}"))?;
-            if force {
-                db.mark_session_force_deleted(session_id)
-                    .map_err(|e| format!("mark_session_force_deleted: {e}"))?;
-                db.clear_session_meta(session_id)
-                    .map_err(|e| format!("clear_session_meta: {e}"))?;
-            }
+            delete_row(db, session_id, force)?;
             report.hook_failures =
                 super::fire_post(crate::session::HookEvent::PostDelete, &hook_ctx);
             return Ok(report);
@@ -99,21 +92,27 @@ pub fn delete_session_headless(
             .map_err(|e| format!("disable_send_automations_for_session: {e}"))?;
     }
 
-    db.soft_delete_session(session_id)
-        .map_err(|e| format!("soft_delete_session: {e}"))?;
-
-    // Record that this delete tore down the worktrees/tmux so the restore list
-    // can tag + block it (a force-delete is not restorable).
-    if force {
-        db.mark_session_force_deleted(session_id)
-            .map_err(|e| format!("mark_session_force_deleted: {e}"))?;
-        db.clear_session_meta(session_id)
-            .map_err(|e| format!("clear_session_meta: {e}"))?;
-    }
+    delete_row(db, session_id, force)?;
 
     report.hook_failures = super::fire_post(crate::session::HookEvent::PostDelete, &hook_ctx);
 
     Ok(report)
+}
+
+/// Mark the row gone. A force delete says so in the same statement rather than
+/// marking twice: the restore list needs to know the worktrees and window were
+/// torn down, and a watcher must not first be told the session is restorable.
+fn delete_row(db: &Database, session_id: SessionId, force: bool) -> Result<(), String> {
+    if force {
+        db.force_delete_session(session_id)
+            .map_err(|e| format!("force_delete_session: {e}"))?;
+        db.clear_session_meta(session_id)
+            .map_err(|e| format!("clear_session_meta: {e}"))?;
+    } else {
+        db.soft_delete_session(session_id)
+            .map_err(|e| format!("soft_delete_session: {e}"))?;
+    }
+    Ok(())
 }
 
 fn string_list(answer: &serde_json::Value, key: &str) -> Vec<String> {

--- a/src/session_ops/delete.rs
+++ b/src/session_ops/delete.rs
@@ -32,9 +32,9 @@ pub struct ForceDeleteReport {
 /// scheduled commands queued against it.
 ///
 /// Worktree and tmux cleanup are best-effort — individual failures are
-/// captured in the report but do not abort the delete. The DB row is
-/// always soft-deleted last so `Ctrl+U` / `restore_session` can still
-/// revive the metadata (the TUI will re-spawn a fresh window on restore).
+/// captured in the report but do not abort the delete. The DB row is always
+/// marked deleted last, in one write (`delete_row`) so a watcher never sees
+/// an intermediate state where a force-delete reads as restorable.
 pub fn delete_session_headless(
     db: &Database,
     session_id: SessionId,

--- a/src/session_ops/mirror.rs
+++ b/src/session_ops/mirror.rs
@@ -321,7 +321,11 @@ pub fn apply(
             }
             report.restored.push(id);
         } else {
-            if let Err(e) = db.upsert_session(&row.session) {
+            // Adopted, not spawned: the host launched it and this database is
+            // taking it on, which is what a watcher's `registered` reason says.
+            if let Err(e) =
+                db.upsert_session_as(&row.session, crate::storage::EventReason::Registered)
+            {
                 tracing::warn!("mirror: could not adopt {id}: {e}");
                 continue;
             }
@@ -350,12 +354,14 @@ pub fn apply(
     for gone in deleted {
         let id = gone.id;
         if local_active.contains_key(&id) {
-            if let Err(e) = db.soft_delete_session(id) {
+            let deleted = if gone.force_deleted {
+                db.force_delete_session(id)
+            } else {
+                db.soft_delete_session(id)
+            };
+            if let Err(e) = deleted {
                 tracing::warn!("mirror: could not delete {id}: {e}");
                 continue;
-            }
-            if gone.force_deleted {
-                let _ = db.mark_session_force_deleted(id);
             }
             report.deleted.push(id);
         } else if let Some(false) = local_deleted.get(&id) {

--- a/src/session_ops/remote_hooks.rs
+++ b/src/session_ops/remote_hooks.rs
@@ -452,7 +452,9 @@ pub(crate) fn poll_remote_hook_states(db: &crate::storage::Database) -> usize {
             .collect();
         for (id, state) in remote_status_updates(&polled, &rows) {
             match db.set_hook_state(id, &state) {
-                Ok(()) => written += 1,
+                // A parked session takes nothing, and that is not a failure:
+                // `session stop` killed the pane the host is still reporting.
+                Ok(taken) => written += usize::from(taken),
                 Err(e) => tracing::debug!("remote status poll write failed for {id}: {e}"),
             }
         }

--- a/src/session_ops/restart.rs
+++ b/src/session_ops/restart.rs
@@ -144,10 +144,6 @@ pub fn stop_session_headless(db: &Database, session_id: SessionId) -> Result<boo
         crate::agent::tmux::kill_window(&session.name, &session.backend_id).is_ok()
     };
 
-    // A stopped session reports nothing, so a leftover `working` would sit on
-    // the status line for as long as it stayed parked — and the quiescence pass
-    // that would normally correct it has no terminal to measure.
-    let _ = db.clear_hook_state(session_id);
     Ok(killed)
 }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -18,10 +18,12 @@ pub mod repo_bookmarks;
 pub mod review;
 mod schema;
 pub use schema::SCHEMA_VERSION;
+pub mod session_events;
 mod session_meta;
 mod sessions;
 mod settings;
-pub use sessions::{DeletedSessionInfo, HookRow};
+pub use session_events::{EventReason, SessionEventKind, SessionEventRow};
+pub use sessions::{DeletedSessionInfo, HookRow, SessionFacts};
 pub mod sync;
 pub mod tasks;
 mod worktrees;
@@ -153,6 +155,9 @@ impl Database {
         }
         if let Err(e) = db.prune_old_messages() {
             tracing::warn!("Failed to prune session messages: {e}");
+        }
+        if let Err(e) = db.prune_session_events() {
+            tracing::warn!("Failed to prune the session event log: {e}");
         }
         Ok(db)
     }

--- a/src/storage/schema/migrations.rs
+++ b/src/storage/schema/migrations.rs
@@ -855,3 +855,35 @@ pub(super) fn migrate_v42_worktree_provenance(conn: &Connection) -> rusqlite::Re
         "INTEGER NOT NULL DEFAULT 1",
     )
 }
+
+/// v42 → v43: `session_events`, the append-only log `thurbox-cli watch`
+/// streams.
+///
+/// `watch` used to sample the whole session table every 250 ms and diff it,
+/// which collapsed any two transitions that landed inside one sample — a
+/// `working → blocked → working` around an auto-answered permission arrived as
+/// nothing at all, and the driver never learned the permission had been asked.
+/// Every writer that changes what a watcher reports now appends a row here in
+/// the same transaction as the change, so the stream is what happened rather
+/// than what a sample could still see.
+///
+/// `AUTOINCREMENT` rather than a bare rowid on purpose: `watch --since <seq>`
+/// resumes from the last seq it saw, and SQLite reuses a plain rowid after the
+/// highest row is pruned — which would replay old events as new ones.
+pub(super) fn migrate_v43_session_events(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS session_events (
+            seq        INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            event      TEXT NOT NULL,
+            reason     TEXT NOT NULL,
+            from_state TEXT,
+            to_state   TEXT,
+            at_ms      INTEGER NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_session_events_at
+            ON session_events(at_ms);
+        CREATE INDEX IF NOT EXISTS idx_session_events_session
+            ON session_events(session_id, seq);",
+    )
+}

--- a/src/storage/schema/mod.rs
+++ b/src/storage/schema/mod.rs
@@ -28,8 +28,12 @@ use rusqlite::Connection;
 /// `worktrees`: a session can now *open* a worktree it did not create,
 /// and provenance is what tells a teardown to leave that directory alone and a
 /// restore not to warn about work no delete could have destroyed.
+/// v43 adds `session_events`, the append-only log `thurbox-cli watch`
+/// streams: every writer that changes what a watcher reports appends a row in
+/// its own transaction, so two writes in the same instant are two events
+/// rather than one sampled diff.
 /// Gaps in the step table are fine (there is no v18 step either).
-pub const SCHEMA_VERSION: u32 = 42;
+pub const SCHEMA_VERSION: u32 = 43;
 
 /// A single migration step: applied when the stored version is below `target`.
 type MigrationStep = (u32, fn(&Connection) -> rusqlite::Result<()>);
@@ -255,6 +259,20 @@ pub fn initialize(conn: &Connection) -> rusqlite::Result<()> {
             updated_at INTEGER NOT NULL,
             PRIMARY KEY (session_id, key)
         );
+
+        CREATE TABLE IF NOT EXISTS session_events (
+            seq        INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            event      TEXT NOT NULL,
+            reason     TEXT NOT NULL,
+            from_state TEXT,
+            to_state   TEXT,
+            at_ms      INTEGER NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_session_events_at
+            ON session_events(at_ms);
+        CREATE INDEX IF NOT EXISTS idx_session_events_session
+            ON session_events(session_id, seq);
         ",
     )?;
 
@@ -326,6 +344,7 @@ fn migrate(conn: &Connection) -> rusqlite::Result<()> {
         (40, migrate_v40_bookmark_git_kind),
         (41, migrate_v41_joinable),
         (42, migrate_v42_worktree_provenance),
+        (43, migrate_v43_session_events),
     ];
 
     for &(target, step) in steps {

--- a/src/storage/session_events.rs
+++ b/src/storage/session_events.rs
@@ -1,0 +1,305 @@
+//! The append-only session event log — what `thurbox-cli watch` streams.
+//!
+//! Every writer that changes what a watcher would report appends one row here
+//! **in the same transaction as the change it describes**. That is the whole
+//! point: the previous `watch` sampled the session table every 250 ms and
+//! diffed it, so two transitions inside one sample collapsed into one — a
+//! `working → blocked → working` around an auto-answered permission arrived as
+//! nothing at all, and a driver never learned the permission had been asked.
+//! A log written by the writer cannot lose a transition, whichever process
+//! made it.
+//!
+//! The log is a stream, not a record: it is pruned on the same retention as
+//! [`crate::storage::audit`] (`settings.toml` `audit_retention_days`), and a
+//! consumer that wants history reads the audit log instead.
+
+use rusqlite::params;
+
+use crate::session::SessionId;
+use crate::sync::current_time_millis;
+
+use super::Database;
+
+const MS_PER_DAY: u64 = 24 * 60 * 60 * 1000;
+
+/// What happened to a session row — the vocabulary `watch` has always emitted.
+///
+/// `present` is not here: it is the baseline `watch --initial` synthesises from
+/// the current rows, never something that *happened*.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionEventKind {
+    /// A row a watcher had not seen before: spawned, registered, or restored.
+    Created,
+    /// A row whose watched facts moved.
+    Changed,
+    /// A row that left the active set.
+    Gone,
+}
+
+impl SessionEventKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Created => "created",
+            Self::Changed => "changed",
+            Self::Gone => "gone",
+        }
+    }
+}
+
+/// Why an event happened — the field that stops a driver needing a follow-up
+/// `session get` to tell two identically-named events apart.
+///
+/// `gone` in particular used to be one word for both deletes, and the two are
+/// not the same fact: a soft-deleted session can be restored, a force-deleted
+/// one has had its worktrees and any uncommitted work torn down.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EventReason {
+    /// `created`: thurbox launched it.
+    Spawned,
+    /// `created`: an already-running session was adopted into this database
+    /// (`session register`, or a mirror pass adopting a shared host's row).
+    Registered,
+    /// `created`: a soft-deleted row came back.
+    Restored,
+    /// `changed`: the agent's reported state moved (`from_state` → `to_state`).
+    State,
+    /// `changed`: parked by `session stop` — the pane is gone, the row stands.
+    Stopped,
+    /// `changed`: un-parked by `session start`.
+    Started,
+    /// `changed`: an identifying fact moved (the name, or the pane the row
+    /// points at).
+    Updated,
+    /// `gone`: soft-deleted, and so restorable.
+    SoftDeleted,
+    /// `gone`: hard-deleted — worktrees and window torn down, not restorable.
+    ForceDeleted,
+}
+
+impl EventReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Spawned => "spawned",
+            Self::Registered => "registered",
+            Self::Restored => "restored",
+            Self::State => "state",
+            Self::Stopped => "stopped",
+            Self::Started => "started",
+            Self::Updated => "updated",
+            Self::SoftDeleted => "soft_deleted",
+            Self::ForceDeleted => "force_deleted",
+        }
+    }
+}
+
+/// One row of the log, as `watch` reads it back.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionEventRow {
+    /// Monotonic, never reused — what `watch --since` resumes from.
+    pub seq: i64,
+    pub session_id: SessionId,
+    pub event: String,
+    pub reason: String,
+    /// The agent state before and after, for a `changed`/`state` event. Both
+    /// `None` where the event is not about the agent's state.
+    pub from_state: Option<String>,
+    pub to_state: Option<String>,
+    pub at_ms: i64,
+}
+
+impl Database {
+    /// Append one event. Call it from inside the writer's own transaction, so
+    /// the event and the change it describes commit together or not at all.
+    pub(super) fn record_session_event(
+        &self,
+        id: SessionId,
+        event: SessionEventKind,
+        reason: EventReason,
+        from_state: Option<&str>,
+        to_state: Option<&str>,
+    ) -> rusqlite::Result<()> {
+        let mut stmt = self.conn.prepare_cached(
+            "INSERT INTO session_events \
+             (session_id, event, reason, from_state, to_state, at_ms) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        )?;
+        stmt.execute(params![
+            id.to_string(),
+            event.as_str(),
+            reason.as_str(),
+            from_state,
+            to_state,
+            current_time_millis() as i64,
+        ])?;
+        Ok(())
+    }
+
+    /// The highest seq in the log, or `0` when it is empty. The baseline a
+    /// watcher starts from when it was not given a `--since`.
+    pub fn latest_session_event_seq(&self) -> rusqlite::Result<i64> {
+        self.conn.query_row(
+            "SELECT COALESCE(MAX(seq), 0) FROM session_events",
+            [],
+            |r| r.get(0),
+        )
+    }
+
+    /// Events after `since`, oldest first, optionally for one session.
+    ///
+    /// `limit` bounds one read, not the stream: a caller that gets `limit` rows
+    /// back asks again from the last seq it saw.
+    pub fn session_events_since(
+        &self,
+        since: i64,
+        only: Option<SessionId>,
+        limit: usize,
+    ) -> rusqlite::Result<Vec<SessionEventRow>> {
+        // One constant statement for both shapes — a NULL `?3` means "every
+        // session" — so `prepare_cached` compiles it once and the filter is
+        // always a bound value.
+        let mut stmt = self.conn.prepare_cached(
+            "SELECT seq, session_id, event, reason, from_state, to_state, at_ms \
+             FROM session_events \
+             WHERE seq > ?1 AND (?3 IS NULL OR session_id = ?3) \
+             ORDER BY seq LIMIT ?2",
+        )?;
+        let rows = stmt.query_map(
+            params![since, limit as i64, only.map(|id| id.to_string())],
+            |row| {
+                let id: String = row.get(1)?;
+                Ok((
+                    id,
+                    SessionEventRow {
+                        seq: row.get(0)?,
+                        session_id: SessionId::default(),
+                        event: row.get(2)?,
+                        reason: row.get(3)?,
+                        from_state: row.get(4)?,
+                        to_state: row.get(5)?,
+                        at_ms: row.get(6)?,
+                    },
+                ))
+            },
+        )?;
+        let mut out = Vec::new();
+        for row in rows {
+            let (id, mut event) = row?;
+            // An unparseable id is a row no consumer can act on; skipping it
+            // beats failing the whole read.
+            if let Ok(id) = id.parse::<SessionId>() {
+                event.session_id = id;
+                out.push(event);
+            }
+        }
+        Ok(out)
+    }
+
+    /// Drop events older than the audit log's retention (`settings.toml`
+    /// `audit_retention_days`). Returns the number of rows removed. Cheap
+    /// thanks to `idx_session_events_at`.
+    pub fn prune_session_events(&self) -> rusqlite::Result<usize> {
+        let retention_days = crate::session::settings::global().audit_retention_days;
+        let cutoff = current_time_millis().saturating_sub(retention_days * MS_PER_DAY);
+        self.conn.execute(
+            "DELETE FROM session_events WHERE at_ms < ?1",
+            params![cutoff as i64],
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sync::SharedSession;
+
+    fn row(name: &str) -> SharedSession {
+        SharedSession {
+            id: SessionId::default(),
+            name: name.into(),
+            agent: "claude".into(),
+            backend_id: "%1".into(),
+            backend_type: "local-tmux".into(),
+            agent_session_id: None,
+            cwd: None,
+            additional_dirs: Vec::new(),
+            worktrees: Vec::new(),
+            shell_backend_id: None,
+            parent_session_id: None,
+            display_order: None,
+            tombstone: false,
+            tombstone_at: None,
+        }
+    }
+
+    #[test]
+    fn seq_orders_two_writes_in_the_same_millisecond() {
+        let db = Database::open_in_memory().unwrap();
+        let session = row("worker");
+        db.upsert_session(&session).unwrap();
+        db.set_hook_state(session.id, "blocked").unwrap();
+        db.set_hook_state(session.id, "working").unwrap();
+
+        let events = db.session_events_since(0, None, 100).unwrap();
+        let seen: Vec<(&str, &str)> = events
+            .iter()
+            .map(|e| (e.event.as_str(), e.reason.as_str()))
+            .collect();
+        assert_eq!(
+            seen,
+            vec![
+                ("created", "spawned"),
+                ("changed", "state"),
+                ("changed", "state"),
+            ]
+        );
+        assert!(events[0].seq < events[1].seq && events[1].seq < events[2].seq);
+        assert_eq!(events[2].from_state.as_deref(), Some("blocked"));
+        assert_eq!(events[2].to_state.as_deref(), Some("working"));
+    }
+
+    #[test]
+    fn since_resumes_without_replaying() {
+        let db = Database::open_in_memory().unwrap();
+        let session = row("worker");
+        db.upsert_session(&session).unwrap();
+        let head = db.latest_session_event_seq().unwrap();
+        db.set_hook_state(session.id, "done").unwrap();
+
+        let events = db.session_events_since(head, None, 100).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].to_state.as_deref(), Some("done"));
+    }
+
+    #[test]
+    fn events_filter_to_one_session() {
+        let db = Database::open_in_memory().unwrap();
+        let mine = row("mine");
+        let theirs = row("theirs");
+        db.upsert_session(&mine).unwrap();
+        db.upsert_session(&theirs).unwrap();
+
+        let events = db.session_events_since(0, Some(mine.id), 100).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].session_id, mine.id);
+    }
+
+    #[test]
+    fn prune_removes_only_events_past_retention() {
+        let db = Database::open_in_memory().unwrap();
+        let session = row("worker");
+        db.upsert_session(&session).unwrap();
+
+        let retention_days = crate::session::settings::global().audit_retention_days;
+        let stale = current_time_millis() - (retention_days + 1) * MS_PER_DAY;
+        db.conn_ref()
+            .execute(
+                "UPDATE session_events SET at_ms = ?1",
+                params![stale as i64],
+            )
+            .unwrap();
+        db.set_hook_state(session.id, "working").unwrap();
+
+        assert_eq!(db.prune_session_events().unwrap(), 1);
+        assert_eq!(db.session_events_since(0, None, 100).unwrap().len(), 1);
+    }
+}

--- a/src/storage/sessions.rs
+++ b/src/storage/sessions.rs
@@ -7,6 +7,7 @@ use crate::session::SessionId;
 use crate::sync::{current_time_millis, SharedSession, SharedWorktree};
 
 use super::audit::{AuditAction, EntityType};
+use super::session_events::{EventReason, SessionEventKind};
 use super::Database;
 
 /// The hooks-driven status columns of a session, read in one batch by the TUI
@@ -20,6 +21,21 @@ pub struct HookRow {
     pub state_at: Option<i64>,
     /// Epoch ms the user last "saw" a `done` state (drives Done → Idle).
     pub seen_at: Option<i64>,
+}
+
+/// The identifying facts an event carries about the session it names.
+///
+/// Read for **every** row, deleted ones included: a `gone` event names a
+/// session that is no longer in any active listing, and a stream that could
+/// only say its UUID would make its reader go and look the name up.
+#[derive(Debug, Clone)]
+pub struct SessionFacts {
+    pub name: String,
+    /// Which agent — what the hook-coverage assessment is decided from.
+    pub agent: String,
+    pub backend_id: String,
+    /// Parked by `session stop`.
+    pub stopped: bool,
 }
 
 /// Information about a soft-deleted session, including its worktrees.
@@ -62,25 +78,51 @@ impl Database {
     /// NULL`). The pre-write existence check decides only the audit label and
     /// can't make the write race — the UPSERT handles both cases regardless.
     ///
-    /// The whole write — row, audits, worktree replacement — is one transaction:
-    /// each statement in autocommit was its own WAL commit, so a single upsert
-    /// cost N+5 `data_version` bumps and re-triggered every peer process's
-    /// refresh that many times. (`unchecked_transaction` because `Database`
-    /// methods take `&self`; the connection is not shared across threads.)
+    /// The whole write — row, audits, worktree replacement, the watch event —
+    /// is one transaction: each statement in autocommit was its own WAL commit,
+    /// so a single upsert cost N+5 `data_version` bumps and re-triggered every
+    /// peer process's refresh that many times. (`unchecked_transaction` because
+    /// `Database` methods take `&self`; the connection is not shared across
+    /// threads.)
     pub fn upsert_session(&self, session: &SharedSession) -> rusqlite::Result<()> {
+        self.upsert_session_as(session, EventReason::Spawned)
+    }
+
+    /// [`upsert_session`](Self::upsert_session), saying why a *new* row appeared.
+    ///
+    /// The row is identical either way; only the `created` event `thurbox-cli
+    /// watch` streams differs, and the difference matters to whoever reads it —
+    /// a session thurbox launched is not one that was already running and got
+    /// adopted (`session register`, a mirror pass taking on a shared host's
+    /// row). `created_as` is ignored when the row already existed.
+    pub fn upsert_session_as(
+        &self,
+        session: &SharedSession,
+        created_as: EventReason,
+    ) -> rusqlite::Result<()> {
         let tx = self.conn.unchecked_transaction()?;
         let now = current_time_millis() as i64;
         let id_str = session.id.to_string();
 
-        let existed = self
+        // The row as it stands, if at all: whether it existed decides the audit
+        // label, and *how* it existed decides the watch event — the UPSERT below
+        // clears `deleted_at`, so a conflict on a soft-deleted row is a session
+        // coming back rather than one being updated.
+        let before = self
             .conn
             .query_row(
-                "SELECT 1 FROM sessions WHERE id = ?1",
+                "SELECT deleted_at, name, backend_id FROM sessions WHERE id = ?1",
                 params![id_str],
-                |_| Ok(()),
+                |row| {
+                    Ok((
+                        row.get::<_, Option<i64>>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                    ))
+                },
             )
-            .optional()?
-            .is_some();
+            .optional()?;
+        let existed = before.is_some();
 
         self.conn.execute(
             "INSERT INTO sessions (id, name, agent, backend_id, backend_type, \
@@ -140,17 +182,68 @@ impl Database {
             self.upsert_worktrees(session.id, &session.worktrees)?;
         }
 
+        match before {
+            None => self.record_session_event(
+                session.id,
+                SessionEventKind::Created,
+                created_as,
+                None,
+                None,
+            )?,
+            // A conflict on a soft-deleted row revives it: the session is back
+            // in every listing, so a watcher that saw it go must see it return.
+            Some((Some(_), _, _)) => self.record_session_event(
+                session.id,
+                SessionEventKind::Created,
+                EventReason::Restored,
+                None,
+                None,
+            )?,
+            // Only the facts a watcher reports are an event; a write that
+            // changes nothing it can see is not one.
+            Some((None, name, backend_id)) => {
+                if name != session.name || backend_id != session.backend_id {
+                    self.record_session_event(
+                        session.id,
+                        SessionEventKind::Changed,
+                        EventReason::Updated,
+                        None,
+                        None,
+                    )?;
+                }
+            }
+        }
+
         tx.commit()
     }
 
-    /// Soft-delete a session.
+    /// Soft-delete a session: the row is hidden, everything it owns stands, and
+    /// a restore brings it back.
     pub fn soft_delete_session(&self, id: SessionId) -> rusqlite::Result<()> {
+        self.delete_session(id, EventReason::SoftDeleted)
+    }
+
+    /// Delete a session **and** mark it force-deleted in one transaction: its
+    /// tmux window and worktrees were torn down, so it can't be restored
+    /// (schema v37).
+    ///
+    /// One call rather than a soft delete followed by
+    /// [`mark_session_force_deleted`](Self::mark_session_force_deleted) because
+    /// the pair emitted two `gone` events, and the first of them told a watcher
+    /// the session was restorable when it never was.
+    pub fn force_delete_session(&self, id: SessionId) -> rusqlite::Result<()> {
+        self.delete_session(id, EventReason::ForceDeleted)
+    }
+
+    fn delete_session(&self, id: SessionId, reason: EventReason) -> rusqlite::Result<()> {
+        let tx = self.conn.unchecked_transaction()?;
         let now = current_time_millis() as i64;
         let id_str = id.to_string();
 
-        self.conn.execute(
-            "UPDATE sessions SET deleted_at = ?1, updated_at = ?1 WHERE id = ?2 AND deleted_at IS NULL",
-            params![now, id_str],
+        let deleted = self.conn.execute(
+            "UPDATE sessions SET deleted_at = ?1, updated_at = ?1, force_deleted = ?3 \
+             WHERE id = ?2 AND deleted_at IS NULL",
+            params![now, id_str, i64::from(reason == EventReason::ForceDeleted)],
         )?;
 
         self.log_audit(
@@ -162,28 +255,51 @@ impl Database {
             None,
         )?;
 
-        Ok(())
+        // A second delete of an already-deleted row changes nothing, so it is
+        // not a second `gone`.
+        if deleted > 0 {
+            self.record_session_event(id, SessionEventKind::Gone, reason, None, None)?;
+        }
+
+        tx.commit()
     }
 
-    /// Mark a soft-deleted session as force-deleted: its tmux window + worktrees
-    /// were torn down, so it can't be restored (schema v37). Safe to call after
-    /// [`soft_delete_session`](Self::soft_delete_session); idempotent.
+    /// Upgrade an **already-deleted** row to force-deleted: its window and
+    /// worktrees turned out to be gone after all (a mirror pass learning what
+    /// the owning host did). A row that is not deleted, or already marked, is
+    /// left alone — so the `gone` event this emits is the news that the session
+    /// stopped being restorable, never a repeat.
+    ///
+    /// Deleting *and* marking in one go is
+    /// [`force_delete_session`](Self::force_delete_session).
     pub fn mark_session_force_deleted(&self, id: SessionId) -> rusqlite::Result<()> {
-        self.conn.execute(
-            "UPDATE sessions SET force_deleted = 1 WHERE id = ?1",
+        let tx = self.conn.unchecked_transaction()?;
+        let marked = self.conn.execute(
+            "UPDATE sessions SET force_deleted = 1 \
+             WHERE id = ?1 AND deleted_at IS NOT NULL AND force_deleted = 0",
             params![id.to_string()],
         )?;
-        Ok(())
+        if marked > 0 {
+            self.record_session_event(
+                id,
+                SessionEventKind::Gone,
+                EventReason::ForceDeleted,
+                None,
+                None,
+            )?;
+        }
+        tx.commit()
     }
 
     /// Restore a soft-deleted session.
     pub fn restore_session(&self, id: SessionId) -> rusqlite::Result<()> {
+        let tx = self.conn.unchecked_transaction()?;
         let now = current_time_millis() as i64;
         let id_str = id.to_string();
 
         // Clear `force_deleted` defensively — the app layer blocks restoring a
         // force-deleted row, so this only matters if a future caller revives one.
-        self.conn.execute(
+        let restored = self.conn.execute(
             "UPDATE sessions SET deleted_at = NULL, force_deleted = 0, updated_at = ?1 WHERE id = ?2 AND deleted_at IS NOT NULL",
             params![now, id_str],
         )?;
@@ -197,7 +313,17 @@ impl Database {
             None,
         )?;
 
-        Ok(())
+        if restored > 0 {
+            self.record_session_event(
+                id,
+                SessionEventKind::Created,
+                EventReason::Restored,
+                None,
+                None,
+            )?;
+        }
+
+        tx.commit()
     }
 
     /// List all active (non-deleted) sessions.
@@ -358,13 +484,59 @@ impl Database {
     ///
     /// The mark is what separates "parked on purpose" from "its window died",
     /// which several subsystems otherwise repair on sight.
+    ///
+    /// Parking also **clears the hook columns**, in the same transaction: a
+    /// parked session has no process, so the last thing its agent said no
+    /// longer describes it, and the quiescence pass that would normally correct
+    /// a stale `working` has no terminal left to measure. Doing it here rather
+    /// than in the caller is what makes it true of every park — and it is the
+    /// same rule [`set_hook_state`](Self::set_hook_state) enforces from the
+    /// other side.
     pub fn set_session_stopped(&self, id: SessionId, stopped: bool) -> rusqlite::Result<()> {
-        let at = stopped.then(|| current_time_millis() as i64);
+        let tx = self.conn.unchecked_transaction()?;
+        let now = current_time_millis() as i64;
+        let id_str = id.to_string();
+
+        let before: Option<(Option<i64>, Option<String>)> = self
+            .conn
+            .query_row(
+                "SELECT stopped_at, hook_state FROM sessions WHERE id = ?1",
+                params![id_str],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .optional()?;
+        let Some((stopped_at, hook_state)) = before else {
+            return Ok(());
+        };
+
+        let at = stopped.then_some(now);
         self.conn.execute(
             "UPDATE sessions SET stopped_at = ?1, updated_at = ?2 WHERE id = ?3",
-            params![at, current_time_millis() as i64, id.to_string()],
+            params![at, now, id_str],
         )?;
-        Ok(())
+        if stopped {
+            self.conn.execute(
+                "UPDATE sessions SET hook_state = NULL, hook_state_at = NULL, seen_at = NULL \
+                 WHERE id = ?1",
+                params![id_str],
+            )?;
+        }
+
+        if stopped_at.is_some() != stopped {
+            self.record_session_event(
+                id,
+                SessionEventKind::Changed,
+                if stopped {
+                    EventReason::Stopped
+                } else {
+                    EventReason::Started
+                },
+                hook_state.as_deref(),
+                None,
+            )?;
+        }
+
+        tx.commit()
     }
 
     /// When a session was stopped, or `None` if it is not stopped.
@@ -395,6 +567,35 @@ impl Database {
             }
         }
         Ok(set)
+    }
+
+    /// Every session row's identifying facts, keyed by id — deleted rows
+    /// included. One lean scan with no worktree join: `thurbox-cli watch` reads
+    /// it once per wake to name the sessions its events are about.
+    pub fn load_session_facts(&self) -> rusqlite::Result<HashMap<SessionId, SessionFacts>> {
+        let mut stmt = self
+            .conn
+            .prepare_cached("SELECT id, name, agent, backend_id, stopped_at FROM sessions")?;
+        let rows = stmt.query_map([], |row| {
+            let id: String = row.get(0)?;
+            Ok((
+                id,
+                SessionFacts {
+                    name: row.get(1)?,
+                    agent: row.get(2)?,
+                    backend_id: row.get(3)?,
+                    stopped: row.get::<_, Option<i64>>(4)?.is_some(),
+                },
+            ))
+        })?;
+        let mut map = HashMap::new();
+        for row in rows {
+            let (id, facts) = row?;
+            if let Ok(id) = id.parse::<SessionId>() {
+                map.insert(id, facts);
+            }
+        }
+        Ok(map)
     }
 
     /// Get the session counter value.
@@ -634,18 +835,57 @@ impl Database {
     /// Record an agent-reported lifecycle state (`working`/`blocked`/`done`) for
     /// a session, stamping `hook_state_at` to now. Written by
     /// `thurbox-cli session signal` (and at spawn, defaulting to `working`).
+    /// Returns whether a row took it.
     ///
     /// Deliberately a targeted UPDATE that touches only the hook columns —
     /// [`upsert_session`](Self::upsert_session) must never list them, so the
     /// TUI's full-row write-back can't clobber a state a headless hook just set.
-    pub fn set_hook_state(&self, id: SessionId, state: &str) -> rusqlite::Result<()> {
+    ///
+    /// A **parked** session takes nothing (`stopped_at IS NOT NULL`), and that
+    /// is the point rather than a side effect: `session stop` killed the pane,
+    /// so anything still reporting into it — a heartbeat's pane-option poll, a
+    /// mirror pass carrying a host's last word — would be writing a state onto
+    /// a session that has no process to be in it, and every watcher of that row
+    /// would see a transition that did not happen.
+    pub fn set_hook_state(&self, id: SessionId, state: &str) -> rusqlite::Result<bool> {
+        let tx = self.conn.unchecked_transaction()?;
         let now = current_time_millis() as i64;
+        let id_str = id.to_string();
+
+        let before: Option<Option<String>> = self
+            .conn
+            .query_row(
+                "SELECT hook_state FROM sessions \
+                 WHERE id = ?1 AND deleted_at IS NULL AND stopped_at IS NULL",
+                params![id_str],
+                |row| row.get(0),
+            )
+            .optional()?;
+        let Some(previous) = before else {
+            return Ok(false);
+        };
+
         self.conn.execute(
             "UPDATE sessions SET hook_state = ?1, hook_state_at = ?2 \
-             WHERE id = ?3 AND deleted_at IS NULL",
-            params![state, now, id.to_string()],
+             WHERE id = ?3 AND deleted_at IS NULL AND stopped_at IS NULL",
+            params![state, now, id_str],
         )?;
-        Ok(())
+
+        // The stamp is refreshed whatever happens — a re-report is news about
+        // the agent's liveness — but only a different word is a *transition*,
+        // and the event log carries transitions.
+        if previous.as_deref() != Some(state) {
+            self.record_session_event(
+                id,
+                SessionEventKind::Changed,
+                EventReason::State,
+                previous.as_deref(),
+                Some(state),
+            )?;
+        }
+
+        tx.commit()?;
+        Ok(true)
     }
 
     /// Record the base branch a session's worktree was forked from. A targeted
@@ -682,11 +922,34 @@ impl Database {
     /// ordinary spawns persist theirs through
     /// [`upsert_session`](Self::upsert_session). Returns whether a row matched.
     pub fn set_backend_id(&self, id: SessionId, pane: &str) -> rusqlite::Result<bool> {
+        let tx = self.conn.unchecked_transaction()?;
+        let id_str = id.to_string();
+        let before: Option<String> = self
+            .conn
+            .query_row(
+                "SELECT backend_id FROM sessions WHERE id = ?1 AND deleted_at IS NULL",
+                params![id_str],
+                |row| row.get(0),
+            )
+            .optional()?;
         let mut stmt = self.conn.prepare_cached(
             "UPDATE sessions SET backend_id = ?1 \
              WHERE id = ?2 AND deleted_at IS NULL",
         )?;
-        let updated = stmt.execute(params![pane, id.to_string()])?;
+        let updated = stmt.execute(params![pane, id_str])?;
+        drop(stmt);
+        // The pane a row points at is one of the facts `watch` reports, so a
+        // real move is an event; re-writing the id it already had is not.
+        if before.as_deref().is_some_and(|had| had != pane) {
+            self.record_session_event(
+                id,
+                SessionEventKind::Changed,
+                EventReason::Updated,
+                None,
+                None,
+            )?;
+        }
+        tx.commit()?;
         Ok(updated > 0)
     }
 
@@ -721,13 +984,36 @@ impl Database {
     /// it to the never-reported `Idle` default. Called on **restart**: the agent
     /// is re-spawned fresh, so a stale `Blocked`/`Working`/`Done` must not linger
     /// until the agent's hooks re-report (which a resumed agent may not do).
+    ///
+    /// Parking clears the same columns inside
+    /// [`set_session_stopped`](Self::set_session_stopped), which reports the
+    /// park rather than a bare state change; this is the restart edge alone.
     pub fn clear_hook_state(&self, id: SessionId) -> rusqlite::Result<()> {
+        let tx = self.conn.unchecked_transaction()?;
+        let id_str = id.to_string();
+        let previous: Option<Option<String>> = self
+            .conn
+            .query_row(
+                "SELECT hook_state FROM sessions WHERE id = ?1",
+                params![id_str],
+                |row| row.get(0),
+            )
+            .optional()?;
         self.conn.execute(
             "UPDATE sessions SET hook_state = NULL, hook_state_at = NULL, seen_at = NULL \
              WHERE id = ?1",
-            params![id.to_string()],
+            params![id_str],
         )?;
-        Ok(())
+        if let Some(Some(previous)) = previous {
+            self.record_session_event(
+                id,
+                SessionEventKind::Changed,
+                EventReason::State,
+                Some(&previous),
+                None,
+            )?;
+        }
+        tx.commit()
     }
 
     /// Load the hook-status columns for every active session in one indexed

--- a/tests/cli_watch.rs
+++ b/tests/cli_watch.rs
@@ -457,6 +457,126 @@ fn toon_declares_its_columns_once() {
     }
 }
 
+/// A `state` transition and a park landing in the same drained batch must each
+/// report their own point-in-time `stopped`, not the batch's final row.
+///
+/// This is the same class of loss the event log exists to prevent, reintroduced
+/// for the derived `state`/`stopped` fields: reading the row once per batch
+/// would make an earlier event in the batch inherit a park that happened after
+/// it, mislabeling a live transition as a park.
+#[test]
+fn a_state_event_sharing_a_batch_with_a_park_reports_its_own_state() {
+    let env = Env::new();
+    let db = env.db();
+    let id = seed(&db, "worker");
+    db.set_hook_state(id, "working").expect("working");
+
+    let watch = env.watch(&["--json", "--for-secs", "30"]);
+    settle();
+
+    // Both inside a single gate window, so `drain` reads them as one batch.
+    db.set_hook_state(id, "blocked").expect("blocked");
+    std::thread::sleep(Duration::from_millis(10));
+    db.set_session_stopped(id, true).expect("park");
+
+    let transition = watch.event("the state transition");
+    let park = watch.event("the park");
+
+    assert_eq!(event_of(&transition), ("changed", "state"));
+    assert_eq!(transition["to_state"], Value::String("blocked".into()));
+    assert_eq!(
+        transition["stopped"],
+        Value::Bool(false),
+        "the transition happened before the park: {transition}"
+    );
+    assert_eq!(
+        transition["state"],
+        Value::String("blocked".into()),
+        "a later park in the same batch must not relabel this event: {transition}"
+    );
+
+    assert_eq!(event_of(&park), ("changed", "stopped"));
+    assert_eq!(park["stopped"], Value::Bool(true));
+    assert_eq!(park["state"], Value::String("stopped".into()));
+}
+
+/// A minimal §7.1-aware split, just enough to prove a quoted TOON row decodes
+/// back to the fields the header promises rather than shifting on an embedded
+/// delimiter.
+fn split_toon_row(row: &str) -> Vec<String> {
+    let mut fields = Vec::new();
+    let mut chars = row.chars().peekable();
+    loop {
+        let mut field = String::new();
+        if chars.peek() == Some(&'"') {
+            chars.next();
+            while let Some(c) = chars.next() {
+                match c {
+                    '"' => break,
+                    '\\' => {
+                        if let Some(next) = chars.next() {
+                            field.push(match next {
+                                'n' => '\n',
+                                'r' => '\r',
+                                't' => '\t',
+                                other => other,
+                            });
+                        }
+                    }
+                    c => field.push(c),
+                }
+            }
+        } else {
+            while let Some(&c) = chars.peek() {
+                if c == ',' {
+                    break;
+                }
+                field.push(c);
+                chars.next();
+            }
+        }
+        fields.push(field);
+        match chars.next() {
+            Some(',') => continue,
+            _ => break,
+        }
+    }
+    fields
+}
+
+/// A session name that itself contains the row delimiter and a colon must not
+/// shift every column after it — the TOON row is quoted and escaped per §7.2
+/// by the shared encoder, not hand-joined.
+#[test]
+fn toon_row_escapes_a_name_that_contains_the_delimiter() {
+    let env = Env::new();
+    let db = env.db();
+    let id = seed(&db, "fix: foo, bar");
+
+    let watch = env.watch(&["--toon", "--for-secs", "30"]);
+    settle();
+    db.set_hook_state(id, "blocked").expect("blocked");
+
+    let _header = watch.line("the TOON header");
+    let row = watch.line("the event row");
+    let fields = split_toon_row(row.trim_start());
+
+    assert_eq!(
+        fields.len(),
+        8,
+        "the comma and colon inside the session name must not add a column: {row}"
+    );
+    assert_eq!(
+        fields[3], "fix: foo, bar",
+        "the name must decode back exactly: {row}"
+    );
+    assert_eq!(
+        fields[7],
+        id.to_string(),
+        "the session column must still be the id, not a shifted fragment: {row}"
+    );
+}
+
 /// `--session` narrows the stream to one session, and the log is filtered
 /// rather than the output.
 #[test]

--- a/tests/cli_watch.rs
+++ b/tests/cli_watch.rs
@@ -1,0 +1,478 @@
+//! What `thurbox-cli watch` streams, and what it can no longer lose.
+//!
+//! The command used to sample every session's state on a 250 ms timer and diff
+//! the samples, which is exactly wrong for the thing a driver watches for: two
+//! transitions inside one sample cancelled out. `working → blocked → working`
+//! around an auto-answered permission arrived as nothing at all, and the driver
+//! never learned the permission had been asked. These tests pin the replacement
+//! — an append-only log written by each writer in its own transaction — by
+//! driving the real binary against a real database file, because the property
+//! under test is the cross-process one: the writer is a different connection.
+//!
+//! No tmux and no agent anywhere here. Every event these tests care about is a
+//! row in the database, written by the storage layer a spawn would have gone
+//! through.
+
+use std::io::{BufRead, BufReader, Read};
+use std::path::PathBuf;
+use std::process::{Child, ChildStdout, Command, Stdio};
+use std::sync::mpsc;
+use std::time::Duration;
+
+use serde_json::Value;
+use thurbox::session::SessionId;
+use thurbox::storage::Database;
+use thurbox::sync::SharedSession;
+
+/// How long a test waits for a line that should already be on its way.
+const WAIT: Duration = Duration::from_secs(15);
+
+/// The agent registry these tests read coverage from: `claude` reports every
+/// state and its `blocked` is a text match, which is what the gating fields on
+/// each event are asserted against.
+const AGENTS_TOML: &str = r#"
+config_version = 1
+default = "claude"
+
+[[agents]]
+name = "claude"
+command = "claude"
+"#;
+
+/// A throwaway thurbox instance: its own config, data, home and multiplexer
+/// socket, so nothing here reads or writes the operator's.
+struct Env {
+    root: tempfile::TempDir,
+}
+
+impl Env {
+    fn new() -> Self {
+        let root = tempfile::TempDir::new().expect("tempdir");
+        for sub in ["home", "config", "data"] {
+            std::fs::create_dir_all(root.path().join(sub)).expect("mkdir");
+        }
+        let agents = root.path().join("config").join("agents.toml");
+        std::fs::write(agents, AGENTS_TOML).expect("write agents.toml");
+        Self { root }
+    }
+
+    fn path(&self, sub: &str) -> PathBuf {
+        self.root.path().join(sub)
+    }
+
+    fn db(&self) -> Database {
+        Database::open(&self.path("data").join("thurbox.db")).expect("open the instance database")
+    }
+
+    /// Start `watch` with the given flags, its stdout on a pipe.
+    fn watch(&self, args: &[&str]) -> Watch {
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_thurbox-cli"));
+        cmd.arg("watch").args(args);
+        cmd.env("HOME", self.path("home"));
+        cmd.env("USERPROFILE", self.path("home"));
+        cmd.env("XDG_DATA_HOME", self.path("home").join("xdg-data"));
+        cmd.env("XDG_CONFIG_HOME", self.path("home").join("xdg-config"));
+        cmd.env("THURBOX_CONFIG_DIR", self.path("config"));
+        cmd.env("THURBOX_DATA_DIR", self.path("data"));
+        // Named outright: a relocated data dir derives a socket of its own, and
+        // nothing here may reach the operator's server even by accident.
+        cmd.env("THURBOX_SOCKET", "thurbox-watch-test");
+        cmd.env_remove("THURBOX_SOCKET_FOR");
+        cmd.env_remove("THURBOX_SESSION");
+        cmd.env_remove("THURBOX_SESSION_ID");
+        let mut child = cmd
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn watch");
+        let stdout = child.stdout.take().expect("piped stdout");
+        Watch {
+            child,
+            lines: reader(stdout),
+        }
+    }
+}
+
+/// A running `watch`, killed when the test drops it so a failure cannot leave a
+/// process behind.
+struct Watch {
+    child: Child,
+    lines: mpsc::Receiver<String>,
+}
+
+impl Watch {
+    /// The next line, or a failure naming what was being waited for.
+    fn line(&self, what: &str) -> String {
+        self.lines
+            .recv_timeout(WAIT)
+            .unwrap_or_else(|_| panic!("watch produced no line while waiting for {what}"))
+    }
+
+    fn event(&self, what: &str) -> Value {
+        serde_json::from_str(&self.line(what)).expect("one JSON object per line")
+    }
+
+    /// Assert nothing more arrives within `grace` — used where the point is an
+    /// event that must *not* be emitted.
+    fn silent_for(&self, grace: Duration) {
+        if let Ok(line) = self.lines.recv_timeout(grace) {
+            panic!("watch emitted an event it should not have: {line}");
+        }
+    }
+}
+
+impl Drop for Watch {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// Pump a child's stdout into a channel, so a test can wait on a line with a
+/// timeout instead of blocking forever on a read.
+fn reader(stdout: ChildStdout) -> mpsc::Receiver<String> {
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        for line in BufReader::new(stdout).lines() {
+            let Ok(line) = line else { return };
+            if tx.send(line).is_err() {
+                return;
+            }
+        }
+    });
+    rx
+}
+
+fn seed(db: &Database, name: &str) -> SessionId {
+    let row = SharedSession {
+        id: SessionId::default(),
+        name: name.into(),
+        agent: "claude".into(),
+        backend_id: "%1".into(),
+        backend_type: "local-tmux".into(),
+        agent_session_id: None,
+        cwd: None,
+        additional_dirs: Vec::new(),
+        worktrees: Vec::new(),
+        shell_backend_id: None,
+        parent_session_id: None,
+        display_order: None,
+        tombstone: false,
+        tombstone_at: None,
+    };
+    db.upsert_session(&row).expect("seed a session row");
+    row.id
+}
+
+/// Let the watcher take its baseline before the test changes anything, so a
+/// write below is unambiguously a change rather than part of the initial state.
+fn settle() {
+    std::thread::sleep(Duration::from_millis(700));
+}
+
+fn event_of(line: &Value) -> (&str, &str) {
+    (
+        line["event"].as_str().unwrap_or_default(),
+        line["reason"].as_str().unwrap_or_default(),
+    )
+}
+
+/// Two writes inside the same sample window are two events, in order.
+///
+/// This is the bug the event log exists for: `working → blocked → working` is
+/// how an auto-answered permission looks, and the old whole-state diff reported
+/// it as nothing at all because both writes landed between two samples.
+#[test]
+fn two_writes_in_one_sample_are_two_events_in_order() {
+    let env = Env::new();
+    let db = env.db();
+    let id = seed(&db, "worker");
+    db.set_hook_state(id, "working").expect("first state");
+
+    let watch = env.watch(&["--json", "--for-secs", "30"]);
+    settle();
+
+    // Both inside a single 250 ms gate window, and far tighter than one.
+    db.set_hook_state(id, "blocked").expect("blocked");
+    std::thread::sleep(Duration::from_millis(10));
+    db.set_hook_state(id, "working").expect("working");
+
+    let blocked = watch.event("the blocked transition");
+    let working = watch.event("the working transition");
+
+    assert_eq!(event_of(&blocked), ("changed", "state"));
+    assert_eq!(blocked["from_state"], Value::String("working".into()));
+    assert_eq!(blocked["to_state"], Value::String("blocked".into()));
+    assert_eq!(event_of(&working), ("changed", "state"));
+    assert_eq!(working["from_state"], Value::String("blocked".into()));
+    assert_eq!(working["to_state"], Value::String("working".into()));
+    assert!(
+        blocked["seq"].as_i64() < working["seq"].as_i64(),
+        "seq must order the two writes"
+    );
+}
+
+/// Every event carries what the reported state is *worth*, so reacting to a
+/// `blocked` needs no follow-up `session get`.
+#[test]
+fn each_event_carries_the_gating_fields() {
+    let env = Env::new();
+    let db = env.db();
+    let id = seed(&db, "worker");
+
+    let watch = env.watch(&["--json", "--for-secs", "30"]);
+    settle();
+    db.set_hook_state(id, "blocked").expect("blocked");
+
+    let event = watch.event("the blocked transition");
+    assert_eq!(event["state"], Value::String("blocked".into()));
+    assert_eq!(event["state_source"], Value::String("hook".into()));
+    assert_eq!(event["hook_coverage"], Value::String("full".into()));
+    // claude's `blocked` is a text match on a notification body, which is
+    // exactly what a driver about to act on one needs told.
+    assert_eq!(event["hook_blocked_is_heuristic"], Value::Bool(true));
+    // Not checked rather than checked-and-consistent: the pane probe is
+    // `--verify`, off by default here as it is on `session list`.
+    assert_eq!(event["hook_state_contradicted"], Value::Null);
+}
+
+/// A soft delete and a force delete are not the same news: one is restorable.
+#[test]
+fn gone_says_which_delete_it_was() {
+    let env = Env::new();
+    let db = env.db();
+    let soft = seed(&db, "soft");
+    let hard = seed(&db, "hard");
+
+    let watch = env.watch(&["--json", "--for-secs", "30"]);
+    settle();
+    db.soft_delete_session(soft).expect("soft delete");
+    db.force_delete_session(hard).expect("force delete");
+
+    let first = watch.event("the soft delete");
+    let second = watch.event("the force delete");
+    assert_eq!(event_of(&first), ("gone", "soft_deleted"));
+    assert_eq!(first["name"], Value::String("soft".into()));
+    assert_eq!(event_of(&second), ("gone", "force_deleted"));
+    assert_eq!(second["name"], Value::String("hard".into()));
+}
+
+/// `created` says where the session came from — thurbox launched it, it was
+/// adopted while already running, or it came back from the deleted list.
+#[test]
+fn created_says_where_the_session_came_from() {
+    let env = Env::new();
+    let db = env.db();
+
+    let watch = env.watch(&["--json", "--for-secs", "30"]);
+    settle();
+    let spawned = seed(&db, "spawned");
+    db.soft_delete_session(spawned).expect("delete");
+    db.restore_session(spawned).expect("restore");
+
+    let created = watch.event("the spawn");
+    assert_eq!(event_of(&created), ("created", "spawned"));
+    assert_eq!(
+        event_of(&watch.event("the delete")),
+        ("gone", "soft_deleted")
+    );
+    assert_eq!(
+        event_of(&watch.event("the restore")),
+        ("created", "restored")
+    );
+}
+
+/// A driver that persisted the last seq it handled resumes with exactly what it
+/// missed, and nothing it already had.
+#[test]
+fn since_resumes_without_replaying() {
+    let env = Env::new();
+    let db = env.db();
+    let id = seed(&db, "worker");
+    db.set_hook_state(id, "working").expect("working");
+    let head = db.latest_session_event_seq().expect("head");
+    db.set_hook_state(id, "done").expect("done");
+
+    let watch = env.watch(&["--json", "--since", &head.to_string(), "--for-secs", "30"]);
+
+    // The missed event, immediately — a resume does not wait for the next
+    // commit by somebody else.
+    let missed = watch.event("the event missed while away");
+    assert_eq!(missed["to_state"], Value::String("done".into()));
+    assert!(missed["seq"].as_i64() > Some(head));
+    watch.silent_for(Duration::from_secs(1));
+}
+
+/// A parked session takes no hook state, so a heartbeat's pane poll — or a
+/// mirror pass carrying a host's last word — cannot report a turn on a session
+/// that has no process to be in one.
+#[test]
+fn a_parked_session_gets_no_hook_events() {
+    let env = Env::new();
+    let db = env.db();
+    let id = seed(&db, "parked");
+    db.set_hook_state(id, "working").expect("working");
+
+    let watch = env.watch(&["--json", "--for-secs", "30"]);
+    settle();
+    db.set_session_stopped(id, true).expect("park");
+
+    let parked = watch.event("the park");
+    assert_eq!(event_of(&parked), ("changed", "stopped"));
+    assert_eq!(parked["stopped"], Value::Bool(true));
+    assert_eq!(parked["state"], Value::String("stopped".into()));
+    // The park cleared the latched state; the word came from thurbox, not the
+    // agent, so nothing may launder it back into the column.
+    assert_eq!(parked["from_state"], Value::String("working".into()));
+
+    assert!(
+        !db.set_hook_state(id, "working").expect("write"),
+        "a parked row must refuse a hook state"
+    );
+    watch.silent_for(Duration::from_secs(1));
+
+    db.set_session_stopped(id, false).expect("un-park");
+    assert_eq!(
+        event_of(&watch.event("the un-park")),
+        ("changed", "started")
+    );
+}
+
+/// The stream ends when its reader does, instead of sitting out the whole of
+/// its `--for-secs`.
+#[test]
+fn the_stream_ends_when_the_reader_closes() {
+    let env = Env::new();
+    let db = env.db();
+    let id = seed(&db, "worker");
+
+    // Read directly rather than through the pump thread: this test has to *drop*
+    // the pipe, which the pump would keep open.
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_thurbox-cli"));
+    cmd.args(["watch", "--json", "--initial", "--for-secs", "120"]);
+    cmd.env("HOME", env.path("home"));
+    cmd.env("USERPROFILE", env.path("home"));
+    cmd.env("XDG_DATA_HOME", env.path("home").join("xdg-data"));
+    cmd.env("XDG_CONFIG_HOME", env.path("home").join("xdg-config"));
+    cmd.env("THURBOX_CONFIG_DIR", env.path("config"));
+    cmd.env("THURBOX_DATA_DIR", env.path("data"));
+    cmd.env("THURBOX_SOCKET", "thurbox-watch-test");
+    cmd.env_remove("THURBOX_SOCKET_FOR");
+    let mut child = cmd
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn watch");
+
+    let mut stdout = child.stdout.take().expect("piped stdout");
+    let mut baseline = [0u8; 1];
+    stdout.read_exact(&mut baseline).expect("the initial line");
+    drop(stdout);
+
+    // Something to write into the closed pipe: the exit is on the write, not on
+    // a timer.
+    settle();
+    db.set_hook_state(id, "working").expect("working");
+
+    let status = wait_for_exit(&mut child, Duration::from_secs(20));
+    assert!(
+        status,
+        "watch must exit when its reader is gone, not run out its --for-secs"
+    );
+}
+
+/// Poll a child for up to `limit`, returning whether it exited.
+fn wait_for_exit(child: &mut Child, limit: Duration) -> bool {
+    let deadline = std::time::Instant::now() + limit;
+    while std::time::Instant::now() < deadline {
+        match child.try_wait() {
+            Ok(Some(_)) => return true,
+            Ok(None) => std::thread::sleep(Duration::from_millis(50)),
+            Err(_) => return false,
+        }
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+    false
+}
+
+/// `--initial` is the baseline plus the changes after it in one stream, and it
+/// obeys `--text` like every other rendering.
+#[test]
+fn initial_emits_the_baseline_in_the_asked_for_format() {
+    let env = Env::new();
+    let db = env.db();
+    let id = seed(&db, "worker");
+    db.set_hook_state(id, "working").expect("working");
+
+    let watch = env.watch(&["--text", "--initial", "--for-secs", "30"]);
+    let baseline = watch.line("the baseline row");
+    assert!(
+        baseline.contains("present") && baseline.contains("worker") && baseline.contains("working"),
+        "a --text baseline reads as a line, not JSON: {baseline}"
+    );
+    assert!(
+        !baseline.trim_start().starts_with('{'),
+        "--text must not emit JSON: {baseline}"
+    );
+
+    settle();
+    db.set_hook_state(id, "done").expect("done");
+    let changed = watch.line("the transition");
+    assert!(
+        changed.contains("changed") && changed.contains("working → done"),
+        "a --text event names its transition: {changed}"
+    );
+}
+
+/// TOON declares its columns once and then writes rows — the shape a stream
+/// wants, and the format a piped reader gets by default.
+#[test]
+fn toon_declares_its_columns_once() {
+    let env = Env::new();
+    let db = env.db();
+    let id = seed(&db, "worker");
+
+    let watch = env.watch(&["--toon", "--for-secs", "30"]);
+    settle();
+    db.set_hook_state(id, "working").expect("working");
+    db.set_hook_state(id, "done").expect("done");
+
+    let header = watch.line("the TOON header");
+    assert!(
+        header.starts_with("events{") && header.ends_with("}:"),
+        "the header names the fields: {header}"
+    );
+    for expected in ["working", "done"] {
+        let row = watch.line("a TOON row");
+        assert!(row.starts_with("  "), "a row is indented under the header");
+        assert!(
+            row.contains(expected),
+            "row {row} should mention {expected}"
+        );
+        assert!(
+            !row.contains("events{"),
+            "the header is written once, not per row: {row}"
+        );
+    }
+}
+
+/// `--session` narrows the stream to one session, and the log is filtered
+/// rather than the output.
+#[test]
+fn session_filter_reports_only_that_session() {
+    let env = Env::new();
+    let db = env.db();
+    let mine = seed(&db, "mine");
+    let theirs = seed(&db, "theirs");
+
+    let watch = env.watch(&["--json", "--session", &mine.to_string(), "--for-secs", "30"]);
+    settle();
+    db.set_hook_state(theirs, "working").expect("theirs");
+    db.set_hook_state(mine, "blocked").expect("mine");
+
+    let event = watch.event("the filtered transition");
+    assert_eq!(event["session"], Value::String(mine.to_string()));
+    assert_eq!(event["to_state"], Value::String("blocked".into()));
+    watch.silent_for(Duration::from_secs(1));
+}

--- a/tests/sync_integration.rs
+++ b/tests/sync_integration.rs
@@ -317,7 +317,9 @@ fn watch_emits_a_line_when_another_process_changes_a_session() {
     // A relocated instance: its own database, and its own tmux socket name,
     // so nothing here can reach the operator's server even by accident.
     let mut child = Command::new(env!("CARGO_BIN_EXE_thurbox-cli"))
-        .args(["watch", "--for-secs", "20"])
+        // `--json`: watch honours the CLI-wide format rule, and a pipe would
+        // otherwise get TOON.
+        .args(["watch", "--json", "--for-secs", "20"])
         .env("HOME", dir.path())
         .env("USERPROFILE", dir.path())
         .env("XDG_DATA_HOME", dir.path().join("xdg-data"))

--- a/website/docs/configuration.html
+++ b/website/docs/configuration.html
@@ -696,7 +696,7 @@ timeout_secs = 120</code></pre>
               <tr>
                 <td><code>audit_retention_days</code></td>
                 <td><code>90</code></td>
-                <td>audit-log history kept (pruned on startup)</td>
+                <td>audit + session-event history kept (pruned on startup)</td>
               </tr>
             </tbody>
           </table>
@@ -713,7 +713,7 @@ timeout_secs = 120</code></pre>
 scrollback_lines      = 1000   # terminal scrollback kept per session
 two_panel_min_cols    = 80     # width below which only the terminal renders
 three_panel_min_cols  = 120    # width unlocking the optional third column
-audit_retention_days  = 90     # audit-log history kept (pruned on startup)
+audit_retention_days  = 90     # audit + session-event history kept (pruned on startup)
 
 [features]
 tasks         = true

--- a/website/docs/features.html
+++ b/website/docs/features.html
@@ -1714,6 +1714,6 @@ thurbox-cli message inbox --for flow --claim</code></pre>
             <code>worktree_errors</code>
             ,
             <code>disabled_automations</code>
-            ) but never abort the delete. The DB row is always soft-deleted last, so even a forced
+            ) but never abort the delete. The DB row is always marked deleted last, in one write, so even a forced
             delete stays restorable &mdash; it just re-spawns from a clean slate.
           </p>

--- a/website/docs/features.html
+++ b/website/docs/features.html
@@ -1158,7 +1158,7 @@ thurbox-cli session start reviewer                           # and put it back
 thurbox-cli session exec reviewer -- git status --porcelain  # run in its dir, not in its pane
 thurbox-cli session meta set reviewer fm.task_id T-1043      # your own key/value space
 thurbox-cli agent launch-args claude                         # what to run so its hooks report
-thurbox-cli watch --initial                                  # one JSON line per change
+thurbox-cli watch --json --initial                           # one event per line, no polling
 thurbox-cli message send --to flow --kind questions --task 5 --body "scope?"
 thurbox-cli message inbox --for flow --claim</code></pre>
           <p>
@@ -1347,7 +1347,7 @@ thurbox-cli message inbox --for flow --claim</code></pre>
             </li>
             <li>
               <strong>watch</strong>
-              &mdash; streams one JSON object per change (
+              &mdash; streams the session event log, one event per line (
               <code>created</code>
               ,
               <code>changed</code>
@@ -1359,7 +1359,46 @@ thurbox-cli message inbox --for flow --claim</code></pre>
               <code>--initial</code>
               ), so nothing driving Thurbox has to poll. It works with no TUI
               running, because everything worth waking on is already in the
-              database.
+              database. Each writer appends its own event in the same
+              transaction as the change, so two transitions in the same instant
+              are two events rather than one &mdash; which is what
+              <code>working &rarr; blocked &rarr; working</code>
+              around an auto-answered permission looks like. Every line carries
+              a monotonic
+              <code>seq</code>
+              (
+              <code>--since &lt;seq&gt;</code>
+              resumes exactly where a driver left off), a
+              <code>reason</code>
+              (
+              <code>spawned</code>
+              /
+              <code>registered</code>
+              /
+              <code>restored</code>
+              ,
+              <code>state</code>
+              /
+              <code>stopped</code>
+              /
+              <code>started</code>
+              /
+              <code>updated</code>
+              ,
+              <code>soft_deleted</code>
+              /
+              <code>force_deleted</code>
+              &mdash; a soft delete can be restored, a force delete cannot), the
+              <code>from_state</code>
+              &rarr;
+              <code>to_state</code>
+              of the transition, and the same
+              <code>state</code>
+              /
+              <code>hook_coverage</code>
+              gating fields
+              <code>session get</code>
+              publishes.
             </li>
             <li>
               <strong>runtime</strong>

--- a/website/docs/orchestration.html
+++ b/website/docs/orchestration.html
@@ -372,7 +372,45 @@ thurbox-cli session list --parent "$LEAD" --json</code></pre>
   <code>session get</code>
   and
   <code>list</code>
-  alike, so a liveness check is the poll you were already doing.
+  alike, so a liveness check is the poll you were already doing. Parking also
+  clears the latched state and refuses a new one &mdash; a parked session has no
+  process, so a heartbeat poll or a mirror pass writing a turn onto it would
+  report something that did not happen.
+</p>
+<h3>watch, for everything that is not a report</h3>
+<p>
+  The mailbox is how a worker says it finished.
+  <code>thurbox-cli watch --json --initial</code>
+  is how a driver learns everything the worker was never going to mail: that it
+  went blocked on a permission, that its pane died, that somebody deleted it.
+</p>
+<p>
+  It streams an
+  <strong>append-only log</strong>
+  , not a sampled diff. Every writer that changes what a watcher reports appends
+  its event in the same transaction as the change, so two transitions in the
+  same instant are two events &mdash; which matters because
+  <code>working &rarr; blocked &rarr; working</code>
+  is exactly what an auto-answered permission looks like, and a sampler reading
+  the row every 250&nbsp;ms sees neither edge. Each line carries a monotonic
+  <code>seq</code>
+  (
+  <code>--since &lt;seq&gt;</code>
+  resumes exactly where a restarted driver left off), a
+  <code>reason</code>
+  saying which kind of event it was &mdash;
+  <code>soft_deleted</code>
+  can be restored,
+  <code>force_deleted</code>
+  cannot &mdash; the
+  <code>from_state</code>
+  &rarr;
+  <code>to_state</code>
+  of the transition, and the same gating fields
+  <code>session get</code>
+  publishes, so acting on a
+  <code>blocked</code>
+  needs no second call. The stream exits the moment its reader closes the pipe.
 </p>
 <h3>Read the exit status before parsing</h3>
 <p>


### PR DESCRIPTION
## Intent

Make `thurbox-cli watch` exact instead of a poll, as specified in a review brief the user handed me (session B1 of a multi-session review of Thurbeen/thurbox).

The user's goal: watch was a 250 ms whole-state diff of the session table, so two hook writes inside one sample collapsed into one — 'working -> blocked -> working' around an auto-answered permission arrived as nothing at all, and a driver never learned the permission had been asked. The brief asked for, and I implemented, all of:

1. An append-only `session_events` table (schema v43: seq/session_id/event/reason/from_state/to_state/at_ms), written in the same transaction as each writer that changes what a watcher reports. I instrumented the storage-layer writers (set_hook_state, set_session_stopped, clear_hook_state, soft/force delete, restore, the upsert, set_backend_id) rather than each of the enumerated call sites, because every call site the brief named (cli/sessions.rs signal, session_ops/restart.rs, cli/automations.rs pane poll, session_ops/remote_hooks.rs pane poll, session_ops/mirror.rs, the spawn upsert) goes through those methods — the brief explicitly asked to prefer removing a source of truth over adding one. Pruned on the existing audit_retention_days rather than adding a new config knob; the setting's description and docs now say it covers both logs.
2. watch tails that table by seq, still gated on PRAGMA data_version so the per-tick cost is unchanged. Added --since <seq>; seq is on every event. Kept the present/created/changed/gone vocabulary and added the reason field the brief specified: spawned|registered|restored for created, soft_deleted|force_deleted for gone, stopped|started for changed. I also added reasons 'state' (a hook-state transition) and 'updated' (name or backend_id moved) beyond the brief's list, deliberately — the brief's enumeration was not exhaustive, and without those two the new stream would silently lose events the old whole-state diff did emit.
3. The gating fields (state_source, hook_state_contradicted, hook_coverage, hook_blocked_is_heuristic) are on each event, built by reusing session::hook_status::Assessment, not re-derived. hook_state_contradicted is null (= not checked) unless the new --verify flag is passed, mirroring the cost trade session list --verify already makes: a pane probe costs a multiplexer query and a ps per event.
4. Exits promptly on BrokenPipe, and honours --json/--toon/--text. This means a piped watch now gets TOON rather than JSON, because that is the CLI-wide rule watch was ignoring; --pretty renders as --json since a stream's frame is the line. That is an intentional behaviour change and is called out in the PR description; the one in-repo consumer (tests/sync_integration.rs) was updated to pass --json.
5. A parked session takes no hook state at all (brief bug I): set_hook_state refuses a row with stopped_at set and now returns whether it wrote, and set_session_stopped(true) clears the hook columns in the same transaction as the mark (so stop_session_headless no longer clears them separately). session signal against a parked session now errors saying to session start first, instead of reporting signaled:true for a write that did nothing.
6. New tests/cli_watch.rs drives the real binary against a real database file (the writer must be a different connection for data_version to move) and pins exactly what the brief asked: two writes 10 ms apart are two events in order; both gone reasons; the three created reasons; --since resumes without replay; parked rows get no hook events; the stream ends when the reader closes. Plus --text/--toon renderings and --session filtering. Docs updated in the same PR: .claude/skills/thurbox-cli/SKILL.md, .claude/skills/thurbox-session-status/SKILL.md, docs/ORCHESTRATION.md, docs/CONFIG.md, website/docs/{features,orchestration,configuration}.html.

One structural change worth knowing: the delete paths now call a single force_delete_session instead of soft_delete_session followed by mark_session_force_deleted. The pair emitted two gone events, the first of which told a watcher the session was restorable when it never was. mark_session_force_deleted is kept for the one case it is still the right verb — a mirror pass learning that an already-deleted local row was torn down on its owning host.

Deliberately left alone, because the brief assigned them to other sessions: session doctor, --on-existing, and the hook-coverage derivation.

I had already committed, pushed and opened PR #1059 by hand before the user's rule change requiring this gate, so the branch and PR already exist.

## What Changed

- Added an append-only `session_events` table (schema v43: seq/session_id/event/reason/from_state/to_state/at_ms) written in the same transaction as the storage-layer writers that change what a watcher reports (`set_hook_state`, `set_session_stopped`, `clear_hook_state`, delete/restore, the upsert, `set_backend_id`), instead of instrumenting each call site individually.
- Consolidated the delete paths onto a single `force_delete_session` (replacing the soft-delete-then-mark-force-deleted pair, which emitted a misleading "restorable" event before the real one); `mark_session_force_deleted` remains only for the mirror pass reconciling an already-deleted local row.
- `watch` now tails `session_events` by `seq` (still gated on `PRAGMA data_version` for per-tick cost), adds `--since <seq>` and `--verify`, and emits gating fields (`state_source`, `hook_state_contradicted`, `hook_coverage`, `hook_blocked_is_heuristic`) built from `session::hook_status::Assessment`; it exits promptly on `BrokenPipe` and now honors `--json`/`--toon`/`--text` (piped output defaults to TOON instead of JSON, a deliberate behavior change; `tests/sync_integration.rs` was updated to pass `--json`).
- Fixed a bug where a parked session could still take hook-state writes: `set_hook_state` now refuses rows with `stopped_at` set and reports whether it wrote, `set_session_stopped(true)` clears hook columns in the same transaction as the stop mark, and `session signal` against a parked session now errors instead of reporting a no-op success.
- Added `tests/cli_watch.rs` driving the real binary against a real database file, and updated `.claude/skills/thurbox-cli/SKILL.md`, `.claude/skills/thurbox-session-status/SKILL.md`, `docs/ORCHESTRATION.md`, `docs/CONFIG.md`, and the corresponding website docs.

## Risk Assessment

⚠️ Medium: The core live-tailing and TOON-escaping fixes from round 1 are correctly implemented and verified against the code, but the stopped-state fix is incomplete for the --since backlog-replay path — a documented, intended usage — where it can silently mislabel a live state transition as a park; this is a real but narrow, non-crashing correctness gap rather than a fundamental design problem.

## Testing

Baseline `cargo nextest run --all` already passed. For this phase I added two focused regression tests to tests/cli_watch.rs — `a_state_event_sharing_a_batch_with_a_park_reports_its_own_state` and `toon_row_escapes_a_name_that_contains_the_delimiter` — since neither round-1-fixed bug (stale stopped-flag in a batched drain, unescaped TOON rows) had any covering test. I verified both are true regression tests by reverting src/cli/watch.rs to the pre-fix version, confirming both tests fail with the exact reported symptoms, then restoring the fix and confirming they pass along with the rest of tests/cli_watch.rs (12/12) and tests/sync_integration.rs (11/11). No product code changes were needed; only the new tests remain in the working tree.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"cc0e9fa8475a77210ed8876f894c44226e061bd1","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

- ⚠️ `src/cli/watch.rs:194` - In `drain()`, `facts` (which carries `SessionFacts::stopped`, the *current* park state) is loaded once per batch, after the whole batch of events has already been fetched (src/cli/watch.rs:182-194). `line()` (src/cli/watch.rs:228-232) special-cases only the event&#39;s own `stopped`/`started` reason to compute the correct point-in-time `stopped` flag; for every other reason (`state`, `updated`, `created`, …) it falls back to `facts.stopped`, i.e. the park state as of *after the whole batch*, not as of that event. Concrete sequence: a session emits a `changed`/`state` event (e.g. blocked→working) and is then parked (`session stop`) shortly after, both landing in the same `data_version` wake-up/batch (very plausible during backlog catch-up with the 512-row BATCH, or two automation writes close together). When `line()` renders the earlier `state` event, `facts.stopped` is already `true` (post-park), so `assess()` calls `hook.parked()`, which sets `state_word()` to `&#34;stopped&#34;` and `state_source` to `null` — while `hook_state` (and the event&#39;s own `to_state`) still correctly show `&#34;blocked&#34;`/`&#34;working&#34;`. The emitted line is then internally contradictory (`hook_state: &#34;blocked&#34;`, `state: &#34;stopped&#34;`), silently mislabeling a live transition as a park. This is the same class of bug (`working → blocked → working` disappearing because of a sample crossing multiple transitions) the whole feature exists to eliminate, reintroduced for the derived `state`/`state_source` fields whenever a park/un-park shares a batch with another event for the same session. No existing test in tests/cli_watch.rs exercises two different-reason events for the same session inside one wake/batch (the parked-session test uses `settle()` between the state write and the park, keeping them in separate polls).
- ⚠️ `src/cli/watch.rs:296` - The TOON rendering path in `Stream::write`/`row()` (src/cli/watch.rs, `COLUMNS`/`row()`/`Stream::write` — the `Format::Toon` arm builds `format!(&#34;  {}&#34;, row(event))`) hand-rolls a comma-joined row from field values with no quoting/escaping, instead of reusing `crate::cli::toon`&#39;s encoder (`scalar`/`needs_quote`/`escape` in src/cli/toon.rs), which exists specifically to quote a string containing the delimiter, a colon, brackets, quotes, control characters, or that looks numeric/boolean per TOON §7.2. Session names are free-form user input (no validation found in src/cli/sessions.rs&#39;s spawn/name handling) and appear in the `name` column. A session named e.g. `&#34;fix: foo, bar&#34;` produces a TOON row like `  10,changed,state,fix: foo, bar,blocked,working,blocked,&lt;uuid&gt;` — the embedded comma silently shifts every subsequent column, and the colon is likewise unescaped, producing output that is not valid TOON despite the PR&#39;s explicit claim that piped `watch` now honours &#34;the CLI-wide rule&#34; (item 4 of the intent) the rest of the CLI enforces via the shared encoder.

🔧 Fix: Fix watch stopped-flag staleness and unescaped TOON rows
1 warning still open:

- ⚠️ `src/cli/watch.rs:105` - The fix for the round-1 &#39;stopped facts stale in batch&#39; finding carries `stopped_state` forward correctly for live tailing, but seeds it once at process start from `db.load_session_facts()` — the CURRENT park state — rather than the park state as of the resume point. This is wrong specifically for `--since &lt;SEQ&gt;` (the driver-restart resume path the PR&#39;s own intent and test `since_resumes_without_replaying` exist to support): if a session had a non-stopped/started event (e.g. a `state` transition) followed later by a `stopped`/`started` event, and both are older than `seq` at start of `--since` and thus get replayed as backlog, the first (non-stopped/started) event in that backlog reads `stopped_state`, which was seeded from *now* (post-park), not from the session&#39;s actual park state at that earlier point in the log. Concrete sequence: session X is `working`, transitions to `blocked` (event A, reason `state`), then gets parked via `session stop` (event B, reason `stopped`) — both before a driver restarts and issues `watch --since &lt;seq before A&gt;`. `load_session_facts()` at startup shows X currently parked (`stopped: true`), so `stopped_state[X]` seeds to `true`. When event A replays, its reason is `state`, so `stopped` falls back to `stopped_state.get(X) == true` — event A is mislabeled as a park (`state: &#34;stopped&#34;`) even though X was not parked when A happened; `hook_state`/`to_state` on the same line still correctly say `blocked`. This is the same silently-wrong-derived-field bug the round-1 fix addressed, now reintroduced specifically on the `--since` backlog-replay path, which is a documented, intended use case (`--since` resume after a driver restart), not a contrived edge case. No test exercises a `--since` replay spanning a stopped/started transition together with another reason for the same session (`since_resumes_without_replaying` in tests/cli_watch.rs only replays a single `state` event, no park in the backlog).
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `cargo nextest run --all`
- `cargo nextest run --test cli_watch (all 12 tests, including 2 new)`
- `cargo nextest run --test sync_integration (all 11 tests)`
- `Reproduction: reverted src/cli/watch.rs to pre-fix commit f8b9862 and confirmed the 2 new tests fail with exactly the reported symptoms (transition event mislabeled stopped=true/state="stopped"; TOON row split into 9 fields instead of 8 on an unescaped comma/colon in the session name), then restored the fixed watch.rs and confirmed both pass`
</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ docs/PERFORMANCE.md&#39;s ADR-P6, docs/ARCHITECTURE.md, src/coordinator/boot.rs, and src/kernel/config.rs illustrate &#39;why settings must publish before Database::open&#39; using &#39;it prunes the audit log to audit_retention_days&#39; as the example. That&#39;s still true but no longer exhaustive — Database::open now also prunes session_events on the same knob (src/storage/mod.rs:153-160). Left alone: these are incidental asides in unrelated architectural narratives, not the owner of the audit_retention_days contract (docs/CONFIG.md, already updated, owns that). Separately, ADR-P6 in docs/PERFORMANCE.md describes a hook-state cache (`App::cached_hook_states`, `App::invalidate_hook_state_cache`) that no longer exists anywhere in src/ — predates this change by several commits (last touched at 3928011, before this diff&#39;s base) and is unrelated to it, so out of scope here, but worth a follow-up since that ADR&#39;s mechanism has drifted from the current kernel/snapshot.rs architecture.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
