### PR TITLE
fix(core): unify session status derivation across cli, kernel, and interface

### DIFF
--- a/.claude/skills/thurbox-cli/SKILL.md
+++ b/.claude/skills/thurbox-cli/SKILL.md
@@ -273,11 +273,30 @@ deletes, and only one of them is restorable. `hook_state_contradicted` is
 `null` — *not checked* — unless you pass `--verify`, which costs a multiplexer
 query and a `ps` per event, the same trade `session list --verify` makes.
 
+`state` is the same `SessionState` word every other surface answers with, and
+it is derived from the event's **own** `to_state` so two transitions inside one
+wake-up stay two events. The `done → idle` acknowledgment is the exception and
+deliberately reads the row's current `seen_at`: "somebody has looked at this
+since" is a fact about now, so a replayed `done` an operator has already read
+reports `idle`, matching what `session get` says for that row in that second.
+`to_state` still carries the event's own word verbatim, so the transition
+itself is never lost.
+
 `--session` narrows it to one (the log is filtered, not the output),
 `--for-secs` bounds it, `--initial` emits the current state as `present` rows
 first, and `--since <seq>` resumes from the last event a driver handled — the
 gap a stream otherwise has across a restart. The stream exits as soon as its
 reader closes the pipe rather than sitting out its `--for-secs`.
+
+**One vocabulary.** `state` on `get`, `list`, `watch`, the bare `thurbox-cli`
+home view and the interface's own session list are all `SessionState`
+(`src/session/hook_status.rs`), derived by the same read-time folds, so a
+driver reconciling two surfaces never reconciles two vocabularies. The folds a
+surface can apply are the ones whose inputs it can observe: everyone reads the
+stored columns (including `seen_at`, so an acknowledged turn is `idle`
+headlessly too), while terminal quiescence and host reachability need a live
+interface and are never guessed. The one remaining difference between `get` and
+`list` is the pane probe — see `session list --help`.
 
 **A parked session takes no hook state at all.** `session stop` killed the
 pane, so a heartbeat's pane-option poll or a mirror pass carrying a host's last

--- a/.claude/skills/thurbox-kernel/SKILL.md
+++ b/.claude/skills/thurbox-kernel/SKILL.md
@@ -74,7 +74,9 @@ already follow.
   `Session` wraps a `SessionBackend`; `TmuxBackend` runs tmux over a
   `TmuxTransport` (`Local` / `Ssh` / `Wsl`). Output is read into
   `Arc<Mutex<vt100::Parser>>`, input written over an mpsc channel.
-- **`session/`** — plain data: `SessionId`, `SessionStatus`, `SessionInfo`,
+- **`session/`** — plain data: `SessionId`, `SessionInfo`, `SessionState` and
+  the read-time status folds (`hook_status`, the one module the kernel *and*
+  the CLI derive a session's state through),
   `SessionConfig`, `AgentDef`/`AgentRegistry`, `HostDef`/`HostRegistry`,
   `PluginSpec`/`PluginLock`/`PackageManifest` (`plugin_spec`, so the kernel and the
   CLI share one definition), plus the logic the kernel needs and cannot import

--- a/.claude/skills/thurbox-session-status/SKILL.md
+++ b/.claude/skills/thurbox-session-status/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: thurbox-session-status
-description: Hooks-driven session status in thurbox: the six SessionStatus states and their glyphs/colours, the session signal callback and its persistence columns, derivation including Unreachable remote hosts and the output-quiescence stuck-working fallback, done-vs-seen acknowledgment, and OS desktop notifications with backend detection and click-to-focus. Use when working on session status, the status dot, hook state, or notifications.
+description: Hooks-driven session status in thurbox: the SessionState vocabulary and its glyphs/colours, the session signal callback and its persistence columns, derivation including Unreachable remote hosts and the output-quiescence stuck-working fallback, done-vs-seen acknowledgment, and OS desktop notifications with backend detection and click-to-focus. Use when working on session status, the status dot, hook state, or notifications.
 ---
 
 # Thurbox session status and notifications
@@ -10,17 +10,32 @@ description: Hooks-driven session status in thurbox: the six SessionStatus state
 ## Session status (hooks-driven)
 
 The session list shows, at a glance, which agents are blocked, working,
-or done. `SessionStatus` (`src/session/mod.rs`) has six states — five driven by
-**agent hooks**, not heuristics, plus `Unreachable` for a down remote host:
+or done. **`SessionState` (`src/session/hook_status.rs`) is the whole
+vocabulary — one enum, every surface.** Four of its words are the agent's own
+hook report; the rest are thurbox's own, and each is spelled apart from `idle`
+on purpose, because collapsing "nothing here is wired to report" or "the host
+is gone" into "the agent says it is at rest" is exactly the conflation the
+module exists to prevent:
 
 | State | Colour | Glyph | Meaning |
 |-------|--------|-------|---------|
-| `Working` | yellow | animated braille spinner (`⠋⠙⠹…`; static `◐`) | agent is actively running |
-| `Blocked` | red | `◆` | agent needs input or approval |
-| `Done` | blue | `●` (filled) | a turn just finished; shown until you switch away |
-| `Idle` | green | `○` (hollow) | acknowledged (you moved off a Done), never active, or at rest |
-| `Error` | red | `✗` | reserved for a crashed agent — **not derived yet** (no exit-code signal; exited → `Idle`) |
-| `Unreachable` | muted grey | `⊘` | remote host down/offline; the ordinary row, derived from a live attach failure, awaiting reconnect |
+| `working` | yellow | animated braille spinner (`⠋⠙⠹…`; static `◐`) | agent is actively running (hook) |
+| `blocked` | red | `◆` | agent needs input or approval (hook) |
+| `done` | blue | `●` (filled) | a turn just finished; shown until you switch away (hook) |
+| `idle` | green | `○` (hollow) | acknowledged (you moved off a Done), never active, or at rest |
+| `unreachable` | muted grey | `⊘` | remote host down/offline; the ordinary row, derived from a live attach failure, awaiting reconnect |
+| `stopped` | — | — | parked by `session stop`: no process at all, which is why it outranks whatever the hook columns still hold |
+| `running` | — | — | an agent holds the pane and nothing has signalled — an observation, never a claim about what it is doing |
+| `uncovered` | — | — | this agent is wired to report nothing, so its silence means nothing |
+| `unreported` | — | — | the agent *can* report and has not yet |
+
+The last four carry no dot: the interface can always observe quiescence and
+reachability and knows the park mark from the row, so its rows resolve to the
+first five. The others are what a headless surface answers when a fact the
+interface has is one it cannot observe. The `Error` state v1 reserved for a
+crashed agent is gone with `SessionStatus`: it was never derived (process exit
+carries no failure signal), and a word no surface can produce is one more thing
+for a driver to handle for nothing.
 
 **Unreachable sessions.** A persisted **remote** session whose host cannot be
 reached **always appears in the list**, tagged `Unreachable`, rather than
@@ -58,8 +73,9 @@ time it is handed (`status_glyph` in `10_sessions.lua`); the clock behind that i
 the kernel's shared **animation tick** (`kernel::host::ANIMATION_HZ` = 8), which
 the loop advances **only while something is actually animating** — a free-running
 one invalidated every `pure` pane on every idle frame (ADR-P16). The filled `●`
-(Done) vs hollow `○` (Idle) pair reads done-vs-seen at a glance;
-`SessionStatus::icon()` is the static glyph, for contexts with no clock.
+(Done) vs hollow `○` (Idle) pair reads done-vs-seen at a glance; the glyphs
+themselves live in `ui/lib/theme.lua`, so a state with no row in the table above
+simply draws the way `idle` does.
 
 - **Reading it headlessly.** `session get`/`list --json` report the raw
   `hook_state` **plus what it takes to judge it**: `hook_state_at` /
@@ -78,6 +94,11 @@ one invalidated every `pure` pane on every idle frame (ADR-P16). The filled `●
   `hook_corroboration` and `hook_state_contradicted`, **never** overwriting
   `hook_state` with the inference. `session list` skips the probe unless
   `--verify`; a remote session is never probed and answers `unavailable`.
+  Without the probe those fields are `null`, meaning **not checked** — a
+  different answer from `false`, and the one reason `state` can read
+  `unreported` on `list` where `get` reads `running`. That is the only
+  difference between the two verbs' answers for one row, and `session list
+  --help` says so.
   `session doctor` is the same picture as a verdict plus the wiring checks
   (extension active, payload on disk carrying the signal marker, `thurbox-cli`
   resolvable on `PATH`), exiting non-zero when a session's wiring is broken —
@@ -126,16 +147,29 @@ one invalidated every `pure` pane on every idle frame (ADR-P16). The filled `●
   `from_state` → `to_state`. That log is what `thurbox-cli watch` streams —
   see the `thurbox-cli` skill — and it exists because sampling the columns
   collapses two transitions that land between two samples.
-- **Derivation.** The snapshot carries each session's `hook_state` and folds
-  attach state into the published status — a *remote* session with no live pane
-  → `Unreachable` (`with_reachability`); a `working` one gone quiet → `Idle`
-  (the fallback below, which subsumes exited → `Idle`); else the persisted state
-  (`working`/`blocked`; `idle`/none → `Idle`). A local session is never
-  unreachable: this is its machine, and a missing pane there means the agent was
-  not launched. The rows are read on the snapshot's own schedule rather than per
-  frame, gated on `PRAGMA data_version` moving (see `docs/PERFORMANCE.md`
-  ADR-P6) — but the quiescence fallback is re-derived every tick, since output
-  moves between reads. `done` shows as `Done` (blue)
+- **One derivation, in `session::hook_status`.** All three read-time rules live
+  in the pure module both the kernel and the CLI may import (`derive_state`,
+  `with_output_quiescence`, `with_reachability`, all returning `SessionState`),
+  because the interface and `thurbox-cli` were each folding the same three
+  columns their own way and answering different words for one row. A caller
+  applies the folds whose inputs it can actually observe:
+
+  | fold | input | who can supply it |
+  |---|---|---|
+  | `derive_state` (incl. the `done → idle` acknowledgment) | `hook_state`, `hook_state_at`, `seen_at` — all stored | everyone |
+  | `with_output_quiescence` | terminal output age | the interface only |
+  | `with_reachability` | a live attach error | the interface only |
+
+  `seen_at` being a **stored fact** rather than a timeout is why the CLI applies
+  it too: the CLI rightly refuses to guess a staleness bound, but this column is
+  simply there to be read, and until it was, a turn the interface had already
+  acknowledged reported `done` on `session get`/`list`/`watch` for the rest of
+  the session's life. The two folds the CLI cannot make it does not fake.
+  A local session is never unreachable: this is its machine, and a missing pane
+  there means the agent was not launched. The rows are read on the snapshot's
+  own schedule rather than per frame, gated on `PRAGMA data_version` moving (see
+  `docs/PERFORMANCE.md` ADR-P6) — but the quiescence fallback is re-derived
+  every tick, since output moves between reads. `done` shows as `Done` (blue)
   **whether focused or not** — so a turn you're watching visibly completes — and
   becomes `Idle` only when you **move focus off it** (acknowledge it): the focus
   change vs. `last_active_session_id` marks the just-left `done` session `seen`
@@ -144,7 +178,7 @@ one invalidated every `pure` pane on every idle frame (ADR-P16). The filled `●
 - **Stuck-`working` fallback.** Hooks can miss the turn-end edge: Claude Code
   fires **no hook on interrupt** (Esc/Ctrl+C) nor when it returns to the idle
   prompt, so an interrupted (or crashed) turn would leave `hook_state = working`
-  forever. `snapshot::with_output_quiescence` guards with an **output-quiescence
+  forever. `session::with_output_quiescence` guards with an **output-quiescence
   fallback** (`WORKING_QUIET_MS`, 10 s): a `working` session with no terminal
   output for that long is treated as `Idle`, and so is one with no live pane —
   which is where v1's exited → `Idle` branch lands, since a pane whose stream
@@ -173,7 +207,7 @@ one invalidated every `pure` pane on every idle frame (ADR-P16). The filled `●
 
 ## OS notifications
 
-When a session goes to `SessionStatus::Blocked` (the agent needs you, reported by a
+When a session goes to `SessionState::Blocked` (the agent needs you, reported by a
 hook) thurbox fires an OS desktop notification. `kernel::notify` owns the
 per-session bookkeeping and the edge detection; `src/notifications.rs` is still the
 leaf side-effect layer that knows only `session` + `paths`.

--- a/.claude/skills/thurbox-session-status/SKILL.md
+++ b/.claude/skills/thurbox-session-status/SKILL.md
@@ -198,9 +198,11 @@ simply draws the way `idle` does.
   group dot would restate what every member row shows. Status only recolors — it
   **never** reorders rows (the order is status-independent).
 - **Colours** are tunable theme fields: `status_working` / `status_blocked`
-  / `status_done` / `status_idle` / `status_error`
+  / `status_done` / `status_idle` / `status_unreachable`
   (`session::theme_config`, all 36 presets + custom-theme overrides), published
-  to Lua as theme roles and read by the pane.
+  to Lua as theme roles and read by the pane. `status_error` is a separate
+  role (a failed *command*, e.g. `bands.rs`'s `Level::Error` — not a session
+  state, and untouched by `SessionState` dropping `Error`).
 - **Wiring the hooks** is the job of the built-in **hooks extension**
   (auto-activated; see the Extensions section) — core thurbox only knows
   the generic `session signal` command.

--- a/.claude/skills/thurbox-testing/SKILL.md
+++ b/.claude/skills/thurbox-testing/SKILL.md
@@ -79,6 +79,13 @@ kernel over the real `ui/`** rather than a harness that imitates either:
   the stamp itself: a row with no pane id at all (the psmux shape) still
   resolves its own window, and restore refuses to adopt a live namesake's
   window rather than putting two rows on one pane.
+- **`tests/session_state_agreement.rs`** — one row, four independent readers
+  (`session get`, `session list`, `watch --initial` via the real binary, and
+  `SnapshotStore` in-process): all four must answer the same `SessionState`.
+  Pins the concrete regression the `session::hook_status` consolidation fixed —
+  `seen_at` is a stored fact only the snapshot used to read, so a turn the
+  interface already showed as `idle` kept answering `done` on every headless
+  surface for the rest of the session's life.
 
 Tests that shell out to `git` **must scrub the `GIT_*` location variables**
 (`git::GIT_LOCATION_ENV`): git exports them to hook processes, so the suite running

--- a/benches/frame_cost.rs
+++ b/benches/frame_cost.rs
@@ -27,6 +27,7 @@ use thurbox::kernel::paint::PlaceholderSurfaces;
 use thurbox::kernel::registry::Registry;
 use thurbox::kernel::snapshot::{SessionRow, Snapshot};
 use thurbox::kernel::theme::Themes;
+use thurbox::session::SessionState;
 
 static SCREEN: std::sync::OnceLock<(u16, u16)> = std::sync::OnceLock::new();
 #[allow(non_snake_case)]
@@ -95,7 +96,12 @@ fn snapshot(sessions: usize) -> Snapshot {
                 name: format!("fix-the-thing-number-{nth}"),
                 agent: "claude".into(),
                 stopped: false,
-                status: ["idle", "working", "blocked", "done"][nth % 4].into(),
+                status: [
+                    SessionState::Idle,
+                    SessionState::Working,
+                    SessionState::Blocked,
+                    SessionState::Done,
+                ][nth % 4],
                 cwd: Some(format!("{repo}/worktrees/w{nth}").into()),
                 repo: Some(repo.into()),
                 repos: vec![repo.into()],

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -492,9 +492,10 @@ that needs your attention**. The trigger is the hooks-driven
 the terminal bell / output): the notification fires when a session crosses
 into `Blocked` (the agent needs input or approval) and, with
 `also_on_waiting = true`, also when it finishes a turn (`Working → Done`).
-The edge is observed once per tick in `refresh_session_statuses` — the
-same place the session-list status icon is computed, so the banner can
-never drift from the list — then deduped per session (`min_interval_secs`)
+The edge is detected once per tick in `kernel::notify`, reading the same
+`SessionState` the session-list status icon draws, so the banner can
+never drift from the list (see `docs/FEATURES.md` → *Why the transition is
+observed in one place*) — then deduped per session (`min_interval_secs`)
 and skipped for the session you're currently viewing (`suppress_for_active`).
 The notification body is the agent's last OSC 9 / OSC 777 message when
 present (truncated to 200 chars), otherwise `Waiting for input` — the OSC
@@ -540,7 +541,7 @@ you), and with `also_on_waiting = true` also on `Working → Done`.
 
 ## Session status
 
-Each session's state (Blocked / Working / Done / Idle / Error) is driven by
+Each session's state (Blocked / Working / Done / Idle) is driven by
 **agent hooks** that call `thurbox-cli session signal --state
 <working|blocked|done|idle>`. The state is persisted on the `sessions` row
 (`hook_state`, `hook_state_at`, `seen_at` — schema v34) and survives the TUI
@@ -552,8 +553,9 @@ no id. A finished turn shows `Done` (blue) — for the session you're watching t
 The hooks are wired up automatically by the built-in **hooks** extension
 (auto-activated on first run). Opt out with `thurbox-cli extension deactivate
 hooks`. The status colours are tunable theme keys (`status_working` /
-`status_blocked` / `status_done` / `status_idle` / `status_error` /
-`status_unreachable` — see `themes.toml`).
+`status_blocked` / `status_done` / `status_idle` / `status_unreachable` — see
+`themes.toml`). `status_error` is a separate role, for a failed *command* in
+the list, not a session state.
 
 The wiring is applied **only to agents thurbox launches** — it never edits your
 own global agent config (e.g. your personal `~/.claude/settings.json`). thurbox's

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -72,17 +72,24 @@ panel, not the list row.
 The colored **status dot** is driven by **agent hooks**, not output
 heuristics. Each agent CLI's lifecycle hooks call `thurbox-cli session
 signal --state <working|blocked|done|idle>` (identity from the injected
-`THURBOX_SESSION`), and `refresh_session_statuses` maps the persisted
-state to one of six `SessionStatus` values once per tick:
+`THURBOX_SESSION`), and the read-time folds in `session::hook_status` map the
+persisted columns onto a `SessionState` once per tick:
 
 | State | Colour | Glyph | Meaning |
 |-------|--------|-------|---------|
-| `Working` | yellow | braille spinner (`⠋⠙⠹…`; static `◐`) | agent is actively running |
-| `Blocked` | red | `◆` | agent needs input or approval |
-| `Done` | blue | `●` | a turn just finished; shown until you switch away |
-| `Idle` | green | `○` | acknowledged, never active, or at rest |
-| `Error` | red | `✗` | reserved for a crashed agent (not derived yet) |
-| `Unreachable` | muted grey | `⊘` | remote host is down/offline; placeholder row awaiting reconnect |
+| `working` | yellow | braille spinner (`⠋⠙⠹…`; static `◐`) | agent is actively running |
+| `blocked` | red | `◆` | agent needs input or approval |
+| `done` | blue | `●` | a turn just finished; shown until you switch away |
+| `idle` | green | `○` | acknowledged, never active, or at rest |
+| `unreachable` | muted grey | `⊘` | remote host is down/offline; placeholder row awaiting reconnect |
+
+`SessionState` carries four more words — `stopped`, `running`, `uncovered`,
+`unreported` — that the interface never has to draw, because it can always
+observe the park mark, the pane and the terminal. They are the answers a
+headless surface gives when one of those facts is out of its reach, and they
+are spelled apart from `idle` so "we cannot know" is never read as "the agent
+says it is at rest". One enum, so `session get`, `session list`,
+`thurbox-cli watch` and the session list cannot disagree about a row.
 
 A `Done` session becomes `Idle` once you move focus off it (you've
 acknowledged it); a `working` session that goes quiet for 10 s is
@@ -95,7 +102,7 @@ restore *and* a live session whose host dies mid-run (detected via the
 control-mode connection dropping). Status only **recolors** the dot — the
 manual order is never disturbed (see *Smart ordering* below). Repo groups
 roll up to their most-urgent member
-(`Blocked > Error > Working > Done > Unreachable > Idle`).
+(`Blocked > Working > Done > Unreachable > Idle`).
 
 The hooks are wired automatically by the built-in **hooks** extension
 (auto-activated on first run; opt out with `thurbox-cli extension
@@ -2362,15 +2369,15 @@ restore, worktree sync, and theme changes.
 Status messages are in-app and transient; OS notifications are the
 out-of-app analog for the one event a user must not miss — a session
 that **needs them**. When a session transitions to
-`SessionStatus::Blocked` (the agent's hook reported it needs input or
+`SessionState::Blocked` (the agent's hook reported it needs input or
 approval), thurbox fires an OS desktop notification. An opt-in
 `also_on_waiting` extends the trigger to the `Working → Done` (finished)
 edge for when you want a nudge each time a turn completes.
 
 ### Why the transition is observed in one place
 
-The edge is detected once per tick in `refresh_session_statuses` — the
-**same** place `SessionStatus` is computed — so the notification rule
+The edge is detected once per tick in `kernel::notify` — reading the very
+`SessionState` the list draws — so the notification rule
 can never drift from the status dot shown in the list. It is
 deduplicated per session by `min_interval_secs`, and the session you
 are currently viewing is skipped by default (`suppress_for_active`),

--- a/docs/ORCHESTRATION.md
+++ b/docs/ORCHESTRATION.md
@@ -242,11 +242,23 @@ gone — and each one comes with what it takes to judge it:
 | `stopped` | whether the session is parked — `session stop`, no pane |
 | `reports_as` | the agent the hook fields were read against, when a driver declared one |
 
-`state` is always a word: `unreported` when nothing has reported for
-this session, `uncovered` when its agent is wired to report nothing, and
-`stopped` when the session is parked. None of the three is a state an
-agent can signal, and `state_source` is null for all of them. The piped
-(TOON) `session list` shows this column.
+`state` is always a word, and one of `SessionState`'s — the single
+vocabulary `session get`, `session list`, `thurbox-cli watch` and the
+interface all derive through, so no two of them answer differently for
+one row. Besides the four an agent can signal it can read `unreported`
+(nothing has reported for this session), `uncovered` (its agent is wired
+to report nothing), `stopped` (the session is parked) or `running` (an
+agent holds the pane and has not signalled — `session get`'s probe only).
+None of those four is a state an agent can signal, and `state_source` is
+null for the first three. The piped (TOON) `session list` shows this
+column.
+
+A finished turn reads `done` until somebody looks at it and `idle`
+after: the interface stamps `seen_at` when focus moves off, and every
+read verb folds that in. It is a stored fact, not a guessed timeout —
+the two folds that *are* timing (a `working` session gone quiet, an
+unreachable host) need a live terminal, so headless answers never
+invent them.
 
 A **parked** session (`session stop`: pane killed, row and checkout
 kept) stays in `session list` and is told apart there — `stopped: true`

--- a/src/agent/backend.rs
+++ b/src/agent/backend.rs
@@ -709,7 +709,7 @@ pub struct Session {
     /// True for a **placeholder** session: a persisted remote session whose host
     /// is currently unreachable, so it has no live backend pane / reader / writer
     /// (its `input_tx` is a dead channel and its `parser` holds a static "host
-    /// unreachable" notice). Rendered with `SessionStatus::Unreachable` and
+    /// unreachable" notice). Rendered with `SessionState::Unreachable` and
     /// replaced in place by the real adopted session once the host recovers.
     ///
     /// **Unused in v2.** Its only caller was v1's remote-restore loop, which went
@@ -901,9 +901,10 @@ impl Session {
     /// writer loops are never spawned, `input_tx` is a dead channel (keystrokes
     /// are silently dropped), and the `parser` is seeded with a static notice.
     /// The row renders like any other (grouping/ordering/nesting all key off
-    /// `info`) but shows `SessionStatus::Unreachable` until the host recovers and
-    /// [`Self::adopt`] replaces it in place. `info.status` is forced to
-    /// `Unreachable` here regardless of the caller's value.
+    /// `info`) but shows [`SessionState::Unreachable`](crate::session::SessionState::Unreachable)
+    /// — derived from the attach failure by
+    /// [`with_reachability`](crate::session::with_reachability) — until the host
+    /// recovers and [`Self::adopt`] replaces it in place.
     pub fn placeholder(
         mut info: SessionInfo,
         rows: u16,
@@ -912,7 +913,6 @@ impl Session {
         provider: &Arc<dyn AgentProvider>,
         env: HashMap<String, String>,
     ) -> Self {
-        info.status = crate::session::SessionStatus::Unreachable;
         info.backend_id = None;
 
         let signals = SignalCells::new();

--- a/src/cli/home.rs
+++ b/src/cli/home.rs
@@ -63,19 +63,11 @@ pub fn run(db: &Database) -> Result<CommandOutput, String> {
     // Every state present is counted, the two silences included: a session
     // nothing can report for is exactly the one an agent orienting itself needs
     // told about, and rolling it into an unlisted `idle` hid it.
-    for state in [
-        "working",
-        "blocked",
-        "done",
-        "idle",
-        crate::session::STATE_RUNNING,
-        crate::session::STATE_UNCOVERED,
-        crate::session::STATE_UNREPORTED,
-        crate::session::STATE_STOPPED,
-    ] {
-        let n = rows.iter().filter(|r| r["state"] == json!(state)).count();
+    for state in crate::session::SessionState::ALL {
+        let word = state.as_str();
+        let n = rows.iter().filter(|r| r["state"] == json!(word)).count();
         if n > 0 {
-            totals.insert(state.into(), json!(n));
+            totals.insert(word.into(), json!(n));
         }
     }
 
@@ -153,7 +145,7 @@ fn suggestions(rows: &[Value], unread: usize, inside_session: bool) -> Vec<Strin
     // diagnostic is the difference between reading that as "at rest" and asking.
     if rows
         .iter()
-        .any(|r| r["state"] == json!(crate::session::STATE_UNCOVERED))
+        .any(|r| r["state"] == json!(crate::session::SessionState::Uncovered.as_str()))
     {
         help.push("thurbox-cli session doctor   why a session reports no state at all".to_string());
     }
@@ -204,7 +196,7 @@ fn human(rows: &[Value], unread: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::session::{SessionId, STATE_UNCOVERED, STATE_UNREPORTED};
+    use crate::session::{SessionId, SessionState};
     use crate::sync::SharedSession;
 
     fn session(name: &str, agent: &str) -> SharedSession {
@@ -284,8 +276,8 @@ mod tests {
         db.set_hook_state(busy.id, "blocked").unwrap();
 
         for (name, want) in [
-            ("quiet", STATE_UNREPORTED),
-            ("foreign", STATE_UNCOVERED),
+            ("quiet", SessionState::Unreported.as_str()),
+            ("foreign", SessionState::Uncovered.as_str()),
             ("busy", "blocked"),
         ] {
             assert_eq!(home_state(&db, name), want, "home view for {name}");
@@ -302,7 +294,10 @@ mod tests {
             .unwrap();
 
         let out = run(&db).unwrap();
-        assert_eq!(out.json["totals"][STATE_UNCOVERED], json!(1));
+        assert_eq!(
+            out.json["totals"][SessionState::Uncovered.as_str()],
+            json!(1)
+        );
         assert_eq!(out.json["totals"]["idle"], Value::Null);
         // And the help names the diagnostic, since the row looks calm and is
         // simply unknown.

--- a/src/cli/session_doctor.rs
+++ b/src/cli/session_doctor.rs
@@ -546,7 +546,7 @@ mod tests {
 
     #[test]
     fn an_agent_with_no_wiring_fails_and_says_how_to_wire_it() {
-        let hook = Assessment::from_hooks(&registry(), "mine", None, None, 0);
+        let hook = Assessment::from_hooks(&registry(), "mine", None, None, None, 0);
         let report = diagnose_agent(&row("s", "mine", "local-tmux"), &hook, true, Some("/bin/x"));
         assert_eq!(report.verdict, Level::Fail);
         assert_eq!(level_of(&report, "coverage"), Level::Fail);
@@ -568,7 +568,8 @@ mod tests {
         // wired nothing) and reports state itself through the documented
         // `session signal`. State is demonstrably arriving, so a `fail` verdict
         // — and the non-zero exit with it — would be false for this row.
-        let hook = Assessment::from_hooks(&registry(), "shell", Some("working"), Some(0), 5_000);
+        let hook =
+            Assessment::from_hooks(&registry(), "shell", Some("working"), Some(0), None, 5_000);
         let report = diagnose_agent(
             &row("s", "shell", "local-tmux"),
             &hook,
@@ -592,7 +593,7 @@ mod tests {
         // Every hook command is `… || true`, so a `thurbox-cli` that is not on
         // PATH looks exactly like an agent that has not signalled. This is the
         // whole reason the subcommand exists.
-        let hook = Assessment::from_hooks(&registry(), "claude", Some("working"), Some(0), 0);
+        let hook = Assessment::from_hooks(&registry(), "claude", Some("working"), Some(0), None, 0);
         let report = diagnose_agent(&row("s", "claude", "local-tmux"), &hook, true, None);
         assert_eq!(level_of(&report, "cli"), Level::Fail);
         assert_eq!(report.verdict, Level::Fail);
@@ -600,7 +601,7 @@ mod tests {
 
     #[test]
     fn a_deactivated_extension_is_a_failure_not_a_silence() {
-        let hook = Assessment::from_hooks(&registry(), "claude", None, None, 0);
+        let hook = Assessment::from_hooks(&registry(), "claude", None, None, None, 0);
         let report = diagnose_agent(&row("s", "claude", "local-tmux"), &hook, false, Some("/x"));
         assert_eq!(level_of(&report, "extension"), Level::Fail);
     }
@@ -609,7 +610,7 @@ mod tests {
     fn a_partial_agent_warns_without_failing() {
         // aider can only ever report `blocked`; that is a fact to know, not
         // breakage to fix, so it must not exit non-zero forever.
-        let hook = Assessment::from_hooks(&registry(), "aider", None, None, 0);
+        let hook = Assessment::from_hooks(&registry(), "aider", None, None, None, 0);
         let report = diagnose_agent(&row("s", "aider", "local-tmux"), &hook, true, Some("/x"));
         assert_eq!(level_of(&report, "coverage"), Level::Warn);
         assert_ne!(report.verdict, Level::Fail);
@@ -620,8 +621,9 @@ mod tests {
     #[test]
     fn a_pane_that_disagrees_is_called_out() {
         let known = vec!["claude".to_string()];
-        let hook = Assessment::from_hooks(&registry(), "claude", Some("working"), Some(0), 1_000)
-            .with_pane("claude", &known, Some("bash"), Some("bash"), Some(false));
+        let hook =
+            Assessment::from_hooks(&registry(), "claude", Some("working"), Some(0), None, 1_000)
+                .with_pane("claude", &known, Some("bash"), Some("bash"), Some(false));
         let report = diagnose_agent(&row("s", "claude", "local-tmux"), &hook, true, Some("/x"));
         assert_eq!(level_of(&report, "pane"), Level::Warn);
         let detail = &report
@@ -638,8 +640,9 @@ mod tests {
         // Its payload lives on the host — either the host's own hooks
         // extension's business or shipped at spawn — and neither is readable
         // here. Reporting a local file as missing would be a false failure.
-        let hook = Assessment::from_hooks(&registry(), "claude", Some("done"), Some(0), 1_000)
-            .pane_unavailable();
+        let hook =
+            Assessment::from_hooks(&registry(), "claude", Some("done"), Some(0), None, 1_000)
+                .pane_unavailable();
         let report = diagnose_agent(&row("s", "claude", "ssh:devbox"), &hook, true, Some("/x"));
         assert_eq!(level_of(&report, "payload"), Level::Warn);
         assert_eq!(level_of(&report, "cli"), Level::Warn);
@@ -653,7 +656,7 @@ mod tests {
         // named after the command's file stem. There is no wiring here to be
         // broken, and failing it made bare `doctor` — which diagnoses every
         // active session — fail the whole machine because one shell existed.
-        let hook = Assessment::from_hooks(&registry(), "bash", None, None, 0);
+        let hook = Assessment::from_hooks(&registry(), "bash", None, None, None, 0);
         let report = diagnose(
             &row("task-7", "bash", "local-tmux"),
             false,
@@ -678,7 +681,7 @@ mod tests {
         // so. Judging the wiring against `bash` reported coverage `none` for a
         // fully instrumented pane — and, worse, `blocked_is_heuristic: false`
         // about claude's text match on a notification body.
-        let hook = Assessment::from_hooks(&registry(), "claude", Some("working"), Some(0), 0);
+        let hook = Assessment::from_hooks(&registry(), "claude", Some("working"), Some(0), None, 0);
         let report = diagnose(
             &row("task-7", "bash", "local-tmux"),
             true,
@@ -702,7 +705,8 @@ mod tests {
         // to this one already answers `stopped` first; this one did not, and
         // printed the dead agent's last word as the current state.
         let hook =
-            Assessment::from_hooks(&registry(), "claude", Some("blocked"), Some(0), 1_000).parked();
+            Assessment::from_hooks(&registry(), "claude", Some("blocked"), Some(0), None, 1_000)
+                .parked();
         let report = diagnose_agent(
             &row("parked", "claude", "local-tmux"),
             &hook,
@@ -726,7 +730,7 @@ mod tests {
         // command session runs the binary, so its absence cannot be what stops
         // state arriving — it is still worth saying, because a driver calling
         // `session signal` from the pane needs it.
-        let hook = Assessment::from_hooks(&registry(), "bash", None, None, 0);
+        let hook = Assessment::from_hooks(&registry(), "bash", None, None, None, 0);
         let report = diagnose(&row("s", "bash", "local-tmux"), false, &hook, true, None);
         assert_eq!(level_of(&report, "cli"), Level::Warn);
         assert_ne!(report.verdict, Level::Fail);
@@ -734,7 +738,8 @@ mod tests {
         // A registry agent thurbox ships no hooks for is the other way round:
         // its driver's `session signal` is the only route state can take, so a
         // binary that is not on PATH really is what breaks it.
-        let owned = Assessment::from_hooks(&registry(), "shell", Some("working"), Some(0), 5_000);
+        let owned =
+            Assessment::from_hooks(&registry(), "shell", Some("working"), Some(0), None, 5_000);
         let report = diagnose_agent(&row("s", "shell", "local-tmux"), &owned, true, None);
         assert_eq!(level_of(&report, "cli"), Level::Fail);
     }
@@ -745,8 +750,9 @@ mod tests {
         // provisioned one under the data dir), nothing named `thurbox-cli` is
         // on PATH. That says nothing about a session whose hooks fire on
         // another host, so it must not turn into a failure.
-        let hook = Assessment::from_hooks(&registry(), "claude", Some("done"), Some(0), 1_000)
-            .pane_unavailable();
+        let hook =
+            Assessment::from_hooks(&registry(), "claude", Some("done"), Some(0), None, 1_000)
+                .pane_unavailable();
         let report = diagnose_agent(&row("s", "claude", "ssh:devbox"), &hook, true, None);
         assert_eq!(level_of(&report, "cli"), Level::Warn);
         assert_ne!(report.verdict, Level::Fail);

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -31,6 +31,17 @@ pub enum Action {
     /// `session stop`. A parked session stays in this list and carries
     /// `stopped: true`, so a driver can tell one from a running session
     /// without probing its pane.
+    ///
+    /// **Unprobed fields are null, and null means "not checked".** Without
+    /// `--verify` the pane is never looked at, so `hook_corroboration`,
+    /// `hook_state_contradicted` and `foreground_process`/`foreground_command`
+    /// are all `null` — *unchecked*, which is a different answer from
+    /// `false`/"nothing found" (a remote session, which has no pane to look at
+    /// from here, says `hook_corroboration: "unavailable"` instead). For the
+    /// same reason a session nothing has ever signalled for reads `unreported`
+    /// / `uncovered` here where `session get` reads `running`: only the probe
+    /// can see an agent thurbox never launched. `--verify` gives this listing
+    /// `get`'s answer at `get`'s cost, per session.
     List {
         /// Only list children of this parent session UUID.
         #[arg(long)]
@@ -42,7 +53,9 @@ pub enum Action {
         /// Also check each session's pane against its reported state.
         ///
         /// Off by default because it costs a multiplexer query and a `ps` **per
-        /// session**; `session get` does it for one session without asking.
+        /// session**; `session get` does it for one session without asking, and
+        /// a mirroring peer lists a whole host every pass. The fields it fills
+        /// are `null` without it — see the command's own help.
         #[arg(long)]
         verify: bool,
     },
@@ -678,10 +691,10 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, CommandError>
                 reports_as.as_deref().unwrap_or(&res.agent),
                 None,
                 None,
+                None,
                 0,
             )
-            .state_word()
-            .to_string();
+            .state_word();
             // A host driven from afar has no interface of its own to arm the
             // heartbeat: this creation is the moment its sessions start needing
             // the tick (status polls, extension self-heal, reaping).
@@ -1925,6 +1938,7 @@ impl SessionFacts {
             agent,
             row.and_then(|r| r.state.as_deref()),
             row.and_then(|r| r.state_at),
+            row.and_then(|r| r.seen_at),
             crate::sync::current_time_millis() as i64,
         );
         if self.parked.contains(&s.id) {

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -35,7 +35,7 @@ use serde_json::{json, Value};
 use crate::cli::output::Format;
 use crate::cli::CommandError;
 use crate::session::{Assessment, SessionId};
-use crate::storage::{Database, SessionEventRow, SessionFacts};
+use crate::storage::{Database, HookRow, SessionEventRow, SessionFacts};
 
 /// How often the change gate is checked. A `PRAGMA data_version` on an open
 /// connection is a memory read, not a query — this is a latency choice, not a
@@ -118,12 +118,11 @@ pub fn run(db: &Database, args: WatchArgs, format: Format) -> Result<(), Command
             let Some(facts) = facts.get(&session.id) else {
                 continue;
             };
-            let row = states.get(&session.id);
+            let row = states.get(&session.id).cloned().unwrap_or_default();
             let hook = assess(
                 &registry,
                 facts,
-                row.and_then(|r| r.state.as_deref()),
-                row.and_then(|r| r.state_at),
+                &row,
                 facts.stopped,
                 args.verify,
                 &session.backend_type,
@@ -255,6 +254,12 @@ fn drain(
 /// re-reading the row would report the later one twice. `stopped` is likewise
 /// the mark as of *this* event ([`drain`]'s `stopped_state`), not the row's
 /// current one.
+///
+/// `seen_at` is the exception, and deliberately the row's: the acknowledgment
+/// is a fact about *now* ("somebody has looked at this since"), so a replayed
+/// `done` an operator has since read reports `idle` — the same answer `session
+/// get` gives for that row in that second. `to_state` still carries the event's
+/// own word verbatim, so nothing about the transition is lost.
 fn line(
     db: &Database,
     registry: &crate::session::AgentRegistry,
@@ -268,6 +273,7 @@ fn line(
         agent: String::new(),
         backend_id: String::new(),
         stopped: false,
+        seen_at: None,
     };
     let facts = facts.get(&event.session_id).unwrap_or(&unknown);
     // Only the pane probe needs the backend, and only a live row has a pane to
@@ -281,8 +287,11 @@ fn line(
     let hook = assess(
         registry,
         facts,
-        event.to_state.as_deref(),
-        Some(event.at_ms),
+        &HookRow {
+            state: event.to_state.clone(),
+            state_at: Some(event.at_ms),
+            seen_at: facts.seen_at,
+        },
         stopped,
         probe,
         &backend_type,
@@ -344,8 +353,7 @@ fn base(id: SessionId, facts: &SessionFacts, hook: &Assessment) -> Value {
 fn assess(
     registry: &crate::session::AgentRegistry,
     facts: &SessionFacts,
-    state: Option<&str>,
-    state_at: Option<i64>,
+    columns: &HookRow,
     stopped: bool,
     verify: bool,
     backend_type: &str,
@@ -353,8 +361,9 @@ fn assess(
     let hook = Assessment::from_hooks(
         registry,
         &facts.agent,
-        state,
-        state_at,
+        columns.state.as_deref(),
+        columns.state_at,
+        columns.seen_at,
         crate::sync::current_time_millis() as i64,
     );
     if stopped {

--- a/src/coordinator/mod.rs
+++ b/src/coordinator/mod.rs
@@ -236,7 +236,7 @@ impl App {
             .current()
             .sessions
             .iter()
-            .any(|row| row.status == "working")
+            .any(|row| row.status == thurbox::session::SessionState::Working)
             || self.commands.has_inflight()
             // The creation flow spins over the repo store's reads too, and it
             // is a pure pane: without the clock its "listing…"/"fetching…"

--- a/src/kernel/events.rs
+++ b/src/kernel/events.rs
@@ -245,7 +245,7 @@ struct Facts {
     agent: String,
     repo: Option<String>,
     repos: Vec<String>,
-    status: String,
+    status: crate::session::SessionState,
     branch: Option<String>,
     parent: Option<String>,
 }
@@ -257,7 +257,7 @@ impl Facts {
             agent: row.agent.clone(),
             repo: row.repo.clone(),
             repos: row.repos.clone(),
-            status: row.status.clone(),
+            status: row.status,
             branch: row.branch.clone(),
             parent: row.parent_id.clone(),
         }
@@ -382,14 +382,15 @@ impl Deriver {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::session::SessionState;
     use std::path::PathBuf;
 
-    fn row(id: &str, status: &str) -> SessionRow {
+    fn row(id: &str, status: SessionState) -> SessionRow {
         SessionRow {
             id: id.to_string(),
             name: format!("name-{id}"),
             agent: "claude".into(),
-            status: status.into(),
+            status,
             cwd: Some(PathBuf::from("/src/thurbox")),
             repo: Some("thurbox".into()),
             repos: vec!["thurbox".into()],
@@ -420,25 +421,37 @@ mod tests {
     #[test]
     fn the_first_snapshot_seeds_silently() {
         let mut deriver = Deriver::new();
-        let events = deriver.observe(&snapshot(vec![row("a", "idle"), row("b", "working")]), 1);
+        let events = deriver.observe(
+            &snapshot(vec![
+                row("a", SessionState::Idle),
+                row("b", SessionState::Working),
+            ]),
+            1,
+        );
         assert!(events.is_empty(), "{events:?}");
     }
 
     #[test]
     fn an_unchanged_version_costs_nothing_and_says_nothing() {
         let mut deriver = Deriver::new();
-        deriver.observe(&snapshot(vec![row("a", "idle")]), 1);
+        deriver.observe(&snapshot(vec![row("a", SessionState::Idle)]), 1);
         assert!(deriver.observe(&snapshot(vec![]), 1).is_empty());
     }
 
     #[test]
     fn arrivals_departures_and_changes_each_fire_once_in_order() {
         let mut deriver = Deriver::new();
-        deriver.observe(&snapshot(vec![row("a", "idle"), row("b", "working")]), 1);
-        let mut renamed = row("a", "blocked");
+        deriver.observe(
+            &snapshot(vec![
+                row("a", SessionState::Idle),
+                row("b", SessionState::Working),
+            ]),
+            1,
+        );
+        let mut renamed = row("a", SessionState::Blocked);
         renamed.name = "renamed".into();
         renamed.branch = Some("other".into());
-        let events = deriver.observe(&snapshot(vec![renamed, row("c", "idle")]), 2);
+        let events = deriver.observe(&snapshot(vec![renamed, row("c", SessionState::Idle)]), 2);
         let names: Vec<&str> = events.iter().map(|e| e.name.as_str()).collect();
         assert_eq!(
             names,
@@ -469,10 +482,10 @@ mod tests {
     #[test]
     fn a_reset_makes_the_next_snapshot_seed_again() {
         let mut deriver = Deriver::new();
-        deriver.observe(&snapshot(vec![row("a", "idle")]), 1);
+        deriver.observe(&snapshot(vec![row("a", SessionState::Idle)]), 1);
         deriver.reset();
         assert!(deriver
-            .observe(&snapshot(vec![row("b", "idle")]), 2)
+            .observe(&snapshot(vec![row("b", SessionState::Idle)]), 2)
             .is_empty());
     }
 

--- a/src/kernel/host/publish.rs
+++ b/src/kernel/host/publish.rs
@@ -647,11 +647,7 @@ fn build_sessions(
             "status",
             to_lua_string(
                 lua,
-                &crate::kernel::snapshot::with_reachability(
-                    &row.status,
-                    &row.backend,
-                    attach_error,
-                ),
+                crate::session::with_reachability(row.status, &row.backend, attach_error).as_str(),
             )?,
         )?;
         set(&entry, "backend", to_lua_string(lua, &row.backend)?)?;

--- a/src/kernel/notify.rs
+++ b/src/kernel/notify.rs
@@ -20,12 +20,7 @@ use std::time::{Duration, Instant};
 
 use super::snapshot::{SessionRow, Snapshot};
 use crate::session::settings::NotificationSettings;
-
-/// Status that means the agent is waiting on the user.
-const BLOCKED: &str = "blocked";
-/// Status that means a turn just finished — the other edge worth notifying on,
-/// and the one that is off by default.
-const DONE: &str = "done";
+use crate::session::SessionState;
 
 /// Watches for sessions becoming blocked and raises one notification each time.
 pub struct Notifier {
@@ -33,7 +28,7 @@ pub struct Notifier {
     /// in which case nothing is ever attempted — not even a resolve.
     sender: Option<crate::notifications::NotificationSender>,
     /// Last status seen per session, so a transition can be told from a state.
-    previous: HashMap<String, String>,
+    previous: HashMap<String, SessionState>,
     /// When each session last had a notification raised for it, for the
     /// per-session floor.
     last_raised: HashMap<String, Instant>,
@@ -85,12 +80,12 @@ impl Notifier {
         let floor = Duration::from_secs(self.settings.min_interval_secs);
 
         for row in &snapshot.sessions {
-            let was = self.previous.insert(row.id.clone(), row.status.clone());
+            let was = self.previous.insert(row.id.clone(), row.status);
 
             // The *edge*, not the state: a session that is already blocked when
             // the interface starts has not just asked for anything.
             let Some(previous) = was else { continue };
-            if previous == row.status || !self.worth_raising(&previous, row, active) {
+            if previous == row.status || !self.worth_raising(previous, row, active) {
                 continue;
             }
             // The floor is per session: an agent flipping between states must not
@@ -121,9 +116,16 @@ impl Notifier {
     /// Blocked always notifies; finishing does so only when asked for. A
     /// notification for the session you are already looking at is noise, so it is
     /// suppressed when configured.
-    fn worth_raising(&self, previous: &str, row: &SessionRow, active: Option<&str>) -> bool {
-        let wanted = row.status == BLOCKED
-            || (row.status == DONE && self.settings.also_on_waiting && previous != BLOCKED);
+    fn worth_raising(
+        &self,
+        previous: SessionState,
+        row: &SessionRow,
+        active: Option<&str>,
+    ) -> bool {
+        let wanted = row.status == SessionState::Blocked
+            || (row.status == SessionState::Done
+                && self.settings.also_on_waiting
+                && previous != SessionState::Blocked);
         if !wanted {
             return false;
         }
@@ -139,7 +141,7 @@ impl Notifier {
         else {
             return;
         };
-        let blocked = row.status == BLOCKED;
+        let blocked = row.status == SessionState::Blocked;
         let (title, body) = match blocked {
             true => (
                 format!("{} needs you", row.name),
@@ -164,12 +166,12 @@ mod tests {
     use super::*;
     use crate::kernel::snapshot::SessionRow;
 
-    fn row(id: &str, status: &str) -> SessionRow {
+    fn row(id: &str, status: SessionState) -> SessionRow {
         SessionRow {
             id: id.into(),
             name: "demo".into(),
             agent: "claude".into(),
-            status: status.into(),
+            status,
             cwd: None,
             repo: None,
             repos: Vec::new(),
@@ -221,25 +223,25 @@ mod tests {
         // First sight of a blocked session is not a transition: it may have
         // been blocked long before the interface opened.
         assert!(notifier
-            .observe(&snap(vec![row("a", "blocked")]), None)
+            .observe(&snap(vec![row("a", SessionState::Blocked)]), None)
             .is_empty());
         // Still blocked: nothing new.
         assert!(notifier
-            .observe(&snap(vec![row("a", "blocked")]), None)
+            .observe(&snap(vec![row("a", SessionState::Blocked)]), None)
             .is_empty());
     }
 
     #[test]
     fn becoming_blocked_raises_exactly_one() {
         let mut notifier = quiet(false);
-        notifier.observe(&snap(vec![row("a", "working")]), None);
+        notifier.observe(&snap(vec![row("a", SessionState::Working)]), None);
         assert_eq!(
-            notifier.observe(&snap(vec![row("a", "blocked")]), None),
+            notifier.observe(&snap(vec![row("a", SessionState::Blocked)]), None),
             vec!["a".to_string()]
         );
         // And not again while it stays blocked.
         assert!(notifier
-            .observe(&snap(vec![row("a", "blocked")]), None)
+            .observe(&snap(vec![row("a", SessionState::Blocked)]), None)
             .is_empty());
     }
 
@@ -249,12 +251,12 @@ mod tests {
         // is about the edge.
         let mut notifier = quiet(false);
         let start = Instant::now();
-        notifier.observe_at(&snap(vec![row("a", "working")]), None, start);
-        notifier.observe_at(&snap(vec![row("a", "blocked")]), None, start);
-        notifier.observe_at(&snap(vec![row("a", "working")]), None, start);
+        notifier.observe_at(&snap(vec![row("a", SessionState::Working)]), None, start);
+        notifier.observe_at(&snap(vec![row("a", SessionState::Blocked)]), None, start);
+        notifier.observe_at(&snap(vec![row("a", SessionState::Working)]), None, start);
         let later = start + Duration::from_secs(60);
         assert_eq!(
-            notifier.observe_at(&snap(vec![row("a", "blocked")]), None, later),
+            notifier.observe_at(&snap(vec![row("a", SessionState::Blocked)]), None, later),
             vec!["a".to_string()]
         );
     }
@@ -268,24 +270,24 @@ mod tests {
             ..NotificationSettings::default()
         });
         let start = Instant::now();
-        notifier.observe_at(&snap(vec![row("a", "working")]), None, start);
+        notifier.observe_at(&snap(vec![row("a", SessionState::Working)]), None, start);
         assert_eq!(
-            notifier.observe_at(&snap(vec![row("a", "blocked")]), None, start),
+            notifier.observe_at(&snap(vec![row("a", SessionState::Blocked)]), None, start),
             vec!["a".to_string()]
         );
-        notifier.observe_at(&snap(vec![row("a", "working")]), None, start);
+        notifier.observe_at(&snap(vec![row("a", SessionState::Working)]), None, start);
         assert!(notifier
             .observe_at(
-                &snap(vec![row("a", "blocked")]),
+                &snap(vec![row("a", SessionState::Blocked)]),
                 None,
                 start + Duration::from_secs(29)
             )
             .is_empty());
         // And delivered again once the floor has passed.
-        notifier.observe_at(&snap(vec![row("a", "working")]), None, start);
+        notifier.observe_at(&snap(vec![row("a", SessionState::Working)]), None, start);
         assert_eq!(
             notifier.observe_at(
-                &snap(vec![row("a", "blocked")]),
+                &snap(vec![row("a", SessionState::Blocked)]),
                 None,
                 start + Duration::from_secs(31)
             ),
@@ -302,13 +304,19 @@ mod tests {
         });
         let start = Instant::now();
         notifier.observe_at(
-            &snap(vec![row("a", "working"), row("b", "working")]),
+            &snap(vec![
+                row("a", SessionState::Working),
+                row("b", SessionState::Working),
+            ]),
             None,
             start,
         );
         assert_eq!(
             notifier.observe_at(
-                &snap(vec![row("a", "blocked"), row("b", "working")]),
+                &snap(vec![
+                    row("a", SessionState::Blocked),
+                    row("b", SessionState::Working)
+                ]),
                 None,
                 start
             ),
@@ -316,7 +324,10 @@ mod tests {
         );
         assert_eq!(
             notifier.observe_at(
-                &snap(vec![row("a", "blocked"), row("b", "blocked")]),
+                &snap(vec![
+                    row("a", SessionState::Blocked),
+                    row("b", SessionState::Blocked)
+                ]),
                 None,
                 start
             ),
@@ -327,9 +338,10 @@ mod tests {
     #[test]
     fn finishing_notifies_only_when_it_is_asked_for() {
         let mut off = quiet(false);
-        off.observe(&snap(vec![row("a", "working")]), None);
+        off.observe(&snap(vec![row("a", SessionState::Working)]), None);
         assert!(
-            off.observe(&snap(vec![row("a", "done")]), None).is_empty(),
+            off.observe(&snap(vec![row("a", SessionState::Done)]), None)
+                .is_empty(),
             "the finish edge is off by default"
         );
 
@@ -337,9 +349,9 @@ mod tests {
             also_on_waiting: true,
             ..NotificationSettings::default()
         });
-        on.observe(&snap(vec![row("a", "working")]), None);
+        on.observe(&snap(vec![row("a", SessionState::Working)]), None);
         assert_eq!(
-            on.observe(&snap(vec![row("a", "done")]), None),
+            on.observe(&snap(vec![row("a", SessionState::Done)]), None),
             vec!["a".to_string()]
         );
     }
@@ -352,9 +364,9 @@ mod tests {
             also_on_waiting: true,
             ..NotificationSettings::default()
         });
-        notifier.observe(&snap(vec![row("a", "blocked")]), None);
+        notifier.observe(&snap(vec![row("a", SessionState::Blocked)]), None);
         assert!(notifier
-            .observe(&snap(vec![row("a", "done")]), None)
+            .observe(&snap(vec![row("a", SessionState::Done)]), None)
             .is_empty());
     }
 
@@ -372,16 +384,16 @@ mod tests {
     #[test]
     fn the_session_in_view_is_suppressed_when_configured() {
         let mut notifier = quiet(true);
-        notifier.observe(&snap(vec![row("a", "working")]), Some("a"));
+        notifier.observe(&snap(vec![row("a", SessionState::Working)]), Some("a"));
         assert!(notifier
-            .observe(&snap(vec![row("a", "blocked")]), Some("a"))
+            .observe(&snap(vec![row("a", SessionState::Blocked)]), Some("a"))
             .is_empty());
 
         // And not suppressed when it is some other session in view.
         let mut notifier = quiet(true);
-        notifier.observe(&snap(vec![row("a", "working")]), Some("b"));
+        notifier.observe(&snap(vec![row("a", SessionState::Working)]), Some("b"));
         assert_eq!(
-            notifier.observe(&snap(vec![row("a", "blocked")]), Some("b")),
+            notifier.observe(&snap(vec![row("a", SessionState::Blocked)]), Some("b")),
             vec!["a".to_string()]
         );
     }
@@ -395,13 +407,13 @@ mod tests {
     #[test]
     fn a_vanished_session_stops_being_tracked() {
         let mut notifier = quiet(false);
-        notifier.observe(&snap(vec![row("a", "working")]), None);
+        notifier.observe(&snap(vec![row("a", SessionState::Working)]), None);
         notifier.observe(&snap(Vec::new()), None);
         assert!(notifier.previous.is_empty());
 
         // So a recreated id is a first sighting again, not a transition.
         assert!(notifier
-            .observe(&snap(vec![row("a", "blocked")]), None)
+            .observe(&snap(vec![row("a", SessionState::Blocked)]), None)
             .is_empty());
     }
 }

--- a/src/kernel/reaper.rs
+++ b/src/kernel/reaper.rs
@@ -69,7 +69,7 @@ mod tests {
             id: id.into(),
             name: id.into(),
             agent: "claude".into(),
-            status: "idle".into(),
+            status: crate::session::SessionState::Idle,
             cwd: None,
             repo: None,
             repos: Vec::new(),

--- a/src/kernel/snapshot.rs
+++ b/src/kernel/snapshot.rs
@@ -14,7 +14,7 @@
 use std::path::PathBuf;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use crate::session::SessionId;
+use crate::session::{derive_state, with_output_quiescence, SessionId, SessionState};
 use crate::storage::Database;
 
 /// How often the snapshot is rebuilt. A read never waits on this; it only
@@ -49,8 +49,10 @@ pub struct SessionRow {
     pub id: String,
     pub name: String,
     pub agent: String,
-    /// `working` / `blocked` / `done` / `idle` — derived below, not raw.
-    pub status: String,
+    /// What to draw, derived from the hook columns and the terminal by
+    /// [`crate::session::SessionState`]'s read-time folds — never the raw
+    /// column, which is [`Self::hook_state`].
+    pub status: SessionState,
     pub cwd: Option<PathBuf>,
     pub repo: Option<String>,
     /// Every repository the session spans, in member order — one entry for a
@@ -101,7 +103,7 @@ pub struct SessionRow {
     /// very thing the operator asked for. Nothing distinguishes the two but
     /// this flag, which is why it is published rather than derived.
     pub stopped: bool,
-    /// The raw persisted hook state, before `derive_status` interprets it.
+    /// The raw persisted hook state, before [`derive_state`] interprets it.
     ///
     /// Kept beside the derived `status` because the two answer different
     /// questions: `status` is what to draw, this is what the agent last
@@ -579,8 +581,8 @@ impl SnapshotStore {
     ///
     /// Called when focus *leaves* a session — looking at a finished turn and then
     /// moving on is what "seen" means, and it is the only thing that retires a
-    /// `done`. Without it the blue dot is permanent, since `derive_status` reads
-    /// a mark nobody writes.
+    /// `done`. Without it the blue dot is permanent, since [`derive_state`]
+    /// reads a mark nobody writes.
     ///
     /// The derived status is corrected in place as well: this write does not move
     /// `PRAGMA data_version` (it is our own connection), so a refresh would
@@ -611,7 +613,7 @@ impl SnapshotStore {
             .iter_mut()
             .find(|row| row.id == session)
         {
-            row.status = "idle".to_string();
+            row.status = SessionState::Idle;
             self.mark_changed();
         }
     }
@@ -688,7 +690,7 @@ impl SnapshotStore {
             // Corrected in place for the same reason `acknowledge` does it: this
             // is our own connection, so `PRAGMA data_version` will not move and a
             // refresh would re-derive from the row we just wrote.
-            row.status = derive_status(Some(&event.state), Some(now_ms()), None);
+            row.status = derive_state(Some(&event.state), Some(now_ms()), None);
             row.hook_state = Some(event.state);
             applied += 1;
         }
@@ -720,7 +722,7 @@ impl SnapshotStore {
             if row.hook_state.as_deref() != Some("working") {
                 continue;
             }
-            let derived = with_output_quiescence("working", quiet_for(&row.id));
+            let derived = with_output_quiescence(SessionState::Working, quiet_for(&row.id));
             if row.status != derived {
                 row.status = derived;
                 changed += 1;
@@ -885,7 +887,7 @@ impl SnapshotStore {
             .into_iter()
             .map(|session| {
                 let hook = hooks.get(&session.id);
-                let status = derive_status(
+                let status = derive_state(
                     hook.and_then(|h| h.state.as_deref()),
                     hook.and_then(|h| h.state_at),
                     hook.and_then(|h| h.seen_at),
@@ -1085,83 +1087,6 @@ fn read_hosts() -> Vec<HostRow> {
         .collect()
 }
 
-/// Map the persisted hook state onto a status name.
-///
-/// The stuck-`working` fallback is deliberately **not** here: it is a question
-/// about the terminal, not the row, so it belongs to the per-frame fold in
-/// [`with_output_quiescence`]. The stored row is never touched — every rule in
-/// this file is a read-time decision, exactly as v1 does it.
-pub fn derive_status(state: Option<&str>, state_at: Option<i64>, seen_at: Option<i64>) -> String {
-    match state {
-        Some("working") => "working".to_string(),
-        Some("blocked") => "blocked".to_string(),
-        Some("done") => {
-            // Acknowledged once the user moved off it, which v1 records by
-            // stamping seen_at at or after the state change.
-            let acknowledged = match (seen_at, state_at) {
-                (Some(seen), Some(at)) => seen >= at,
-                _ => false,
-            };
-            if acknowledged {
-                "idle".to_string()
-            } else {
-                "done".to_string()
-            }
-        }
-        _ => "idle".to_string(),
-    }
-}
-
-/// How long a `working` session may produce **no terminal output** before it is
-/// reported as idle. v1 uses the same 10s bound.
-///
-/// The signal is output, not the age of the hook state, and the difference is
-/// the whole point: a turn that runs for a minute is still `working` the whole
-/// minute, because the agent is printing throughout. Keying on the hook's
-/// timestamp instead ends every turn after ten seconds and starts it again at
-/// the next hook — a spinner that stops early and restarts, which is precisely
-/// what the fallback exists to avoid.
-const WORKING_QUIET_MS: u64 = 10_000;
-
-/// Fold terminal quiescence into a `working` session's status.
-///
-/// Agents fire no hook when a turn is **interrupted** (Esc / Ctrl+C) and none
-/// when they return to the idle prompt, so a `working` state can stand forever
-/// with nothing running behind it. TUI agents animate their in-progress line
-/// while a turn runs (Claude's `(Xs · esc to interrupt)` ticks every second), so
-/// a genuinely live turn is never quiet for `WORKING_QUIET_MS` and only the
-/// stuck state falls through.
-///
-/// `quiet_for_ms` is `None` when the session has no live pane — nothing can be
-/// producing output, so that reads as quiet too. This is where v1's `exited →
-/// Idle` branch lands: a pane whose stream ended is dropped from the live set.
-/// Only `working` is time-gated; `blocked` is a standing request for input and
-/// says nothing about output.
-pub fn with_output_quiescence(status: &str, quiet_for_ms: Option<u64>) -> String {
-    if status == "working" && quiet_for_ms.unwrap_or(u64::MAX) > WORKING_QUIET_MS {
-        return "idle".to_string();
-    }
-    status.to_string()
-}
-
-/// Fold what the terminal store knows into a session's status.
-///
-/// The hook state says what the *agent* is doing; it cannot say that the machine
-/// the agent runs on has gone away, because a host that is down reports nothing
-/// at all — it just leaves the last state standing. So a remote session with no
-/// live pane reads `unreachable` rather than the stale `idle` its row still
-/// carries, which is v1's placeholder row by another name.
-///
-/// Local sessions are never unreachable: this *is* their machine, and a missing
-/// pane there means the agent has not been launched, not that it cannot be
-/// reached.
-pub fn with_reachability(status: &str, backend: &str, attach_error: Option<&str>) -> String {
-    if attach_error.is_some() && crate::session::is_remote_backend(backend) {
-        return "unreachable".to_string();
-    }
-    status.to_string()
-}
-
 /// A remote session's bare host name, read off its backend name.
 fn remote_host_of(backend: &str) -> Option<String> {
     backend
@@ -1254,80 +1179,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn an_unreported_session_is_idle() {
-        assert_eq!(derive_status(None, None, None), "idle");
-        assert_eq!(derive_status(Some("unknown"), None, None), "idle");
-    }
-
-    #[test]
-    fn a_fresh_working_state_is_working() {
-        let now = now_ms();
-        assert_eq!(derive_status(Some("working"), Some(now), None), "working");
-    }
-
-    #[test]
-    fn a_long_turn_stays_working_however_old_its_hook_is() {
-        // The regression this guards: keyed on the hook's own timestamp, every
-        // turn reported itself finished ten seconds in and started again at the
-        // next hook — a spinner that stopped early and restarted. How long ago
-        // the agent said "working" says nothing about whether it still is.
-        let long_ago = now_ms() - 600_000;
-        assert_eq!(
-            derive_status(Some("working"), Some(long_ago), None),
-            "working"
-        );
-    }
-
-    #[test]
-    fn a_quiet_working_session_falls_back_to_idle() {
-        // Agents fire no hook on interrupt, so without this a cancelled turn
-        // would spin forever. v1 guards the same way, on the same signal.
-        assert_eq!(
-            with_output_quiescence("working", Some(WORKING_QUIET_MS + 1)),
-            "idle"
-        );
-    }
-
-    #[test]
-    fn a_printing_working_session_stays_working() {
-        assert_eq!(with_output_quiescence("working", Some(0)), "working");
-        assert_eq!(
-            with_output_quiescence("working", Some(WORKING_QUIET_MS)),
-            "working"
-        );
-    }
-
-    #[test]
-    fn a_working_session_with_no_live_pane_is_idle() {
-        // Nothing can be producing output, which is where v1's exited → Idle
-        // branch lands: a pane whose stream ended leaves the live set.
-        assert_eq!(with_output_quiescence("working", None), "idle");
-    }
-
-    #[test]
-    fn blocked_is_never_time_gated() {
-        let long_ago = now_ms() - 600_000;
-        assert_eq!(
-            derive_status(Some("blocked"), Some(long_ago), None),
-            "blocked"
-        );
-        // A session waiting on you produces no output while it waits.
-        assert_eq!(with_output_quiescence("blocked", None), "blocked");
-        assert_eq!(
-            with_output_quiescence("done", Some(WORKING_QUIET_MS * 10)),
-            "done"
-        );
-    }
-
-    #[test]
-    fn done_stays_done_until_acknowledged() {
-        let at = now_ms();
-        assert_eq!(derive_status(Some("done"), Some(at), None), "done");
-        assert_eq!(derive_status(Some("done"), Some(at), Some(at - 1)), "done");
-        assert_eq!(derive_status(Some("done"), Some(at), Some(at)), "idle");
-    }
-
-    #[test]
     fn a_remote_backend_yields_its_host_name() {
         assert_eq!(remote_host_of("ssh:devbox").as_deref(), Some("devbox"));
         assert_eq!(remote_host_of("wsl:Ubuntu").as_deref(), Some("Ubuntu"));
@@ -1361,35 +1212,6 @@ mod tests {
         for _ in 0..1000 {
             assert!(store.current().sessions.is_empty());
         }
-    }
-
-    #[test]
-    fn a_reachable_session_keeps_the_status_its_hooks_reported() {
-        assert_eq!(with_reachability("working", "ssh:devbox", None), "working");
-        assert_eq!(with_reachability("done", "local-tmux", None), "done");
-    }
-
-    #[test]
-    fn a_remote_session_with_no_pane_is_unreachable() {
-        assert_eq!(
-            with_reachability("idle", "ssh:devbox", Some("host unreachable")),
-            "unreachable"
-        );
-        assert_eq!(
-            with_reachability("working", "wsl:ubuntu", Some("connect timed out")),
-            "unreachable"
-        );
-    }
-
-    #[test]
-    fn a_local_session_without_a_pane_is_not_unreachable() {
-        // This is the machine it runs on: no pane means the agent has not been
-        // launched, which the pane itself says. Calling it unreachable would
-        // claim a host problem that does not exist.
-        assert_eq!(
-            with_reachability("idle", "local-tmux", Some("session has no pane yet")),
-            "idle"
-        );
     }
 
     #[test]

--- a/src/kernel/terminal/mod.rs
+++ b/src/kernel/terminal/mod.rs
@@ -1683,7 +1683,7 @@ mod tests {
             id: id.to_string(),
             name: "demo".to_string(),
             agent: "claude".to_string(),
-            status: "idle".to_string(),
+            status: crate::session::SessionState::Idle,
             cwd: None,
             repo: None,
             repos: Vec::new(),

--- a/src/session/hook_status.rs
+++ b/src/session/hook_status.rs
@@ -1,10 +1,22 @@
-//! What a session's hooks-driven state is *worth* — its age, the coverage of
-//! the agent that reports it, and whether the pane agrees.
+//! What a session's hooks-driven state *is*, and what it is *worth* — the one
+//! vocabulary ([`SessionState`]), the read-time rules that derive it, and the
+//! age, coverage and pane agreement that say how much to trust it.
 //!
-//! [`crate::session::HOOK_STATES`] is the vocabulary; this module is the
-//! honesty around it. `hook_state` is latched: it is whatever was written last,
-//! by an agent that may since have crashed, been interrupted, or never have
-//! been wired to report at all. A consumer reading the bare word cannot tell
+//! It lives in `session` rather than in either consumer because both the
+//! interface and `thurbox-cli` have to answer "what state is this session in",
+//! and while they each derived it themselves they answered different words for
+//! one row — an acknowledged turn was `idle` on screen and `done` on `session
+//! get` for the rest of the session's life. `session` is the pure module both
+//! may import (`tests/architecture_rules.rs`), so the rules live here and each
+//! caller applies the folds whose inputs it can actually observe:
+//! [`derive_state`] everywhere (its inputs are all stored columns),
+//! [`with_output_quiescence`] and [`with_reachability`] only where there is a
+//! live terminal to ask.
+//!
+//! [`crate::session::HOOK_STATES`] is the agent's half of that vocabulary, and
+//! the rest of this module is the honesty around it. `hook_state` is latched:
+//! it is whatever was written last, by an agent that may since have crashed,
+//! been interrupted, or never have been wired to report at all. A consumer reading the bare word cannot tell
 //! `idle` ("the agent says it is at rest") from `idle` ("this agent has no hook
 //! coverage and never said anything"), nor `working` ("a turn is running") from
 //! `working` ("a turn was running an hour ago and the agent is gone").
@@ -14,9 +26,9 @@
 //! - **Age** — [`age_secs`]. A stamp plus a duration lets a consumer apply its
 //!   own policy instead of trusting a bare word. Deliberately *not* a built-in
 //!   timeout: a turn may legitimately run for an hour, and a guessed bound
-//!   would report it finished. The TUI has a better signal (terminal
-//!   quiescence, `kernel::snapshot::with_output_quiescence`) which needs a live
-//!   pane and so does not exist headless.
+//!   would report it finished. An interface has a better signal
+//!   ([`with_output_quiescence`]) which needs a live pane and so cannot be
+//!   asked headless.
 //! - **Coverage** — [`coverage_for`]. Which states an agent's wiring *can*
 //!   produce, from the built-in `hooks` extension's payloads. `aider` reports
 //!   only `blocked`; a user's own agent reports nothing. Absence of `working`
@@ -26,7 +38,8 @@
 //!   can contradict a latched state, and the only way to see an agent thurbox
 //!   never launched.
 //!
-//! Pure data and decisions: no process is run here, no file is read. The
+//! Pure data and decisions: no process is run here, no file is read, and
+//! nothing overwrites the stored state — every rule is read-time. The
 //! callers gather the facts (`agent::tmux::pane_state`, the agent registry, the
 //! hook columns) and ask this module what they mean.
 
@@ -435,49 +448,218 @@ impl StateSource {
     }
 }
 
-/// The state word a process observation alone can justify.
+/// The one word every surface answers with, and the whole vocabulary of them.
 ///
-/// Deliberately outside [`HOOK_STATES`]: an agent holding the pane is running,
-/// and no amount of process inspection distinguishes a turn in flight from a
-/// prompt waiting for input. Spelling it `working` would launder an
-/// observation into a claim the observation cannot support.
-pub const STATE_RUNNING: &str = "running";
-
-/// The word for a session whose agent is wired to report nothing at all.
+/// Four of these are [`HOOK_STATES`] — the agent's own report, verbatim. The
+/// rest are thurbox's own, and each is spelled apart from `idle` deliberately:
+/// collapsing "nothing here is wired to report" or "the host is gone" into
+/// "the agent says it is at rest" is the conflation this whole module exists
+/// to prevent.
 ///
-/// Outside [`HOOK_STATES`] for the same reason [`STATE_RUNNING`] is: it is an
-/// observation about the *wiring*, and spelling it `idle` would launder "we
-/// cannot know" into "the agent says it is at rest".
-pub const STATE_UNCOVERED: &str = "uncovered";
+/// Every surface derives through this enum — `session get`, `session list`,
+/// `thurbox-cli watch`, `thurbox-cli` bare and the interface's own session
+/// list — so a driver reconciling two of them never has to reconcile two
+/// vocabularies. The read-time rules that produce it are [`derive_state`],
+/// [`with_output_quiescence`] and [`with_reachability`]; a caller applies the
+/// ones whose inputs it can actually observe.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SessionState {
+    /// A turn is running (hook).
+    Working,
+    /// The agent is waiting on input or approval (hook).
+    Blocked,
+    /// A turn finished and nobody has looked at it yet (hook).
+    Done,
+    /// At rest: acknowledged, never active, or a stored word nothing knows.
+    Idle,
+    /// Parked by `session stop`: the row and its checkout stand, the pane does
+    /// not.
+    ///
+    /// It outranks everything else here for the sharpest version of the reason
+    /// the two silences below exist: a parked session has no process at all, so
+    /// *every* other word would describe an agent that is not running. It is
+    /// also the one state thurbox knows first-hand rather than infers.
+    Stopped,
+    /// A remote session whose host cannot be reached. The row stands; the
+    /// machine behind it does not, and the hook columns just hold its last
+    /// word.
+    Unreachable,
+    /// An agent holds the pane and nothing has signalled.
+    ///
+    /// Outside [`HOOK_STATES`] on purpose: no amount of process inspection
+    /// distinguishes a turn in flight from a prompt waiting for input, and
+    /// spelling it `working` would launder an observation into a claim the
+    /// observation cannot support.
+    Running,
+    /// This session's agent is wired to report nothing, so its silence means
+    /// nothing. Spelling it `idle` would launder "we cannot know" into "the
+    /// agent says it is at rest".
+    Uncovered,
+    /// The agent *can* report and has not yet.
+    Unreported,
+}
 
-/// The word for a session whose agent *can* report and has not yet.
-pub const STATE_UNREPORTED: &str = "unreported";
+impl SessionState {
+    /// Every word, in the order a reader scans them — so a surface that counts
+    /// or documents the vocabulary enumerates it rather than restating it.
+    pub const ALL: &'static [SessionState] = &[
+        SessionState::Working,
+        SessionState::Blocked,
+        SessionState::Done,
+        SessionState::Idle,
+        SessionState::Stopped,
+        SessionState::Unreachable,
+        SessionState::Running,
+        SessionState::Uncovered,
+        SessionState::Unreported,
+    ];
 
-/// The word for a session that was deliberately parked (`session stop`).
+    /// The stable lowercase word every surface prints.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            SessionState::Working => "working",
+            SessionState::Blocked => "blocked",
+            SessionState::Done => "done",
+            SessionState::Idle => "idle",
+            SessionState::Stopped => "stopped",
+            SessionState::Unreachable => "unreachable",
+            SessionState::Running => "running",
+            SessionState::Uncovered => "uncovered",
+            SessionState::Unreported => "unreported",
+        }
+    }
+
+    /// The state a hook's own word names — `None` for anything outside
+    /// [`HOOK_STATES`], which is how a stored word nothing recognises stops
+    /// short of being reported as an agent's report.
+    pub fn from_hook_state(word: &str) -> Option<Self> {
+        match word {
+            "working" => Some(SessionState::Working),
+            "blocked" => Some(SessionState::Blocked),
+            "done" => Some(SessionState::Done),
+            "idle" => Some(SessionState::Idle),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for SessionState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Whether a finished turn has been acknowledged: the interface stamps
+/// `seen_at` when the user moves focus off a `done` session.
 ///
-/// Outside [`HOOK_STATES`] like the three above, and for the sharpest version
-/// of the same reason: a parked session has no process at all, so *every* other
-/// word here would describe an agent that is not running. It is the one state
-/// thurbox knows first-hand rather than infers — the mark `session stop` wrote
-/// — which is why it outranks anything the hook columns still hold.
-pub const STATE_STOPPED: &str = "stopped";
+/// A **stored fact**, not a timeout — which is why every surface can apply it.
+/// The CLI has no terminal to ask about quiescence and refuses to guess a
+/// staleness bound, but this column is simply there to be read, and until it
+/// was a turn the interface had already acknowledged stayed `done` on every
+/// headless surface for the rest of the session's life.
+fn acknowledged(state_at: Option<i64>, seen_at: Option<i64>) -> bool {
+    matches!((seen_at, state_at), (Some(seen), Some(at)) if seen >= at)
+}
+
+/// Map the persisted hook columns onto the state a reader should see.
+///
+/// The stuck-`working` fallback is deliberately **not** here: it is a question
+/// about the terminal, not the row, so it belongs to [`with_output_quiescence`].
+/// The stored row is never touched — every rule in this module is a read-time
+/// decision.
+pub fn derive_state(
+    hook_state: Option<&str>,
+    state_at: Option<i64>,
+    seen_at: Option<i64>,
+) -> SessionState {
+    match hook_state.and_then(SessionState::from_hook_state) {
+        Some(SessionState::Done) if acknowledged(state_at, seen_at) => SessionState::Idle,
+        Some(state) => state,
+        None => SessionState::Idle,
+    }
+}
+
+/// How long a `working` session may produce **no terminal output** before it is
+/// reported as idle. v1 uses the same 10s bound.
+///
+/// The signal is output, not the age of the hook state, and the difference is
+/// the whole point: a turn that runs for a minute is still `working` the whole
+/// minute, because the agent is printing throughout. Keying on the hook's
+/// timestamp instead ends every turn after ten seconds and starts it again at
+/// the next hook — a spinner that stops early and restarts, which is precisely
+/// what the fallback exists to avoid.
+pub const WORKING_QUIET_MS: u64 = 10_000;
+
+/// Fold terminal quiescence into a `working` session's state.
+///
+/// Agents fire no hook when a turn is **interrupted** (Esc / Ctrl+C) and none
+/// when they return to the idle prompt, so a `working` state can stand forever
+/// with nothing running behind it. TUI agents animate their in-progress line
+/// while a turn runs (Claude's `(Xs · esc to interrupt)` ticks every second), so
+/// a genuinely live turn is never quiet for [`WORKING_QUIET_MS`] and only the
+/// stuck state falls through.
+///
+/// `quiet_for_ms` is `None` when the session has no live pane — nothing can be
+/// producing output, so that reads as quiet too. This is where v1's `exited →
+/// Idle` branch lands: a pane whose stream ended is dropped from the live set.
+/// Only `working` is time-gated; `blocked` is a standing request for input and
+/// says nothing about output.
+///
+/// Only a caller with a live terminal can answer this, which is why it is a
+/// fold a surface opts into rather than part of [`derive_state`]: headless,
+/// there is nothing to ask, and guessing a bound would report a running turn
+/// as finished.
+pub fn with_output_quiescence(state: SessionState, quiet_for_ms: Option<u64>) -> SessionState {
+    if state == SessionState::Working && quiet_for_ms.unwrap_or(u64::MAX) > WORKING_QUIET_MS {
+        return SessionState::Idle;
+    }
+    state
+}
+
+/// Fold what the terminal store knows about the host into a session's state.
+///
+/// The hook state says what the *agent* is doing; it cannot say that the machine
+/// the agent runs on has gone away, because a host that is down reports nothing
+/// at all — it just leaves the last state standing. So a remote session with no
+/// live pane reads `unreachable` rather than the stale `idle` its row still
+/// carries, which is v1's placeholder row by another name.
+///
+/// Local sessions are never unreachable: this *is* their machine, and a missing
+/// pane there means the agent has not been launched, not that it cannot be
+/// reached.
+pub fn with_reachability(
+    state: SessionState,
+    backend: &str,
+    attach_error: Option<&str>,
+) -> SessionState {
+    if attach_error.is_some() && super::is_remote_backend(backend) {
+        return SessionState::Unreachable;
+    }
+    state
+}
 
 /// The best answer available for a session, and where it came from.
 ///
-/// The hook state wins whenever there is one — it is the agent's own report,
-/// and richer than anything observable. Only when nothing ever signalled does
-/// the pane get a say, and then only to the extent of [`STATE_RUNNING`].
-/// `None` is the honest third outcome: no hook, no agent in the pane.
+/// The hook columns win whenever they hold anything — they are the agent's own
+/// report, read through [`derive_state`], and richer than anything observable.
+/// Only when nothing ever signalled does the pane get a say, and then only to
+/// the extent of [`SessionState::Running`]. `None` is the honest third outcome:
+/// no hook, no agent in the pane.
 pub fn best_state(
     hook_state: Option<&str>,
+    state_at: Option<i64>,
+    seen_at: Option<i64>,
     corroboration: Option<Corroboration>,
-) -> Option<(String, StateSource)> {
-    if let Some(state) = hook_state {
-        return Some((state.to_string(), StateSource::Hook));
+) -> Option<(SessionState, StateSource)> {
+    if hook_state.is_some() {
+        return Some((
+            derive_state(hook_state, state_at, seen_at),
+            StateSource::Hook,
+        ));
     }
     match corroboration {
         Some(Corroboration::Agent | Corroboration::ForeignAgent) => {
-            Some((STATE_RUNNING.to_string(), StateSource::Process))
+            Some((SessionState::Running, StateSource::Process))
         }
         _ => None,
     }
@@ -498,6 +680,9 @@ pub struct Assessment {
     pub hook_state: Option<String>,
     /// Epoch ms it was stored.
     pub state_at: Option<i64>,
+    /// Epoch ms the interface stamped when the user moved focus off a finished
+    /// turn — the `done → idle` acknowledgment, folded in by [`derive_state`].
+    pub seen_at: Option<i64>,
     pub age_secs: Option<u64>,
     /// Whether any hook has *ever* reported for this session. The distinction
     /// the brief's "explicit uninstrumented state" turns on: a session that has
@@ -518,7 +703,7 @@ pub struct Assessment {
     /// `None` = not checked; `Some(false)` = checked and consistent.
     pub contradicted: Option<bool>,
     /// The best answer available, and where it came from — see [`best_state`].
-    pub state: Option<String>,
+    pub state: Option<SessionState>,
     pub state_source: Option<StateSource>,
     /// Parked by `session stop`: the row and its checkout stand, the pane does
     /// not. Set by [`Self::parked`], and the one fact here that is thurbox's
@@ -534,30 +719,33 @@ pub struct Assessment {
 }
 
 impl Assessment {
-    /// The one word every surface shows for this session, never absent.
+    /// The one state every surface shows for this session, never absent.
     ///
     /// [`Self::state`] is `None` when nothing signalled and nothing observable
     /// holds the pane, and a bare null leaves a reader unable to tell the two
     /// silences apart. They are different facts and get different words:
-    /// [`STATE_UNCOVERED`] (this agent is wired to report nothing, so silence
-    /// means nothing) and [`STATE_UNREPORTED`] (it can report and has not).
-    /// Neither is in [`crate::session::HOOK_STATES`], so neither can be read
-    /// as an agent's own report. A session [`parked`](Self::parked) by `session
-    /// stop` answers [`STATE_STOPPED`] ahead of all three: it has no process,
-    /// so nothing the hook columns still hold describes it.
+    /// [`SessionState::Uncovered`] (this agent is wired to report nothing, so
+    /// silence means nothing) and [`SessionState::Unreported`] (it can report
+    /// and has not). A session [`parked`](Self::parked) by `session stop`
+    /// answers [`SessionState::Stopped`] ahead of both.
     ///
     /// Every rendering goes through here — the human table, the agent-facing
-    /// TOON view and the home view — so no surface can invent a third answer
-    /// for the same row.
-    pub fn state_word(&self) -> &str {
+    /// TOON view, the home view and the event stream — so no surface can invent
+    /// a third answer for the same row.
+    pub fn state(&self) -> SessionState {
         if self.stopped {
-            return STATE_STOPPED;
+            return SessionState::Stopped;
         }
-        match self.state.as_deref() {
+        match self.state {
             Some(state) => state,
-            None if self.coverage == Coverage::None => STATE_UNCOVERED,
-            None => STATE_UNREPORTED,
+            None if self.coverage == Coverage::None => SessionState::Uncovered,
+            None => SessionState::Unreported,
         }
+    }
+
+    /// [`Self::state`](Self::state) as the word a document carries.
+    pub fn state_word(&self) -> &'static str {
+        self.state().as_str()
     }
 
     /// Every state this session's agent can report — empty when it is wired to
@@ -592,13 +780,15 @@ impl Assessment {
         agent: &str,
         hook_state: Option<&str>,
         state_at: Option<i64>,
+        seen_at: Option<i64>,
         now: i64,
     ) -> Self {
         let found = coverage_for(registry, agent);
-        let state = best_state(hook_state, None);
+        let state = best_state(hook_state, state_at, seen_at, None);
         Self {
             hook_state: hook_state.map(str::to_string),
             state_at,
+            seen_at,
             age_secs: age_secs(state_at, now),
             reported: hook_state.is_some(),
             coverage: Coverage::of(found.map(|(c, _)| c)),
@@ -608,7 +798,7 @@ impl Assessment {
             foreground_process: None,
             foreground_command: None,
             contradicted: None,
-            state: state.as_ref().map(|(s, _)| s.clone()),
+            state: state.map(|(state, _)| state),
             state_source: state.map(|(_, source)| source),
             stopped: false,
             agent: agent.to_string(),
@@ -634,7 +824,12 @@ impl Assessment {
         self.foreground_process = process.filter(|p| !p.is_empty()).map(str::to_string);
         self.foreground_command = command_line.filter(|c| !c.is_empty()).map(str::to_string);
         self.corroboration = Some(corroboration);
-        if let Some((state, source)) = best_state(self.hook_state.as_deref(), Some(corroboration)) {
+        if let Some((state, source)) = best_state(
+            self.hook_state.as_deref(),
+            self.state_at,
+            self.seen_at,
+            Some(corroboration),
+        ) {
             self.state = Some(state);
             self.state_source = Some(source);
         }
@@ -689,6 +884,158 @@ mod tests {
             resume_latest: false,
             hook_schema: hook_schema.map(str::to_string),
         }
+    }
+
+    /// A fixed instant, so nothing here depends on a clock.
+    const NOW: i64 = 1_700_000_000_000;
+
+    #[test]
+    fn an_unreported_session_is_idle() {
+        assert_eq!(derive_state(None, None, None), SessionState::Idle);
+        // A stored word nothing recognises is not an agent's report.
+        assert_eq!(
+            derive_state(Some("unknown"), None, None),
+            SessionState::Idle
+        );
+    }
+
+    #[test]
+    fn a_long_turn_stays_working_however_old_its_hook_is() {
+        // The regression this guards: keyed on the hook's own timestamp, every
+        // turn reported itself finished ten seconds in and started again at the
+        // next hook — a spinner that stopped early and restarted. How long ago
+        // the agent said "working" says nothing about whether it still is.
+        assert_eq!(
+            derive_state(Some("working"), Some(NOW), None),
+            SessionState::Working
+        );
+        assert_eq!(
+            derive_state(Some("working"), Some(NOW - 600_000), None),
+            SessionState::Working
+        );
+    }
+
+    #[test]
+    fn done_stays_done_until_acknowledged() {
+        assert_eq!(
+            derive_state(Some("done"), Some(NOW), None),
+            SessionState::Done
+        );
+        assert_eq!(
+            derive_state(Some("done"), Some(NOW), Some(NOW - 1)),
+            SessionState::Done
+        );
+        assert_eq!(
+            derive_state(Some("done"), Some(NOW), Some(NOW)),
+            SessionState::Idle
+        );
+    }
+
+    #[test]
+    fn a_quiet_working_session_falls_back_to_idle() {
+        // Agents fire no hook on interrupt, so without this a cancelled turn
+        // would spin forever. v1 guards the same way, on the same signal.
+        assert_eq!(
+            with_output_quiescence(SessionState::Working, Some(WORKING_QUIET_MS + 1)),
+            SessionState::Idle
+        );
+    }
+
+    #[test]
+    fn a_printing_working_session_stays_working() {
+        assert_eq!(
+            with_output_quiescence(SessionState::Working, Some(0)),
+            SessionState::Working
+        );
+        assert_eq!(
+            with_output_quiescence(SessionState::Working, Some(WORKING_QUIET_MS)),
+            SessionState::Working
+        );
+    }
+
+    #[test]
+    fn a_working_session_with_no_live_pane_is_idle() {
+        // Nothing can be producing output, which is where v1's exited → Idle
+        // branch lands: a pane whose stream ended leaves the live set.
+        assert_eq!(
+            with_output_quiescence(SessionState::Working, None),
+            SessionState::Idle
+        );
+    }
+
+    #[test]
+    fn blocked_is_never_time_gated() {
+        assert_eq!(
+            derive_state(Some("blocked"), Some(NOW - 600_000), None),
+            SessionState::Blocked
+        );
+        // A session waiting on you produces no output while it waits.
+        assert_eq!(
+            with_output_quiescence(SessionState::Blocked, None),
+            SessionState::Blocked
+        );
+        assert_eq!(
+            with_output_quiescence(SessionState::Done, Some(WORKING_QUIET_MS * 10)),
+            SessionState::Done
+        );
+    }
+
+    #[test]
+    fn a_reachable_session_keeps_the_state_its_hooks_reported() {
+        assert_eq!(
+            with_reachability(SessionState::Working, "ssh:devbox", None),
+            SessionState::Working
+        );
+        assert_eq!(
+            with_reachability(SessionState::Done, "local-tmux", None),
+            SessionState::Done
+        );
+    }
+
+    #[test]
+    fn a_remote_session_with_no_pane_is_unreachable() {
+        assert_eq!(
+            with_reachability(SessionState::Idle, "ssh:devbox", Some("host unreachable")),
+            SessionState::Unreachable
+        );
+        assert_eq!(
+            with_reachability(
+                SessionState::Working,
+                "wsl:ubuntu",
+                Some("connect timed out")
+            ),
+            SessionState::Unreachable
+        );
+    }
+
+    #[test]
+    fn a_local_session_without_a_pane_is_not_unreachable() {
+        // This is the machine it runs on: no pane means the agent has not been
+        // launched, which the pane itself says. Calling it unreachable would
+        // claim a host problem that does not exist.
+        assert_eq!(
+            with_reachability(
+                SessionState::Idle,
+                "local-tmux",
+                Some("session has no pane yet")
+            ),
+            SessionState::Idle
+        );
+    }
+
+    /// The acknowledgment is a stored fact, so it applies headlessly too — the
+    /// divergence that let `session get` report `done` for the rest of a
+    /// session's life after the interface had already shown `idle`.
+    #[test]
+    fn an_assessment_folds_the_acknowledgment_the_snapshot_writes() {
+        let reg = registry(vec![agent("claude", "claude", None)]);
+        let unseen = Assessment::from_hooks(&reg, "claude", Some("done"), Some(NOW), None, NOW);
+        assert_eq!(unseen.state(), SessionState::Done);
+
+        let seen = Assessment::from_hooks(&reg, "claude", Some("done"), Some(NOW), Some(NOW), NOW);
+        assert_eq!(seen.state(), SessionState::Idle);
+        // The column a consumer applying its own policy reads stays verbatim.
+        assert_eq!(seen.hook_state.as_deref(), Some("done"));
     }
 
     #[test]
@@ -848,8 +1195,8 @@ mod tests {
         assert_eq!(seen, Corroboration::ForeignAgent);
         assert_eq!(seen.agent_present(), Some(true));
         assert_eq!(
-            best_state(None, Some(seen)),
-            Some((STATE_RUNNING.to_string(), StateSource::Process))
+            best_state(None, None, None, Some(seen)),
+            Some((SessionState::Running, StateSource::Process))
         );
 
         // And the shell that pane was asked for is still just a shell — even
@@ -857,7 +1204,7 @@ mod tests {
         // as an agent running is the failure this branch exists to avoid.
         let idle = classify_foreground("bash", &known, Some("bash"), Some("bash -i"), Some(false));
         assert_eq!(idle, Corroboration::Shell);
-        assert_eq!(best_state(None, Some(idle)), None);
+        assert_eq!(best_state(None, None, None, Some(idle)), None);
     }
 
     #[test]
@@ -865,12 +1212,12 @@ mod tests {
         // The agent's own report is richer than anything observable, so the
         // pane never overwrites it — it only ever adds the contradiction flag.
         assert_eq!(
-            best_state(Some("blocked"), Some(Corroboration::Shell)),
-            Some(("blocked".to_string(), StateSource::Hook))
+            best_state(Some("blocked"), None, None, Some(Corroboration::Shell)),
+            Some((SessionState::Blocked, StateSource::Hook))
         );
         assert_eq!(
-            best_state(Some("idle"), Some(Corroboration::Agent)),
-            Some(("idle".to_string(), StateSource::Hook))
+            best_state(Some("idle"), None, None, Some(Corroboration::Agent)),
+            Some((SessionState::Idle, StateSource::Hook))
         );
     }
 
@@ -884,7 +1231,7 @@ mod tests {
             assert_eq!(state, Corroboration::Unknown);
             assert_eq!(state.agent_present(), None);
             assert!(!contradicts(Some("working"), state));
-            assert_eq!(best_state(None, Some(state)), None);
+            assert_eq!(best_state(None, None, None, Some(state)), None);
         }
         // A remote pane is not unknown but unreadable, and says so.
         assert_eq!(Corroboration::Unavailable.agent_present(), None);

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -25,9 +25,10 @@ pub use hook_def::{
     HookContext, HookEvent, HookWorktree, HooksFile, LifecycleHook, DEFAULT_HOOK_TIMEOUT_SECS,
 };
 pub use hook_status::{
-    age_secs, best_state, classify_foreground, contradicts, coverage_for, AgentHookCoverage,
-    Assessment, Corroboration, Coverage, CoverageSource, HookDelivery, StateSource,
-    AGENT_HOOK_COVERAGE, STATE_RUNNING, STATE_STOPPED, STATE_UNCOVERED, STATE_UNREPORTED,
+    age_secs, best_state, classify_foreground, contradicts, coverage_for, derive_state,
+    with_output_quiescence, with_reachability, AgentHookCoverage, Assessment, Corroboration,
+    Coverage, CoverageSource, HookDelivery, SessionState, StateSource, AGENT_HOOK_COVERAGE,
+    WORKING_QUIET_MS,
 };
 pub use host_def::{
     is_remote_backend, is_ssh_backend, is_wsl_backend, HostDef, HostKind, HostRegistry,
@@ -180,64 +181,6 @@ impl std::str::FromStr for SessionId {
     }
 }
 
-/// A session's lifecycle state, driven by agent hooks (see
-/// `thurbox-cli session signal`). Repo groups in the session list roll up to
-/// their most-urgent member so the whole list scans at a glance.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SessionStatus {
-    /// 🟡 The agent is actively running (reported by a hook).
-    Working,
-    /// 🔴 The agent needs user input or approval (reported by a hook).
-    Blocked,
-    /// 🔵 A turn just finished; shown until the user switches focus off it.
-    Done,
-    /// 🟢 Acknowledged (focus moved off a `Done`), at rest, or never-active.
-    Idle,
-    /// Reserved for a crashed agent. **Not currently derived** — process exit has
-    /// no failure signal yet (a clean or crashed exit both map to `Idle`), so this
-    /// variant is wired through colour/glyph/rollup but never assigned. Kept for
-    /// when exit-code plumbing lands.
-    Error,
-    /// The session lives on a remote host that is currently unreachable (SSH
-    /// down / auth failing / host offline). Assigned to placeholder rows so a
-    /// remote session never silently vanishes from the list; cleared to the
-    /// real hook-driven status once the host recovers and the session adopts.
-    Unreachable,
-}
-
-impl SessionStatus {
-    /// A status glyph chosen for **shape** distinctiveness, not just colour, so
-    /// the state survives in greyscale / for colour-blind users: a spinner
-    /// (working — the live session list animates it from `theme.spinner` in
-    /// `ui/lib/theme.lua`)
-    /// vs. diamond (blocked) vs. filled circle (done, unseen) vs. hollow circle
-    /// (idle, seen) vs. cross (error). The filled/hollow pair makes
-    /// done-vs-idle read at a glance.
-    pub fn icon(self) -> &'static str {
-        match self {
-            Self::Working => "◐",
-            Self::Blocked => "◆",
-            Self::Done => "●",
-            Self::Idle => "○",
-            Self::Error => "✗",
-            Self::Unreachable => "⊘",
-        }
-    }
-}
-
-impl fmt::Display for SessionStatus {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Working => write!(f, "Working"),
-            Self::Blocked => write!(f, "Blocked"),
-            Self::Done => write!(f, "Done"),
-            Self::Idle => write!(f, "Idle"),
-            Self::Error => write!(f, "Error"),
-            Self::Unreachable => write!(f, "Unreachable"),
-        }
-    }
-}
-
 /// Agent metrics collected from the Claude CLI statusline mechanism.
 #[derive(Debug, Clone, Default)]
 pub struct AgentMetrics {
@@ -384,7 +327,6 @@ impl AgentUsage {
 pub struct SessionInfo {
     pub id: SessionId,
     pub name: String,
-    pub status: SessionStatus,
     /// Name of the coding agent driving this session (e.g. `"claude"`).
     pub agent: String,
     pub worktrees: Vec<WorktreeInfo>,
@@ -403,7 +345,7 @@ pub struct SessionInfo {
     /// captured from the terminal and refreshed each tick. Agent-neutral.
     pub agent_activity: Option<String>,
     /// Message text from the agent's latest attention notification (OSC 9/777),
-    /// shown as the status when `status == SessionStatus::Blocked`.
+    /// shown as the status when the session reads [`SessionState::Blocked`].
     pub notification: Option<String>,
     /// Real git state of the session's worktree(s), refreshed periodically by
     /// the app layer. `None` until first computed (or for non-git sessions).
@@ -430,7 +372,6 @@ impl SessionInfo {
         Self {
             id: SessionId::default(),
             name,
-            status: SessionStatus::Working,
             agent: DEFAULT_AGENT_NAME.to_string(),
             worktrees: Vec::new(),
             agent_session_id: None,
@@ -503,21 +444,9 @@ mod tests {
     }
 
     #[test]
-    fn session_status_display_and_icon() {
-        assert_eq!(SessionStatus::Working.to_string(), "Working");
-        // Glyphs are shape-distinct (not all circles) so status reads without colour.
-        assert_eq!(SessionStatus::Working.icon(), "◐");
-        assert_eq!(SessionStatus::Blocked.icon(), "◆");
-        assert_eq!(SessionStatus::Done.icon(), "●");
-        assert_eq!(SessionStatus::Idle.icon(), "○");
-        assert_eq!(SessionStatus::Error.icon(), "✗");
-    }
-
-    #[test]
     fn session_info_new_defaults() {
         let info = SessionInfo::new("Test".to_string());
         assert_eq!(info.name, "Test");
-        assert_eq!(info.status, SessionStatus::Working);
         assert_eq!(info.agent, DEFAULT_AGENT_NAME);
         assert!(info.worktrees.is_empty());
         assert!(info.agent_session_id.is_none());

--- a/src/session_ops/builtin_hooks.rs
+++ b/src/session_ops/builtin_hooks.rs
@@ -1,6 +1,6 @@
 //! The built-in **hooks** extension: wires each coding agent's lifecycle hooks
 //! to `thurbox-cli session signal` so sessions report `working`/`blocked`/`done`
-//! back to thurbox (see the hooks-driven `SessionStatus`). For **remote**
+//! back to thurbox (see the hooks-driven `SessionState`). For **remote**
 //! sessions the same hook file is shipped with its commands rewritten to a tmux
 //! pane user option (`rewrite_hook_signals_for_remote`) — the local TUI
 //! receives those over its control-mode subscription.

--- a/src/storage/sessions.rs
+++ b/src/storage/sessions.rs
@@ -11,11 +11,12 @@ use super::session_events::{EventReason, SessionEventKind};
 use super::Database;
 
 /// The hooks-driven status columns of a session, read in one batch by the TUI
-/// each tick to derive [`crate::session::SessionStatus`]. See schema v34.
+/// each tick to derive [`crate::session::SessionState`]. See schema v34.
 #[derive(Debug, Clone, Default)]
 pub struct HookRow {
     /// `working` / `blocked` / `done` / `idle`, or `None` when no hook has fired
-    /// yet. (`idle` and unknown values render as [`crate::session::SessionStatus`]`::Idle`.)
+    /// yet. (`idle` and unknown values both derive to
+    /// [`SessionState::Idle`](crate::session::SessionState::Idle).)
     pub state: Option<String>,
     /// Epoch ms the state was last reported.
     pub state_at: Option<i64>,
@@ -36,6 +37,11 @@ pub struct SessionFacts {
     pub backend_id: String,
     /// Parked by `session stop`.
     pub stopped: bool,
+    /// Epoch ms an interface stamped when the user moved focus off a finished
+    /// turn. Read here so the stream applies the same `done → idle`
+    /// acknowledgment every other surface does, rather than reporting a turn
+    /// somebody has already looked at as unseen forever.
+    pub seen_at: Option<i64>,
 }
 
 /// Information about a soft-deleted session, including its worktrees.
@@ -629,9 +635,9 @@ impl Database {
     /// included. One lean scan with no worktree join: `thurbox-cli watch` reads
     /// it once per wake to name the sessions its events are about.
     pub fn load_session_facts(&self) -> rusqlite::Result<HashMap<SessionId, SessionFacts>> {
-        let mut stmt = self
-            .conn
-            .prepare_cached("SELECT id, name, agent, backend_id, stopped_at FROM sessions")?;
+        let mut stmt = self.conn.prepare_cached(
+            "SELECT id, name, agent, backend_id, stopped_at, seen_at FROM sessions",
+        )?;
         let rows = stmt.query_map([], |row| {
             let id: String = row.get(0)?;
             Ok((
@@ -641,6 +647,7 @@ impl Database {
                     agent: row.get(2)?,
                     backend_id: row.get(3)?,
                     stopped: row.get::<_, Option<i64>>(4)?.is_some(),
+                    seen_at: row.get(5)?,
                 },
             ))
         })?;

--- a/tests/attach_by_name.rs
+++ b/tests/attach_by_name.rs
@@ -16,6 +16,7 @@ use std::process::Command;
 
 use thurbox::kernel::snapshot::{SessionRow, Snapshot};
 use thurbox::kernel::terminal::Terminals;
+use thurbox::session::SessionState;
 
 /// A socket of this test's own, so it can never see — or kill — a real session.
 const SOCKET: &str = "thurbox-attach-test";
@@ -47,7 +48,7 @@ fn row(name: &str) -> SessionRow {
         id: "11111111-1111-1111-1111-111111111111".into(),
         name: name.into(),
         agent: "claude".into(),
-        status: "idle".into(),
+        status: SessionState::Idle,
         cwd: None,
         repo: None,
         repos: Vec::new(),

--- a/tests/chrome.rs
+++ b/tests/chrome.rs
@@ -17,6 +17,7 @@ use thurbox::kernel::node::ClickVerb;
 use thurbox::kernel::registry::Registry;
 use thurbox::kernel::snapshot::{AutomationRow, SessionRow, Snapshot};
 use thurbox::kernel::theme::Themes;
+use thurbox::session::SessionState;
 
 fn host() -> LuaHost {
     let dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("ui");
@@ -30,7 +31,7 @@ fn session(name: &str, branch: &str) -> SessionRow {
         id: format!("{name}-0000-0000-0000-000000000000"),
         name: name.into(),
         agent: "claude".into(),
-        status: "idle".into(),
+        status: SessionState::Idle,
         cwd: Some(std::path::PathBuf::from("/src/repo")),
         repo: Some("repo".into()),
         repos: vec!["repo".into()],

--- a/tests/core_settings.rs
+++ b/tests/core_settings.rs
@@ -12,6 +12,7 @@
 
 use thurbox::kernel::config::{Config, Reloaded};
 use thurbox::session::settings::Settings;
+use thurbox::session::SessionState;
 
 /// Isolate config and data into a tempdir, process-wide so a worker sees it too.
 fn isolate() -> tempfile::TempDir {
@@ -266,7 +267,7 @@ fn session_row() -> thurbox::kernel::snapshot::SessionRow {
         id: "11111111-1111-1111-1111-111111111111".into(),
         name: "fix-osc52".into(),
         agent: "claude".into(),
-        status: "idle".into(),
+        status: SessionState::Idle,
         cwd: Some(std::path::PathBuf::from("/src/thurbox")),
         repo: Some("thurbox".into()),
         repos: vec!["thurbox".into()],

--- a/tests/events.rs
+++ b/tests/events.rs
@@ -15,6 +15,7 @@ use thurbox::kernel::host::{LuaHost, Phase, Published, RenderContext};
 use thurbox::kernel::registry::Registry;
 use thurbox::kernel::snapshot::{SessionRow, Snapshot};
 use thurbox::kernel::theme::Themes;
+use thurbox::session::SessionState;
 
 /// An interface directory holding the given plugins, each `(file, source)`.
 fn interface(plugins: &[(&str, &str)]) -> tempfile::TempDir {
@@ -39,7 +40,7 @@ fn row(name: &str, status: &str) -> SessionRow {
         id: format!("{name}-0000-0000-0000-000000000000"),
         name: name.to_string(),
         agent: "claude".to_string(),
-        status: status.to_string(),
+        status: SessionState::from_hook_state(status).expect("a hook state"),
         cwd: Some(PathBuf::from("/src/thurbox")),
         repo: Some("thurbox".to_string()),
         repos: vec!["thurbox".to_string()],

--- a/tests/frames.rs
+++ b/tests/frames.rs
@@ -33,6 +33,7 @@ use thurbox::kernel::paint::{render, PlaceholderSurfaces, ProgramPaint, SurfaceP
 use thurbox::kernel::registry::Registry;
 use thurbox::kernel::snapshot::{SessionRow, Snapshot};
 use thurbox::kernel::theme::Themes;
+use thurbox::session::SessionState;
 
 // --- the world --------------------------------------------------------------
 
@@ -98,7 +99,7 @@ fn row(name: &str, repo: &str, status: &str) -> SessionRow {
         id: format!("{name}-0000-0000-0000-000000000000"),
         name: name.to_string(),
         agent: "claude".to_string(),
-        status: status.to_string(),
+        status: SessionState::from_hook_state(status).expect("a hook state"),
         cwd: Some(std::path::PathBuf::from(format!("/src/{repo}"))),
         repo: Some(repo.to_string()),
         repos: vec![repo.to_string()],

--- a/tests/hover.rs
+++ b/tests/hover.rs
@@ -23,6 +23,7 @@ use thurbox::kernel::node::Identity;
 use thurbox::kernel::registry::Registry;
 use thurbox::kernel::snapshot::Snapshot;
 use thurbox::kernel::theme::Themes;
+use thurbox::session::SessionState;
 
 fn host() -> LuaHost {
     let dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("ui");
@@ -135,7 +136,7 @@ fn one_session() -> Snapshot {
             id: "s1-0000-0000-0000-000000000000".into(),
             name: "fix-osc52".into(),
             agent: "claude".into(),
-            status: "idle".into(),
+            status: SessionState::Idle,
             cwd: None,
             repo: Some("thurbox".into()),
             repos: vec!["thurbox".into()],

--- a/tests/kernel_frame_cost.rs
+++ b/tests/kernel_frame_cost.rs
@@ -162,7 +162,7 @@ fn row(id: &str, name: &str) -> SessionRow {
         id: id.into(),
         name: name.into(),
         agent: "claude".into(),
-        status: "idle".into(),
+        status: thurbox::session::SessionState::Idle,
         cwd: None,
         repo: None,
         repos: Vec::new(),

--- a/tests/kernel_mvp.rs
+++ b/tests/kernel_mvp.rs
@@ -101,7 +101,7 @@ fn row(name: &str, repo: &str, status: &str) -> SessionRow {
         id: format!("{name}-0000-0000-0000-000000000000"),
         name: name.to_string(),
         agent: "claude".to_string(),
-        status: status.to_string(),
+        status: SessionState::from_hook_state(status).expect("a hook state"),
         cwd: None,
         repo: Some(repo.to_string()),
         repos: vec![repo.to_string()],
@@ -840,6 +840,7 @@ fn a_session_backed_surface_falls_back_when_nothing_is_attached() {
 // --- command bus -----------------------------------------------------------
 
 use thurbox::kernel::command::{Command, InFlight, Phase};
+use thurbox::session::SessionState;
 
 /// Press a key and route it exactly as the binary does: registry first
 /// (declared actions), then raw `on_key`. Returns whatever commands it issued.

--- a/tests/keymap.rs
+++ b/tests/keymap.rs
@@ -19,6 +19,7 @@ use thurbox::kernel::layout::resolve;
 use thurbox::kernel::registry::{is_ctrl_letter_chord, normalise_chord, Registry, Scope, RESERVED};
 use thurbox::kernel::snapshot::{SessionRow, Snapshot};
 use thurbox::kernel::theme::Themes;
+use thurbox::session::SessionState;
 /// v1's keymap tables, compiled into this test crate only — see the module's
 /// own doc for why the oracle lives here rather than in `src/`.
 #[path = "support/v1_keymap.rs"]
@@ -53,7 +54,7 @@ fn row(name: &str) -> SessionRow {
         id: format!("{name}-0000-0000-0000-000000000000"),
         name: name.to_string(),
         agent: "claude".to_string(),
-        status: "idle".to_string(),
+        status: SessionState::Idle,
         cwd: Some(PathBuf::from("/src/thurbox")),
         repo: Some("thurbox".to_string()),
         repos: Vec::new(),

--- a/tests/modals.rs
+++ b/tests/modals.rs
@@ -21,6 +21,7 @@ use thurbox::kernel::modals::{self, ModalKind, Modals, World};
 use thurbox::kernel::registry::{binding_from, Registry, Setting, Value};
 use thurbox::kernel::snapshot::{SessionRow, Snapshot};
 use thurbox::kernel::theme::Themes;
+use thurbox::session::SessionState;
 use thurbox::storage::Database;
 
 const WIDTH: u16 = 150;
@@ -48,7 +49,7 @@ fn row(name: &str) -> SessionRow {
         id: format!("{name}-0000-0000-0000-000000000000"),
         name: name.into(),
         agent: "claude".into(),
-        status: "idle".into(),
+        status: SessionState::Idle,
         cwd: Some(std::path::PathBuf::from("/src/thurbox")),
         repo: Some("thurbox".into()),
         repos: vec!["thurbox".into()],

--- a/tests/mouse.rs
+++ b/tests/mouse.rs
@@ -20,6 +20,7 @@ use thurbox::kernel::paint::{render_recording, Hit, PlaceholderSurfaces};
 use thurbox::kernel::registry::Registry;
 use thurbox::kernel::snapshot::{SessionRow, Snapshot};
 use thurbox::kernel::theme::Themes;
+use thurbox::session::SessionState;
 
 fn host() -> LuaHost {
     let dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("ui");
@@ -33,7 +34,7 @@ fn row(name: &str, repo: &str) -> SessionRow {
         id: format!("{name}-0000-0000-0000-000000000000"),
         name: name.into(),
         agent: "claude".into(),
-        status: "idle".into(),
+        status: SessionState::Idle,
         cwd: Some(std::path::PathBuf::from(format!("/src/{repo}"))),
         repo: Some(repo.into()),
         repos: Vec::new(),

--- a/tests/plugin_settings.rs
+++ b/tests/plugin_settings.rs
@@ -26,7 +26,7 @@ fn row(name: &str, repo: &str) -> SessionRow {
         id: format!("{name}-0000"),
         name: name.into(),
         agent: "claude".into(),
-        status: "idle".into(),
+        status: thurbox::session::SessionState::Idle,
         cwd: None,
         repo: Some(repo.into()),
         repos: vec![repo.into()],

--- a/tests/remote_status.rs
+++ b/tests/remote_status.rs
@@ -63,7 +63,7 @@ fn status_of(store: &SnapshotStore, id: SessionId) -> String {
         .sessions
         .iter()
         .find(|row| row.id == id.to_string())
-        .map(|row| row.status.clone())
+        .map(|row| row.status.as_str().to_string())
         .unwrap_or_else(|| "<missing>".to_string())
 }
 

--- a/tests/render_props.rs
+++ b/tests/render_props.rs
@@ -27,6 +27,7 @@ use thurbox::kernel::selection::{
 };
 use thurbox::kernel::snapshot::{SessionRow, Snapshot};
 use thurbox::kernel::theme::Themes;
+use thurbox::session::SessionState;
 
 fn host() -> LuaHost {
     let host = LuaHost::new(std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("ui"));
@@ -39,7 +40,7 @@ fn row(name: &str, status: &str) -> SessionRow {
         id: format!("{name}-0000-0000-0000-000000000000"),
         name: name.to_string(),
         agent: "claude".to_string(),
-        status: status.to_string(),
+        status: SessionState::from_hook_state(status).expect("a hook state"),
         cwd: Some(std::path::PathBuf::from("/src/thurbox")),
         repo: Some("thurbox".to_string()),
         repos: vec!["thurbox".to_string()],

--- a/tests/search.rs
+++ b/tests/search.rs
@@ -16,6 +16,7 @@ use thurbox::kernel::host::{KeyPress, LuaHost, Published, RenderContext};
 use thurbox::kernel::registry::Registry;
 use thurbox::kernel::snapshot::{SessionRow, Snapshot};
 use thurbox::kernel::theme::Themes;
+use thurbox::session::SessionState;
 
 const PLUGIN: &str = "search";
 const SESSIONS: &str = "sessions";
@@ -32,7 +33,7 @@ fn row(id: &str, name: &str, agent: &str, branch: &str) -> SessionRow {
         id: id.into(),
         name: name.into(),
         agent: agent.into(),
-        status: "idle".into(),
+        status: SessionState::Idle,
         cwd: Some(std::path::PathBuf::from("/src/thurbox")),
         repo: Some("thurbox".into()),
         repos: vec!["thurbox".into()],

--- a/tests/session_lifetime.rs
+++ b/tests/session_lifetime.rs
@@ -15,13 +15,14 @@
 
 use thurbox::kernel::snapshot::{SessionRow, Snapshot};
 use thurbox::kernel::terminal::Terminals;
+use thurbox::session::SessionState;
 
 fn row(id: &str, name: &str, backend: &str, pane: Option<&str>) -> SessionRow {
     SessionRow {
         id: id.into(),
         name: name.into(),
         agent: "claude".into(),
-        status: "idle".into(),
+        status: SessionState::Idle,
         cwd: None,
         repo: None,
         repos: Vec::new(),

--- a/tests/session_list.rs
+++ b/tests/session_list.rs
@@ -12,6 +12,7 @@ use thurbox::kernel::host::{KeyPress, LuaHost, Published, RenderContext};
 use thurbox::kernel::registry::{Registry, Value};
 use thurbox::kernel::snapshot::{GitState, SessionRow, Snapshot};
 use thurbox::kernel::theme::Themes;
+use thurbox::session::SessionState;
 
 const PLUGIN: &str = "sessions";
 
@@ -27,7 +28,7 @@ fn row(id: &str, name: &str) -> SessionRow {
         id: id.into(),
         name: name.into(),
         agent: "claude".into(),
-        status: "idle".into(),
+        status: SessionState::Idle,
         cwd: Some(std::path::PathBuf::from("/src/thurbox")),
         repo: Some("thurbox".into()),
         repos: vec!["thurbox".into()],

--- a/tests/session_state_agreement.rs
+++ b/tests/session_state_agreement.rs
@@ -1,0 +1,204 @@
+//! One row, four surfaces, one word.
+//!
+//! `state` is answered by `session get`, `session list`, `watch` and the
+//! interface's own snapshot, and each used to derive it from the same three
+//! hook columns in its own way. The concrete divergence this pins: `seen_at`
+//! is a *stored fact* — the interface stamps it when the user moves focus off
+//! a finished turn — and only the snapshot ever read it, so a turn the TUI had
+//! already acknowledged as `idle` stayed `done` on every headless surface for
+//! the rest of the session's life.
+//!
+//! Driven through the real binary for the three CLI surfaces and through
+//! `SnapshotStore` for the fourth, because the property under test is that
+//! four *independent* readers of one database row agree.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use serde_json::Value;
+use thurbox::kernel::snapshot::SnapshotStore;
+use thurbox::session::SessionId;
+use thurbox::storage::Database;
+use thurbox::sync::SharedSession;
+
+/// `claude` reports every state, so nothing here is answered by a coverage gap.
+const AGENTS_TOML: &str = r#"
+config_version = 1
+default = "claude"
+
+[[agents]]
+name = "claude"
+command = "claude"
+"#;
+
+/// A throwaway instance whose config and data share one directory — the layout
+/// `paths::TestPathGuard` imposes in-process, so the subprocess surfaces and
+/// the in-process one read the very same files.
+struct Env {
+    root: tempfile::TempDir,
+}
+
+impl Env {
+    fn new() -> Self {
+        let root = tempfile::TempDir::new().expect("tempdir");
+        std::fs::write(root.path().join("agents.toml"), AGENTS_TOML).expect("write agents.toml");
+        Self { root }
+    }
+
+    fn base(&self) -> PathBuf {
+        self.root.path().to_path_buf()
+    }
+
+    fn db(&self) -> Database {
+        Database::open(&self.base().join("thurbox.db")).expect("open the instance database")
+    }
+
+    fn cli(&self, args: &[&str]) -> Value {
+        let out = Command::new(env!("CARGO_BIN_EXE_thurbox-cli"))
+            .args(args)
+            .env("HOME", self.base())
+            .env("USERPROFILE", self.base())
+            .env("THURBOX_CONFIG_DIR", self.base())
+            .env("THURBOX_DATA_DIR", self.base())
+            // Named outright: a relocated data dir derives a socket of its own,
+            // and nothing here may reach the operator's server by accident.
+            .env("THURBOX_SOCKET", "thurbox-agreement-test")
+            .env_remove("THURBOX_SOCKET_FOR")
+            .env_remove("THURBOX_SESSION")
+            .output()
+            .expect("run thurbox-cli");
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            out.status.success(),
+            "thurbox-cli {args:?} failed:\n{stdout}\n{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        // The stream commands print one JSON document per line, the rest print
+        // exactly one — so the first document is the answer in both shapes.
+        serde_json::Deserializer::from_str(&stdout)
+            .into_iter::<Value>()
+            .next()
+            .and_then(Result::ok)
+            .unwrap_or_else(|| panic!("{args:?} printed no JSON:\n{stdout}"))
+    }
+}
+
+fn seed(db: &Database, name: &str) -> SessionId {
+    let row = SharedSession {
+        id: SessionId::default(),
+        name: name.into(),
+        agent: "claude".into(),
+        backend_id: "%7".into(),
+        backend_type: "local-tmux".into(),
+        agent_session_id: Some("sid".into()),
+        cwd: Some(PathBuf::from("/srv/repo")),
+        additional_dirs: Vec::new(),
+        worktrees: Vec::new(),
+        shell_backend_id: None,
+        parent_session_id: None,
+        display_order: None,
+        tombstone: false,
+        tombstone_at: None,
+    };
+    db.upsert_session(&row).expect("upsert");
+    row.id
+}
+
+/// What each of the four surfaces answers for `id`, in one call.
+fn states(env: &Env, id: SessionId) -> [String; 4] {
+    let get = env.cli(&["--json", "session", "get", &id.to_string()]);
+    let list = env.cli(&["--json", "session", "list"]);
+    let watch = env.cli(&["--json", "watch", "--initial", "--for-secs", "1"]);
+
+    let _guard = thurbox::paths::TestPathGuard::new(env.base());
+    let mut store = SnapshotStore::with_database(env.db());
+    store.refresh();
+    let tui = store
+        .current()
+        .sessions
+        .iter()
+        .find(|row| row.id == id.to_string())
+        .map(|row| row.status.as_str().to_string())
+        .expect("the session is in the snapshot");
+
+    [
+        word(&get),
+        word(
+            list.as_array()
+                .expect("session list is an array")
+                .iter()
+                .find(|row| row["id"] == json_id(id))
+                .expect("the session is in the listing"),
+        ),
+        word(&watch),
+        tui,
+    ]
+}
+
+fn json_id(id: SessionId) -> Value {
+    Value::String(id.to_string())
+}
+
+fn word(row: &Value) -> String {
+    row["state"]
+        .as_str()
+        .unwrap_or_else(|| panic!("no state in {row}"))
+        .to_string()
+}
+
+/// The regression. The interface stamped `seen_at` when the user looked away
+/// from a finished turn; every headless surface went on reporting `done`.
+#[test]
+fn an_acknowledged_done_is_idle_on_every_surface() {
+    let env = Env::new();
+    let db = env.db();
+    let id = seed(&db, "acknowledged");
+    db.set_hook_state(id, "done").expect("signal");
+    let at = db
+        .load_hook_state(id)
+        .expect("read back")
+        .expect("row")
+        .state_at
+        .expect("stamped");
+    db.mark_session_seen(id, at).expect("acknowledge");
+
+    let states = states(&env, id);
+    assert_eq!(
+        states,
+        ["idle", "idle", "idle", "idle"],
+        "get, list, watch, tui"
+    );
+}
+
+/// The other half of the same rule: an unacknowledged finish is `done`
+/// everywhere, so the fold above cannot be a blanket downgrade.
+#[test]
+fn an_unacknowledged_done_is_done_on_every_surface() {
+    let env = Env::new();
+    let db = env.db();
+    let id = seed(&db, "finished");
+    db.set_hook_state(id, "done").expect("signal");
+
+    let states = states(&env, id);
+    assert_eq!(
+        states,
+        ["done", "done", "done", "done"],
+        "get, list, watch, tui"
+    );
+}
+
+/// A standing request for input is never folded away by anything.
+#[test]
+fn a_blocked_session_is_blocked_on_every_surface() {
+    let env = Env::new();
+    let db = env.db();
+    let id = seed(&db, "waiting");
+    db.set_hook_state(id, "blocked").expect("signal");
+
+    let states = states(&env, id);
+    assert_eq!(
+        states,
+        ["blocked", "blocked", "blocked", "blocked"],
+        "get, list, watch, tui"
+    );
+}

--- a/tests/session_status.rs
+++ b/tests/session_status.rs
@@ -68,7 +68,7 @@ fn status_of(store: &SnapshotStore, id: &str) -> String {
         .sessions
         .iter()
         .find(|row| row.id == id)
-        .map(|row| row.status.clone())
+        .map(|row| row.status.as_str().to_string())
         .unwrap_or_else(|| "<missing>".to_string())
 }
 

--- a/tests/terminal_pane.rs
+++ b/tests/terminal_pane.rs
@@ -17,6 +17,7 @@ use thurbox::kernel::paint::{render, render_recording, Hit, PlaceholderSurfaces}
 use thurbox::kernel::registry::Registry;
 use thurbox::kernel::snapshot::{SessionRow, Snapshot};
 use thurbox::kernel::theme::Themes;
+use thurbox::session::SessionState;
 
 /// The plugin under test. It keeps its `agent` name: the name is what
 /// `command("focus", …)`, the footer's focus label and the tests below spell,
@@ -35,7 +36,7 @@ fn row(name: &str) -> SessionRow {
         id: format!("{name}-0000-0000-0000-000000000000"),
         name: name.into(),
         agent: "claude".into(),
-        status: "idle".into(),
+        status: SessionState::Idle,
         cwd: None,
         repo: Some("thurbox".into()),
         repos: vec!["thurbox".into()],

--- a/ui/plugins/20_agent.lua
+++ b/ui/plugins/20_agent.lua
@@ -211,8 +211,8 @@ end
 
 -- --- the title -------------------------------------------------------------
 
---- The status as v1's `SessionStatus` Display writes it: capitalised, spelled
---- out, never a glyph. The snapshot hands Lua the lowercase state name.
+--- The status the way v1's session title writes it: capitalised, spelled out,
+--- never a glyph. The snapshot hands Lua the lowercase state name.
 local function status_word(status)
   local word = status or "idle"
   return (word:gsub("^%l", string.upper))


### PR DESCRIPTION
## Intent

Collapse thurbox's two session-status derivations into one, so session get, session list, thurbox-cli watch and the interface's own session list can never answer different words for the same row.

Background from a code review: status was derived twice over the same three hook columns. The interface used kernel::snapshot::derive_status + with_output_quiescence + with_reachability (working|blocked|done|idle|unreachable); the CLI used hook_status::best_state (which returned hook_state verbatim) plus state_word (stopped|running|uncovered|unreported). The sharpest consequence: seen_at is a stored fact — the interface stamps it when focus leaves a finished turn — and only kernel::snapshot ever read it, so a turn the list already showed as idle reported 'done' on every headless surface for the rest of that session's life. A fourth vocabulary, SessionStatus in session/mod.rs, was written but never read by anything.

What the user asked for, in order:
1. Move the three read-time rules into src/session/hook_status.rs, the pure module both kernel and cli may import per tests/architecture_rules.rs. Each caller supplies what it can observe. Keep hook_state verbatim in JSON (a documented contract: a consumer sets its own staleness policy); only state/state_word may change.
2. One enum for the vocabulary; get/list/watch/TUI agree on one row. list and get either use the same probing defaults, OR list documents that unprobed fields are null-with-reason.
3. Write the failing test first: one row, four surfaces, same answer. Update the thurbox-session-status and thurbox-cli skills.

Decisions made while doing the work, which a reviewer reading only the diff would not know:

- SessionState is the single enum (working, blocked, done, idle, stopped, unreachable, running, uncovered, unreported). It replaces the CLI's four STATE_* string constants, the snapshot's bare status String, and SessionStatus. SessionStatus and SessionInfo.status were deleted outright rather than kept: nothing read them (Session::placeholder set the field and has no caller; icon()/Display had no non-test callers), so this removes a vocabulary rather than adding one. That deliberately drops the Error variant, which the code documented as 'not currently derived' — a word no surface can produce is one more case for a driver to handle for nothing. The status_error theme role is untouched; 10_sessions.lua uses it for failed *commands*, not for a session status.

- Only derive_state (which includes the seen_at acknowledgment) is applied by every surface, because all of its inputs are stored columns. with_output_quiescence and with_reachability need a live terminal, and the CLI deliberately does NOT fake them — the skill's argument that the CLI refuses to guess a staleness bound is preserved intact. That is the point of keeping them as opt-in folds rather than parameters of one function.

- On item 2's 'or': list keeps its cheap default (no pane probe) and documents the difference instead of adopting get's. Probing per row would cost a tmux query plus a ps per session on every , and the ADR-24 mirror runs over SSH against a whole host every mirror pass — a real, repeating cost. session list --help now states which fields are null because the pane was not checked (as distinct from checked-and-false, and from a remote session's 'unavailable'), and that state reads unreported/uncovered there where get reads running. Both skills say the same.

- watch applies the acknowledgment from the row's current seen_at even for replayed historical events, while to_state still carries the event's own word verbatim. Reasoning documented in cli/watch.rs: 'somebody has looked at this since' is a fact about now, so a replayed done that has since been read answers idle — the same answer session get gives for that row in that second — and the transition itself is not lost.

- storage::SessionFacts gained seen_at so watch reads it in the lean per-wake scan it already runs, rather than a second query.

- Assessment::from_hooks took a seen_at parameter rather than a builder method, so a caller cannot forget the acknowledgment; watch's assess() helper takes a &HookRow to stay under clippy's argument limit.

The test is tests/session_state_agreement.rs: it drives one row through session get, session list, watch --initial and SnapshotStore, and asserts all four agree. It fails on the parent commit with ["done", "done", "done", "idle"] and passes after. Local gate before running this: just lint clean, cargo nextest run --all = 2384 passed, RUSTDOCFLAGS=-D warnings cargo doc clean.

Deliberately out of scope: Session::placeholder itself (dead but about remote placeholder rows), the two reapers, and the window-identity work — each is another session's branch.

## What Changed

- Consolidated the two divergent status derivations (kernel::snapshot's `derive_status` + `with_output_quiescence` + `with_reachability`, and the CLI's `hook_status::best_state`/`state_word`) into a single `SessionState` enum and `derive_state` function in `src/session/hook_status.rs`, the shared pure module both `kernel` and `cli` may import. Deleted the unused `SessionStatus` enum and `SessionInfo.status`, and the CLI's four `STATE_*` string constants.
- Every surface — `session get`, `session list`, `thurbox-cli watch`, and the interface's `SnapshotStore` — now applies the same `derive_state`, including the `seen_at` acknowledgment, fixing the case where a turn already shown as idle in the interface kept reporting "done" on every other surface for the rest of its life. `with_output_quiescence`/`with_reachability` remain opt-in folds applied only where a live terminal is available; `hook_state` stays verbatim in JSON as a documented contract.
- `session list` keeps its cheap no-probe default and documents which fields are null-with-reason rather than adopting `get`'s pane probing; `--help` text for both commands now describes the difference.
- `storage::SessionFacts` gained `seen_at` so `watch` reads it in its existing per-wake scan; `Assessment::from_hooks` takes `seen_at` as a required parameter, and `watch` applies the current row's acknowledgment to replayed historical events while still carrying the event's own word in `to_state`.
- Added `tests/session_state_agreement.rs`, which drives one row through `session get`, `session list`, `watch --initial`, and `SnapshotStore` and asserts all four agree; updated the `thurbox-session-status`, `thurbox-cli`, `thurbox-kernel`, and `thurbox-testing` skills plus `docs/CONFIG.md`, `docs/FEATURES.md`, and `docs/ORCHESTRATION.md`.

## Risk Assessment

✅ Low: The refactor collapses two status-derivation vocabularies into one pure module (session::hook_status) exactly as the intent specifies: derive_state/with_output_quiescence/with_reachability now live in the shared pure module, every caller (session get, session list, watch, SnapshotStore/TUI, notify, events) was migrated to the new SessionState enum with call sites correctly threading seen_at through (SessionFacts and storage::HookRow both gained/already had seen_at, watch.rs deliberately reads the row's current seen_at for replayed events while carrying the event's own to_state verbatim, matching the documented reasoning), the dead SessionStatus vocabulary and STATE_* constants were removed with no surviving references, list vs get's differing probe defaults are consistent with the code and documented identically in both skills, the new tests/session_state_agreement.rs test drives four real independent surfaces (subprocess CLI × 3 + in-process SnapshotStore) and includes the required regression case (fails on parent commit per the intent, exercises real interfaces not source greps), and `cargo check --all` completed cleanly with no compile errors across all the touched call sites.

## Testing

Baseline `cargo nextest run --all` had already passed; on top of that I re-ran the branch's own end-to-end regression test (tests/session_state_agreement.rs), which exercises the real thurbox-cli binary across session get/list/watch plus the in-process TUI snapshot store for one seeded session row and confirms all four surfaces now answer the same state word (idle/done/blocked) — directly demonstrating the collapsed-status-derivation intent as an end user (via CLI JSON and TUI snapshot) would see it. All targeted suites touching the refactor (session_status, remote_status, session_list, hook_status/snapshot/watch/sessions unit tests, architecture_rules) pass with no failures, and no fix was required this round.

<details>
<summary>Evidence: session_state_agreement end-to-end test transcript (four surfaces agreeing on one row&#39;s state)</summary>

```text
    Finished `test` profile [optimized + debuginfo] target(s) in 0.14s
────────────
 Nextest run ID 07441192-e389-47d8-bc16-51cfdcd7e07d with nextest profile: default
    Starting 3 tests across 1 binary
       START [         ] (1/3) thurbox::session_state_agreement a_blocked_session_is_blocked_on_every_surface

running 1 test
test a_blocked_session_is_blocked_on_every_surface ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 1.02s

        PASS [   1.023s] (1/3) thurbox::session_state_agreement a_blocked_session_is_blocked_on_every_surface
       START [         ] (2/3) thurbox::session_state_agreement an_acknowledged_done_is_idle_on_every_surface

running 1 test
test an_acknowledged_done_is_idle_on_every_surface ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 1.03s

        PASS [   1.042s] (2/3) thurbox::session_state_agreement an_acknowledged_done_is_idle_on_every_surface
       START [         ] (3/3) thurbox::session_state_agreement an_unacknowledged_done_is_done_on_every_surface

running 1 test
test an_unacknowledged_done_is_done_on_every_surface ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 1.05s

        PASS [   1.066s] (3/3) thurbox::session_state_agreement an_unacknowledged_done_is_done_on_every_surface
────────────
     Summary [   3.132s] 3 tests run: 3 passed, 0 skipped
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (9m4s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"8d2e207fdbbed72143023d3a92712d2f42e40b68","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- 🚨 tests failed with exit code 101
- `cargo nextest run --all`

🔧 Fix: confirm session_state_agreement test passes; prior fail was disk full
✅ Re-checked - no issues remain.
- `cargo nextest run --all`
- `cargo nextest run --test session_state_agreement (drives thurbox-cli session get/list/watch + SnapshotStore for one row, asserts all four surfaces agree — the intent's own regression test)`
- `cargo nextest run --test session_status --test remote_status --test session_list (26 passed)`
- `cargo nextest run -p thurbox --lib -E 'test(hook_status) + test(snapshot) + test(watch) + test(sessions)' (111 passed)`
- `cargo nextest run --test architecture_rules (module-boundary rule that hook_status.rs stays importable by both kernel and cli, 12 passed)`
- `git status --porcelain (confirmed clean worktree, no transient artifacts left behind)`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
