### PR TITLE
fix(git): recognise every merge strategy in the delete safety check

### DIFF
--- a/.claude/skills/thurbox-cli/SKILL.md
+++ b/.claude/skills/thurbox-cli/SKILL.md
@@ -476,12 +476,16 @@ the session has work at risk** — uncommitted/untracked files, unpushed commits
 multi-worktree session whose other checkouts the snapshot does not stat, or a
 state that can't be read at all (remote host / git error → confirm to be safe) —
 itemizing what would be lost; a known-clean session is deleted with no prompt.
-"Unpushed" is `ahead > 0` **and** `git.merged ~= true`: a squash-merged branch
-stays permanently ahead of the default branch (its commits are ancestors of
-nothing), so `git::merged_into_default` compares *patches* — `merge-base
---is-ancestor` first, then `git cherry` against the branch squared off onto its
-merge base — against `origin/HEAD` (→ `origin/main`/`origin/master`). Local refs
-only, so it is forge-agnostic; `nil` means unknown and keeps the question.
+"Unpushed" is `ahead > 0` **and** `git.merged ~= true`: a branch the forge
+rewrote on merge stays permanently ahead of the default branch (its commits are
+ancestors of nothing), so `git::merged_into_default` asks four questions of
+`origin/HEAD` (→ `origin/main`/`origin/master`) in ascending cost, first `true`
+winning — `merge-base --is-ancestor` (merge commit, fast-forward), `diff
+--quiet` against the default (an identical tree, whichever route the content
+took), `git cherry <default> HEAD <base>` with every line `-` (rebase-and-merge,
+GitLab semi-linear merge), and `git cherry` against the branch squared off onto
+its merge base by `commit-tree` (squash). Local refs only, so it is
+forge-agnostic; `nil` means unknown and keeps the question.
 The answer is cached against the **commit** it was computed for (`branch.oid`,
 already free from the same `status --porcelain=v2 --branch` run), never against
 the session: `merged` is a fact about HEAD, and a session that keeps working

--- a/src/git/diff.rs
+++ b/src/git/diff.rs
@@ -349,55 +349,93 @@ fn remote_default_ref(cwd: &Path) -> Option<String> {
 /// default ref, a git failure) — never assumed, because the caller uses this
 /// to decide whether a delete needs confirming.
 ///
-/// Two questions, because a merge is not always a fast-forward:
+/// A merge is rarely a fast-forward, and each forge rewrites the work its own
+/// way, so no single comparison sees them all:
 ///
 /// ```text
-///   origin/main   A ── S ── U        S = the branch, squashed
+///   origin/main   A ── U ── S        S = the branch, squashed or replayed
 ///   feature        \── B ── C ── D    D is an ancestor of nothing
 /// ```
 ///
-/// `merge-base --is-ancestor` answers the merge-commit and fast-forward cases
-/// outright. A **squash** merge (this project's only merge mode, and the
-/// default on every forge) rewrites the branch into one new commit, so no
-/// commit of it is ever reachable from the default branch — the branch stays
-/// permanently "3 ahead". Comparing *patches* is what sees through that:
-/// square the branch off into a single throwaway commit on the merge base, and
-/// ask `git cherry` whether the default branch already carries that patch.
-/// `git cherry` prefixes `-` for a patch that is already upstream and `+` for
-/// one that is not.
+/// Four questions in ascending cost, each a different kind of evidence that
+/// the work is already upstream, and the first `true` is the answer:
+///
+/// 1. `reachable_from` — a merge commit, or a fast-forward.
+/// 2. `same_tree_as` — strategy-agnostic: however the content got there, a
+///    branch whose tree equals the default branch's loses nothing by going.
+/// 3. `every_commit_upstream` — rebase-and-merge, and GitLab's semi-linear
+///    merge: every commit replayed with a new sha but the same patch.
+/// 4. `squashed_upstream` — a squash merge: no commit of the branch is
+///    upstream, only the sum of them.
 ///
 /// Local refs only — no network, and no forge CLI — so GitHub, GitLab,
 /// Bitbucket and a bare repository behind an SSH remote all answer alike.
 pub fn merged_into_default(cwd: &Path) -> Option<bool> {
     let default = remote_default_ref(cwd)?;
-
-    // Fast path: a merge commit or a fast-forward leaves HEAD reachable.
-    let ancestor = git_command(
-        None,
-        cwd,
-        &["merge-base", "--is-ancestor", "HEAD", &default],
-    )
-    .stdout(Stdio::null())
-    .stderr(Stdio::null())
-    .status()
-    .ok()?;
-    match ancestor.code() {
-        Some(0) => return Some(true),
-        // 1 is "not an ancestor"; anything else is git failing to answer, and
-        // an unanswered question must not read as "unmerged".
-        Some(1) => {}
-        _ => return None,
+    if reachable_from(cwd, &default)? {
+        return Some(true);
     }
-
-    // Squash path. `commit-tree` writes one dangling commit object, which git's
-    // own gc prunes; nothing references it and no ref moves.
+    if same_tree_as(cwd, &default)? {
+        return Some(true);
+    }
     let base = run_git_capture(&["merge-base", &default, "HEAD"], cwd)?;
     let base = base.trim();
+    if every_commit_upstream(cwd, &default, base)? {
+        return Some(true);
+    }
+    squashed_upstream(cwd, &default, base)
+}
+
+/// A git question answered by exit status: `Some` for the 0/1 the command
+/// documents, `None` for anything else, since git failing to answer must not
+/// read as "unmerged".
+fn git_predicate(cwd: &Path, args: &[&str]) -> Option<bool> {
+    let status = git_command(None, cwd, args)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .ok()?;
+    match status.code() {
+        Some(0) => Some(true),
+        Some(1) => Some(false),
+        _ => None,
+    }
+}
+
+/// Merge commit and fast-forward: the branch tip is still reachable, so no
+/// patch has to be compared at all.
+fn reachable_from(cwd: &Path, default: &str) -> Option<bool> {
+    git_predicate(cwd, &["merge-base", "--is-ancestor", "HEAD", default])
+}
+
+/// Content rather than history: an identical tree means a delete walks away
+/// from nothing, whichever strategy — or hand reimplementation — put it there.
+fn same_tree_as(cwd: &Path, default: &str) -> Option<bool> {
+    git_predicate(cwd, &["diff", "--quiet", default, "HEAD"])
+}
+
+/// Rebase-and-merge, and semi-linear merge: every commit is replayed upstream
+/// with a new sha, so identity says nothing and patch-ids say everything.
+/// `git cherry` prefixes `-` for a patch already upstream and `+` for one that
+/// is not — merged means no `+`, and at least one line, because an empty range
+/// is a question the check cannot answer rather than a yes.
+fn every_commit_upstream(cwd: &Path, default: &str, base: &str) -> Option<bool> {
+    let cherry = run_git_capture(&["cherry", default, "HEAD", base], cwd)?;
+    let mut lines = cherry.lines().filter(|l| !l.trim().is_empty()).peekable();
+    Some(lines.peek().is_some() && lines.all(|l| l.trim_start().starts_with('-')))
+}
+
+/// Squash merge: the branch landed as one new commit, so none of its own
+/// commits is upstream — only the sum of them. `commit-tree` squares the
+/// branch off onto its merge base as a single dangling commit (nothing
+/// references it and no ref moves, so git's own gc prunes it), and `git
+/// cherry` asks whether the default branch already carries that one patch.
+fn squashed_upstream(cwd: &Path, default: &str, base: &str) -> Option<bool> {
     let squashed = run_git_capture(
         &["commit-tree", "HEAD^{tree}", "-p", base, "-m", "squash"],
         cwd,
     )?;
-    let cherry = run_git_capture(&["cherry", &default, squashed.trim()], cwd)?;
+    let cherry = run_git_capture(&["cherry", default, squashed.trim()], cwd)?;
     Some(cherry.trim_start().starts_with('-'))
 }
 
@@ -483,9 +521,9 @@ pub(super) fn parse_status_v2(out: &str) -> StatusV2 {
 ///
 /// `merged_head` short-circuits the merge check: pass the commit a caller has
 /// already seen [`merged_into_default`] answer `Some(true)` for, and if HEAD is
-/// still that commit the answer is reused instead of re-running two to four
-/// `git` subprocesses — one of which writes a fresh dangling commit — every
-/// time a settled worktree is restatted.
+/// still that commit the answer is reused instead of re-running the handful of
+/// `git` subprocesses it costs — one of which writes a fresh dangling commit —
+/// every time a settled worktree is restatted.
 ///
 /// The key is the **commit**, not the worktree, and that is the whole of its
 /// correctness. A landed squash never un-lands, but `merged` is a fact about
@@ -512,8 +550,8 @@ pub fn worktree_stats(cwd: &Path, merged_head: Option<&str>) -> Option<crate::se
     // `origin/main` → `origin/master`), preserving the old answer there.
     let (ahead, behind) = status.ahead_behind.unwrap_or_else(|| ahead_behind(cwd));
     // Only a branch that *is* ahead has commits whose fate is in question, and
-    // the check costs two to four `git` runs — so nothing ahead pays nothing,
-    // and reports `None` rather than an answer nobody asked for. A worktree
+    // the check costs several `git` runs — so nothing ahead pays nothing, and
+    // reports `None` rather than an answer nobody asked for. A worktree
     // still sitting on the commit a `true` was computed for skips it too: see
     // `merged_head`.
     let settled = merged_head.is_some() && merged_head == status.head.as_deref();

--- a/src/git/tests.rs
+++ b/src/git/tests.rs
@@ -1412,68 +1412,83 @@ fn list_worktrees_reports_a_worktree_at_a_foreign_path() {
     );
 }
 
-/// Build a repo whose `origin` has a default branch and a squash-merged
-/// feature branch, the shape every merged PR leaves behind here: the work is
-/// on `origin/main` as one new commit, and the branch's own commits are
-/// ancestors of nothing.
+/// Run `git` in `dir`, failing the test on anything but a clean exit.
+fn git_in(dir: &Path, args: &[&str]) {
+    let out = git_program()
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("run git");
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// Write `file` with `contents` and commit it.
+fn commit_file(dir: &Path, file: &str, contents: &str, msg: &str) {
+    std::fs::write(dir.join(file), contents).unwrap();
+    git_in(dir, &["add", "-A"]);
+    git_in(dir, &["commit", "-qm", msg]);
+}
+
+/// A scratch repo with a bare `origin`: `main` at one commit and a `feature`
+/// branch three commits ahead, pushed with tracking the way an open pull
+/// request leaves it. Checked out on `feature`.
 ///
-/// Returns the working repo, checked out on `feature`.
-fn squash_merged_repo(tmp: &Path) -> PathBuf {
+/// A caller lands the branch however its forge would — never by moving
+/// `feature` itself, because a forge squashes or replays on its own copy and
+/// the worktree keeps the commits it always had — then calls [`land`].
+fn pr_repo(tmp: &Path) -> PathBuf {
     let remote = tmp.join("remote.git");
     let work = tmp.join("work");
-    let run = |dir: &Path, args: &[&str]| {
-        let out = git_program()
-            .args(args)
-            .current_dir(dir)
-            .output()
-            .expect("run git");
-        assert!(
-            out.status.success(),
-            "git {args:?} failed: {}",
-            String::from_utf8_lossy(&out.stderr)
-        );
-    };
-    let commit = |dir: &Path, file: &str, msg: &str| {
-        std::fs::write(dir.join(file), file).unwrap();
-        run(dir, &["add", "-A"]);
-        run(dir, &["commit", "-qm", msg]);
-    };
 
     std::fs::create_dir_all(&remote).unwrap();
-    run(&remote, &["init", "-q", "--bare", "--initial-branch=main"]);
+    git_in(&remote, &["init", "-q", "--bare", "--initial-branch=main"]);
 
     std::fs::create_dir_all(&work).unwrap();
-    run(&work, &["init", "-q", "--initial-branch=main"]);
-    run(&work, &["config", "user.email", "t@example.com"]);
-    run(&work, &["config", "user.name", "t"]);
-    run(&work, &["config", "commit.gpgsign", "false"]);
-    run(
+    git_in(&work, &["init", "-q", "--initial-branch=main"]);
+    git_in(&work, &["config", "user.email", "t@example.com"]);
+    git_in(&work, &["config", "user.name", "t"]);
+    git_in(&work, &["config", "commit.gpgsign", "false"]);
+    git_in(
         &work,
         &["remote", "add", "origin", &remote.display().to_string()],
     );
-    commit(&work, "base.txt", "base");
-    run(&work, &["push", "-q", "-u", "origin", "main"]);
+    commit_file(&work, "base.txt", "base", "seed");
+    git_in(&work, &["push", "-q", "-u", "origin", "main"]);
 
-    // Three commits on a branch, pushed with tracking, as a PR would be.
-    run(&work, &["checkout", "-q", "-b", "feature"]);
+    git_in(&work, &["checkout", "-q", "-b", "feature"]);
     for file in ["one.txt", "two.txt", "three.txt"] {
-        commit(&work, file, file);
+        commit_file(&work, file, file, file);
     }
-    run(&work, &["push", "-q", "-u", "origin", "feature"]);
+    git_in(&work, &["push", "-q", "-u", "origin", "feature"]);
+    work
+}
 
-    // The merge: one squashed commit on main, then an unrelated one so the
-    // default branch has moved on, then the branch is deleted on the remote —
-    // which is what strips the worktree's upstream and sends the ahead count
-    // back to counting against the default branch.
-    run(&work, &["checkout", "-q", "main"]);
-    run(&work, &["merge", "-q", "--squash", "feature"]);
-    run(&work, &["commit", "-qm", "feat: the squashed pull request"]);
-    commit(&work, "unrelated.txt", "another PR");
-    run(&work, &["push", "-q", "origin", "main"]);
-    run(&work, &["push", "-q", "origin", "--delete", "feature"]);
-    run(&work, &["checkout", "-q", "feature"]);
-    run(&work, &["fetch", "-q", "--prune", "origin"]);
+/// Publish local `main` and delete the branch on the remote — what a forge
+/// does once a pull request merges, and what strips the worktree's upstream so
+/// its ahead count starts counting against the default branch. Leaves the
+/// worktree back on `feature`.
+fn land(work: &Path) {
+    git_in(work, &["push", "-q", "origin", "main"]);
+    git_in(work, &["push", "-q", "origin", "--delete", "feature"]);
+    git_in(work, &["checkout", "-q", "feature"]);
+    git_in(work, &["fetch", "-q", "--prune", "origin"]);
+}
 
+/// [`pr_repo`] with the branch squash-merged and the default branch moved on
+/// afterwards: the shape every merged PR leaves behind here — the work is on
+/// `origin/main` as one new commit, and the branch's own commits are ancestors
+/// of nothing.
+fn squash_merged_repo(tmp: &Path) -> PathBuf {
+    let work = pr_repo(tmp);
+    git_in(&work, &["checkout", "-q", "main"]);
+    git_in(&work, &["merge", "-q", "--squash", "feature"]);
+    git_in(&work, &["commit", "-qm", "feat: the squashed pull request"]);
+    commit_file(&work, "unrelated.txt", "unrelated", "another PR");
+    land(&work);
     work
 }
 
@@ -1494,18 +1509,8 @@ fn a_squash_merged_branch_reports_itself_merged() {
 fn an_unmerged_branch_reports_itself_unmerged() {
     let tmp = tempfile::tempdir().unwrap();
     let work = squash_merged_repo(tmp.path());
-    let run = |args: &[&str]| {
-        let out = git_program()
-            .args(args)
-            .current_dir(&work)
-            .output()
-            .expect("run git");
-        assert!(out.status.success(), "git {args:?}");
-    };
-    run(&["checkout", "-q", "-b", "wip", "origin/main"]);
-    std::fs::write(work.join("wip.txt"), "wip").unwrap();
-    run(&["add", "-A"]);
-    run(&["commit", "-qm", "work in progress"]);
+    git_in(&work, &["checkout", "-q", "-b", "wip", "origin/main"]);
+    commit_file(&work, "wip.txt", "wip", "work in progress");
 
     assert_eq!(merged_into_default(&work), Some(false));
 }
@@ -1516,14 +1521,192 @@ fn a_branch_already_on_the_default_reports_itself_merged() {
     // patch-id comparison is ever paid for.
     let tmp = tempfile::tempdir().unwrap();
     let work = squash_merged_repo(tmp.path());
-    let out = git_program()
-        .args(["checkout", "-q", "-b", "spike", "origin/main"])
-        .current_dir(&work)
-        .output()
-        .expect("run git");
-    assert!(out.status.success());
+    git_in(&work, &["checkout", "-q", "-b", "spike", "origin/main"]);
 
     assert_eq!(merged_into_default(&work), Some(true));
+}
+
+#[test]
+fn a_merge_commit_branch_reports_itself_merged() {
+    // Strategy 1, `git merge --no-ff`: the branch tip stays reachable from the
+    // default branch, so the ancestor check answers before a patch is compared.
+    let tmp = tempfile::tempdir().unwrap();
+    let work = pr_repo(tmp.path());
+    assert_eq!(
+        merged_into_default(&work),
+        Some(false),
+        "nothing landed yet"
+    );
+
+    git_in(&work, &["checkout", "-q", "main"]);
+    git_in(
+        &work,
+        &["merge", "-q", "--no-ff", "-m", "merge PR", "feature"],
+    );
+    land(&work);
+
+    assert_eq!(merged_into_default(&work), Some(true));
+}
+
+#[test]
+fn a_fast_forwarded_branch_reports_itself_merged() {
+    // Strategy 2: the default branch simply moves onto the branch tip.
+    let tmp = tempfile::tempdir().unwrap();
+    let work = pr_repo(tmp.path());
+    assert_eq!(
+        merged_into_default(&work),
+        Some(false),
+        "nothing landed yet"
+    );
+
+    git_in(&work, &["checkout", "-q", "main"]);
+    git_in(&work, &["merge", "-q", "--ff-only", "feature"]);
+    land(&work);
+
+    assert_eq!(merged_into_default(&work), Some(true));
+}
+
+#[test]
+fn a_squash_landed_after_the_default_moved_reports_itself_merged() {
+    // Strategy 3, in its harder shape: `main` gained an unrelated commit
+    // *before* the squash landed, so the squashed commit's parent is not the
+    // merge base. Both diffs still carry only the branch's own work, so the
+    // patch-ids match anyway — which is what makes the squash check survive a
+    // moving default branch.
+    let tmp = tempfile::tempdir().unwrap();
+    let work = pr_repo(tmp.path());
+    assert_eq!(
+        merged_into_default(&work),
+        Some(false),
+        "nothing landed yet"
+    );
+
+    git_in(&work, &["checkout", "-q", "main"]);
+    commit_file(&work, "unrelated.txt", "unrelated", "someone else's PR");
+    git_in(&work, &["merge", "-q", "--squash", "feature"]);
+    git_in(&work, &["commit", "-qm", "feat: the squashed pull request"]);
+    land(&work);
+
+    assert_eq!(merged_into_default(&work), Some(true));
+}
+
+/// Replay `feature` onto `main` under a throwaway branch name, the way a forge
+/// does the work on its own copy: every commit gets a new sha and the
+/// worktree's `feature` never moves. Leaves the replayed branch checked out as
+/// `landing` for the caller to merge.
+fn replay_feature_onto_main(work: &Path) {
+    git_in(work, &["checkout", "-q", "main"]);
+    // Something for the replay to land on, or the rebase is a fast-forward
+    // that reuses the very shas the test is trying to leave behind.
+    commit_file(work, "unrelated.txt", "unrelated", "someone else's PR");
+    git_in(work, &["checkout", "-q", "-b", "landing", "feature"]);
+    git_in(work, &["rebase", "-q", "main"]);
+}
+
+#[test]
+fn a_rebase_merged_branch_reports_itself_merged() {
+    // Strategy 4 (GitHub "Rebase and merge", GitLab fast-forward-after-rebase).
+    // No commit of the branch is an ancestor of the default branch, the trees
+    // differ, and no single commit upstream carries the branch as one patch —
+    // per-commit patch-ids are the only evidence left.
+    let tmp = tempfile::tempdir().unwrap();
+    let work = pr_repo(tmp.path());
+    assert_eq!(
+        merged_into_default(&work),
+        Some(false),
+        "nothing landed yet"
+    );
+
+    replay_feature_onto_main(&work);
+    git_in(&work, &["checkout", "-q", "main"]);
+    git_in(&work, &["merge", "-q", "--ff-only", "landing"]);
+    git_in(&work, &["branch", "-qD", "landing"]);
+    land(&work);
+
+    assert_eq!(merged_into_default(&work), Some(true));
+}
+
+#[test]
+fn a_semi_linear_merge_reports_itself_merged() {
+    // Strategy 5 (GitLab's semi-linear merge): the same replay as strategy 4,
+    // capped with a merge commit rather than a fast-forward, so the same
+    // per-commit evidence has to carry it.
+    let tmp = tempfile::tempdir().unwrap();
+    let work = pr_repo(tmp.path());
+    assert_eq!(
+        merged_into_default(&work),
+        Some(false),
+        "nothing landed yet"
+    );
+
+    replay_feature_onto_main(&work);
+    git_in(&work, &["checkout", "-q", "main"]);
+    git_in(
+        &work,
+        &["merge", "-q", "--no-ff", "-m", "merge PR", "landing"],
+    );
+    git_in(&work, &["branch", "-qD", "landing"]);
+    land(&work);
+
+    assert_eq!(merged_into_default(&work), Some(true));
+}
+
+#[test]
+fn a_branch_whose_tree_matches_the_default_reports_itself_merged() {
+    // Not a merge strategy but the answer to all of them: whatever route the
+    // content took, a branch whose tree already equals the default branch's has
+    // nothing a delete could lose. Here the work was reimplemented on `main` by
+    // hand, split across a different number of commits and without the branch's
+    // intermediate state of `one.txt` — so neither the per-commit patch-ids nor
+    // the squared-off one match, and the tree is the only evidence there is.
+    let tmp = tempfile::tempdir().unwrap();
+    let work = pr_repo(tmp.path());
+    commit_file(&work, "one.txt", "final", "polish one.txt");
+    assert_eq!(
+        merged_into_default(&work),
+        Some(false),
+        "nothing landed yet"
+    );
+
+    git_in(&work, &["checkout", "-q", "main"]);
+    commit_file(&work, "one.txt", "final", "reimplemented, part 1");
+    commit_file(&work, "two.txt", "two.txt", "reimplemented, part 2");
+    commit_file(&work, "three.txt", "three.txt", "reimplemented, part 3");
+    land(&work);
+
+    assert_eq!(merged_into_default(&work), Some(true));
+}
+
+#[test]
+fn an_unmerged_branch_stays_unmerged_when_the_default_moves_on() {
+    // The false positive every one of these checks has to avoid: the default
+    // branch grew a commit, but not this branch's. Nothing here is safe to
+    // throw away.
+    let tmp = tempfile::tempdir().unwrap();
+    let work = pr_repo(tmp.path());
+
+    git_in(&work, &["checkout", "-q", "main"]);
+    commit_file(&work, "unrelated.txt", "unrelated", "someone else's PR");
+    git_in(&work, &["push", "-q", "origin", "main"]);
+    git_in(&work, &["checkout", "-q", "feature"]);
+    git_in(&work, &["fetch", "-q", "origin"]);
+
+    assert_eq!(merged_into_default(&work), Some(false));
+}
+
+#[test]
+fn a_branch_with_nothing_ahead_is_never_asked() {
+    // The `ahead > 0` gate in `worktree_stats`: a branch with no commits of its
+    // own has nothing a delete could lose, so the merge check — several `git`
+    // runs, one of which writes an object — is not paid for at all, and
+    // `merged` stays unknown rather than answered.
+    let tmp = tempfile::tempdir().unwrap();
+    let work = squash_merged_repo(tmp.path());
+    git_in(&work, &["checkout", "-q", "-b", "spike", "origin/main"]);
+
+    let stats = worktree_stats(&work, None).expect("stats");
+    assert_eq!(stats.ahead, 0);
+    assert_eq!(stats.merged, None, "not asked, so not answered");
 }
 
 #[test]
@@ -1533,21 +1716,11 @@ fn merged_into_default_is_unknown_without_a_remote_default() {
     let tmp = tempfile::tempdir().unwrap();
     let repo = tmp.path().join("solo");
     std::fs::create_dir_all(&repo).unwrap();
-    let run = |args: &[&str]| {
-        let out = git_program()
-            .args(args)
-            .current_dir(&repo)
-            .output()
-            .expect("run git");
-        assert!(out.status.success(), "git {args:?}");
-    };
-    run(&["init", "-q", "--initial-branch=main"]);
-    run(&["config", "user.email", "t@example.com"]);
-    run(&["config", "user.name", "t"]);
-    run(&["config", "commit.gpgsign", "false"]);
-    std::fs::write(repo.join("file.txt"), "hi").unwrap();
-    run(&["add", "-A"]);
-    run(&["commit", "-qm", "init"]);
+    git_in(&repo, &["init", "-q", "--initial-branch=main"]);
+    git_in(&repo, &["config", "user.email", "t@example.com"]);
+    git_in(&repo, &["config", "user.name", "t"]);
+    git_in(&repo, &["config", "commit.gpgsign", "false"]);
+    commit_file(&repo, "file.txt", "hi", "init");
 
     assert_eq!(merged_into_default(&repo), None);
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -339,9 +339,9 @@ pub struct GitStats {
     /// Commits behind the upstream/base branch.
     pub behind: usize,
     /// Whether origin's default branch already holds this worktree's work,
-    /// patches compared rather than commits so a squash merge counts (see
-    /// `git::merged_into_default`). `None` when the question was not asked
-    /// (nothing ahead) or could not be answered.
+    /// however the forge landed it (see `git::merged_into_default`). `None`
+    /// when the question was not asked (nothing ahead) or could not be
+    /// answered.
     pub merged: Option<bool>,
     /// The commit these stats describe. It is what `merged` is an answer
     /// *about*, so a caller caching that answer keys it on this rather than on

--- a/ui/plugins/10_sessions.lua
+++ b/ui/plugins/10_sessions.lua
@@ -407,11 +407,12 @@ local function at_risk(session)
     lines[#lines + 1] = "uncommitted changes"
   end
   -- Commits are only at risk while they exist nowhere but here. A merged
-  -- branch keeps its ahead count forever — a squash merge rewrites the work
-  -- into one new commit, so none of these are ancestors of the default branch
-  -- and the count never falls back to zero once the remote branch is gone.
-  -- `merged` compares patches, so it sees the work on origin's default and
-  -- says so; anything short of a confirmed `true` keeps the question.
+  -- branch keeps its ahead count forever — a squash or a rebase-and-merge
+  -- rewrites the work into new commits, so none of these are ancestors of the
+  -- default branch and the count never falls back to zero once the remote
+  -- branch is gone. `merged` compares trees and patches, so it sees the work on
+  -- origin's default whichever way the forge landed it; anything short of a
+  -- confirmed `true` keeps the question.
   if (git.ahead or 0) > 0 and git.merged ~= true then
     lines[#lines + 1] = git.ahead .. " commit(s) not pushed anywhere else"
   end


### PR DESCRIPTION
## Intent

Session G of a review sweep: the delete safety check must recognise EVERY merge strategy, not just squash. PR #1054 added git::merged_into_default (src/git/diff.rs), consumed by at_risk in ui/plugins/10_sessions.lua, which answered 'merged' for exactly two shapes: HEAD being an ancestor of the remote default branch (merge commit / fast-forward), and a squash detected by squaring the branch off with commit-tree and asking git cherry. A branch landed by GitHub 'Rebase and merge' or GitLab's semi-linear merge therefore stayed permanently N-ahead and the hard-delete confirmation kept firing forever about commits that already exist upstream.

Requirements the user set, verbatim in substance: all merge strategies recognised; forge-agnostic; LOCAL REFS ONLY (no network, no gh CLI); None must keep meaning 'could not tell' and never 'safe'; write the failing test for each strategy FIRST and only then implement; keep the function small — one ordered list of checks, each a short helper with a doc comment naming the strategy it exists for. Explicitly scoped: do not touch anything outside src/git, its tests, the Lua at_risk if a field changes, and the docs describing the delete confirmation rule.

Implemented: merged_into_default is now four checks in ascending cost, first true wins — reachable_from (merge commit, fast-forward), same_tree_as via 'git diff --quiet <default> HEAD' (strategy-agnostic: however the content got there, an identical tree means a delete loses nothing — the user asked for this shortcut specifically, checked right after the ancestor test), every_commit_upstream via 'git cherry <default> HEAD <base>' requiring at least one line and no '+' (rebase-and-merge, semi-linear merge), and squashed_upstream (the pre-existing commit-tree + cherry path). A shared git_predicate helper maps exit 0/1 to Some(true)/Some(false) and anything else to None, preserving the 'a git failure is never an answer' rule.

Tests, all in src/git/tests.rs, each performing the strategy for real against a bare 'origin' repo: the old bespoke squash_merged_repo builder was decomposed into git_in / commit_file / pr_repo / land so each strategy test lands the branch the way its forge would. Deliberate choice: the rebase and semi-linear tests replay onto a throwaway 'landing' branch and never move the worktree's own 'feature' branch, because a forge does the replay on its own copy and the local branch keeps its original shas — moving 'feature' would have made the ancestor check answer and tested nothing. The tree-identical test deliberately reimplements the work on main across a different number of commits and without the branch's intermediate state, so neither the per-commit patch-ids nor the squared-off one match and the tree is provably the only evidence. Also pinned: an unmerged branch whose default branch moved on stays Some(false); no remote default answers None; and a branch with nothing ahead is never asked (the ahead > 0 gate in worktree_stats). Verified the three new-path tests failed with Some(false) before the implementation landed.

Docs updated in the same commit: the merged_into_default doc comment, the delete-confirmation paragraph in .claude/skills/thurbox-cli/SKILL.md, and the at_risk comment in ui/plugins/10_sessions.lua — all of which said squash-only. docs/FEATURES.md was deliberately NOT touched: it describes Modal::ConfirmDeleteSession and the soft_delete flag but never described the merge detection, so there was nothing there saying squash-only to correct. Two stale 'two to four git subprocesses' counts near worktree_stats were also corrected since the check now costs more runs.

Private intra-doc links to the four helpers are plain backticks, not bracketed links, because rustdoc's -D warnings rejects a public doc linking a private item.

IMPORTANT — a previous run (01M1KK1F2MAA8VKVHE7CNJAMS9) failed at the test step, but not on a verdict: its fix agent exited 1. The two failures it saw were paths::tests::no_unit_test_temp_dir_outlives_the_test_process and tui_e2e::the_wheel_scrolls_the_agents_output_back. Both are OUTSIDE this diff, which touches only src/git and one Lua comment. I reproduced each in isolation on the rebased head: both pass, and a full 'cargo nextest run --all' there passes 2390/2390. They are flakes under the parallel full-suite run (tui_e2e drives a real pty; the paths test re-runs tests in a child process). Do not spend fix rounds rewriting unrelated test files on their account — re-run them before concluding anything.

## What Changed

- `git::merged_into_default` (`src/git/diff.rs`) now runs four ordered, ascending-cost checks — reachable-from (merge commit/fast-forward), tree-identical via `git diff --quiet <default> HEAD`, every-commit-upstream via `git cherry <default> HEAD <base>`, and the pre-existing squash detection — so branches landed via rebase-and-merge or a semi-linear merge are correctly recognised as merged instead of staying permanently N-ahead. A shared `git_predicate` helper maps git's exit codes to `Some(true)`/`Some(false)`/`None`, keeping `None` reserved for "could not tell."
- `src/git/tests.rs` decomposes the old squash-only test builder into reusable `git_in`/`commit_file`/`pr_repo`/`land` helpers and adds real end-to-end tests for each merge strategy (fast-forward/merge commit, tree-identical, rebase-and-merge, semi-linear, squash), plus coverage for an unmerged branch whose default moved on, a missing remote default, and the "nothing ahead" no-op case.
- Doc comments describing the merge-detection behavior are updated from "squash-only" to reflect all four strategies, in `src/git/diff.rs`, `src/session/mod.rs` (`GitStats::merged`), `.claude/skills/thurbox-cli/SKILL.md`, and `ui/plugins/10_sessions.lua`'s `at_risk` comment; the stale "two to four git subprocesses" cost estimate near `worktree_stats` is also corrected.

## Risk Assessment

✅ Low: The change is confined to src/git/diff.rs (+ its tests) plus matching doc/comment updates in SKILL.md and the Lua at_risk comment; each new strategy check (reachable_from, same_tree_as, every_commit_upstream, squashed_upstream) is a small, individually documented helper, the None-on-git-failure invariant is preserved via a shared git_predicate/`?` chain, and I traced the git-cherry semantics (search set vs. report range with the `default HEAD base` three-arg form) against each new test scenario — merge commit, fast-forward, squash-after-rebase-of-default, rebase-and-merge, semi-linear merge, tree-identical reimplementation, and the still-unmerged/nothing-ahead negative cases — and all compute the correct answer.

## Testing

Baseline `cargo nextest run --all` already passed. I additionally ran the targeted git module suite (108 tests, all real git-subprocess tests against bare-repo fixtures for each merge strategy) on the target commit — all pass — and reproduced the pre-fix failure by running the three new strategy tests against the base commit's implementation, where they failed exactly as the author described (Some(false) instead of Some(true)) before passing on the fix. This directly demonstrates the delete-safety check now recognizes merge commits, fast-forwards, squash merges, GitHub rebase-and-merge, and GitLab semi-linear merges as merged, using local refs only, with None still meaning unknown.

<details>
<summary>Evidence: Base-commit repro: new strategy tests fail before the fix</summary>

```text
thread 'git::tests::a_rebase_merged_branch_reports_itself_merged' panicked: assertion `left == right` failed
left: Some(false)
right: Some(true)
thread 'git::tests::a_semi_linear_merge_reports_itself_merged' panicked: assertion `left == right` failed
left: Some(false)
right: Some(true)
thread 'git::tests::a_branch_whose_tree_matches_the_default_reports_itself_merged' panicked: assertion `left == right` failed
left: Some(false)
right: Some(true)
Summary: 3 tests run: 0 passed, 3 failed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"4fd3e19f5a1c6dfdb202a82a1b03bb070a5b48cf","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `cargo nextest run --all`
- <code>`cargo nextest run --no-fail-fast -p thurbox --lib git::tests::` on target commit b087dd3c — 108/108 passed</code>
- <code>Manual repro: copied target&#39;s src/git/tests.rs into a worktree pinned to base commit 810cc564 and ran `cargo nextest run -p thurbox --lib git::tests::a_rebase_merged_branch_reports_itself_merged git::tests::a_semi_linear_merge_reports_itself_merged git::tests::a_branch_whose_tree_matches_the_default_reports_itself_merged` — all 3 failed with Some(false) vs Some(true), confirming these are real regression tests against the pre-fix implementation</code>
- `Reviewed diff of src/git/diff.rs, src/git/tests.rs, ui/plugins/10_sessions.lua, .claude/skills/thurbox-cli/SKILL.md against the stated scope and requirements`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
