### PR TITLE
fix(cli): fix driver-facing session verbs — doctor, reports-as, on-existing, restore

### DIFF
--- a/.claude/skills/thurbox-cli/SKILL.md
+++ b/.claude/skills/thurbox-cli/SKILL.md
@@ -35,7 +35,7 @@ thurbox-cli session list --parent <lead-uuid> --json | jq  # direct children onl
 ```
 
 Subcommands: `agent` (launch-args — see below), `session` (create/list [`--deleted`]/get/delete/restore/restart
-[`--if-missing`]/stop/start/fork/exec/meta/send [`--no-enter`]/key/capture/focus/signal/doctor/sync/register —
+[`--if-missing`]/stop/start/fork/exec/meta/reports-as/send [`--no-enter`]/key/capture/focus/signal/doctor/sync/register —
 `sync`/`register` and the flags serve session sharing, ADR-24), `watch` (stream
 the session event log, one event per line), `runtime` (status/stop — what
 thurbox runs that is not a session), `automation` (alias `auto`:
@@ -78,8 +78,11 @@ Every session verb takes the same reference, resolved in that order: a full
 UUID first (unambiguous by construction), then an exact name, then a unique id
 prefix. **Ambiguity is refused, never guessed** — names are not unique (thurbox
 does not enforce it, and a mirrored host contributes rows that legitimately
-collide), so a reference matching two sessions exits non-zero and names both
-ids. `--parent` resolves the same way.
+collide), so a reference matching two sessions exits **3** and names both ids —
+its own code, because a driver reconciles "no such session" (exit 1) by creating
+one and can only escalate "several answer to that name". `--parent` and
+`session restore` resolve the same way; restore resolves against the *deleted*
+rows, since that is where its subject now is.
 
 `session create --on-existing <allow|adopt|replace|fail>` answers "a session of
 this name already exists" — one question, four answers, because none of them is
@@ -92,6 +95,17 @@ safe to assume:
 | `replace` | tear the old one down (`delete --force`) first |
 | `fail` | refuse, naming the id in the way; exit 1 |
 
+**The match is scoped to the backend the creation lands on** — `local-tmux`, or
+the `ssh:`/`wsl:` backend of its `--host`. The name namespace is not: a mirrored
+host's rows sit in the same table, so an unscoped match let a local `replace`
+force-delete a session on another machine, `fail` refuse a local create because
+of a remote namesake, and `adopt` return an id whose pane is elsewhere.
+
+`adopt` answers with `stopped` and `state` as well, because the reason to adopt
+is to skip the follow-up read — and what it hands back may be a **parked**
+session, which refuses `send`/`key`/`capture`. `create` publishes the same two
+(`false`/`unreported`) so the shapes stay identical.
+
 `allow` is the default because thurbox **cannot** enforce uniqueness: a database
 mirroring a shareable host (ADR-24) holds that host's rows beside its own, and
 two machines may each legitimately have a session called `build`. Uniqueness is
@@ -100,9 +114,15 @@ is why `fail` exists at all, and why both firstmate and a Gas City provider were
 each hand-rolling it with their own list-then-create race.
 
 `adopt` and `replace` refuse an *ambiguous* name (one matching several
-sessions), for the same reason the reference resolver does: adopting one of two,
-or destroying one of two, is a guess. Every mode is decided before anything is
-spawned, so a refusal leaves no window, worktree or row behind. It is a check,
+sessions) with exit 3, for the same reason the reference resolver does: adopting
+one of two, or destroying one of two, is a guess. Every mode is decided before
+anything is spawned, so a refusal leaves no window, worktree or row behind.
+
+`replace` is the one mode that acts before the spawn, and it cannot be reordered
+— the replacement wants the branch and the checkout the old session holds. So a
+spawn that fails after the teardown **rolls back**: the session it replaced is
+restored best-effort (row, branch, agent), and the error says so. Uncommitted
+work went with the force delete and does not come back. It is a check,
 not a lock — two simultaneous creates can still both pass, which is inherent to
 a spawn that must make a multiplexer window before it has a row.
 
@@ -319,7 +339,13 @@ The shape that follows from that:
   quietly.
 - **Errors are structured on stdout, never stderr**, and the exit code says
   which kind: `0` success, `1` the command ran and failed, `2` the invocation
-  was wrong. The trap that follows is worth naming to integrators:
+  was wrong, `3` a session reference matched more than one session. The
+  implication runs **one way only**: an `error` key ⇒ a non-zero exit, *never*
+  the converse — `session doctor` on a broken session and `config validate` on
+  a bad file each exit 1 with a valid, error-free report on stdout, so a driver
+  that gates on `$?` before parsing throws away every diagnosis it asks for.
+  Read the document; use the code to classify, not to decide whether to parse.
+  The trap that follows is worth naming to integrators:
   `thurbox-cli … --json | jq -r .field` exits **0 with empty output** on a
   failure, because `jq` parsed the error object and the pipeline carries `jq`'s
   status (`pipefail` does not help — `jq` succeeded). Capture, branch on the
@@ -363,6 +389,30 @@ backend are delegated to that host's own `thurbox-cli` (`delegate_to_host` in
 window that was never there. The refusal survives only where delegation is
 genuinely impossible: a backend with no `hosts.toml` entry, or one whose
 `thurbox-cli` could not be reached.
+
+### A pane can run an agent thurbox did not launch
+
+`session create --command <exe>` makes a session *anything*, and the row is
+named after the command's file stem. A driver that opens a shell and then starts
+`claude` in it (the `agent launch-args claude` shape) leaves thurbox reading hook
+coverage against `bash`: `hook_coverage: "none"`, no reportable states, and —
+worst of all — `hook_blocked_is_heuristic: false`, asserting the block signal is
+structured when it is claude's text match on a notification body.
+
+`session create --reports-as <agent>` and `session reports-as <ref> <agent>`
+(`--clear` to take it back) are how the driver says what is in there. The
+declaration is stored on the row (`sessions.reports_as`, schema v44), survives
+restart, and changes **only** what coverage is read against: `session restart`
+still replays the recorded command. It is refused for an agent thurbox ships no
+hooks for, since the whole point is the coverage it unlocks and a typo would
+unlock nothing silently. `get`/`list`/`doctor` publish it as `reports_as` (null
+when the row reports as itself).
+
+`session doctor` follows the same fact from the other end: a `--command` session
+that has declared nothing is **`ok`, "no hooks expected"** rather than `fail` —
+there is no wiring here to be broken, and failing it made bare `session doctor`
+(which diagnoses every active session) fail the whole machine over the exact
+session shape thurbox advertises for drivers.
 
 `session delete <uuid>` **soft-deletes** by default — only the DB row is marked
 deleted (the TUI tears down the tmux window/worktree on its next sync), and

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -188,7 +188,22 @@ payload's events and that test fails until the table agrees.**
 `thurbox-cli session doctor [uuid]` is the runtime half — whether a given
 session's payload is actually installed where its agent reads it, whether a hook
 command could resolve `thurbox-cli` at all, and whether what was last reported
-is corroborated by the pane.
+is corroborated by the pane. A `--command` session is the one shape it does not
+judge: thurbox never had an agent there to wire, so it reports **no hooks
+expected** rather than broken wiring.
+
+**A pane can run an agent thurbox did not launch.** A `--command` session is
+named after the command's file stem, so a driver that opens a shell and starts
+`claude` inside it leaves every field above resolved against `bash` — coverage
+`none`, no reportable states, and `hook_blocked_is_heuristic: false`, which
+asserts the block signal is structured when it is claude's text match on a
+notification body. `session create --reports-as <agent>` and
+`thurbox-cli session reports-as <ref> <agent>` (`--clear` to take it back) let
+the driver name the agent that actually reports; it is stored on the row
+(`sessions.reports_as`, schema v44), survives restart, and changes nothing about
+the launch — `session restart` still replays the recorded command. Only an agent
+in the table above (or a custom agent that asserts a family with `hook_schema`)
+may be declared: a name with no coverage would unlock nothing, silently.
 
 **On a shared host** (`hosts.toml` `share_sessions = true`, the default — see
 ADR-24) none of the remote rewriting applies: the host's own `thurbox-cli`

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1897,6 +1897,12 @@ four answers. `allow` (the default) creates a second session with that name;
 `adopt` returns the existing one with `created: false`; `replace` tears it down
 first; `fail` refuses and exits 1, naming the session in the way.
 
+The question is asked of **the backend the creation lands on** — this machine,
+or the `--host` it names. The name namespace is wider than that (a mirrored
+host's rows share the table), and matching across it made `replace`
+force-delete a session on another machine, `fail` refuse a local create over a
+remote namesake, and `adopt` hand back an id whose pane is not here.
+
 The default is `allow` because thurbox **cannot** make names unique: a database
 mirroring a shareable host (ADR-24) carries that host's rows beside its own, and
 two machines may each legitimately have a session called `build`. Uniqueness is
@@ -1905,7 +1911,32 @@ namespace — and `fail` exists because, without it, every external driver wrote
 its own list-then-create check with its own race.
 
 `adopt` and `replace` refuse a name matching *several* sessions, on the same
-principle the reference resolver follows: picking one of two is a guess.
+principle the reference resolver follows: picking one of two is a guess — and
+with the same exit code (3), so a driver can tell it from "nothing matched".
+
+`adopt` answers with `stopped` and `state` alongside the rest, because the
+reason to adopt is to skip the follow-up read and what comes back may be a
+parked session — no pane, `send`/`key`/`capture` refused — with nothing else in
+the answer saying so. A real creation publishes the same two fields, so the
+shapes stay identical.
+
+`replace` acts before the spawn and cannot be reordered: the replacement wants
+the branch and the checkout the old session is holding. A spawn that fails after
+the teardown therefore **rolls back** — the replaced session is restored
+best-effort (its row, its branch and its agent), and the error says so.
+Uncommitted work went with the force delete and does not return.
+
+### Saying which agent a pane actually runs
+
+A `--command` session is named after the command's file stem, so a driver that
+opens a shell and starts `claude` in it leaves thurbox reading hook coverage
+against `bash`. `session create --reports-as <agent>` and `session reports-as
+<ref> <agent>` (`--clear` to take it back) record which agent reports;
+`hook_coverage`, `hook_states_reportable`, `hook_delivery` and
+`hook_blocked_is_heuristic` are then read against it, and `reports_as` is
+published beside them. The launch is untouched: `session restart` still replays
+the recorded command. `session doctor` reads the same fact — an undeclared
+command session is "no hooks expected", not broken wiring.
 
 ### Stopping is not deleting
 

--- a/docs/ORCHESTRATION.md
+++ b/docs/ORCHESTRATION.md
@@ -335,7 +335,7 @@ Errors are **structured documents on stdout**, not lines on stderr —
 AXI principle 6, because an agent reads one stream and a message on
 stderr is one it has to be told to capture. The exit code carries the
 verdict: `0` success, `1` the command ran and failed, `2` the invocation
-was wrong.
+was wrong, `3` a session reference matched more than one session.
 
 The consequence is a trap worth naming. `thurbox-cli … --json | jq -r
 '.field'` exits **0 with empty output** when the command failed: `jq`

--- a/docs/ORCHESTRATION.md
+++ b/docs/ORCHESTRATION.md
@@ -240,6 +240,7 @@ gone — and each one comes with what it takes to judge it:
 | `hook_corroboration`, `hook_state_contradicted` | what actually holds the pane, and whether it agrees |
 | `state`, `state_source` | the best answer available, and where it came from |
 | `stopped` | whether the session is parked — `session stop`, no pane |
+| `reports_as` | the agent the hook fields were read against, when a driver declared one |
 
 `state` is always a word: `unreported` when nothing has reported for
 this session, `uncovered` when its agent is wired to report nothing, and
@@ -274,7 +275,17 @@ lives on its own host's multiplexer. `thurbox-cli session doctor` is the
 same information as a verdict, plus whether the wiring is installed at
 all; it exits non-zero when a session's wiring is broken. An agent
 thurbox ships no hooks for but which is signalling anyway — a driver
-calling `session signal` itself — is a warning, not a failure.
+calling `session signal` itself — is a warning, not a failure, and a
+`--command` session is "no hooks expected": thurbox never had an agent
+there to wire, so there is nothing to find broken.
+
+If your driver launches an agent *inside* such a session, say so with
+`session create --reports-as <agent>` or `session reports-as <ref>
+<agent>`. Every field in the table is then read against that agent
+instead of the command's file stem — including
+`hook_blocked_is_heuristic`, which otherwise reports `false` for a pane
+running claude and tells a supervisor the block signal is structured
+when it is a text match on a notification body.
 
 `session capture --json` adds the pane's live state alongside its text —
 `cursor_row`/`cursor_col`, `foreground_process` and `foreground_command`,

--- a/src/bin/thurbox-cli.rs
+++ b/src/bin/thurbox-cli.rs
@@ -5,9 +5,16 @@
 //! are about the *process* rather than about any one command: a failure that
 //! left nothing to print is a structured document on **stdout**, and the exit
 //! code says which kind of failure it was — `0` success, `1` the command ran
-//! and failed, `2` the invocation was wrong. An agent reads one stream and one
-//! status; splitting the answer across stdout and stderr costs it a retry to
-//! find out what happened.
+//! and failed, `2` the invocation was wrong, `3` the session reference matched
+//! more than one session. An agent reads one stream and one status; splitting
+//! the answer across stdout and stderr costs it a retry to find out what
+//! happened.
+//!
+//! The exit code is the *only* half of that contract a caller may invert. An
+//! `error` key on stdout implies a non-zero exit; the converse does not hold,
+//! because a command whose report *is* the answer (`session doctor`, `config
+//! validate`) prints that report and asks for a non-zero exit anyway. Gate on
+//! the document, not on `$?`.
 //!
 //! The other half of that promise is that stdout carries **exactly one**
 //! document. A command that renders its report and then asks for a non-zero
@@ -18,12 +25,7 @@
 //! single-document parser on exactly the commands an integrator scripts.
 
 use clap::Parser;
-use thurbox::cli::{self, output::Format, output::FormatFlags, Cli};
-
-/// The command ran and failed.
-const EXIT_ERROR: i32 = 1;
-/// The invocation was wrong: an unknown flag, a missing argument, a bad value.
-const EXIT_USAGE: i32 = 2;
+use thurbox::cli::{self, output::Format, output::FormatFlags, Cli, EXIT_ERROR, EXIT_USAGE};
 
 fn main() {
     tracing_subscriber::fmt()
@@ -87,21 +89,29 @@ fn main() {
         // with its own wording and exit 2. Advising `--help` here misattributes
         // "that session has exited" to the arguments, and points at a page that
         // cannot fix it — so the suggestion sends the caller to the state the
-        // message is about.
-        Err(e) => fail(
-            &e,
+        // message is about. The code travels with the message: an ambiguous
+        // session reference is a different answer from a missing one, and only
+        // the failure itself knows which it was.
+        Err(e) => fail_with(
+            &e.message,
             "the command ran and failed; the message says what went wrong — \
              `thurbox-cli` prints the state it was working against",
             "thurbox-cli",
             format,
+            e.exit_code,
         ),
     }
 }
 
 /// Print a structured failure on stdout and exit [`EXIT_ERROR`].
 fn fail(message: &str, suggestion: &str, next: &str, format: Format) -> ! {
+    fail_with(message, suggestion, next, format, EXIT_ERROR)
+}
+
+/// [`fail`], with the exit code the failure asked for.
+fn fail_with(message: &str, suggestion: &str, next: &str, format: Format, code: i32) -> ! {
     println!("{}", cli::error_output(message, suggestion, next, format));
-    std::process::exit(EXIT_ERROR)
+    std::process::exit(code)
 }
 
 /// Turn a clap outcome into an exit.

--- a/src/cli/agents.rs
+++ b/src/cli/agents.rs
@@ -16,6 +16,7 @@ use clap::Subcommand;
 use serde_json::json;
 
 use crate::cli::output::CommandOutput;
+use crate::cli::CommandError;
 use crate::storage::Database;
 
 #[derive(Subcommand, Debug)]
@@ -41,7 +42,7 @@ pub enum Action {
     },
 }
 
-pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
+pub fn run(action: Action, db: &Database) -> Result<CommandOutput, CommandError> {
     match action {
         Action::LaunchArgs { agent, session } => {
             let session = session

--- a/src/cli/home.rs
+++ b/src/cli/home.rs
@@ -31,8 +31,7 @@ pub fn run(db: &Database) -> Result<CommandOutput, String> {
     let sessions = db
         .list_active_sessions()
         .map_err(|e| format!("list_active_sessions: {e}"))?;
-    let states = db.load_hook_states().unwrap_or_default();
-    let parked = db.load_stopped_sessions().unwrap_or_default();
+    let facts = crate::cli::sessions::SessionFacts::load(db);
     let registry = crate::agent::agent_config::load_or_seed();
 
     // The rows are trimmed to the four fields that let an agent decide what to
@@ -49,7 +48,7 @@ pub fn run(db: &Database) -> Result<CommandOutput, String> {
     let rows: Vec<Value> = sessions
         .iter()
         .map(|s| {
-            let hook = crate::cli::sessions::assess(&registry, s, &states, &parked, false);
+            let hook = facts.assess(&registry, s, false);
             json!({
                 "name": s.name,
                 "agent": s.agent,

--- a/src/cli/messages.rs
+++ b/src/cli/messages.rs
@@ -9,6 +9,7 @@ use serde_json::{json, Value};
 
 use crate::cli::identity::calling_session;
 use crate::cli::output::{self, CommandOutput};
+use crate::cli::CommandError;
 use crate::session::{SessionId, SessionMessage};
 use crate::storage::messages::{NewMessage, DEFAULT_RETENTION_DAYS};
 use crate::storage::Database;
@@ -92,7 +93,7 @@ pub enum Action {
     },
 }
 
-pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
+pub fn run(action: Action, db: &Database) -> Result<CommandOutput, CommandError> {
     match action {
         Action::Send {
             to,
@@ -131,7 +132,7 @@ fn send_message(
     task: Option<i64>,
     from: Option<String>,
     no_wake: bool,
-) -> Result<CommandOutput, String> {
+) -> Result<CommandOutput, CommandError> {
     let recipient = resolve_uuid_or_name(db, &to)?;
     // Provenance + task tag default to the calling session's injected
     // identity (`THURBOX_SESSION` / `THURBOX_TASK`), so an agent never has
@@ -156,7 +157,7 @@ fn reply_message(
     kind: String,
     from: Option<String>,
     no_wake: bool,
-) -> Result<CommandOutput, String> {
+) -> Result<CommandOutput, CommandError> {
     let original = db
         .get_message(message_id)
         .map_err(|e| format!("get_message: {e}"))?
@@ -182,7 +183,7 @@ fn reply_message(
 
 /// Resolve the `--from` provenance: an explicit reference, else the calling
 /// session's injected id (`THURBOX_SESSION`).
-fn resolve_from(db: &Database, from: Option<&str>) -> Result<Option<SessionId>, String> {
+fn resolve_from(db: &Database, from: Option<&str>) -> Result<Option<SessionId>, CommandError> {
     match from {
         Some(f) => Ok(Some(resolve_uuid_or_name(db, f)?.id)),
         None => Ok(calling_session_id(db)),
@@ -196,7 +197,7 @@ fn read_inbox(
     claim: bool,
     all: bool,
     limit: Option<usize>,
-) -> Result<CommandOutput, String> {
+) -> Result<CommandOutput, CommandError> {
     let recipient = match for_session {
         Some(ref r) => resolve_uuid_or_name(db, r)?,
         None => calling_session(db).ok_or_else(|| {
@@ -234,7 +235,7 @@ fn prune_messages(
     db: &Database,
     older_than_days: Option<u64>,
     read_only: bool,
-) -> Result<CommandOutput, String> {
+) -> Result<CommandOutput, CommandError> {
     let days = older_than_days.unwrap_or(DEFAULT_RETENTION_DAYS);
     let cutoff = current_time_millis().saturating_sub(days * MS_PER_DAY);
     let pruned = db
@@ -300,7 +301,7 @@ fn enqueue_and_wake(
     recipient: &SharedSession,
     new: NewMessage,
     no_wake: bool,
-) -> Result<CommandOutput, String> {
+) -> Result<CommandOutput, CommandError> {
     let id = db
         .enqueue_message(&new)
         .map_err(|e| format!("enqueue_message: {e}"))?;
@@ -358,7 +359,7 @@ fn calling_task_id() -> Option<i64> {
 /// This module had the only name-aware resolver in the CLI; it now shares the
 /// one every session verb uses ([`super::session_ref`]), which also refuses a
 /// name matching two sessions rather than picking one.
-fn resolve_uuid_or_name(db: &Database, reference: &str) -> Result<SharedSession, String> {
+fn resolve_uuid_or_name(db: &Database, reference: &str) -> Result<SharedSession, CommandError> {
     super::session_ref::resolve(db, reference)
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -16,9 +16,9 @@
 //! with no subcommand prints live state instead of a usage dump
 //! ([`home::run`], principle 8), every result can carry `help[N]:` next steps
 //! ([`output::AgentView`], principle 9), and errors are structured on stdout
-//! with the exit code saying which kind they are — 0 success, 1 failure, 2
-//! usage ([`error_output`], principle 6). The rest are per-command and marked
-//! where they are met.
+//! with the exit code saying which kind they are — [`EXIT_ERROR`],
+//! [`EXIT_USAGE`], [`EXIT_AMBIGUOUS`] ([`error_output`], principle 6). The rest
+//! are per-command and marked where they are met.
 //!
 //! One consequence of principle 6 is a rule the entrypoint enforces: **stdout
 //! carries exactly one document per invocation**. A command that renders a
@@ -26,6 +26,12 @@
 //! validate`) has already written it, so its failure comes back as
 //! [`Outcome::Failed`] and the sentence explaining the exit goes to stderr —
 //! see [`Outcome`].
+//!
+//! That is also why the exit code is only half a contract in one direction: an
+//! `error` key on stdout implies a non-zero exit, but a non-zero exit does
+//! **not** imply an `error` key. `session doctor` on a broken session exits 1
+//! with its report — the report *is* the answer, and a caller that gates on
+//! `$?` before parsing throws away every diagnosis it will ever ask for.
 
 use clap::{Parser, Subcommand};
 
@@ -58,6 +64,76 @@ pub mod version;
 pub mod watch;
 
 use output::{CommandOutput, Format, FormatFlags};
+
+/// The command ran and failed.
+pub const EXIT_ERROR: i32 = 1;
+/// The invocation was wrong: an unknown flag, a missing argument, a bad value.
+pub const EXIT_USAGE: i32 = 2;
+/// The session reference matched more than one session.
+///
+/// Its own code because the answer is different in kind: "no such session" is
+/// something a driver reconciles by creating one, while "several sessions
+/// answer to that name" is something only an operator can settle. AXI
+/// principle 6 asks the two to exit differently, and string-matching the
+/// message was the only way to tell them apart.
+pub const EXIT_AMBIGUOUS: i32 = 3;
+
+/// A failure that left nothing on stdout, and the exit code it deserves.
+///
+/// Almost every failure in the CLI is a plain sentence and takes
+/// [`EXIT_ERROR`]; those travel as `String` inside the subcommand modules and
+/// convert here. The exception is the one a driver has to branch on — an
+/// ambiguous session reference — which carries [`EXIT_AMBIGUOUS`]. There is
+/// deliberately no `From<CommandError> for String`: dropping the code where a
+/// helper happens to return a `String` is exactly how the distinction was lost
+/// before.
+#[derive(Debug)]
+pub struct CommandError {
+    pub message: String,
+    pub exit_code: i32,
+}
+
+impl From<String> for CommandError {
+    fn from(message: String) -> Self {
+        Self {
+            message,
+            exit_code: EXIT_ERROR,
+        }
+    }
+}
+
+impl From<&str> for CommandError {
+    fn from(message: &str) -> Self {
+        Self::from(message.to_string())
+    }
+}
+
+impl CommandError {
+    /// A failure with an exit code of its own.
+    pub fn with_code(message: impl Into<String>, exit_code: i32) -> Self {
+        Self {
+            message: message.into(),
+            exit_code,
+        }
+    }
+}
+
+// Deref to the message so `err.contains("…")` at a call site — overwhelmingly a
+// test asserting what the failure says — reads the sentence rather than the
+// struct, exactly as `CommandOutput` derefs to its JSON.
+impl std::ops::Deref for CommandError {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.message
+    }
+}
+
+impl std::fmt::Display for CommandError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
 
 /// Drive thurbox's sessions, tasks, automations and interface without the TUI.
 ///
@@ -270,7 +346,7 @@ pub enum Outcome {
 ///
 /// `Err` means nothing was printed. A command that rendered normally and still
 /// wants a non-zero exit comes back as [`Outcome::Failed`].
-pub fn run(cli: Cli, db: &Database) -> Result<Outcome, String> {
+pub fn run(cli: Cli, db: &Database) -> Result<Outcome, CommandError> {
     // A peer probing this machine looks for its CLI under the data dir; keep
     // that pointer true (a readlink when it already is).
     crate::session_ops::host_cli::advertise_running_cli();
@@ -290,9 +366,9 @@ pub fn run(cli: Cli, db: &Database) -> Result<Outcome, String> {
 
     let mut output: CommandOutput = match cli.command {
         // No subcommand: live state, not a usage dump (AXI principle 8).
-        None => home::run(db),
-        Some(command) => dispatch(command, db),
-    }?;
+        None => home::run(db)?,
+        Some(command) => dispatch(command, db)?,
+    };
     if cli.full {
         output.agent.max_text = None;
     }
@@ -332,28 +408,28 @@ fn parse_fields(spec: &str) -> Vec<String> {
 }
 
 /// Route one subcommand to the module that owns it.
-fn dispatch(command: Command, db: &Database) -> Result<CommandOutput, String> {
-    match command {
-        Command::Editor { action } => editor::run(action, db),
-        Command::Agent { action } => agents::run(action, db),
-        Command::Session { action } => sessions::run(action, db),
-        Command::Automation { action } => automations::run(action, db),
-        Command::Task { action } => tasks::run(action, db),
-        Command::Message { action } => messages::run(action, db),
-        Command::Config { action } => config::run(action, db),
-        Command::Extension { action } => extensions::run(action, db),
-        Command::Version(args) => Ok(version::run(args)),
-        Command::Update(args) => Ok(update::run(args)),
-        Command::Notify(args) => Ok(notify::run(args)),
-        Command::Perf => perf::run(db),
+fn dispatch(command: Command, db: &Database) -> Result<CommandOutput, CommandError> {
+    Ok(match command {
+        Command::Editor { action } => editor::run(action, db)?,
+        Command::Agent { action } => agents::run(action, db)?,
+        Command::Session { action } => sessions::run(action, db)?,
+        Command::Automation { action } => automations::run(action, db)?,
+        Command::Task { action } => tasks::run(action, db)?,
+        Command::Message { action } => messages::run(action, db)?,
+        Command::Config { action } => config::run(action, db)?,
+        Command::Extension { action } => extensions::run(action, db)?,
+        Command::Version(args) => version::run(args),
+        Command::Update(args) => update::run(args),
+        Command::Notify(args) => notify::run(args),
+        Command::Perf => perf::run(db)?,
         // Never returns a document: it *is* the document, one line at a time,
         // written as each change lands. Handled before dispatch for that
         // reason — see `run`.
         Command::Watch(_) => unreachable!("handled in run(), which owns the stream"),
-        Command::Runtime { action } => Ok(runtime::run(action)),
+        Command::Runtime { action } => runtime::run(action),
         // The only command that needs no database: a plugin is a file.
-        Command::Plugin { action } => plugins::run(action),
-    }
+        Command::Plugin { action } => plugins::run(action)?,
+    })
 }
 
 /// Render a failure the way AXI principle 6 asks for: a structured document on

--- a/src/cli/session_doctor.rs
+++ b/src/cli/session_doctor.rs
@@ -15,6 +15,7 @@
 use serde_json::{json, Value};
 
 use crate::cli::output::{self, CommandOutput};
+use crate::cli::CommandError;
 use crate::session::{Assessment, Corroboration, Coverage, HookDelivery};
 use crate::storage::Database;
 use crate::sync::SharedSession;
@@ -58,15 +59,14 @@ impl Level {
 /// those are facts to know, not breakage to fix, and a permanent non-zero exit
 /// for `aider`'s one-state coverage — or for a driver reporting its own state
 /// exactly as documented — would be noise rather than signal.
-pub fn run(db: &Database, uuid: Option<&str>) -> Result<CommandOutput, String> {
+pub fn run(db: &Database, uuid: Option<&str>) -> Result<CommandOutput, CommandError> {
     let sessions = match uuid {
         Some(uuid) => vec![super::sessions::resolve(db, uuid)?],
         None => db
             .list_active_sessions()
             .map_err(|e| format!("list_active_sessions: {e}"))?,
     };
-    let states = db.load_hook_states().unwrap_or_default();
-    let parked = db.load_stopped_sessions().unwrap_or_default();
+    let facts = super::sessions::SessionFacts::load(db);
     let registry = crate::agent::agent_config::load_or_seed();
     let hooks_active = crate::session_ops::builtin_hooks::hooks_enabled(db);
     // Resolved once: the same answer for every session, and each probe is a
@@ -75,9 +75,10 @@ pub fn run(db: &Database, uuid: Option<&str>) -> Result<CommandOutput, String> {
 
     let mut reports = Vec::new();
     for session in &sessions {
-        let hook = super::sessions::assess(&registry, session, &states, &parked, true);
+        let hook = facts.assess(&registry, session, true);
         reports.push(diagnose(
             session,
+            facts.hooks_expected(session),
             &hook,
             hooks_active,
             cli_on_path.as_deref(),
@@ -130,6 +131,9 @@ struct Report {
     verdict: Level,
     findings: Vec<Finding>,
     hook: Assessment,
+    /// The agent the wiring was judged against — the row's own unless a driver
+    /// declared another with `session reports-as`.
+    agent: String,
 }
 
 impl Report {
@@ -138,6 +142,10 @@ impl Report {
             "session_id": s.id.to_string(),
             "session_name": s.name,
             "agent": s.agent,
+            // Null unless the two differ: a driver reading `agent` alone would
+            // otherwise have no way to see that coverage was judged against
+            // something else.
+            "reports_as": (self.agent != s.agent).then(|| self.agent.clone()),
             "verdict": self.verdict.as_str(),
             "hook_state": self.hook.hook_state,
             "hook_state_age_secs": self.hook.age_secs,
@@ -155,10 +163,13 @@ impl Report {
     }
 
     fn render(&self, s: &SharedSession) -> String {
+        let agent = match self.agent == s.agent {
+            true => s.agent.clone(),
+            false => format!("{}, reporting as {}", s.agent, self.agent),
+        };
         let mut out = format!(
-            "{} ({}) — {}\n",
+            "{} ({agent}) — {}\n",
             s.name,
-            s.agent,
             self.verdict.as_str().to_uppercase()
         );
         for f in &self.findings {
@@ -177,12 +188,19 @@ impl Report {
 /// would ask it: is the machinery on, does this agent have any, is its payload
 /// where the agent will look, can the hook command find the binary it names,
 /// has anything actually arrived, and does the pane agree.
+///
+/// The wiring is judged against [`Assessment::agent`] — the row's own agent, or
+/// the one a driver declared with `--reports-as`. `hooks_expected` is false for
+/// a `--command` session that declared nothing: it runs a shell, a REPL or a
+/// build watcher, so there is no wiring for a check to find broken.
 fn diagnose(
     session: &SharedSession,
+    hooks_expected: bool,
     hook: &Assessment,
     hooks_active: bool,
     cli_on_path: Option<&str>,
 ) -> Report {
+    let agent = &hook.agent;
     let mut findings = Vec::new();
     let remote = crate::session::is_remote_backend(&session.backend_type);
 
@@ -203,6 +221,22 @@ fn diagnose(
     });
 
     findings.push(match hook.coverage {
+        // A `--command` session runs whatever the caller asked for — a shell, a
+        // REPL, a build watcher — and thurbox never had an agent to wire. There
+        // is no breakage here to report, and reporting one made bare `doctor`
+        // fail the whole machine over the exact session shape thurbox
+        // advertises for drivers.
+        Coverage::None if !hooks_expected => Finding {
+            key: "coverage",
+            level: Level::Ok,
+            detail: format!(
+                "'{agent}' is this session's own command, not an agent from agents.toml, so \
+                 thurbox wired no hooks and none are expected — declare what actually runs \
+                 in the pane with `thurbox-cli session reports-as {} <agent>` if it is a \
+                 coding agent, or have your driver call `thurbox-cli session signal`",
+                session.name
+            ),
+        },
         // Nothing thurbox ships wires this agent — but a driver that owns the
         // agent launch is *documented* to call `session signal` itself, and
         // when it does, state is demonstrably reaching thurbox. Failing that
@@ -212,36 +246,33 @@ fn diagnose(
             key: "coverage",
             level: Level::Warn,
             detail: format!(
-                "thurbox ships no status hooks for agent '{}', but signals are arriving — \
+                "thurbox ships no status hooks for agent '{agent}', but signals are arriving — \
                  something in the pane is calling `thurbox-cli session signal`, so this \
-                 session reports what that caller chooses to report",
-                session.agent
+                 session reports what that caller chooses to report"
             ),
         },
         Coverage::None => Finding {
             key: "coverage",
             level: Level::Fail,
             detail: format!(
-                "thurbox ships no status hooks for agent '{}' — set `hook_schema` in \
+                "thurbox ships no status hooks for agent '{agent}' — set `hook_schema` in \
                  agents.toml if it speaks a built-in's hook format, or have your driver call \
                  `thurbox-cli session signal --state <s>` (identity comes from the injected \
-                 $THURBOX_SESSION, so it needs no arguments)",
-                session.agent
+                 $THURBOX_SESSION, so it needs no arguments)"
             ),
         },
         Coverage::Partial => Finding {
             key: "coverage",
             level: Level::Warn,
             detail: format!(
-                "'{}' can only report {} — silence about any other state means nothing",
-                session.agent,
+                "'{agent}' can only report {} — silence about any other state means nothing",
                 hook.states_reportable().join(", ")
             ),
         },
         Coverage::Full => Finding {
             key: "coverage",
             level: Level::Ok,
-            detail: format!("'{}' can report every state", session.agent),
+            detail: format!("'{agent}' can report every state"),
         },
     });
 
@@ -266,6 +297,21 @@ fn diagnose(
             level: Level::Ok,
             detail: format!("hook commands resolve `thurbox-cli` to {path}"),
         },
+        // Nothing thurbox installed for this session invokes the binary, so
+        // "every hook command fails silently" is not true of it, and the
+        // verdict — the maximum over the findings — would otherwise come back
+        // `fail` for a session the coverage check has just declared healthy.
+        // Still worth saying: a driver reporting from the pane with `session
+        // signal` does need the binary. A session with an agent thurbox ships
+        // no hooks for is the other way round — its driver's `session signal`
+        // *is* the only route, so a missing binary there is a genuine failure.
+        None if !hooks_expected => Finding {
+            key: "cli",
+            level: Level::Warn,
+            detail: "`thurbox-cli` is not on PATH — nothing thurbox installed for this session \
+                     runs it, but a driver calling `session signal` from the pane needs it"
+                .into(),
+        },
         None => Finding {
             key: "cli",
             level: Level::Fail,
@@ -275,19 +321,23 @@ fn diagnose(
         },
     });
 
+    // A parked session reports nothing because there is nothing running to
+    // report — `stop` clears the state for exactly that reason. Warning about
+    // the silence would be warning about the operator's own request, and the
+    // check has to come *first*: `Assessment::parked` deliberately leaves the
+    // hook columns alone, and `stop` writes the mark and clears the state as
+    // two separate writes, so a stale `blocked` outlives the pane it described
+    // and would otherwise be printed as this session's current state.
     findings.push(match (&hook.hook_state, hook.age_secs) {
-        (Some(state), Some(age)) => Finding {
-            key: "last-signal",
-            level: Level::Ok,
-            detail: format!("{state}, {} ago", output::duration_short(age)),
-        },
-        // A parked session reports nothing because there is nothing running to
-        // report — `stop` clears the state for exactly that reason. Warning
-        // about the silence would be warning about the operator's own request.
         _ if hook.stopped => Finding {
             key: "last-signal",
             level: Level::Ok,
             detail: "stopped, so nothing is reporting".into(),
+        },
+        (Some(state), Some(age)) => Finding {
+            key: "last-signal",
+            level: Level::Ok,
+            detail: format!("{state}, {} ago", output::duration_short(age)),
         },
         _ => Finding {
             key: "last-signal",
@@ -353,6 +403,7 @@ fn diagnose(
         verdict,
         findings,
         hook: hook.clone(),
+        agent: agent.clone(),
     }
 }
 
@@ -472,6 +523,18 @@ mod tests {
         }
     }
 
+    /// [`diagnose`] for a session that names a registry agent — the ordinary
+    /// case, where the row's own agent is also what reports and hooks are
+    /// therefore expected.
+    fn diagnose_agent(
+        row: &SharedSession,
+        hook: &Assessment,
+        hooks_active: bool,
+        cli_on_path: Option<&str>,
+    ) -> Report {
+        diagnose(row, true, hook, hooks_active, cli_on_path)
+    }
+
     fn level_of(report: &Report, key: &str) -> Level {
         report
             .findings
@@ -484,7 +547,7 @@ mod tests {
     #[test]
     fn an_agent_with_no_wiring_fails_and_says_how_to_wire_it() {
         let hook = Assessment::from_hooks(&registry(), "mine", None, None, 0);
-        let report = diagnose(&row("s", "mine", "local-tmux"), &hook, true, Some("/bin/x"));
+        let report = diagnose_agent(&row("s", "mine", "local-tmux"), &hook, true, Some("/bin/x"));
         assert_eq!(report.verdict, Level::Fail);
         assert_eq!(level_of(&report, "coverage"), Level::Fail);
         // The point of failing rather than shrugging: there *is* a route, and
@@ -506,7 +569,7 @@ mod tests {
         // `session signal`. State is demonstrably arriving, so a `fail` verdict
         // — and the non-zero exit with it — would be false for this row.
         let hook = Assessment::from_hooks(&registry(), "shell", Some("working"), Some(0), 5_000);
-        let report = diagnose(
+        let report = diagnose_agent(
             &row("s", "shell", "local-tmux"),
             &hook,
             true,
@@ -530,7 +593,7 @@ mod tests {
         // PATH looks exactly like an agent that has not signalled. This is the
         // whole reason the subcommand exists.
         let hook = Assessment::from_hooks(&registry(), "claude", Some("working"), Some(0), 0);
-        let report = diagnose(&row("s", "claude", "local-tmux"), &hook, true, None);
+        let report = diagnose_agent(&row("s", "claude", "local-tmux"), &hook, true, None);
         assert_eq!(level_of(&report, "cli"), Level::Fail);
         assert_eq!(report.verdict, Level::Fail);
     }
@@ -538,7 +601,7 @@ mod tests {
     #[test]
     fn a_deactivated_extension_is_a_failure_not_a_silence() {
         let hook = Assessment::from_hooks(&registry(), "claude", None, None, 0);
-        let report = diagnose(&row("s", "claude", "local-tmux"), &hook, false, Some("/x"));
+        let report = diagnose_agent(&row("s", "claude", "local-tmux"), &hook, false, Some("/x"));
         assert_eq!(level_of(&report, "extension"), Level::Fail);
     }
 
@@ -547,7 +610,7 @@ mod tests {
         // aider can only ever report `blocked`; that is a fact to know, not
         // breakage to fix, so it must not exit non-zero forever.
         let hook = Assessment::from_hooks(&registry(), "aider", None, None, 0);
-        let report = diagnose(&row("s", "aider", "local-tmux"), &hook, true, Some("/x"));
+        let report = diagnose_agent(&row("s", "aider", "local-tmux"), &hook, true, Some("/x"));
         assert_eq!(level_of(&report, "coverage"), Level::Warn);
         assert_ne!(report.verdict, Level::Fail);
         // aider's wiring is a launch arg alone, so there is no file to check.
@@ -559,7 +622,7 @@ mod tests {
         let known = vec!["claude".to_string()];
         let hook = Assessment::from_hooks(&registry(), "claude", Some("working"), Some(0), 1_000)
             .with_pane("claude", &known, Some("bash"), Some("bash"), Some(false));
-        let report = diagnose(&row("s", "claude", "local-tmux"), &hook, true, Some("/x"));
+        let report = diagnose_agent(&row("s", "claude", "local-tmux"), &hook, true, Some("/x"));
         assert_eq!(level_of(&report, "pane"), Level::Warn);
         let detail = &report
             .findings
@@ -577,11 +640,103 @@ mod tests {
         // here. Reporting a local file as missing would be a false failure.
         let hook = Assessment::from_hooks(&registry(), "claude", Some("done"), Some(0), 1_000)
             .pane_unavailable();
-        let report = diagnose(&row("s", "claude", "ssh:devbox"), &hook, true, Some("/x"));
+        let report = diagnose_agent(&row("s", "claude", "ssh:devbox"), &hook, true, Some("/x"));
         assert_eq!(level_of(&report, "payload"), Level::Warn);
         assert_eq!(level_of(&report, "cli"), Level::Warn);
         assert_ne!(report.verdict, Level::Fail);
         assert_eq!(hook.corroboration, Some(Corroboration::Unavailable));
+    }
+
+    #[test]
+    fn a_command_session_expects_no_hooks_and_is_never_a_failure() {
+        // The shape thurbox advertises for drivers: `--command $SHELL --arg -i`,
+        // named after the command's file stem. There is no wiring here to be
+        // broken, and failing it made bare `doctor` — which diagnoses every
+        // active session — fail the whole machine because one shell existed.
+        let hook = Assessment::from_hooks(&registry(), "bash", None, None, 0);
+        let report = diagnose(
+            &row("task-7", "bash", "local-tmux"),
+            false,
+            &hook,
+            true,
+            Some("/bin/x"),
+        );
+        assert_eq!(level_of(&report, "coverage"), Level::Ok);
+        assert_ne!(report.verdict, Level::Fail);
+        let detail = &report
+            .findings
+            .iter()
+            .find(|f| f.key == "coverage")
+            .unwrap()
+            .detail;
+        assert!(detail.contains("reports-as"), "got {detail}");
+    }
+
+    #[test]
+    fn a_declared_agent_decides_coverage_rather_than_the_rows_own_name() {
+        // The driver launched claude inside a `--command bash` session and said
+        // so. Judging the wiring against `bash` reported coverage `none` for a
+        // fully instrumented pane — and, worse, `blocked_is_heuristic: false`
+        // about claude's text match on a notification body.
+        let hook = Assessment::from_hooks(&registry(), "claude", Some("working"), Some(0), 0);
+        let report = diagnose(
+            &row("task-7", "bash", "local-tmux"),
+            true,
+            &hook,
+            true,
+            Some("/bin/x"),
+        );
+        assert_eq!(level_of(&report, "coverage"), Level::Ok);
+        assert!(hook.blocked_is_heuristic());
+        let json = report.to_json(&row("task-7", "bash", "local-tmux"));
+        assert_eq!(json["agent"], "bash");
+        assert_eq!(json["reports_as"], "claude");
+        assert_eq!(json["hook_coverage"], "full");
+    }
+
+    #[test]
+    fn a_stopped_session_reports_the_park_rather_than_a_stale_signal() {
+        // `stop` writes the mark and clears the hook state as two separate
+        // writes, and `Assessment::parked` leaves the columns alone — so a
+        // stale `blocked` outlives the pane it described. The pane check next
+        // to this one already answers `stopped` first; this one did not, and
+        // printed the dead agent's last word as the current state.
+        let hook =
+            Assessment::from_hooks(&registry(), "claude", Some("blocked"), Some(0), 1_000).parked();
+        let report = diagnose_agent(
+            &row("parked", "claude", "local-tmux"),
+            &hook,
+            true,
+            Some("/x"),
+        );
+        let detail = &report
+            .findings
+            .iter()
+            .find(|f| f.key == "last-signal")
+            .unwrap()
+            .detail;
+        assert_eq!(detail, "stopped, so nothing is reporting", "got {detail}");
+    }
+
+    #[test]
+    fn a_missing_cli_does_not_undo_the_no_hooks_expected_carve_out() {
+        // The verdict is the maximum over the findings, so an unconditional
+        // `fail` here came back as the session's verdict however healthy the
+        // coverage check had just declared it. Nothing thurbox installed for a
+        // command session runs the binary, so its absence cannot be what stops
+        // state arriving — it is still worth saying, because a driver calling
+        // `session signal` from the pane needs it.
+        let hook = Assessment::from_hooks(&registry(), "bash", None, None, 0);
+        let report = diagnose(&row("s", "bash", "local-tmux"), false, &hook, true, None);
+        assert_eq!(level_of(&report, "cli"), Level::Warn);
+        assert_ne!(report.verdict, Level::Fail);
+
+        // A registry agent thurbox ships no hooks for is the other way round:
+        // its driver's `session signal` is the only route state can take, so a
+        // binary that is not on PATH really is what breaks it.
+        let owned = Assessment::from_hooks(&registry(), "shell", Some("working"), Some(0), 5_000);
+        let report = diagnose_agent(&row("s", "shell", "local-tmux"), &owned, true, None);
+        assert_eq!(level_of(&report, "cli"), Level::Fail);
     }
 
     #[test]
@@ -592,13 +747,13 @@ mod tests {
         // another host, so it must not turn into a failure.
         let hook = Assessment::from_hooks(&registry(), "claude", Some("done"), Some(0), 1_000)
             .pane_unavailable();
-        let report = diagnose(&row("s", "claude", "ssh:devbox"), &hook, true, None);
+        let report = diagnose_agent(&row("s", "claude", "ssh:devbox"), &hook, true, None);
         assert_eq!(level_of(&report, "cli"), Level::Warn);
         assert_ne!(report.verdict, Level::Fail);
 
         // The same absent CLI is still a failure for a local session, whose
         // hooks really do shell out to it.
-        let local = diagnose(&row("s", "claude", "local-tmux"), &hook, true, None);
+        let local = diagnose_agent(&row("s", "claude", "local-tmux"), &hook, true, None);
         assert_eq!(level_of(&local, "cli"), Level::Fail);
     }
 }

--- a/src/cli/session_ref.rs
+++ b/src/cli/session_ref.rs
@@ -19,6 +19,7 @@
 //! every candidate named. Acting on whichever row sorted first is the one
 //! behaviour that would make a driver corrupt the wrong session silently.
 
+use crate::cli::{CommandError, EXIT_AMBIGUOUS};
 use crate::session::SessionId;
 use crate::storage::Database;
 use crate::sync::SharedSession;
@@ -33,15 +34,22 @@ pub enum Ambiguity {
 
 /// Resolve a reference to exactly one active session.
 ///
-/// `Err` carries the rendered explanation; callers that need to distinguish
-/// "none" from "several" use [`resolve_detailed`].
-pub fn resolve(db: &Database, reference: &str) -> Result<SharedSession, String> {
-    resolve_detailed(db, reference).map_err(|(reason, _)| reason)
+/// `Err` carries the rendered explanation and the exit code the failure earns:
+/// a reference matching several sessions exits [`EXIT_AMBIGUOUS`] rather than
+/// the generic failure code, because the two failures ask different things of
+/// the caller — one is reconciled by creating a session, the other only by an
+/// operator picking which was meant.
+pub fn resolve(db: &Database, reference: &str) -> Result<SharedSession, CommandError> {
+    resolve_detailed(db, reference).map_err(|(reason, kind)| match kind {
+        Ambiguity::NotFound => CommandError::from(reason),
+        Ambiguity::Many(_) => CommandError::with_code(reason, EXIT_AMBIGUOUS),
+    })
 }
 
-/// [`resolve`], also returning which kind of failure it was so a caller can
-/// pick an exit code (AXI principle 6 asks a usage error and a missing thing to
-/// exit differently).
+/// [`resolve`], also returning which kind of failure it was — the distinction
+/// [`resolve`] turns into an exit code (AXI principle 6 asks a usage error and
+/// a missing thing to exit differently), and which a caller rendering its own
+/// refusal document reads directly.
 pub fn resolve_detailed(
     db: &Database,
     reference: &str,
@@ -87,6 +95,72 @@ pub fn resolve_detailed(
             Ambiguity::NotFound,
         )),
         _ => Err((ambiguous(reference, &by_prefix), Ambiguity::Many(by_prefix))),
+    }
+}
+
+/// Resolve a reference against the **deleted** rows, the way [`resolve`] does
+/// against the active ones.
+///
+/// `session restore` is the one verb whose subject is a row that no longer
+/// exists, so it cannot share the active-session resolver — but it can share
+/// its rules, and a driver that holds a name rather than a UUID has no other
+/// way in. Same three spellings, same refusal to guess between two candidates,
+/// same exit code for the ambiguity.
+///
+/// Filtered in memory rather than in SQL because the deleted set is what
+/// `session list --deleted` already reads whole.
+pub fn resolve_deleted(
+    db: &Database,
+    reference: &str,
+) -> Result<crate::storage::DeletedSessionInfo, CommandError> {
+    let deleted = db
+        .list_deleted_sessions()
+        .map_err(|e| CommandError::from(format!("list_deleted_sessions: {e}")))?;
+    if let Ok(id) = reference.parse::<SessionId>() {
+        return deleted
+            .into_iter()
+            .find(|d| d.id == id)
+            .ok_or_else(|| CommandError::from(format!("Deleted session not found: {reference}")));
+    }
+    let by_name: Vec<_> = deleted
+        .iter()
+        .filter(|d| d.name == reference)
+        .cloned()
+        .collect();
+    if let Some(one) = pick_deleted(reference, by_name)? {
+        return Ok(one);
+    }
+    let by_prefix: Vec<_> = deleted
+        .into_iter()
+        .filter(|d| d.id.to_string().starts_with(reference))
+        .collect();
+    pick_deleted(reference, by_prefix)?.ok_or_else(|| {
+        CommandError::from(format!(
+            "Deleted session not found: {reference} (tried it as a UUID, a name, and an id prefix)"
+        ))
+    })
+}
+
+/// One candidate, none, or a refusal naming them all — the deleted half of the
+/// rule [`resolve`] follows.
+fn pick_deleted(
+    reference: &str,
+    mut found: Vec<crate::storage::DeletedSessionInfo>,
+) -> Result<Option<crate::storage::DeletedSessionInfo>, CommandError> {
+    match found.len() {
+        0 => Ok(None),
+        1 => Ok(Some(found.remove(0))),
+        n => {
+            let list = found
+                .iter()
+                .map(|d| format!("  {}  {}", d.id, d.name))
+                .collect::<Vec<_>>()
+                .join("\n");
+            Err(CommandError::with_code(
+                format!("'{reference}' matches {n} deleted sessions:\n{list}"),
+                EXIT_AMBIGUOUS,
+            ))
+        }
     }
 }
 
@@ -171,7 +245,29 @@ mod tests {
     fn a_reference_that_matches_nothing_says_what_it_tried() {
         let db = db();
         let err = resolve(&db, "nope").unwrap_err();
-        assert!(err.contains("nope"));
-        assert!(err.contains("prefix"), "the message names every spelling");
+        assert!(err.message.contains("nope"));
+        assert!(
+            err.message.contains("prefix"),
+            "the message names every spelling"
+        );
+        assert_eq!(err.exit_code, crate::cli::EXIT_ERROR);
+    }
+
+    #[test]
+    fn an_ambiguous_reference_exits_differently_from_a_missing_one() {
+        // A driver reconciles "no such session" by creating one; only an
+        // operator can settle "two sessions answer to that name". Telling them
+        // apart used to mean string-matching the message.
+        let db = db();
+        db.upsert_session(&row("twin")).unwrap();
+        db.upsert_session(&row("twin")).unwrap();
+        assert_eq!(
+            resolve(&db, "twin").unwrap_err().exit_code,
+            crate::cli::EXIT_AMBIGUOUS
+        );
+        assert_eq!(
+            resolve(&db, "solo").unwrap_err().exit_code,
+            crate::cli::EXIT_ERROR
+        );
     }
 }

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -633,7 +633,8 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, CommandError>
             // decision about *this* backend, since a mirrored host's rows share
             // the namespace.
             let backend = crate::session_ops::spawn::backend_type_for(host.as_deref())?;
-            let existing = resolve_existing(db, &name, on_existing, &backend)?;
+            let existing =
+                resolve_existing(db, &name, on_existing, &backend, reports_as.as_deref())?;
             if let Existing::Answered(output) = existing {
                 return Ok(*output);
             }
@@ -660,8 +661,15 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, CommandError>
                 Err(e) => return Err(rollback_replace(db, &existing, e).into()),
             };
             if let Some(declared) = &reports_as {
-                db.set_reports_as(res.session_id, Some(declared))
-                    .map_err(|e| format!("set_reports_as: {e}"))?;
+                if let Err(e) = db.set_reports_as(res.session_id, Some(declared)) {
+                    return Err(format!(
+                        "session '{}' ({}) was created, but declaring it as '{declared}' \
+                         failed: set_reports_as: {e}. Retry with `thurbox-cli session \
+                         reports-as {} {declared}`",
+                        res.name, res.session_id, res.session_id
+                    )
+                    .into());
+                }
             }
             // Nothing has signalled yet, so this is `uncovered` or `unreported`
             // — read against whatever will actually report.
@@ -1566,11 +1574,16 @@ enum Existing {
 /// same-named sessions, or destroying one of them, is a guess about which was
 /// meant. It is the same rule [`super::session_ref`] follows, and it still
 /// applies within one backend — thurbox enforces no uniqueness there either.
+///
+/// `reports_as` is only consulted on the `adopt` arm: `replace` and `None`
+/// both flow back into the normal creation path, which already applies it to
+/// the freshly spawned session.
 fn resolve_existing(
     db: &Database,
     name: &str,
     mode: OnExisting,
     backend: &str,
+    reports_as: Option<&str>,
 ) -> Result<Existing, CommandError> {
     if mode == OnExisting::Allow {
         return Ok(Existing::None);
@@ -1594,9 +1607,15 @@ fn resolve_existing(
                 .join(", ")
         )
         .into()),
-        (OnExisting::Adopt, 1) => Ok(Existing::Answered(Box::new(existing_session_output(
-            db, &found[0],
-        )))),
+        (OnExisting::Adopt, 1) => {
+            if let Some(declared) = reports_as {
+                db.set_reports_as(found[0].id, Some(declared))
+                    .map_err(|e| format!("set_reports_as: {e}"))?;
+            }
+            Ok(Existing::Answered(Box::new(existing_session_output(
+                db, &found[0],
+            ))))
+        }
         (OnExisting::Replace, 1) => {
             crate::session_ops::delete::delete_session_headless(db, found[0].id, true)?;
             Ok(Existing::Replaced(found[0].id))
@@ -2126,7 +2145,7 @@ mod tests {
         for mode in [OnExisting::Fail, OnExisting::Adopt, OnExisting::Replace] {
             assert!(
                 matches!(
-                    resolve_existing(&db, "build", mode, "local-tmux"),
+                    resolve_existing(&db, "build", mode, "local-tmux", None),
                     Ok(Existing::None)
                 ),
                 "{mode:?} must not act on a row belonging to another host"
@@ -2136,7 +2155,7 @@ mod tests {
         assert!(db.get_session_by_id(remote.id).unwrap().is_some());
 
         // A create *for that host* does see it, on the same terms.
-        assert!(resolve_existing(&db, "build", OnExisting::Fail, "ssh:devbox").is_err());
+        assert!(resolve_existing(&db, "build", OnExisting::Fail, "ssh:devbox", None).is_err());
     }
 
     /// Ambiguity here is the same failure the reference resolver reports, so it
@@ -2147,7 +2166,8 @@ mod tests {
         let db = db();
         db.upsert_session(&make_test_session("twin")).unwrap();
         db.upsert_session(&make_test_session("twin")).unwrap();
-        let err = resolve_existing(&db, "twin", OnExisting::Adopt, "local-tmux").unwrap_err();
+        let err =
+            resolve_existing(&db, "twin", OnExisting::Adopt, "local-tmux", None).unwrap_err();
         assert_eq!(err.exit_code, super::super::EXIT_AMBIGUOUS);
         assert!(err.contains("matches 2"), "got {err}");
     }

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -2166,8 +2166,7 @@ mod tests {
         let db = db();
         db.upsert_session(&make_test_session("twin")).unwrap();
         db.upsert_session(&make_test_session("twin")).unwrap();
-        let err =
-            resolve_existing(&db, "twin", OnExisting::Adopt, "local-tmux", None).unwrap_err();
+        let err = resolve_existing(&db, "twin", OnExisting::Adopt, "local-tmux", None).unwrap_err();
         assert_eq!(err.exit_code, super::super::EXIT_AMBIGUOUS);
         assert!(err.contains("matches 2"), "got {err}");
     }

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -6,6 +6,7 @@ use clap::Subcommand;
 use serde_json::{json, Value};
 
 use crate::cli::output::{self, CommandOutput};
+use crate::cli::CommandError;
 use crate::session::SessionId;
 use crate::storage::Database;
 use crate::sync::SharedSession;
@@ -134,9 +135,19 @@ pub enum Action {
         /// `--repo-path`, its conversation as this.
         #[arg(long)]
         resume: Option<String>,
-        /// What to do when a session of this name is already active.
+        /// What to do when a session of this name is already active on this
+        /// backend.
         #[arg(long = "on-existing", value_enum, default_value_t = OnExisting::Allow)]
         on_existing: OnExisting,
+        /// The agent this session's pane will actually run, when that is not
+        /// what thurbox launches.
+        ///
+        /// The `--command` companion: a driver that opens a shell and starts
+        /// its own agent in it says so here, and thurbox reads hook coverage
+        /// against that agent instead of against the command's file stem. Same
+        /// declaration `session reports-as` makes, at creation time.
+        #[arg(long = "reports-as")]
+        reports_as: Option<String>,
     },
     /// Soft-delete a session. (`remove` is an alias.)
     #[command(alias = "remove")]
@@ -156,8 +167,10 @@ pub enum Action {
     },
     /// Restore a soft-deleted session.
     Restore {
-        /// Session UUID.
-        uuid: String,
+        /// Session name, UUID, or unique id prefix — resolved against the
+        /// deleted rows, since that is where the session now is.
+        #[arg(value_name = "SESSION")]
+        session: String,
         /// Recover a force-deleted session best-effort: only committed branch
         /// state comes back (uncommitted/untracked work was lost on delete).
         #[arg(long)]
@@ -345,6 +358,29 @@ pub enum Action {
         #[arg(trailing_var_arg = true, required = true)]
         command: Vec<String>,
     },
+    /// Declare which agent a session's pane actually runs.
+    ///
+    /// A `--command` session is named after the command it launches, so a
+    /// driver that opens a shell and starts `claude` in it leaves thurbox
+    /// reading hook coverage against `bash`: coverage `none`, no reportable
+    /// states, and `hook_blocked_is_heuristic: false` — asserting the block
+    /// signal is structured when it is claude's text match on a notification
+    /// body. This is how the driver says what is in there. It changes nothing
+    /// about the launch; `session restart` still replays the recorded command.
+    #[command(name = "reports-as")]
+    ReportsAs {
+        /// Session name, UUID, or unique id prefix.
+        #[arg(value_name = "SESSION")]
+        session: String,
+        /// The agent whose hooks the pane speaks — a name from `agents.toml`
+        /// or a `hook_schema` family thurbox ships hooks for.
+        #[arg(required_unless_present = "clear")]
+        agent: Option<String>,
+        /// Forget the declaration: read coverage against the row's own agent
+        /// again.
+        #[arg(long, conflicts_with = "agent")]
+        clear: bool,
+    },
     /// Read/write a session's metadata — the driver's own key/value space.
     Meta {
         #[command(subcommand)]
@@ -449,7 +485,7 @@ pub enum MetaAction {
     },
 }
 
-pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
+pub fn run(action: Action, db: &Database) -> Result<CommandOutput, CommandError> {
     match action {
         Action::List {
             deleted: true,
@@ -486,8 +522,8 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
                 )
                 .empty("0 deleted sessions to restore")
                 .help([
-                    "thurbox-cli session restore <id>   bring one back",
-                    "thurbox-cli session restore <id> --best-effort   for a force-deleted row",
+                    "thurbox-cli session restore <name|id>   bring one back",
+                    "thurbox-cli session restore <name|id> --best-effort   for a force-deleted row",
                 ]))
         }
         Action::List {
@@ -505,13 +541,12 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
                 .into_iter()
                 .filter(|s| parent_id.is_none() || s.parent_session_id == parent_id)
                 .collect();
-            let states = db.load_hook_states().unwrap_or_default();
-            let parked = db.load_stopped_sessions().unwrap_or_default();
+            let facts = SessionFacts::load(db);
             let bases = db.load_base_branches().unwrap_or_default();
             let registry = crate::agent::agent_config::load_or_seed();
             let assessments: Vec<crate::session::Assessment> = sessions
                 .iter()
-                .map(|s| assess(&registry, s, &states, &parked, verify))
+                .map(|s| facts.assess(&registry, s, verify))
                 .collect();
             let json = Value::Array(
                 sessions
@@ -550,11 +585,10 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
         }
         Action::Get { uuid, no_verify } => {
             let session = resolve(db, &uuid)?;
-            let states = db.load_hook_states().unwrap_or_default();
-            let parked = db.load_stopped_sessions().unwrap_or_default();
+            let facts = SessionFacts::load(db);
             let bases = db.load_base_branches().unwrap_or_default();
             let registry = crate::agent::agent_config::load_or_seed();
-            let hook = assess(&registry, &session, &states, &parked, !no_verify);
+            let hook = facts.assess(&registry, &session, !no_verify);
             Ok(CommandOutput::new(
                 crate::session_ops::mirror::session_to_json_assessed(
                     &session,
@@ -579,6 +613,7 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
             env,
             resume,
             on_existing,
+            reports_as,
         } => {
             let parent_session_id = parent
                 .as_deref()
@@ -586,10 +621,21 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
                 .transpose()?;
             let extra_repos = super::parse_extra_repos(&add_repo, &add_dir);
             let env = parse_env(&env)?;
+            let registry = crate::agent::agent_config::load_or_seed();
+            // Checked before anything is spawned: a typo here is silent
+            // otherwise, and the session it would have described is already
+            // running by the time the caller could notice.
+            if let Some(declared) = &reports_as {
+                check_reports_as(&registry, declared)?;
+            }
             // Names are not unique, so "already exists" is a decision the
-            // caller makes rather than something thurbox assumes.
-            if let Some(found) = resolve_existing(db, &name, on_existing)? {
-                return Ok(found);
+            // caller makes rather than something thurbox assumes — and it is a
+            // decision about *this* backend, since a mirrored host's rows share
+            // the namespace.
+            let backend = crate::session_ops::spawn::backend_type_for(host.as_deref())?;
+            let existing = resolve_existing(db, &name, on_existing, &backend)?;
+            if let Existing::Answered(output) = existing {
+                return Ok(*output);
             }
             let req = crate::session_ops::SpawnRequest {
                 name,
@@ -606,7 +652,28 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
                 resume_session_id: resume,
                 ..Default::default()
             };
-            let res = crate::session_ops::spawn_session_headless(db, req)?;
+            let res = match crate::session_ops::spawn_session_headless(db, req) {
+                Ok(res) => res,
+                // `replace` tore the old session down first, so a spawn that
+                // fails here would otherwise leave the caller with neither
+                // session. Put back what can be put back before reporting.
+                Err(e) => return Err(rollback_replace(db, &existing, e).into()),
+            };
+            if let Some(declared) = &reports_as {
+                db.set_reports_as(res.session_id, Some(declared))
+                    .map_err(|e| format!("set_reports_as: {e}"))?;
+            }
+            // Nothing has signalled yet, so this is `uncovered` or `unreported`
+            // — read against whatever will actually report.
+            let state = crate::session::Assessment::from_hooks(
+                &registry,
+                reports_as.as_deref().unwrap_or(&res.agent),
+                None,
+                None,
+                0,
+            )
+            .state_word()
+            .to_string();
             // A host driven from afar has no interface of its own to arm the
             // heartbeat: this creation is the moment its sessions start needing
             // the tick (status polls, extension self-heal, reaping).
@@ -638,13 +705,23 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
                     "parent_session_id": res.parent_session_id.map(|id| id.to_string()),
                     "hook_failures": res.hook_failures,
                     "sharing": res.sharing,
+                    "reports_as": reports_as,
+                    // Present here only so `--on-existing adopt` can answer in
+                    // the same shape: a session that was just spawned is
+                    // running by construction and has said nothing yet, while
+                    // one that was already there may be parked.
+                    "stopped": false,
+                    "state": state,
                     "created": true,
                 }),
                 human,
             ))
         }
         Action::Delete { uuid, force } => delete_session(db, &uuid, force),
-        Action::Restore { uuid, best_effort } => restore_deleted(db, &uuid, best_effort),
+        Action::Restore {
+            session,
+            best_effort,
+        } => restore_deleted(db, &session, best_effort),
         Action::Restart { uuid, if_missing } => {
             let session = resolve(db, &uuid)?;
             let report = crate::session_ops::restart::restart_session_headless_with(
@@ -839,6 +916,11 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
             exit_passthrough,
             command,
         } => exec_in_session(db, &session, &command, exit_passthrough),
+        Action::ReportsAs {
+            session,
+            agent,
+            clear,
+        } => set_reports_as(db, &session, agent.as_deref(), clear),
         Action::Meta { action } => run_meta(action, db),
         Action::Doctor { uuid } => super::session_doctor::run(db, uuid.as_deref()),
         Action::Signal { state, session } => {
@@ -851,7 +933,8 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
                     "'{}' is parked, so it has no turn to report; \
                      thurbox-cli session start {} first",
                     target.name, target.id
-                ));
+                )
+                .into());
             }
             // The same state on the pane, for a peer's live subscription:
             // best-effort, and nothing at all outside tmux.
@@ -886,7 +969,7 @@ fn capture_pane(
     uuid: &str,
     lines: u32,
     ansi: bool,
-) -> Result<CommandOutput, String> {
+) -> Result<CommandOutput, CommandError> {
     let session = resolve(db, uuid)?;
     refuse_if_parked(db, &session)?;
     let id = session.id.to_string();
@@ -933,7 +1016,7 @@ fn capture_pane(
 }
 
 /// Delete a session, reporting what `--force` teardown actually managed.
-fn delete_session(db: &Database, uuid: &str, force: bool) -> Result<CommandOutput, String> {
+fn delete_session(db: &Database, uuid: &str, force: bool) -> Result<CommandOutput, CommandError> {
     let session = resolve(db, uuid)?;
     let report = crate::session_ops::delete_session_headless(db, session.id, force)?;
     let mut human = format!("Deleted session '{}' ({})", session.name, session.id);
@@ -996,19 +1079,18 @@ fn force_delete_detail(
 /// restoring means (it used to clear the flag alone, handing back a session
 /// with no worktree and no window). Whatever [`crate::session_ops::restore_refusal`]
 /// objects to is refused without `--best-effort`.
-fn restore_deleted(db: &Database, uuid: &str, best_effort: bool) -> Result<CommandOutput, String> {
-    let id: SessionId = uuid
-        .parse()
-        .map_err(|_| format!("Invalid session UUID: {uuid}"))?;
+fn restore_deleted(
+    db: &Database,
+    reference: &str,
+    best_effort: bool,
+) -> Result<CommandOutput, CommandError> {
     // The pipeline refuses this too, and on exactly the same terms — asking it
     // rather than re-deciding is what keeps the two from disagreeing about what
     // is restorable (`force_deleted` alone says yes to a borrowed worktree that
     // is gone and no to one that is not). The command line only adds the
     // sentence the pipeline cannot: `--best-effort` is how you say yes here.
-    let deleted = db
-        .get_deleted_session_by_id(id)
-        .map_err(|e| format!("get_deleted_session_by_id: {e}"))?
-        .ok_or_else(|| format!("Deleted session not found: {uuid}"))?;
+    let deleted = super::session_ref::resolve_deleted(db, reference)?;
+    let id = deleted.id;
     if !best_effort {
         if let Some(reason) = crate::session_ops::restore_refusal(
             &deleted.name,
@@ -1016,7 +1098,7 @@ fn restore_deleted(db: &Database, uuid: &str, best_effort: bool) -> Result<Comma
             &deleted.backend_type,
             &deleted.worktrees,
         ) {
-            return Err(format!("{reason} — pass --best-effort to restore anyway"));
+            return Err(format!("{reason} — pass --best-effort to restore anyway").into());
         }
     }
     let report = crate::session_ops::restore_session_headless(db, id, best_effort)?;
@@ -1052,6 +1134,47 @@ fn restore_deleted(db: &Database, uuid: &str, best_effort: bool) -> Result<Comma
     ))
 }
 
+/// `session reports-as` — record (or forget) the agent a pane actually runs.
+///
+/// The agent is checked against the hook table rather than merely stored: the
+/// whole point of the declaration is the coverage it unlocks, and a typo that
+/// silently unlocked nothing would leave the driver believing the opposite of
+/// what thurbox now reports.
+fn set_reports_as(
+    db: &Database,
+    reference: &str,
+    agent: Option<&str>,
+    clear: bool,
+) -> Result<CommandOutput, CommandError> {
+    let session = resolve(db, reference)?;
+    let declared = agent.filter(|_| !clear);
+    if let Some(agent) = declared {
+        check_reports_as(&crate::agent::agent_config::load_or_seed(), agent)?;
+    }
+    db.set_reports_as(session.id, declared)
+        .map_err(|e| format!("set_reports_as: {e}"))?;
+    let human = match declared {
+        Some(agent) => format!(
+            "'{}' reports as '{agent}' — coverage is read against its hooks.",
+            session.name
+        ),
+        None => format!(
+            "'{}' reports as '{}' again — the agent it was created with.",
+            session.name, session.agent
+        ),
+    };
+    Ok(CommandOutput::new(
+        json!({
+            "session_id": session.id.to_string(),
+            "session_name": session.name,
+            "agent": session.agent,
+            "reports_as": declared,
+        }),
+        human,
+    )
+    .help(["thurbox-cli session doctor <id>   what its wiring can now report"]))
+}
+
 /// The human half of a post-hook failure list: one indented line each. The
 /// operation succeeded; these are what the user's own hooks had to say.
 fn push_hook_failures(human: &mut String, failures: &[String]) {
@@ -1064,7 +1187,10 @@ fn push_hook_failures(human: &mut String, failures: &[String]) {
 /// the calling session from `$THURBOX_SESSION`, else a lookup by the agent
 /// conversation id from `$THURBOX_SESSION_ID` (the env fallback for agents whose
 /// hooks don't inherit `$THURBOX_SESSION`). Errors when none resolves.
-fn resolve_signal_target(db: &Database, session: Option<&str>) -> Result<SharedSession, String> {
+fn resolve_signal_target(
+    db: &Database,
+    session: Option<&str>,
+) -> Result<SharedSession, CommandError> {
     if let Some(uuid) = session {
         return resolve(db, uuid);
     }
@@ -1217,7 +1343,7 @@ fn exec_in_session(
     reference: &str,
     command: &[String],
     exit_passthrough: bool,
-) -> Result<CommandOutput, String> {
+) -> Result<CommandOutput, CommandError> {
     let session = resolve(db, reference)?;
     let cwd = session
         .cwd
@@ -1298,7 +1424,7 @@ fn exec_in_session(
 }
 
 /// `session meta` — storage, and nothing more. Nothing here interprets a key.
-fn run_meta(action: MetaAction, db: &Database) -> Result<CommandOutput, String> {
+fn run_meta(action: MetaAction, db: &Database) -> Result<CommandOutput, CommandError> {
     match action {
         MetaAction::Set {
             session,
@@ -1409,34 +1535,56 @@ fn worktree_json(w: &crate::sync::SharedWorktree) -> Value {
     })
 }
 
+/// What [`resolve_existing`] decided, and what the creation still owes it.
+#[derive(Debug)]
+enum Existing {
+    /// Nothing of that name on this backend — spawn.
+    None,
+    /// The answer is already a document (`adopt`); the creation must not run.
+    Answered(Box<CommandOutput>),
+    /// `replace` tore this session down. A spawn that now fails has to put it
+    /// back, or the caller is left with neither.
+    Replaced(SessionId),
+}
+
 /// Apply the caller's [`OnExisting`] answer before anything is spawned.
 ///
-/// `Ok(Some(output))` means the creation is already answered and must not
-/// proceed; `Ok(None)` means carry on and spawn. A refusal is an `Err`, which
-/// the entrypoint renders as a structured document on stdout and exits 1 —
-/// what Gas City's `RPP-LIFECYCLE-002` requires of a duplicate start, and what
-/// firstmate was hand-rolling a `session list` pre-check to achieve.
+/// A refusal is an `Err`, which the entrypoint renders as a structured document
+/// on stdout and exits non-zero — what Gas City's `RPP-LIFECYCLE-002` requires
+/// of a duplicate start, and what firstmate was hand-rolling a `session list`
+/// pre-check to achieve.
+///
+/// `backend` scopes the match to the machine the new session will land on. The
+/// name namespace is *not* per-machine: a database mirroring a shareable host
+/// (ADR-24) holds that host's rows beside its own, and two machines may
+/// legitimately each have a session called `build`. Matching across all of them
+/// made `replace` force-delete a session on another host, `fail` refuse a local
+/// create because of a remote namesake, and `adopt` hand back an id whose pane
+/// is not on this machine.
 ///
 /// Ambiguity blocks `adopt` and `replace` but not `allow`: adopting one of two
 /// same-named sessions, or destroying one of them, is a guess about which was
-/// meant. It is the same rule [`super::session_ref`] follows, and it has to
-/// hold here because a database that mirrors a shareable host can legitimately
-/// already contain two.
+/// meant. It is the same rule [`super::session_ref`] follows, and it still
+/// applies within one backend — thurbox enforces no uniqueness there either.
 fn resolve_existing(
     db: &Database,
     name: &str,
     mode: OnExisting,
-) -> Result<Option<CommandOutput>, String> {
+    backend: &str,
+) -> Result<Existing, CommandError> {
     if mode == OnExisting::Allow {
-        return Ok(None);
+        return Ok(Existing::None);
     }
-    let found = db
+    let found: Vec<SharedSession> = db
         .find_sessions_by_name(name)
-        .map_err(|e| format!("find_sessions_by_name: {e}"))?;
+        .map_err(|e| format!("find_sessions_by_name: {e}"))?
+        .into_iter()
+        .filter(|s| s.backend_type == backend)
+        .collect();
     match (mode, found.len()) {
-        (OnExisting::Allow, _) | (_, 0) => Ok(None),
+        (OnExisting::Allow, _) | (_, 0) => Ok(Existing::None),
         (OnExisting::Fail, _) => Err(format!(
-            "a session named '{name}' is already active ({}). Use \
+            "a session named '{name}' is already active on {backend} ({}). Use \
              `--on-existing adopt` to take it as it is, `--on-existing replace` \
              to tear it down first, or pick another name",
             found
@@ -1444,27 +1592,87 @@ fn resolve_existing(
                 .map(|s| s.id.to_string())
                 .collect::<Vec<_>>()
                 .join(", ")
-        )),
-        (OnExisting::Adopt, 1) => Ok(Some(existing_session_output(&found[0]))),
+        )
+        .into()),
+        (OnExisting::Adopt, 1) => Ok(Existing::Answered(Box::new(existing_session_output(
+            db, &found[0],
+        )))),
         (OnExisting::Replace, 1) => {
             crate::session_ops::delete::delete_session_headless(db, found[0].id, true)?;
-            Ok(None)
+            Ok(Existing::Replaced(found[0].id))
         }
-        (OnExisting::Adopt | OnExisting::Replace, n) => Err(format!(
-            "'{name}' matches {n} active sessions, so there is no single one to \
-             {}. Address them by id, or pick another name:\n{}",
-            if mode == OnExisting::Adopt {
-                "adopt"
-            } else {
-                "replace"
-            },
-            found
-                .iter()
-                .map(|s| format!("  {}  {}", s.id, s.agent))
-                .collect::<Vec<_>>()
-                .join("\n")
+        (OnExisting::Adopt | OnExisting::Replace, n) => Err(CommandError::with_code(
+            format!(
+                "'{name}' matches {n} active sessions on {backend}, so there is no single one \
+                 to {}. Address them by id, or pick another name:\n{}",
+                if mode == OnExisting::Adopt {
+                    "adopt"
+                } else {
+                    "replace"
+                },
+                found
+                    .iter()
+                    .map(|s| format!("  {}  {}", s.id, s.agent))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            ),
+            super::EXIT_AMBIGUOUS,
         )),
     }
+}
+
+/// Put back what `replace` tore down when the replacement could not be spawned.
+///
+/// `replace` is a force delete followed by a create, and it cannot be the other
+/// way round: the new session wants the branch and the checkout the old one is
+/// holding. So the failure it has to answer for is the one in the middle —
+/// a spawn that fails after the teardown used to leave the caller with neither
+/// session. The undo is the same best-effort restore the interface runs, which
+/// brings back the row, the branch and the agent; uncommitted work went with
+/// the force delete and does not come back, and the message says so rather than
+/// implying the replace was free.
+fn rollback_replace(db: &Database, existing: &Existing, spawn_error: String) -> String {
+    let Existing::Replaced(id) = existing else {
+        return spawn_error;
+    };
+    match crate::session_ops::restore_session_headless(db, *id, true) {
+        Ok(report) => format!(
+            "{spawn_error} — the replacement could not be spawned, so '{}' ({id}) was restored \
+             best-effort: committed branch state is back, uncommitted work went with the \
+             force delete",
+            report.name
+        ),
+        Err(e) => format!(
+            "{spawn_error} — the replacement could not be spawned and the session it replaced \
+             ({id}) could not be restored either ({e}). `thurbox-cli session restore {id} \
+             --best-effort` is the retry"
+        ),
+    }
+}
+
+/// Refuse a `--reports-as`/`reports-as` agent thurbox ships no hooks for.
+///
+/// The declaration exists for the coverage it unlocks, so one that unlocks
+/// nothing is a typo rather than a preference — and a silent one, since the
+/// only symptom is the coverage the caller was trying to fix staying `none`.
+fn check_reports_as(
+    registry: &crate::session::AgentRegistry,
+    agent: &str,
+) -> Result<(), CommandError> {
+    if crate::session::coverage_for(registry, agent).is_some() {
+        return Ok(());
+    }
+    Err(format!(
+        "thurbox ships no status hooks for agent '{agent}', so declaring it would change \
+         nothing. Covered agents: {}. A custom agent asserts a family with `hook_schema` in \
+         agents.toml.",
+        crate::session::AGENT_HOOK_COVERAGE
+            .iter()
+            .map(|c| c.agent)
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
+    .into())
 }
 
 /// What `create --on-existing adopt` returns when the session was already there.
@@ -1472,7 +1680,15 @@ fn resolve_existing(
 /// The same document shape a real creation produces, with `created: false` as
 /// the only difference — so a caller reads one shape and needs no branch for
 /// "did I make this or find it".
-fn existing_session_output(session: &SharedSession) -> CommandOutput {
+///
+/// `stopped` and `state` are in both shapes for this verb's sake: the whole
+/// reason to adopt is to skip the follow-up read, and without them the answer
+/// could be a **parked** session — no pane, every `send`/`key`/`capture`
+/// refused — with nothing in it saying so.
+fn existing_session_output(db: &Database, session: &SharedSession) -> CommandOutput {
+    let registry = crate::agent::agent_config::load_or_seed();
+    let facts = SessionFacts::load(db);
+    let hook = facts.assess(&registry, session, true);
     CommandOutput::new(
         json!({
             "id": session.id.to_string(),
@@ -1486,11 +1702,19 @@ fn existing_session_output(session: &SharedSession) -> CommandOutput {
             "parent_session_id": session.parent_session_id.map(|id| id.to_string()),
             "hook_failures": Vec::<String>::new(),
             "sharing": Value::Null,
+            "reports_as": facts.declared_agent(session),
+            "stopped": hook.stopped,
+            "state": hook.state_word(),
             "created": false,
         }),
         format!(
-            "Session '{}' already exists ({}) — left as it is.",
-            session.name, session.id
+            "Session '{}' already exists ({}) — {}.",
+            session.name,
+            session.id,
+            match hook.stopped {
+                true => "stopped, so it has no pane; `session start` puts one back",
+                false => "left as it is",
+            }
         ),
     )
     .help(["thurbox-cli session get <id>   what it is doing now"])
@@ -1520,7 +1744,7 @@ fn refuse_if_parked(db: &Database, session: &SharedSession) -> Result<(), String
 
 /// Resolve the session a command was pointed at — a name, a UUID or an id
 /// prefix, all equally. See [`super::session_ref`] for why one resolver.
-pub(crate) fn resolve(db: &Database, reference: &str) -> Result<SharedSession, String> {
+pub(crate) fn resolve(db: &Database, reference: &str) -> Result<SharedSession, CommandError> {
     super::session_ref::resolve(db, reference)
 }
 
@@ -1598,49 +1822,108 @@ fn unknown_key(key: &str) -> String {
 /// **remote** session is never probed: its pane lives on its own host's
 /// multiplexer, so the answer is `unavailable` rather than a guess.
 ///
-/// `parked` is the set `session stop` marked. It short-circuits everything
-/// else: a parked session has no pane to probe and no agent to have reported,
-/// so probing one would ask tmux about a window that was deliberately killed
-/// and read the answer as if it meant something.
-pub(crate) fn assess(
-    registry: &crate::session::AgentRegistry,
-    s: &SharedSession,
-    states: &std::collections::HashMap<crate::session::SessionId, crate::storage::HookRow>,
-    parked: &std::collections::HashSet<crate::session::SessionId>,
-    probe: bool,
-) -> crate::session::Assessment {
-    let row = states.get(&s.id);
-    let hook = crate::session::Assessment::from_hooks(
-        registry,
-        &s.agent,
-        row.and_then(|r| r.state.as_deref()),
-        row.and_then(|r| r.state_at),
-        crate::sync::current_time_millis() as i64,
-    );
-    if parked.contains(&s.id) {
-        return hook.parked();
+/// The three per-row columns every assessment needs, read once for the whole
+/// database instead of once per session.
+///
+/// A listing that asked for each of them separately was three loads at every
+/// call site and, when a fourth arrived, three call sites to remember to
+/// update. Bundling them also fixes the order the answer is built in: the
+/// declared agent decides coverage before the hook columns are read against it.
+pub(crate) struct SessionFacts {
+    /// The latched `hook_state` columns, keyed by session.
+    states: std::collections::HashMap<crate::session::SessionId, crate::storage::HookRow>,
+    /// The set `session stop` marked. It short-circuits everything else: a
+    /// parked session has no pane to probe and no agent to have reported, so
+    /// probing one would ask tmux about a window that was deliberately killed
+    /// and read the answer as if it meant something.
+    parked: std::collections::HashSet<crate::session::SessionId>,
+    /// The agent a driver declared actually runs in the pane
+    /// (`--reports-as` / `session reports-as`), for the rows that have one.
+    reports_as: std::collections::HashMap<crate::session::SessionId, String>,
+    /// The rows created from a raw `--command` rather than an `agents.toml`
+    /// entry — the ones thurbox never had an agent to wire hooks for.
+    command_sessions: std::collections::HashSet<crate::session::SessionId>,
+}
+
+impl SessionFacts {
+    /// Read every per-row column an assessment needs, once.
+    ///
+    /// Each load falls back to empty: none of these is worth failing a listing
+    /// over, and an empty map means exactly what it meant before the column
+    /// existed.
+    pub(crate) fn load(db: &Database) -> Self {
+        Self {
+            states: db.load_hook_states().unwrap_or_default(),
+            parked: db.load_stopped_sessions().unwrap_or_default(),
+            reports_as: db.load_reports_as().unwrap_or_default(),
+            command_sessions: db.load_command_sessions().unwrap_or_default(),
+        }
     }
-    if !probe {
-        return hook;
+
+    /// The agent whose hook wiring this session's state should be read
+    /// against: the one a driver declared, else the one the row was created
+    /// with.
+    pub(crate) fn reporting_agent<'a>(&'a self, s: &'a SharedSession) -> &'a str {
+        self.reports_as
+            .get(&s.id)
+            .map(String::as_str)
+            .unwrap_or(&s.agent)
     }
-    if crate::session::is_remote_backend(&s.backend_type) {
-        return hook.pane_unavailable();
+
+    /// The agent a driver declared for this session, if any — `None` when the
+    /// row reports as the agent it was created with.
+    pub(crate) fn declared_agent(&self, s: &SharedSession) -> Option<&str> {
+        self.reports_as.get(&s.id).map(String::as_str)
     }
-    // The agent *binary*, not the agent name: `antigravity` runs `agy`, and the
-    // pane's foreground process is spelled the way it was invoked.
-    let command = registry
-        .get(&s.agent)
-        .map(|d| d.command.clone())
-        .unwrap_or_else(|| s.agent.clone());
-    let known: Vec<String> = registry.agents.iter().map(|a| a.command.clone()).collect();
-    let pane = crate::agent::tmux::pane_state(&s.name, &s.backend_id);
-    hook.with_pane(
-        &command,
-        &known,
-        pane.foreground_process.as_deref(),
-        pane.foreground_command.as_deref(),
-        pane.dead,
-    )
+
+    /// Whether thurbox ever had an agent here to wire hooks for.
+    ///
+    /// False for a `--command` session that has not declared one: it runs a
+    /// shell, a REPL or a build watcher, and there is no wiring to be broken.
+    pub(crate) fn hooks_expected(&self, s: &SharedSession) -> bool {
+        !self.command_sessions.contains(&s.id) || self.reports_as.contains_key(&s.id)
+    }
+
+    pub(crate) fn assess(
+        &self,
+        registry: &crate::session::AgentRegistry,
+        s: &SharedSession,
+        probe: bool,
+    ) -> crate::session::Assessment {
+        let agent = self.reporting_agent(s);
+        let row = self.states.get(&s.id);
+        let hook = crate::session::Assessment::from_hooks(
+            registry,
+            agent,
+            row.and_then(|r| r.state.as_deref()),
+            row.and_then(|r| r.state_at),
+            crate::sync::current_time_millis() as i64,
+        );
+        if self.parked.contains(&s.id) {
+            return hook.parked();
+        }
+        if !probe {
+            return hook;
+        }
+        if crate::session::is_remote_backend(&s.backend_type) {
+            return hook.pane_unavailable();
+        }
+        // The agent *binary*, not the agent name: `antigravity` runs `agy`, and
+        // the pane's foreground process is spelled the way it was invoked.
+        let command = registry
+            .get(agent)
+            .map(|d| d.command.clone())
+            .unwrap_or_else(|| agent.to_string());
+        let known: Vec<String> = registry.agents.iter().map(|a| a.command.clone()).collect();
+        let pane = crate::agent::tmux::pane_state(&s.name, &s.backend_id);
+        hook.with_pane(
+            &command,
+            &known,
+            pane.foreground_process.as_deref(),
+            pane.foreground_command.as_deref(),
+            pane.dead,
+        )
+    }
 }
 
 /// A deleted row as `session list --deleted` prints it: the session's facts
@@ -1693,14 +1976,14 @@ fn render_mirror_report(r: &crate::session_ops::mirror::MirrorReport) -> String 
 fn register_running_session(
     db: &Database,
     row: crate::session_ops::mirror::HostRow,
-) -> Result<CommandOutput, String> {
+) -> Result<CommandOutput, CommandError> {
     let mut session = row.session;
     if db
         .get_session_by_id(session.id)
         .map_err(|e| format!("get_session_by_id: {e}"))?
         .is_some()
     {
-        return Err(format!("session {} is already registered here", session.id));
+        return Err(format!("session {} is already registered here", session.id).into());
     }
     if let Some(existing) = db
         .get_session_by_name(&session.name)
@@ -1709,7 +1992,8 @@ fn register_running_session(
         return Err(format!(
             "a session named '{}' already exists here ({})",
             session.name, existing.id
-        ));
+        )
+        .into());
     }
     let pane = crate::agent::tmux::agent_window_pane(None, &session.name)
         .map_err(|e| format!("could not list windows: {e:#}"))?
@@ -1824,6 +2108,132 @@ mod tests {
             tombstone: false,
             tombstone_at: None,
         }
+    }
+
+    /// The name namespace spans machines (ADR-24 mirrors a shareable host's
+    /// rows into this database), so `--on-existing` has to ask about the
+    /// backend the creation will land on. Matching across all of them let a
+    /// local `replace` force-delete a session on another host, `fail` refuse a
+    /// local create because of a remote namesake, and `adopt` hand back an id
+    /// whose pane is on a different machine.
+    #[test]
+    fn on_existing_never_sees_a_namesake_on_another_host() {
+        let db = db();
+        let mut remote = make_test_session("build");
+        remote.backend_type = "ssh:devbox".into();
+        db.upsert_session(&remote).unwrap();
+
+        for mode in [OnExisting::Fail, OnExisting::Adopt, OnExisting::Replace] {
+            assert!(
+                matches!(
+                    resolve_existing(&db, "build", mode, "local-tmux"),
+                    Ok(Existing::None)
+                ),
+                "{mode:?} must not act on a row belonging to another host"
+            );
+        }
+        // The row is untouched — nothing was replaced on the other machine.
+        assert!(db.get_session_by_id(remote.id).unwrap().is_some());
+
+        // A create *for that host* does see it, on the same terms.
+        assert!(resolve_existing(&db, "build", OnExisting::Fail, "ssh:devbox").is_err());
+    }
+
+    /// Ambiguity here is the same failure the reference resolver reports, so it
+    /// earns the same exit code: a driver can act on "none" and only an
+    /// operator can settle "several".
+    #[test]
+    fn an_ambiguous_name_refuses_with_the_ambiguity_exit_code() {
+        let db = db();
+        db.upsert_session(&make_test_session("twin")).unwrap();
+        db.upsert_session(&make_test_session("twin")).unwrap();
+        let err = resolve_existing(&db, "twin", OnExisting::Adopt, "local-tmux").unwrap_err();
+        assert_eq!(err.exit_code, super::super::EXIT_AMBIGUOUS);
+        assert!(err.contains("matches 2"), "got {err}");
+    }
+
+    /// A driver that applied `agent launch-args claude` inside a `--command`
+    /// session is the one party that knows what the pane runs. Without the
+    /// declaration thurbox read coverage against the command's file stem and
+    /// published `hook_blocked_is_heuristic: false` — asserting the block
+    /// signal is structured when it is claude's text match on a notification
+    /// body, the single caveat a supervisor most needs.
+    #[test]
+    fn a_declared_agent_is_what_coverage_is_read_against() {
+        let db = db();
+        let mut session = make_test_session("task-7");
+        session.agent = "bash".into();
+        db.upsert_session(&session).unwrap();
+        db.set_launch_recipe(
+            session.id,
+            &crate::session::LaunchRecipe {
+                command: "/bin/bash".into(),
+                args: vec!["-i".into()],
+                env: Default::default(),
+            },
+        )
+        .unwrap();
+        let registry = crate::agent::agent_config::builtin_registry();
+
+        let facts = SessionFacts::load(&db);
+        let hook = facts.assess(&registry, &session, false);
+        assert_eq!(hook.coverage, crate::session::Coverage::None);
+        assert!(!hook.blocked_is_heuristic());
+        assert!(!facts.hooks_expected(&session), "no agent was ever wired");
+
+        run(
+            Action::ReportsAs {
+                session: "task-7".into(),
+                agent: Some("claude".into()),
+                clear: false,
+            },
+            &db,
+        )
+        .unwrap();
+
+        let facts = SessionFacts::load(&db);
+        let hook = facts.assess(&registry, &session, false);
+        assert_eq!(hook.coverage, crate::session::Coverage::Full);
+        assert!(hook.blocked_is_heuristic());
+        assert_eq!(facts.declared_agent(&session), Some("claude"));
+        // Declaring an agent is also the answer to "no hooks expected": there
+        // is one now, and doctor judges its wiring.
+        assert!(facts.hooks_expected(&session));
+
+        // And it survives being taken back.
+        run(
+            Action::ReportsAs {
+                session: "task-7".into(),
+                agent: None,
+                clear: true,
+            },
+            &db,
+        )
+        .unwrap();
+        assert_eq!(SessionFacts::load(&db).declared_agent(&session), None);
+    }
+
+    #[test]
+    fn declaring_an_agent_thurbox_ships_no_hooks_for_is_refused() {
+        // The declaration exists for the coverage it unlocks; one that unlocks
+        // nothing is a typo, and its only symptom would be the coverage the
+        // caller was trying to fix staying `none`.
+        let db = db();
+        db.upsert_session(&make_test_session("task-7")).unwrap();
+        let err = run(
+            Action::ReportsAs {
+                session: "task-7".into(),
+                agent: Some("clyde".into()),
+                clear: false,
+            },
+            &db,
+        )
+        .unwrap_err();
+        assert!(err.contains("clyde"), "got {err}");
+        assert!(
+            err.contains("claude"),
+            "the covered agents are named: {err}"
+        );
     }
 
     #[test]
@@ -2303,7 +2713,7 @@ mod tests {
         assert!(db.get_automation(auto).unwrap().unwrap().enabled);
         let restored = run(
             Action::Restore {
-                uuid: id.to_string(),
+                session: id.to_string(),
                 best_effort: false,
             },
             &db,
@@ -2333,7 +2743,7 @@ mod tests {
 
         let err = run(
             Action::Restore {
-                uuid: id.to_string(),
+                session: id.to_string(),
                 best_effort: false,
             },
             &db,
@@ -2345,7 +2755,7 @@ mod tests {
 
         let restored = run(
             Action::Restore {
-                uuid: id.to_string(),
+                session: id.to_string(),
                 best_effort: true,
             },
             &db,
@@ -2384,7 +2794,7 @@ mod tests {
 
         let restored = run(
             Action::Restore {
-                uuid: id.to_string(),
+                session: id.to_string(),
                 best_effort: false,
             },
             &db,
@@ -2422,7 +2832,7 @@ mod tests {
 
         let err = run(
             Action::Restore {
-                uuid: id.to_string(),
+                session: id.to_string(),
                 best_effort: false,
             },
             &db,

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -33,6 +33,7 @@ use clap::Args;
 use serde_json::{json, Value};
 
 use crate::cli::output::Format;
+use crate::cli::CommandError;
 use crate::session::{Assessment, SessionId};
 use crate::storage::{Database, SessionEventRow, SessionFacts};
 
@@ -77,7 +78,7 @@ pub struct WatchArgs {
 
 /// Stream session changes until the deadline (or forever) — one event per line,
 /// flushed as it is written so a reader blocked on the pipe wakes on it.
-pub fn run(db: &Database, args: WatchArgs, format: Format) -> Result<(), String> {
+pub fn run(db: &Database, args: WatchArgs, format: Format) -> Result<(), CommandError> {
     let filter = args
         .session
         .as_deref()

--- a/src/session/hook_status.rs
+++ b/src/session/hook_status.rs
@@ -524,6 +524,13 @@ pub struct Assessment {
     /// not. Set by [`Self::parked`], and the one fact here that is thurbox's
     /// own rather than the agent's or the pane's.
     pub stopped: bool,
+    /// The agent every answer above was resolved against.
+    ///
+    /// Usually the session's own, but a `--command` session whose driver
+    /// declared what it launched (`session reports-as`) is judged against
+    /// *that* agent — so a reader can see which name the coverage belongs to
+    /// rather than assuming it is the row's.
+    pub agent: String,
 }
 
 impl Assessment {
@@ -604,6 +611,7 @@ impl Assessment {
             state: state.as_ref().map(|(s, _)| s.clone()),
             state_source: state.map(|(_, source)| source),
             stopped: false,
+            agent: agent.to_string(),
         }
     }
 

--- a/src/session_ops/mirror.rs
+++ b/src/session_ops/mirror.rs
@@ -164,6 +164,14 @@ pub fn session_to_json_assessed(
     // the stream learn the same fact from the same key. Without it the two
     // verbs describe a parked session exactly as they describe a running one.
     put("stopped", json!(hook.stopped));
+    // Null unless a driver declared one: the agent the hook fields above were
+    // resolved against, when that is not the agent the row was created with.
+    // Without it a `--command` session's `hook_coverage: "full"` reads as a
+    // claim about the shell it launched.
+    put(
+        "reports_as",
+        json!((hook.agent != s.agent).then(|| hook.agent.clone())),
+    );
     value
 }
 

--- a/src/session_ops/spawn.rs
+++ b/src/session_ops/spawn.rs
@@ -1316,6 +1316,17 @@ fn dir_label(path: &std::path::Path) -> String {
         .unwrap_or_else(|| "repo".to_string())
 }
 
+/// The backend a creation on `host` will land on — `local-tmux`, or
+/// `ssh:<host>`/`wsl:<distro>`.
+///
+/// Exposed for `--on-existing`, which has to compare a proposed creation
+/// against the rows already on *that* backend: a database mirroring a shareable
+/// host (ADR-24) holds that host's rows beside its own, and matching a name
+/// across all of them let a local create replace a session on another machine.
+pub(crate) fn backend_type_for(host: Option<&str>) -> Result<String, String> {
+    resolve_host(host).map(|(backend, _)| backend)
+}
+
 /// Resolve `--host` to `(backend_type, host)`.
 ///
 /// `None`/empty → the local backend. A named host must exist in `hosts.toml`

--- a/src/storage/schema/migrations.rs
+++ b/src/storage/schema/migrations.rs
@@ -887,3 +887,21 @@ pub(super) fn migrate_v43_session_events(conn: &Connection) -> rusqlite::Result<
             ON session_events(session_id, seq);",
     )
 }
+
+/// v43 → v44: the agent a session's pane actually runs, when that is not the
+/// agent the row was created with.
+///
+/// A `--command` session is named after the command's file stem, so a driver
+/// that opens a shell and starts `claude` in it leaves thurbox reading hook
+/// coverage against `bash`: coverage `none`, no reportable states, and
+/// `blocked_is_heuristic` false — asserting the block signal is structured when
+/// it is claude's text match on a notification body. `reports_as` is how the
+/// driver says which agent is in there; `NULL` (every pre-v44 row) means "the
+/// one the row names", which is what was always assumed.
+///
+/// Deliberately not part of `upsert_session`, for the same reason the launch
+/// recipe is not: a peer mirroring this machine round-trips rows through that
+/// upsert, and one on an older release would clear the column on every tick.
+pub(super) fn migrate_v44_reports_as(conn: &Connection) -> rusqlite::Result<()> {
+    add_column_if_absent(conn, "sessions", "reports_as", "TEXT")
+}

--- a/src/storage/schema/mod.rs
+++ b/src/storage/schema/mod.rs
@@ -31,9 +31,11 @@ use rusqlite::Connection;
 /// v43 adds `session_events`, the append-only log `thurbox-cli watch`
 /// streams: every writer that changes what a watcher reports appends a row in
 /// its own transaction, so two writes in the same instant are two events
-/// rather than one sampled diff.
+/// rather than one sampled diff. v44 adds `reports_as` to `sessions`: the
+/// agent a driver actually launched inside a pane thurbox opened for
+/// something else, which is what hook coverage has to be read against.
 /// Gaps in the step table are fine (there is no v18 step either).
-pub const SCHEMA_VERSION: u32 = 43;
+pub const SCHEMA_VERSION: u32 = 44;
 
 /// A single migration step: applied when the stored version is below `target`.
 type MigrationStep = (u32, fn(&Connection) -> rusqlite::Result<()>);
@@ -105,6 +107,7 @@ pub fn initialize(conn: &Connection) -> rusqlite::Result<()> {
             launch_args       TEXT,
             launch_env        TEXT,
             stopped_at        INTEGER,
+            reports_as        TEXT,
             created_at        INTEGER NOT NULL,
             updated_at        INTEGER NOT NULL,
             deleted_at        INTEGER
@@ -345,6 +348,7 @@ fn migrate(conn: &Connection) -> rusqlite::Result<()> {
         (41, migrate_v41_joinable),
         (42, migrate_v42_worktree_provenance),
         (43, migrate_v43_session_events),
+        (44, migrate_v44_reports_as),
     ];
 
     for &(target, step) in steps {

--- a/src/storage/sessions.rs
+++ b/src/storage/sessions.rs
@@ -480,6 +480,60 @@ impl Database {
         }))
     }
 
+    /// Record which agent a session's pane actually runs, or clear the record
+    /// with `None`.
+    ///
+    /// The row's own `agent` says what thurbox launched; for a `--command`
+    /// session that is a shell, a REPL or a build watcher, and a driver that
+    /// then starts a coding agent inside it is the only party that knows. Hook
+    /// coverage is read against this when it is set — see
+    /// [`crate::session::coverage_for`].
+    ///
+    /// Written by name rather than through [`upsert_session`](Self::upsert_session)
+    /// for the reason the launch recipe is: a peer mirroring this machine
+    /// round-trips rows through that upsert and would clear the column.
+    pub fn set_reports_as(&self, id: SessionId, agent: Option<&str>) -> rusqlite::Result<()> {
+        self.conn.execute(
+            "UPDATE sessions SET reports_as = ?1 WHERE id = ?2",
+            params![agent, id.to_string()],
+        )?;
+        Ok(())
+    }
+
+    /// The agent every session declared with [`set_reports_as`](Self::set_reports_as),
+    /// keyed by id — one query for a listing rather than one per row.
+    ///
+    /// Absent from the map means "the agent the row names", which is what every
+    /// caller assumed before the column existed.
+    pub fn load_reports_as(&self) -> rusqlite::Result<HashMap<SessionId, String>> {
+        let mut stmt = self.conn.prepare_cached(
+            "SELECT id, reports_as FROM sessions              WHERE reports_as IS NOT NULL AND reports_as <> ''",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?.parse().unwrap_or_default(),
+                row.get::<_, String>(1)?,
+            ))
+        })?;
+        rows.collect()
+    }
+
+    /// Whether a session was created from a raw command rather than an
+    /// `agents.toml` entry, for every session at once.
+    ///
+    /// `launch_command` is the discriminant the restart path already reads
+    /// (schema v41); a diagnostic needs the same answer for a whole listing,
+    /// and asking per row would be a query per session.
+    pub fn load_command_sessions(&self) -> rusqlite::Result<HashSet<SessionId>> {
+        let mut stmt = self.conn.prepare_cached(
+            "SELECT id FROM sessions WHERE launch_command IS NOT NULL AND launch_command <> ''",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok(row.get::<_, String>(0)?.parse().unwrap_or_default())
+        })?;
+        rows.collect()
+    }
+
     /// Mark a session stopped (`true`) or running again (`false`).
     ///
     /// The mark is what separates "parked on purpose" from "its window died",

--- a/tests/cli_stdout_contract.rs
+++ b/tests/cli_stdout_contract.rs
@@ -706,7 +706,10 @@ fn a_failed_reports_as_write_leaves_the_new_session_in_place() {
     // Tear down the real tmux window this test spawned.
     let version = env.run(&["version", "--json"]);
     let version: Value = serde_json::from_slice(&version.stdout).expect("JSON");
-    let socket = version["tmux_socket"].as_str().expect("tmux_socket").to_string();
+    let socket = version["tmux_socket"]
+        .as_str()
+        .expect("tmux_socket")
+        .to_string();
     env.run(&["session", "delete", &id, "--force", "--json"]);
     let _ = std::process::Command::new("tmux")
         .args(["-L", &socket, "kill-server"])

--- a/tests/cli_stdout_contract.rs
+++ b/tests/cli_stdout_contract.rs
@@ -132,6 +132,16 @@ fn open_db(env: &Env) -> thurbox::storage::Database {
         .expect("open the instance database")
 }
 
+/// Whether a real multiplexer is on `PATH`, for the one test here that spawns
+/// a real window. Mirrors `create_e2e.rs`/`attach_by_name.rs`/`reap_e2e.rs`.
+fn have_tmux() -> bool {
+    Command::new("tmux")
+        .arg("-V")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
 /// A `--command` session: the shape thurbox advertises for drivers (firstmate
 /// creates every task as `--command $SHELL --arg -i`), named after the
 /// command's file stem and with the launch recipe that makes it one.
@@ -649,8 +659,18 @@ fn adopt_applies_reports_as_to_the_session_it_hands_back() {
 /// `Database` wraps a plain `rusqlite::Connection` with no fault-injection
 /// seam, so the only way to reach this branch is to sabotage the one column
 /// this write touches, in the real database file, after the schema exists.
+///
+/// Spawns a real window through the real multiplexer (`--command` needs a
+/// live pane to be created against), so — same as `create_e2e.rs`,
+/// `attach_by_name.rs` and the rest of the real-spawn suite — it skips rather
+/// than fails where no multiplexer binary is installed (the Windows CI job
+/// installs neither `tmux` nor `psmux`).
 #[test]
 fn a_failed_reports_as_write_leaves_the_new_session_in_place() {
+    if !have_tmux() {
+        eprintln!("skipping: tmux is not installed");
+        return;
+    }
     let env = Env::new();
     let repo = env.path("home");
 

--- a/tests/cli_stdout_contract.rs
+++ b/tests/cli_stdout_contract.rs
@@ -599,6 +599,46 @@ fn create_answers_an_existing_name_four_ways() {
     assert_eq!(rows.as_array().map(Vec::len), Some(1));
 }
 
+/// `--on-existing adopt --reports-as <agent>` must apply the declaration to
+/// the row it hands back, not silently drop it: `resolve_existing` used to
+/// return the adopted session before the create path's `reports_as` handling
+/// ever ran, so a driver adopting an existing `--command` session and
+/// declaring what actually runs in it got exit 0 with the declaration
+/// discarded.
+#[test]
+fn adopt_applies_reports_as_to_the_session_it_hands_back() {
+    let env = Env::new();
+    let repo = env.path("home");
+    let id = seed_command_session(&env, "worker");
+
+    let out = env.run(&[
+        "session",
+        "create",
+        "--name",
+        "worker",
+        "--repo-path",
+        repo.to_str().expect("utf-8 path"),
+        "--on-existing",
+        "adopt",
+        "--reports-as",
+        "claude",
+        "--json",
+    ]);
+    assert_eq!(out.status.code(), Some(0));
+    let doc: Value = serde_json::from_slice(&out.stdout).expect("JSON");
+    assert_eq!(doc["id"], Value::String(id.clone()));
+    assert_eq!(doc["created"], Value::Bool(false));
+    assert_eq!(doc["reports_as"], Value::String("claude".into()), "{doc}");
+
+    let db = open_db(&env);
+    let declared = db
+        .load_reports_as()
+        .expect("query")
+        .get(&id.parse().expect("seeded id"))
+        .cloned();
+    assert_eq!(declared, Some("claude".into()));
+}
+
 /// A name matching more than one session is refused for `adopt` and `replace`,
 /// because either would be a guess about which session was meant.
 ///

--- a/tests/cli_stdout_contract.rs
+++ b/tests/cli_stdout_contract.rs
@@ -639,6 +639,80 @@ fn adopt_applies_reports_as_to_the_session_it_hands_back() {
     assert_eq!(declared, Some("claude".into()));
 }
 
+/// A post-spawn failure to record `--reports-as` must not be silently dropped
+/// nor mistaken for the whole command failing: by the time `db.set_reports_as`
+/// runs, `spawn_session_headless` already succeeded and the session is live,
+/// so the error has to say the *declaration* failed, point at the retry verb,
+/// and leave the session itself in place — unlike a `replace` spawn failure,
+/// there is nothing here to roll back to.
+///
+/// `Database` wraps a plain `rusqlite::Connection` with no fault-injection
+/// seam, so the only way to reach this branch is to sabotage the one column
+/// this write touches, in the real database file, after the schema exists.
+#[test]
+fn a_failed_reports_as_write_leaves_the_new_session_in_place() {
+    let env = Env::new();
+    let repo = env.path("home");
+
+    open_db(&env)
+        .conn_ref()
+        .execute_batch(
+            "CREATE TRIGGER sabotage_reports_as \
+             BEFORE UPDATE OF reports_as ON sessions \
+             BEGIN SELECT RAISE(ABORT, 'injected failure'); END;",
+        )
+        .expect("install trigger");
+
+    let out = env.run(&[
+        "session",
+        "create",
+        "--name",
+        "worker",
+        "--repo-path",
+        repo.to_str().expect("utf-8 path"),
+        "--command",
+        "/bin/sleep",
+        "--arg",
+        "300",
+        "--reports-as",
+        "claude",
+        "--json",
+    ]);
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let doc: Value = serde_json::from_slice(&out.stdout).expect("JSON");
+    let error = doc["error"].as_str().unwrap_or_default();
+    assert!(
+        error.contains("was created, but declaring it as 'claude' failed")
+            && error.contains("session reports-as"),
+        "{doc}"
+    );
+
+    // The session itself was not rolled back: it is a real, listed row, just
+    // without the declaration that failed to write.
+    let listed = env.run(&["session", "list", "--json"]);
+    let rows: Value = serde_json::from_slice(&listed.stdout).expect("JSON");
+    let rows = rows.as_array().expect("array");
+    assert_eq!(rows.len(), 1, "{rows:?}");
+    assert_eq!(rows[0]["name"], Value::String("worker".into()));
+    assert_eq!(rows[0]["reports_as"], Value::Null, "{rows:?}");
+    let id = rows[0]["id"].as_str().expect("id").to_string();
+
+    // Tear down the real tmux window this test spawned.
+    let version = env.run(&["version", "--json"]);
+    let version: Value = serde_json::from_slice(&version.stdout).expect("JSON");
+    let socket = version["tmux_socket"].as_str().expect("tmux_socket").to_string();
+    env.run(&["session", "delete", &id, "--force", "--json"]);
+    let _ = std::process::Command::new("tmux")
+        .args(["-L", &socket, "kill-server"])
+        .output();
+}
+
 /// A name matching more than one session is refused for `adopt` and `replace`,
 /// because either would be a guess about which session was meant.
 ///

--- a/tests/cli_stdout_contract.rs
+++ b/tests/cli_stdout_contract.rs
@@ -125,6 +125,31 @@ fn seed_session(env: &Env, name: &str, agent: &str) -> String {
     row.id.to_string()
 }
 
+/// Open the instance database directly, for the columns no verb sets from
+/// outside a real spawn.
+fn open_db(env: &Env) -> thurbox::storage::Database {
+    thurbox::storage::Database::open(&env.path("data").join("thurbox.db"))
+        .expect("open the instance database")
+}
+
+/// A `--command` session: the shape thurbox advertises for drivers (firstmate
+/// creates every task as `--command $SHELL --arg -i`), named after the
+/// command's file stem and with the launch recipe that makes it one.
+fn seed_command_session(env: &Env, name: &str) -> String {
+    let id = seed_session(env, name, "bash");
+    let db = open_db(env);
+    db.set_launch_recipe(
+        id.parse().expect("seeded id"),
+        &thurbox::session::LaunchRecipe {
+            command: "/bin/bash".into(),
+            args: vec!["-i".into()],
+            env: Default::default(),
+        },
+    )
+    .expect("record the launch recipe");
+    id
+}
+
 #[test]
 fn session_doctor_on_a_broken_session_prints_one_document_and_exits_non_zero() {
     let env = Env::new();
@@ -146,6 +171,229 @@ fn session_doctor_on_a_broken_session_prints_one_document_and_exits_non_zero() {
         "the failing session is named on stderr: {}",
         String::from_utf8_lossy(&out.stderr)
     );
+    // The half of the contract a driver has to read the other way round: an
+    // `error` key implies a non-zero exit, never the converse. A supervisor
+    // that gates on `$?` before parsing throws away every diagnosis it will
+    // ever ask for — so the document it discarded must be shown to be a
+    // *report*, not an error.
+    assert!(
+        report.get("error").is_none() && doc.get("error").is_none(),
+        "a failed doctor run is a report, not an error document: {doc}"
+    );
+}
+
+/// `doctor` must not fail a session thurbox never wired an agent for.
+///
+/// A `--command` session is by construction uncovered and, until something
+/// types an agent into it, unreported — so the old `Coverage::None` + not
+/// reported => Fail turned the exact session shape thurbox advertises for
+/// drivers into "hook wiring is broken". Worse, bare `session doctor`
+/// diagnoses every active session, so one shell session failed the whole
+/// machine.
+#[test]
+fn session_doctor_expects_no_hooks_from_a_command_session() {
+    let env = Env::new();
+    seed_command_session(&env, "task-7");
+
+    for args in [
+        vec!["session", "doctor", "task-7", "--json"],
+        vec!["session", "doctor", "--json"],
+    ] {
+        let out = env.run(&args);
+        assert_eq!(
+            out.status.code(),
+            Some(0),
+            "{args:?} must not fail a session with no agent to wire:\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let doc: Value = serde_json::from_slice(&out.stdout).expect("one JSON document");
+        let report = doc.as_array().expect("one report per session")[0].clone();
+        assert_ne!(report["verdict"], Value::String("fail".into()), "{report}");
+    }
+}
+
+/// The row has to be able to say "this pane runs claude".
+///
+/// A driver that applied `agent launch-args claude` inside a `--command bash`
+/// session left thurbox reading coverage against `bash`: `hook_coverage:
+/// "none"`, no reportable states, and `hook_blocked_is_heuristic: false` —
+/// asserting the block signal is structured when it is claude's text match on a
+/// notification body, which is the single caveat a supervisor most needs.
+#[test]
+fn a_declared_agent_is_what_coverage_is_published_against() {
+    let env = Env::new();
+    seed_command_session(&env, "task-7");
+
+    let before: Value = serde_json::from_slice(
+        &env.run(&["session", "get", "task-7", "--no-verify", "--json"])
+            .stdout,
+    )
+    .expect("JSON");
+    assert_eq!(before["hook_coverage"], Value::String("none".into()));
+    assert_eq!(before["hook_blocked_is_heuristic"], Value::Bool(false));
+
+    let declared = env.run(&["session", "reports-as", "task-7", "claude", "--json"]);
+    assert_eq!(
+        declared.status.code(),
+        Some(0),
+        "{}",
+        String::from_utf8_lossy(&declared.stderr)
+    );
+
+    let after: Value = serde_json::from_slice(
+        &env.run(&["session", "get", "task-7", "--no-verify", "--json"])
+            .stdout,
+    )
+    .expect("JSON");
+    assert_eq!(
+        after["hook_coverage"],
+        Value::String("full".into()),
+        "{after}"
+    );
+    assert_eq!(after["hook_blocked_is_heuristic"], Value::Bool(true));
+    // The row still runs what it always ran; only what reports changed.
+    assert_eq!(after["agent"], Value::String("bash".into()));
+
+    // A typo is refused rather than silently recording a declaration that
+    // unlocks nothing.
+    let typo = env.run(&["session", "reports-as", "task-7", "clyde", "--json"]);
+    assert_eq!(typo.status.code(), Some(1));
+}
+
+/// `session restore` takes a reference like every other session verb.
+///
+/// It was the one that did not: a raw UUID, error `Invalid session UUID`. A
+/// driver holding a name had to keep its own name-to-id map for that one verb.
+#[test]
+fn session_restore_takes_a_reference_like_every_other_verb() {
+    let env = Env::new();
+    let id = seed_session(&env, "gone", "claude");
+    assert_eq!(
+        env.run(&["session", "delete", &id, "--json"]).status.code(),
+        Some(0)
+    );
+
+    let out = env.run(&["session", "restore", "gone", "--json"]);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "restore by name: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let doc: Value = serde_json::from_slice(&out.stdout).expect("JSON");
+    assert_eq!(doc["id"], Value::String(id.clone()));
+
+    // And a reference that matches nothing still says what it tried.
+    let missing = env.run(&["session", "restore", "never-existed", "--json"]);
+    assert_eq!(missing.status.code(), Some(1));
+}
+
+/// A reference matching two sessions is a different answer from one matching
+/// none, and a driver has to be able to tell them apart without matching on the
+/// message: it reconciles the first by creating a session, and can only escalate
+/// the second.
+#[test]
+fn an_ambiguous_reference_exits_differently_from_a_missing_one() {
+    let env = Env::new();
+    seed_session(&env, "twin", "claude");
+    seed_session(&env, "twin", "codex");
+
+    let ambiguous = env.run(&["session", "get", "twin", "--json"]);
+    assert_eq!(
+        ambiguous.status.code(),
+        Some(3),
+        "stdout: {}",
+        String::from_utf8_lossy(&ambiguous.stdout)
+    );
+    let doc: Value = serde_json::from_slice(&ambiguous.stdout).expect("JSON");
+    assert!(
+        doc["error"].as_str().is_some_and(|e| e.contains("twin")),
+        "{doc}"
+    );
+
+    assert_eq!(
+        env.run(&["session", "get", "nope", "--json"]).status.code(),
+        Some(1)
+    );
+}
+
+/// `replace` is a force delete followed by a create, and it cannot be the other
+/// way round: the new session wants the branch and the checkout the old one
+/// holds. So a spawn that fails after the teardown used to leave the caller
+/// with neither session — the mode's own help said "tear the existing session
+/// down first", and the skill's "a refusal leaves no window, worktree or row
+/// behind" read as a safety claim `replace` did not honour.
+#[test]
+fn replace_puts_the_old_session_back_when_the_replacement_cannot_spawn() {
+    let env = Env::new();
+    let id = seed_session(&env, "worker", "claude");
+
+    // A worktree branch off a directory that is not a git repository: the
+    // spawn fails after the teardown and before any window exists, which is
+    // exactly the window this rollback covers.
+    let out = env.run(&[
+        "session",
+        "create",
+        "--name",
+        "worker",
+        "--repo-path",
+        env.path("home").to_str().expect("utf-8 path"),
+        "--worktree-branch",
+        "feat",
+        "--on-existing",
+        "replace",
+        "--json",
+    ]);
+    assert_ne!(out.status.code(), Some(0), "the spawn must have failed");
+    let doc: Value = serde_json::from_slice(&out.stdout).expect("JSON");
+    let error = doc["error"].as_str().unwrap_or_default();
+    assert!(
+        error.contains("restored"),
+        "the answer says what became of the session it replaced: {doc}"
+    );
+
+    // The row is back, and addressable — not left as a tombstone.
+    let listed = env.run(&["session", "list", "--json"]);
+    let rows: Value = serde_json::from_slice(&listed.stdout).expect("JSON");
+    assert!(
+        rows.as_array()
+            .expect("array")
+            .iter()
+            .any(|r| r["id"] == Value::String(id.clone())),
+        "the replaced session came back: {rows}"
+    );
+}
+
+/// `--on-existing adopt` exists so a reconciling driver can skip the follow-up
+/// read. A **parked** session — no pane, every `send`/`key`/`capture` refused —
+/// came back with nothing in the answer saying so.
+#[test]
+fn adopt_says_when_the_session_it_hands_back_has_no_pane() {
+    let env = Env::new();
+    let repo = env.path("home");
+    let id = seed_session(&env, "worker", "claude");
+    open_db(&env)
+        .set_session_stopped(id.parse().expect("seeded id"), true)
+        .expect("park it");
+
+    let out = env.run(&[
+        "session",
+        "create",
+        "--name",
+        "worker",
+        "--repo-path",
+        repo.to_str().expect("utf-8 path"),
+        "--on-existing",
+        "adopt",
+        "--json",
+    ]);
+    assert_eq!(out.status.code(), Some(0));
+    let doc: Value = serde_json::from_slice(&out.stdout).expect("JSON");
+    assert_eq!(doc["id"], Value::String(id));
+    assert_eq!(doc["created"], Value::Bool(false));
+    assert_eq!(doc["stopped"], Value::Bool(true), "{doc}");
+    assert_eq!(doc["state"], Value::String("stopped".into()), "{doc}");
 }
 
 #[test]
@@ -378,8 +626,8 @@ fn an_ambiguous_name_is_never_adopted_or_replaced() {
         ]);
         assert_eq!(
             out.status.code(),
-            Some(1),
-            "--on-existing {mode} must refuse an ambiguous name"
+            Some(3),
+            "--on-existing {mode} must refuse an ambiguous name with the ambiguity code"
         );
         let doc = String::from_utf8_lossy(&out.stdout);
         assert!(doc.contains('2'), "the refusal counts the matches: {doc}");

--- a/website/docs/agent-hooks.html
+++ b/website/docs/agent-hooks.html
@@ -551,6 +551,15 @@ thurbox-cli session doctor &lt;uuid&gt;       # just one</code></pre>
             <code>thurbox-cli extension reinstall hooks</code>
             is the repair.
           </p>
+          <p>
+            A
+            <code>--command</code>
+            session is the one shape it will not fail: Thurbox never had an agent there to wire, so
+            it reports
+            <em>no hooks expected</em>
+            rather than broken wiring. If your driver started an agent inside one, say so &mdash;
+            see below.
+          </p>
 
           <h2 id="own-agent">
             Reporting state for an agent Thurbox did not launch
@@ -580,6 +589,33 @@ thurbox-cli session signal --state blocked --session &lt;uuid&gt;   # from outsi
             with
             <code>state_source: "process"</code>
             , which is coarser than a hook by design but is not silence.
+          </p>
+          <p>
+            If what you launched in that pane
+            <em>is</em>
+            an agent Thurbox ships hooks for &mdash; you passed
+            <code>thurbox-cli agent launch-args claude</code>
+            through yourself, say &mdash; tell the row so:
+          </p>
+          <pre><code class="language-bash">thurbox-cli session create --name task-7 --command "$SHELL" --arg -i --reports-as claude
+thurbox-cli session reports-as task-7 claude   # or afterwards
+thurbox-cli session reports-as task-7 --clear  # take it back</code></pre>
+          <p>
+            The session is named after the command it launches, so without this
+            <code>hook_coverage</code>
+            ,
+            <code>hook_states_reportable</code>
+            and
+            <code>hook_blocked_is_heuristic</code>
+            are all read against
+            <code>bash</code>
+            &mdash; and that last one answering
+            <code>false</code>
+            tells a supervisor the block signal is structured when it is really a text match on a
+            notification body. The declaration changes only what coverage is read against: the
+            launch is untouched, and
+            <code>session restart</code>
+            still replays the command you recorded.
           </p>
 
           <h2 id="optout">

--- a/website/docs/features.html
+++ b/website/docs/features.html
@@ -1281,7 +1281,15 @@ thurbox-cli message inbox --for flow --claim</code></pre>
               <code>allow</code>
               is the default because a database mirroring a shareable host
               carries that host's rows beside its own, so Thurbox cannot make
-              names unique; uniqueness is something a caller asks for.
+              names unique; uniqueness is something a caller asks for. The
+              question is asked of the backend the creation lands on, so a
+              namesake on another host is never adopted or torn down, and
+              <code>replace</code>
+              puts the old session back if the replacement cannot be spawned.
+              <code>--reports-as &lt;agent&gt;</code>
+              records which agent a
+              <code>--command</code>
+              pane actually runs, so hook coverage is read against it.
             </li>
             <li>
               <strong>session exec</strong>

--- a/website/docs/orchestration.html
+++ b/website/docs/orchestration.html
@@ -422,7 +422,9 @@ thurbox-cli session list --parent "$LEAD" --json</code></pre>
   <code>1</code>
   ran and failed,
   <code>2</code>
-  bad invocation), and the trap that follows is worth naming:
+  bad invocation,
+  <code>3</code>
+  a session reference matched more than one session), and the trap that follows is worth naming:
   <code>thurbox-cli &hellip; --json | jq -r '.field'</code>
   exits
   <strong>0 with empty output</strong>


### PR DESCRIPTION
## Intent

Fix the driver-facing session verbs in thurbox-cli, from the 2026-09-03 review's "CLI contract" bugs 2, 3, 7, 8, 9, 10, C and H plus recent-diff findings 4 and 9. This is session B2 of a split review; the task brief named four required changes and an explicit "leave alone" list.

1. session doctor must never Fail a session with no registry agent. A `--command` session (the exact shape thurbox advertises for drivers: firstmate creates every task as `--command $SHELL --arg -i`) is by construction Coverage::None and, until something signals, !reported, which was Level::Fail "hook wiring is broken" — and bare `session doctor` diagnoses every active session, so one shell session failed the whole machine. It must be Ok/"no hooks expected". Its "last-signal" finding must also check `stopped` first, like the adjacent "pane" finding, because stop() writes the mark and clears the hook state as two separate writes and Assessment::parked leaves the columns alone.

2. hook_blocked_is_heuristic / hook_coverage / hook_states_reportable were derived from the row's `agent` column, so a `--command bash` session actually running claude reported the blocked signal as reliable (false) when it is claude's text match on a notification body — the single most important caveat for a supervisor. The brief asked for `session create --reports-as <agent>` plus a `session set-agent`-or-equivalent verb, "pick the simplest that survives restart", and to document it in the thurbox-cli skill, docs/AGENTS.md and the website docs. I chose a `sessions.reports_as` column (schema v43) over session_meta because session_meta's stated contract is that thurbox never interprets a key, and over a SharedSession field because the launch-recipe columns already establish the pattern of a session column deliberately outside upsert_session (a peer mirroring this machine on an older release would otherwise clear it every tick). The verb is spelled `session reports-as <ref> <agent> [--clear]` to match the create flag. It is refused for an agent thurbox ships no hooks for, since the declaration exists for the coverage it unlocks and a typo would unlock nothing silently. I also collapsed the three per-listing loads (hook states, parked set, and now reports_as + command sessions) into one SessionFacts struct rather than growing `assess`'s parameter list.

3. --on-existing matched every non-deleted row by name including mirrored remote rows (ADR-24), so `replace` could force-delete a session on another host, `fail` refused a local create over a remote namesake, and `adopt` returned a remote id. Scope the match to the backend the creation lands on. `replace` was destroy-then-create with no rollback; the brief said "spawns first or otherwise rolls back". Spawning first is impossible here — the replacement wants the branch and checkout the old session holds, so git worktree add would fail — so I took the rollback branch: a spawn that fails restores the replaced session best-effort through the existing restore pipeline, and the error says what came back and what did not (uncommitted work went with the force delete). `adopt` must include `stopped` and `state`; I added them to the real creation's output too so the documented "same shape, created:false is the only difference" claim stays true.

4. `session restore` took a raw UUID while every other verb takes a session reference; it now resolves against the deleted rows with the same three spellings and the same refusal to guess. resolve_detailed/Ambiguity was dead code because every reference failure exited 1, so a driver could not tell "no such session" from "ambiguous name" except by string-matching. Ambiguity now exits 3 (AXI principle 6), carried by a new cli::CommandError that deliberately has no From<CommandError> for String so a helper returning a plain String cannot silently drop the code; --on-existing adopt/replace ambiguity uses the same code. The exit-code taxonomy and the "an error key implies a non-zero exit, never the converse" invariant are documented in the skill, cli/mod.rs and the binary header, with a stdout-contract test asserting a failed doctor document carries no `error` key and still exits non-zero.

Deliberate scope decisions a reviewer would not see in the diff:
- Explicitly out of scope per the brief and left untouched: `watch` (a separate session), unifying the `state` vocabulary across get/list/watch/TUI, and anything in src/agent/tmux.rs or session_ops teardown (another session owns the misdirected-kill bug there). That is also why `replace` rolls back rather than spawning first and deleting by id — deleting by id currently falls back to killing by name, which is that other session's bug.
- Recent-diff finding 9 asked that doctor's "cli" check not drag the verdict to Fail despite the coverage carve-out. I applied that only to a command session, where nothing thurbox installed runs the binary. For a registry agent thurbox ships no hooks for (`shell`), an existing test (doctor_fails_a_session_whose_hook_command_cannot_find_the_binary_it_names) deliberately pins Fail, and it is right: there the driver's own `thurbox-cli session signal` is the only route state can take, so a missing binary really is what breaks it. The review's premise that no test covered cli_on_path=None for that combination was factually wrong.
- The `an_ambiguous_name_is_never_adopted_or_replaced` test was updated from exit 1 to exit 3 on purpose; that is the intended behaviour change.
- Everything was gated locally before this run: `just lint`, `RUSTDOCFLAGS="-D warnings" cargo doc`, `npm run lint:website`, and `cargo nextest run --all` (2343 passed). The commit went through all 20 prek hooks, signed. A `tui_e2e` wheel-scroll test flaked once during an earlier hook run and passes consistently on re-run.

Note: I pushed the branch and opened PR #1060 by hand before the lead's rule change; from here the gate owns push and PR.

## What Changed

- `session doctor` no longer marks a `--command` session `Fail` just because it has no registry agent (its coverage is `Coverage::None` by design); its last-signal check now looks at `stopped` first, mirroring the adjacent pane check. Per-listing hook-state/parked/reports-as/command-session loads were consolidated into a single `SessionFacts` struct instead of growing `assess`'s parameters.
- Added a `sessions.reports_as` column (schema migration v43) plus a `session reports-as <ref> <agent> [--clear]` CLI verb so a `--command` session can declare which agent it's actually running; `hook_blocked_is_heuristic`, `hook_coverage`, and `hook_states_reportable` now derive from that declared agent instead of the raw `agent` column, and the verb refuses agents thurbox ships no hooks for. Documented in the thurbox-cli skill, `docs/AGENTS.md`, and the website docs.
- `--on-existing` now scopes its name match to the backend the new session lands on instead of matching across local/remote rows; `replace` performs a best-effort rollback (restoring the replaced session) if the new spawn fails, reporting what was and wasn't recovered; `adopt` and normal creation output now both include `stopped` and `state`.
- `session restore` now takes a session reference (same three spellings/resolution as other verbs) instead of a raw UUID; reference-resolution ambiguity now exits code 3 via a new `cli::CommandError` (no `From<CommandError> for String>`) instead of always exiting 1, applied consistently to restore and `--on-existing` adopt/replace; the exit-code taxonomy is documented in the skill, `cli/mod.rs`, and the binary header, with a new stdout-contract test asserting a failed doctor document carries no `error` key while still exiting non-zero.

## Risk Assessment

✅ Low: Both prior findings (adopt silently dropping --reports-as; ambiguous error messaging on a post-creation set_reports_as failure) are correctly fixed: check_reports_as still validates before resolve_existing runs, the adopt arm now writes reports_as before returning, existing_session_output re-reads SessionFacts fresh so the returned JSON reflects the write, and the replace-mode failure message now honestly states the session was created and gives a retry command instead of implying nothing happened. The fix is minimal, scoped, and backed by a real CLI-driven test that checks JSON output and DB state.

## Testing

Baseline `cargo nextest run --all` already passed on this commit per the harness. The gate step's only content is a new focused test covering the previously-flagged gap (finding test-1): it, plus the two related adopt/ambiguity tests it sits beside, all pass; the working tree is clean with no transient artifacts to clean up.

<details>
<summary>Evidence: cargo nextest run for the new regression test + related adopt/ambiguity tests</summary>

```text
PASS a_failed_reports_as_write_leaves_the_new_session_in_place
PASS adopt_applies_reports_as_to_the_session_it_hands_back
PASS an_ambiguous_name_is_never_adopted_or_replaced
3 tests run: 3 passed, 11 skipped
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (13m33s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"74c6c6587ae243df1df3dd1a9d469d75e8e68f84","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `src/cli/sessions.rs:636` - `session create --on-existing adopt --reports-as &lt;agent&gt;` silently drops the `--reports-as` declaration. `resolve_existing` is called and, on an `Existing::Answered` match (the adopt path), the function returns immediately at line 637-638 (`return Ok(*output)`) before the `reports_as` handling block at line 662-664 is ever reached. Concretely: a session named `worker` already exists as a `--command bash` session; a driver runs `session create --name worker --on-existing adopt --reports-as claude --json` — the command exits 0, `check_reports_as` has already validated `claude` as a real covered agent, yet the adopted session&#39;s `reports_as` in the response (and in the DB) stays null and `hook_coverage` stays `none`. The caller gets no error and no indication the flag was ignored, which directly undermines this change&#39;s stated goal of the CLI answering a driver honestly. Neither the tests nor the docs/skill updates in this diff mention or cover this combination.
- ℹ️ `src/cli/sessions.rs:662` - After a `replace`-mode creation, if `db.set_reports_as` fails (line 662-664), the function returns a hard `Err` even though `spawn_session_headless` already succeeded and the new session is live. Unlike the preceding spawn failure (line 655-660), this path never calls `rollback_replace`, so a caller sees an error document and may assume nothing was created/replaced, while in fact the old session was torn down and a new (uncovered-declaration) one now exists in its place.

🔧 Fix: Fix adopt dropping --reports-as and honor replace rollback message on set_reports_as failure
✅ Re-checked - no issues remain.
</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `src/cli/sessions.rs:663` - The review-round-1 fix for finding review-2 (post-spawn `db.set_reports_as` failure now returns an honest &#39;session was created but declaring it failed, retry with `session reports-as`&#39; message instead of a bare error) has no test covering that branch, and none was added in 85bf4c6 (only the adopt fix got a test). I was unable to construct one: `Database` wraps a concrete `rusqlite::Connection` with no mock/fault-injection seam, and reaching this branch requires a real, successful spawn (which itself writes to the same connection) immediately followed by a failing write on that same connection — not achievable through the existing subprocess-driven (`tests/cli_stdout_contract.rs`) or in-memory-db unit-test harnesses without adding a new fault-injection point to production code, which is outside a test-only change. Flagging so the author can decide whether to accept the gap or add a seam.
- `cargo nextest run --all`
- <code>`cargo nextest run --test cli_stdout_contract` (13 tests, incl. new `adopt_applies_reports_as_to_the_session_it_hands_back`, `replace_puts_the_old_session_back_when_the_replacement_cannot_spawn`, `an_ambiguous_name_is_never_adopted_or_replaced`, `session_doctor_expects_no_hooks_from_a_command_session`) — all pass</code>
- <code>`cargo nextest run --lib cli::sessions::` (21 unit tests) — all pass</code>
- <code>`cargo nextest run --lib cli::session_doctor::` (12 unit tests) — all pass</code>
- <code>Manual regression bisection: swapped src/cli/sessions.rs to the pre-fix (a9c3de1) version while keeping the new test, reran `adopt_applies_reports_as_to_the_session_it_hands_back` — it failed with `reports_as: null` (the exact reported bug), then restored the target file and reran — passes; worktree left clean</code>

🔧 Fix: test: add regression test for reports-as write failure after spawn
✅ Re-checked - no issues remain.
- `cargo nextest run --all`
- `cargo nextest run --test cli_stdout_contract -E 'test(a_failed_reports_as_write_leaves_the_new_session_in_place) or test(adopt_applies_reports_as_to_the_session_it_hands_back) or test(an_ambiguous_name_is_never_adopted_or_replaced)'`
- <code>Diffed a9c3de1 vs 85bf4c6 to confirm the new test&#39;s error-message assertion would have failed against the pre-fix bare `set_reports_as: {e}` message, satisfying the regression-test-must-fail-before-fix rule</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: {&#34;summary&#34;: &#34;fix: apply rustfmt to sessions.rs and cli_stdout_contract.rs&#34;}
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
