### PR TITLE
fix(core): make remote session delete teardown stick on both sides

### DIFF
--- a/.claude/skills/thurbox-cli/SKILL.md
+++ b/.claude/skills/thurbox-cli/SKILL.md
@@ -34,7 +34,7 @@ thurbox-cli session list --json | jq           # machine output for scripts
 thurbox-cli session list --parent <lead-uuid> --json | jq  # direct children only
 ```
 
-Subcommands: `agent` (launch-args — see below), `session` (create/list [`--deleted`]/get/delete/restore/restart
+Subcommands: `agent` (launch-args — see below), `session` (create/list [`--deleted`]/get/delete/reap/restore/restart
 [`--if-missing`]/stop/start/fork/exec/meta/reports-as/send [`--no-enter`]/key/capture/focus/signal/doctor/sync/register —
 `sync`/`register` and the flags serve session sharing, ADR-24), `watch` (stream
 the session event log, one event per line), `runtime` (status/stop — what
@@ -434,10 +434,14 @@ there is no wiring here to be broken, and failing it made bare `session doctor`
 session shape thurbox advertises for drivers.
 
 `session delete <uuid>` **soft-deletes** by default — only the DB row is marked
-deleted, and `session restore` revives it. The window is torn down once the undo
-window closes (`UNDO_WINDOW`, 10s): by the TUI's `kernel::reaper`, or headlessly
-by `reap_overdue_soft_deletes` on the heartbeat. Only the **window** — worktrees
-are what makes the undo lossless and are never touched by a soft delete. `--force`
+deleted, and `session restore` revives it. The windows are torn down once the
+undo window closes (`UNDO_WINDOW`, 10s): by the TUI's `kernel::reaper`, or
+headlessly by `reap_overdue_soft_deletes` on the heartbeat, or on demand with
+`session reap <ref>` — which is how a peer collects a row on a host that has no
+interface of its own (ADR-24), and resolves against the *deleted* rows the way
+`session restore` does. Only the **windows** (agent and companion shell, both
+found by their `@thurbox_session` stamp) — worktrees are what makes the undo
+lossless and are never touched by a soft delete. `--force`
 (`session_ops::delete_session_headless`) also kills the tmux window, removes
 the worktrees **thurbox created** + the symlink workspace, disables `send`
 automations targeting the session, and clears its `session meta` key/value space

--- a/.claude/skills/thurbox-remote-hosts/SKILL.md
+++ b/.claude/skills/thurbox-remote-hosts/SKILL.md
@@ -210,19 +210,61 @@ session), never on the loop, ADR-P12).
 - **Remote teardown** (WSL inherits the SSH path): `session delete --force`
   teardown is **backend-aware** — `teardown_runtime_resources` resolves the
   session's `HostDef` from its `backend_type` and, for a remote session, kills
-  the pane via `kill_pane_remote(host, session_id, name, backend_id)` and removes
-  each worktree via `git::remove_worktree_on(Some(host), …)` (local sessions keep
-  the `kill_window`/`remove_worktree` + Windows pane-reap path). Both kills are
-  resolved from the window's own `@thurbox_session` stamp, not the row's pane id
-  or its name (ADR-25) — the host's tmux server reissues pane ids when it
-  restarts, so a remembered `%N` there can be a live namesake's pane; the
-  `backend_id` argument is the psmux fallback only. Best-effort: an
+  its windows via `kill_remote_windows(host, session_id, name, SessionPanes)` and
+  removes each worktree via `git::remove_worktree_on(Some(host), …)` (local
+  sessions keep the `kill_window`/`remove_worktree` + Windows pane-reap path).
+  Every kill is resolved from the window's own `@thurbox_session` stamp, not the
+  row's pane id or its name (ADR-25) — the host's tmux server reissues pane ids
+  when it restarts, so a remembered `%N` there can be a live namesake's pane; the
+  `SessionPanes` argument is the psmux fallback only. Best-effort: an
   unreachable host or a missing `hosts.toml` entry is recorded in
   `ForceDeleteReport.remote_teardown_error` (surfaced in the CLI JSON) and the
   row is still soft-/force-deleted. Like local force-delete it removes the
   worktree *directory* only, leaving the branch. `wsl.exe`'s exact arg-passing
   isn't verified in CI (no WSL runner); the construction is unit-tested
   (`transport::tests::wsl_*`, `git_command_wsl_*`).
+- **A session owns two windows**, and every teardown takes both: the agent
+  (`tb-`) and the companion shell (`tbs-`). The shell is found by its stamp
+  (`@thurbox_role = shell`) rather than by `sessions.shell_backend_id`, which is
+  written only once the interface has actually opened one — so the column is
+  NULL for nearly every remote row, and a teardown keyed on it left a live
+  `tbs-` window behind for good. `stop` and `restart` take it down too; the
+  interface reopens one on demand.
+- **A remote teardown never starts a server.** `ensure_ready` creates the
+  multiplexer server *and* the thurbox session as a side effect, so a one-shot
+  `thurbox-cli` tearing a session down used to leave an empty server on the
+  host. `kill_remote_windows` / `remote_window_index` / `agent_window` read one
+  `list-windows` (guarded by `has-session`) and kill with a one-shot
+  `kill-pane`. And they only act on a socket the host has vouched for:
+  `known_host_socket` takes `hosts.toml`'s `socket`, else what the host's own
+  CLI reported (`learn_host_socket`), else — for a host with `share_sessions =
+  false`, where nothing but this thurbox writes there — this build's default.
+  A **shareable** host that has reported nothing is refused with "socket
+  unknown for host '…'", because this build's default is a guess about someone
+  else's machine (a dev build aims at `thurbox-dev`; a relocated data dir
+  derives its own name).
+- **A remote soft delete is reaped on the host.** `reap_soft_deleted` no longer
+  gives up on a remote row: it asks a shareable host to collect it
+  (`thurbox-cli session reap <ref>` there, which owns the host's own row), and
+  otherwise kills the windows itself through the stamp. Driven by the TUI's
+  `kernel::reaper` and, with no interface open, by `reap_overdue_soft_deletes`
+  on the heartbeat — which gates a remote row on the *host's* window listing,
+  exactly as it gates a local one on this machine's. Without it every soft
+  delete of a remote session (the TUI's default) leaked its `tb-`/`tbs-` pair
+  forever, and re-creating the name put a second agent beside the first.
+- **A local tombstone beats a host-active row** unless the host wrote the row
+  *after* the delete. `session list` carries `updated_at` for exactly this;
+  `mirror::apply` compares it with the local `deleted_at`, reports the losers in
+  `MirrorReport.tombstoned`, and `mirror_host` pushes each as a `session delete`
+  to the host — the symmetric counterpart of `register_unknown`. Before that, a
+  delete taken while the host's CLI was in backoff was undone on the next mirror
+  pass, forever.
+- **A delegated delete the host does not know falls through** to the local
+  teardown instead of erroring: a fork minted here, a pre-ADR-24 row, or one a
+  peer already deleted there all make the host answer "Session not found", and
+  aborting left the local row active and attached. The fall-through is recorded
+  in `ForceDeleteReport.host_unknown`. Any *other* host error still aborts — the
+  session may still be running there.
 - **Local e2e**: `scripts/dev/e2e/linux-container.sh up` spins a throwaway Podman
   container (sshd + tmux + git) and `… test` asserts a session lands on the
   `ssh:podman` backend (state under `target/`, never touches your real

--- a/.claude/skills/thurbox-remote-hosts/SKILL.md
+++ b/.claude/skills/thurbox-remote-hosts/SKILL.md
@@ -253,8 +253,13 @@ session), never on the loop, ADR-P12).
   delete of a remote session (the TUI's default) leaked its `tb-`/`tbs-` pair
   forever, and re-creating the name put a second agent beside the first.
 - **A local tombstone beats a host-active row** unless the host wrote the row
-  *after* the delete. `session list` carries `updated_at` for exactly this;
-  `mirror::apply` compares it with the local `deleted_at`, reports the losers in
+  *after* this database's own last-known reading of that host's clock for the
+  row. `session list` carries `updated_at` for exactly this; `mirror::apply`
+  compares it with the snapshot `sessions.host_updated_at` was last given
+  (schema v45), not with the local `deleted_at` — the host's `updated_at` and
+  this machine's `deleted_at` are two different clocks, and comparing them
+  directly let a host whose clock merely ran behind this one look
+  not-yet-restored and get re-deleted. Reports the losers in
   `MirrorReport.tombstoned`, and `mirror_host` pushes each as a `session delete`
   to the host — the symmetric counterpart of `register_unknown`. Before that, a
   delete taken while the host's CLI was in backoff was undone on the next mirror

--- a/.claude/skills/thurbox-testing/SKILL.md
+++ b/.claude/skills/thurbox-testing/SKILL.md
@@ -64,7 +64,7 @@ kernel over the real `ui/`** rather than a harness that imitates either:
   smoke script, which could not see the byte stream and duplicated this harness.
 - **`tests/reap_e2e.rs`** — window-teardown ownership against a *real* tmux on a
   throwaway socket (skipped when tmux is absent), because the bug it pins only
-  exists in how tmux resolves a target. Ten tests. Six pin the reap itself: a
+  exists in how tmux resolves a target. 13 tests. Six pin the reap itself: a
   stale row's reap spares a live namesake's window, a namesake's pane the stale
   row still remembers, a live window whose name only collides after
   `sanitize_window_name` ('fleet 1' and 'fleet_1' share one `tb-fleet_1`), and a
@@ -75,10 +75,15 @@ kernel over the real `ui/`** rather than a harness that imitates either:
   Force delete, `stop` and `restart` share the reap's ownership gate (ADR-25,
   `agent::tmux::WindowIndex`) rather than each resolving `tb-<name>` on their
   own, so one test walks all three against their own live namesake, plus one
-  asserting force delete still kills the row's own window. The last two cover
+  asserting force delete still kills the row's own window. Two more cover
   the stamp itself: a row with no pane id at all (the psmux shape) still
   resolves its own window, and restore refuses to adopt a live namesake's
-  window rather than putting two rows on one pane.
+  window rather than putting two rows on one pane. The last three cover the
+  companion shell and the no-server guarantee (ADR-24/25's remote teardown):
+  force delete and reap both collect the companion shell alongside the agent's
+  window, a teardown spares a live namesake's companion shell, and a teardown
+  never brings a tmux server into being (the `ensure_ready` side effect this
+  path must not trigger).
 - **`tests/session_state_agreement.rs`** — one row, four independent readers
   (`session get`, `session list`, `watch --initial` via the real binary, and
   `SnapshotStore` in-process): all four must answer the same `SessionState`.

--- a/README.md
+++ b/README.md
@@ -560,6 +560,7 @@ thurbox-cli session doctor [<uuid>]      # are this session's status hooks wired
 thurbox-cli session restart <uuid>       # kill + re-spawn with --resume
 thurbox-cli session delete <uuid>        # soft-delete (see below)
 thurbox-cli session restore <uuid>       # undo a soft-delete
+thurbox-cli session reap <uuid>          # collect a soft-delete's windows on demand
 ```
 
 `create` runs synchronously — the tmux window is live by the time it returns.
@@ -672,14 +673,18 @@ name rather than reaching for a window that is deliberately gone (see
 contract).
 
 **Deleting.** `session delete <uuid>` is a soft-delete: it only marks the
-database row. A running TUI kills the tmux window once the 10-second undo
-window closes; the worktrees stay, which is what makes `session restore <uuid>`
-lossless.
+database row, and `session restore <uuid>` brings it back. The session's tmux
+windows — the agent's and its companion shell's — come down once the
+10-second undo window closes: a running TUI does it, the `automation tick`
+heartbeat does it with no TUI open, and `session reap <uuid>` does it on
+demand (what a host running only the CLI needs, since it has no interface of
+its own). The worktrees stay, which is what makes the restore lossless.
 
 Pass `--force` to tear down the runtime resources in the same call, for headless
-cleanup with no TUI running. It kills the tmux window, removes the session's git
-worktrees (the underlying repos are left intact), removes the multi-repo symlink
-workspace if any, and disables `send` automations targeting the session.
+cleanup with no TUI running. It kills the session's tmux windows, removes the
+session's git worktrees (the underlying repos are left intact), removes the
+multi-repo symlink workspace if any, and disables `send` automations targeting
+the session.
 Teardown is best-effort: individual failures are recorded in the JSON report
 (`killed_window`, `removed_worktrees`, `worktree_errors`,
 `disabled_automations`) but never abort the delete, and the row is always

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1326,15 +1326,20 @@ follow from the host owning the record, none of which the first cut had:
   was in backoff — or while sharing was off — was undone on the next pass, and
   on every pass after. The listing carries `updated_at` for the ordering the
   two sides otherwise lack: the host's row wins only when the host wrote it
-  *after* the local `deleted_at` (a peer restored it there). Otherwise the
-  tombstone stands and the delete is pushed to the host as `session delete`,
-  the symmetric counterpart of `session sync --adopt`'s `register_unknown` —
-  and unconditional where that one is opt-in, since a delete the host never
-  hears is a window running there forever. The two timestamps come from two
-  clocks, which is tolerable here and nowhere near a lock: the comparison only
-  decides which of two *user* actions minutes or hours apart came first, and
-  its failure mode under skew is a delete pushed again rather than a session
-  destroyed.
+  *after* this database's own last-known reading of that same host's clock for
+  that row (schema v45's `host_updated_at`, snapshotted on every mirrored
+  write). Otherwise the tombstone stands and the delete is pushed to the host
+  as `session delete`, the symmetric counterpart of `session sync --adopt`'s
+  `register_unknown` — and unconditional where that one is opt-in, since a
+  delete the host never hears is a window running there forever. Ordering
+  against a prior reading of the *same* clock, rather than the host's
+  `updated_at` against this machine's `deleted_at`, is what keeps the two
+  sides' independent clocks out of the comparison: a slower or faster host
+  clock changes nothing, since both readings came from it. The one row for
+  which there is no prior reading — a session deleted before this database
+  ever mirrored it from that host — still falls back to comparing against
+  local `deleted_at`, the same approximation the comparison used everywhere
+  before v45.
 - **"The host does not know this row" is not a failure to delete.** The host
   resolves the id against its *active* rows, so a fork minted here, a
   pre-ADR-24 row, and one a peer already deleted all answer "Session not

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1318,6 +1318,40 @@ legacy path and is registered on the host by `session sync --adopt`, as is
 any session created before this change. `session register` is the one place
 a row is made for a window that already runs, and it refuses to launch.
 
+Reconciliation has a direction, and delegation has a fallback. Three rules
+follow from the host owning the record, none of which the first cut had:
+
+- **A local tombstone is a decision, not a gap.** The mirror read "the host
+  lists it as active" as "restore it", so a delete taken while the host's CLI
+  was in backoff — or while sharing was off — was undone on the next pass, and
+  on every pass after. The listing carries `updated_at` for the ordering the
+  two sides otherwise lack: the host's row wins only when the host wrote it
+  *after* the local `deleted_at` (a peer restored it there). Otherwise the
+  tombstone stands and the delete is pushed to the host as `session delete`,
+  the symmetric counterpart of `session sync --adopt`'s `register_unknown` —
+  and unconditional where that one is opt-in, since a delete the host never
+  hears is a window running there forever. The two timestamps come from two
+  clocks, which is tolerable here and nowhere near a lock: the comparison only
+  decides which of two *user* actions minutes or hours apart came first, and
+  its failure mode under skew is a delete pushed again rather than a session
+  destroyed.
+- **"The host does not know this row" is not a failure to delete.** The host
+  resolves the id against its *active* rows, so a fork minted here, a
+  pre-ADR-24 row, and one a peer already deleted all answer "Session not
+  found". Aborting on it left the local row active and attached. It falls
+  through to the local teardown instead, recorded in the report's
+  `host_unknown`; any other host error still aborts, because the session may
+  still be running there.
+- **A soft delete is reaped on the host.** Nothing reaps a soft-deleted row
+  but an interface's `kernel::reaper` or the heartbeat's sweep, and a host
+  running only `thurbox-cli` has neither — so the undo window never closed
+  there and every remote soft delete leaked its windows. `session reap <ref>`
+  is that operation as a verb, and a peer calls it once the undo window is up
+  (a non-shareable host's windows are killed directly instead). A remote
+  teardown also never calls `ensure_ready`, which would *create* the server
+  and the thurbox session on the host as a side effect of tearing one down,
+  and acts only on a socket the host has vouched for (`known_host_socket`).
+
 ---
 
 ## ADR-25: A window's identity is a stamp on the window, not its name
@@ -1378,4 +1412,9 @@ while it is the only one with that name, and it is stamped on adoption
 (`restore`'s adopt, `session register`), so a pre-ADR-25 window converts on
 first use. psmux (ADR-13) has no usable window options, so every window there
 reads as unstamped and the name fallback stands — the one place it still
-does, matching the shape of the other psmux carve-outs.
+does, matching the shape of the other psmux carve-outs. And because the stamp
+answers for a *role*, the companion shell became reachable: a session owns a
+`tb-` and a `tbs-` window, `sessions.shell_backend_id` is written only once
+the interface has opened one, and every teardown — force delete, reap, `stop`,
+`restart`, `--on-existing replace` — now takes both down through the stamp
+rather than through a column that is usually NULL.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1327,8 +1327,9 @@ follow from the host owning the record, none of which the first cut had:
   on every pass after. The listing carries `updated_at` for the ordering the
   two sides otherwise lack: the host's row wins only when the host wrote it
   *after* this database's own last-known reading of that same host's clock for
-  that row (schema v45's `host_updated_at`, snapshotted on every mirrored
-  write). Otherwise the tombstone stands and the delete is pushed to the host
+  that row (schema v45's `host_updated_at`, snapshotted whenever this database
+  adopts, restores, or applies a change to the row from the host's listing).
+  Otherwise the tombstone stands and the delete is pushed to the host
   as `session delete`, the symmetric counterpart of `session sync --adopt`'s
   `register_unknown` — and unconditional where that one is opt-in, since a
   delete the host never hears is a window running there forever. Ordering

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -595,8 +595,19 @@ has the rationale; the shape:
 - **Undo and restore.** `Ctrl+Z` inside the undo window leaves no
   trace. Once the host records a deletion every mirror shows it;
   a restore from any side runs on the host and every mirror shows it
-  back. A soft delete asked for headlessly is reaped by the host's tick
-  once the undo window has passed.
+  back. Once the undo window has passed the session's windows come down
+  on the host — asked for with `thurbox-cli session reap <ref>` there,
+  since a host running only the CLI has no interface of its own to
+  collect them.
+- **A delete sticks.** A tombstone here outranks a row the host still
+  lists as active, unless the host wrote that row *after* the delete
+  (which is a restore taken there): the listing carries `updated_at`
+  for exactly that comparison. A delete the host has not heard —
+  taken while its CLI was unreachable, or while sharing was off — is
+  pushed to it on the next mirror pass, so the two converge instead of
+  undoing each other. And a delete the host answers "no such session"
+  to is taken from here rather than failing: a fork, a row from before
+  sharing, or one a peer already deleted there.
 - **Windows hosts** share through the same path: the probe, the
   provisioning (the release zip) and every delegated command go
   through the PowerShell path the probes already use.

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -334,8 +334,16 @@ fn parse_discovered(line: &str) -> Option<DiscoveredSession> {
 /// `tb-foo` would resolve ambiguously when both `tb-foo` and
 /// `tb-foo-bar` exist — `send-keys`/`capture-pane` then fails with
 /// "ambiguous window" and the caller's text is silently dropped.
-fn window_target(session_name: &str) -> String {
-    format!("{TMUX_SESSION}:={}", agent_window_name(session_name))
+fn window_target(window_name: &str) -> String {
+    format!("{TMUX_SESSION}:={window_name}")
+}
+
+/// The window name a session's `role` window carries.
+fn window_name_for(role: WindowRole, session_name: &str) -> String {
+    match role {
+        WindowRole::Shell => shell_window_name(session_name),
+        _ => agent_window_name(session_name),
+    }
 }
 
 /// The tmux window option carrying the id of the session row that owns a
@@ -499,6 +507,14 @@ impl WindowIndex {
         self.locate(session_id, session_name, WindowRole::Agent, true)
     }
 
+    /// Where a session's companion shell window is. Resolved by the same stamp
+    /// as its agent: the row's `shell_backend_id` is only ever set once the
+    /// interface has opened the shell, so a session that has one is routinely a
+    /// session whose column is NULL.
+    pub fn shell_window(&self, session_id: &str, session_name: &str) -> Located {
+        self.locate(session_id, session_name, WindowRole::Shell, false)
+    }
+
     /// Whether the listing puts `pane` in an agent window this session may
     /// claim — the positive reading, where a pane the listing does not place is
     /// only an absence.
@@ -560,10 +576,7 @@ impl WindowIndex {
                 }
             }
         }
-        let window = match role {
-            WindowRole::Shell => shell_window_name(session_name),
-            _ => agent_window_name(session_name),
-        };
+        let window = window_name_for(role, session_name);
         let named: Vec<&ListedWindow> = self
             .by_name
             .get(&window)
@@ -621,6 +634,18 @@ pub fn local_window_index() -> Result<WindowIndex> {
     Ok(WindowIndex::from_listing(TmuxBackend::local().discover()?))
 }
 
+/// Every thurbox window on `host`'s server, indexed — [`local_window_index`]
+/// for a machine that is not this one.
+///
+/// One `list-windows` over the transport and nothing else: no control mode, so
+/// asking what a host holds never brings a server into being there.
+pub fn remote_window_index(host: &crate::session::HostDef) -> Result<WindowIndex> {
+    known_host_socket(host)?;
+    Ok(WindowIndex::from_listing(
+        TmuxBackend::from_host(host).discover()?,
+    ))
+}
+
 /// Whether the local multiplexer is psmux, which has no usable window options
 /// (ADR-13) and so leaves every window unstamped.
 ///
@@ -639,8 +664,14 @@ fn local_mux_is_psmux() -> bool {
 /// tmux matches exactly and resolves to an arbitrary one of a session's
 /// namesakes.
 fn agent_target(session_id: &str, session_name: &str) -> Option<String> {
+    owned_target(session_id, session_name, WindowRole::Agent)
+}
+
+/// [`agent_target`] for any of a session's windows — its agent, or the
+/// companion shell a teardown has to take down with it.
+fn owned_target(session_id: &str, session_name: &str, role: WindowRole) -> Option<String> {
     let located = match local_window_index() {
-        Ok(index) => index.agent_window(session_id, session_name),
+        Ok(index) => index.locate(session_id, session_name, role, false),
         Err(e) => {
             debug!("could not list windows to resolve '{session_name}': {e:#}");
             Located::Unknown
@@ -649,7 +680,9 @@ fn agent_target(session_id: &str, session_name: &str) -> Option<String> {
     match located {
         Located::At(pane) => Some(pane),
         Located::Absent => None,
-        Located::Unknown => local_mux_is_psmux().then(|| window_target(session_name)),
+        Located::Unknown => {
+            local_mux_is_psmux().then(|| window_target(&window_name_for(role, session_name)))
+        }
     }
 }
 
@@ -818,6 +851,22 @@ impl TmuxBackend {
     fn tmux_run(&self, args: &[&str]) -> Result<()> {
         self.run_tmux(args)?;
         Ok(())
+    }
+
+    /// Kill a pane with a one-shot command rather than through control mode.
+    ///
+    /// The teardown path's kill. [`SessionBackend::kill`] goes through control
+    /// mode, which a caller must open with
+    /// [`ensure_ready`](SessionBackend::ensure_ready) — and that *creates* the
+    /// server and the thurbox session when they are absent, so tearing a
+    /// session down on a host would leave an empty server behind. A pane that
+    /// is already gone is not an error: the teardown got what it wanted.
+    fn kill_pane_oneshot(&self, pane: &str) -> Result<()> {
+        match self.run_tmux(&["kill-pane", "-t", pane]) {
+            Ok(_) => Ok(()),
+            Err(e) if format!("{e:#}").contains("find pane") => Ok(()),
+            Err(e) => Err(e),
+        }
     }
 
     /// Execute a tmux command on the thurbox socket and check for errors.
@@ -2682,9 +2731,15 @@ pub fn agent_window(
     session_name: &str,
 ) -> Result<Located> {
     let backend = match host {
-        Some(host) => TmuxBackend::from_host(host),
+        Some(host) => {
+            known_host_socket(host)?;
+            TmuxBackend::from_host(host)
+        }
         None => TmuxBackend::local(),
     };
+    // A one-shot `list-windows`, and deliberately nothing more: `discover`
+    // answers empty for a server that is not there, where starting control
+    // mode would bring one into being.
     let index = WindowIndex::from_listing(backend.discover()?);
     Ok(index.live_agent_window(session_id, session_name))
 }
@@ -2748,36 +2803,110 @@ pub(crate) fn own_socket_path(tmux_env: &str) -> Option<String> {
     (!path.is_empty()).then(|| path.to_string())
 }
 
-/// Kill a session's window on `host`, best-effort.
+/// The socket a remote operation on `host` may act on, or why it must not act
+/// at all.
+///
+/// A host that runs a thurbox of its own owns the socket its sessions live on:
+/// its `hosts.toml` override, or what its CLI reported ([`learn_host_socket`]).
+/// This build's compile-time default is a guess about somebody else's machine —
+/// a dev build would aim at `thurbox-dev` while the host's release binary runs
+/// `thurbox`, and a host with a relocated data dir derives a name of its own —
+/// so a teardown refuses rather than acting on it. With sharing off nothing but
+/// this thurbox writes there, so the default is ours by construction.
+pub fn known_host_socket(host: &crate::session::HostDef) -> Result<String> {
+    if let Some(socket) = host
+        .socket
+        .clone()
+        .or_else(|| learned_host_socket(&host.backend_name()))
+    {
+        return Ok(socket);
+    }
+    if !host.shareable() {
+        return Ok(TMUX_SOCKET.to_string());
+    }
+    bail!(
+        "socket unknown for host '{}': it runs a thurbox of its own and has not \
+         reported which socket that is (set `socket` in hosts.toml, or make its \
+         thurbox-cli reachable)",
+        host.name
+    )
+}
+
+/// Kill the windows a session owns on `host`: its agent and, when it has one,
+/// its companion shell. Returns whether the *agent* window came down.
 ///
 /// Mirror of [`kill_window`] for the SSH transport, and strict in the same
 /// way: the pane a row remembers is a *hint* — the host's tmux server reissues
 /// ids from `%0` when it restarts, so a remembered `%N` can be a live
 /// namesake's pane afterwards. Only a window the host's own listing stamps for
-/// this session is killed. `pane_id` is the psmux fallback, where nothing is
+/// this session is killed. `panes` is the psmux fallback, where nothing is
 /// stamped and a name cannot be told apart from its namesake's.
-pub fn kill_pane_remote(
+///
+/// One listing serves both roles — an ssh round trip per role would double the
+/// cost of every remote teardown — and nothing here starts control mode:
+/// [`TmuxBackend::ensure_ready`] *creates* the server and the thurbox session
+/// on the host, which is how tearing a session down came to leave empty
+/// servers on other people's machines.
+pub fn kill_remote_windows(
     host: &crate::session::HostDef,
     session_id: &str,
     session_name: &str,
-    pane_id: &str,
+    panes: SessionPanes<'_>,
 ) -> Result<bool> {
+    known_host_socket(host)?;
     let backend = TmuxBackend::from_host(host);
-    backend.ensure_ready()?;
-    let located =
-        WindowIndex::from_listing(backend.discover()?).agent_window(session_id, session_name);
+    let index = WindowIndex::from_listing(backend.discover()?);
+    let killed = kill_located(
+        &backend,
+        index.agent_window(session_id, session_name),
+        panes.agent,
+        session_name,
+        &host.name,
+    )?;
+    kill_located(
+        &backend,
+        index.shell_window(session_id, session_name),
+        panes.shell,
+        session_name,
+        &host.name,
+    )?;
+    Ok(killed)
+}
+
+/// The pane ids a row remembers for its two windows — the psmux fallback and
+/// nothing more, since a stamped window is resolved without them.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SessionPanes<'a> {
+    pub agent: &'a str,
+    /// Usually empty: `shell_backend_id` is written only once the interface has
+    /// opened a shell for the session.
+    pub shell: &'a str,
+}
+
+impl<'a> SessionPanes<'a> {
+    /// The agent's pane alone, for a caller with no shell to speak of.
+    pub fn agent(agent: &'a str) -> Self {
+        Self { agent, shell: "" }
+    }
+}
+
+/// Kill what a listing placed, if it placed anything this session may claim.
+fn kill_located(
+    backend: &TmuxBackend,
+    located: Located,
+    psmux_fallback: &str,
+    session_name: &str,
+    host_name: &str,
+) -> Result<bool> {
     match located {
-        Located::At(pane) => backend.kill(&pane).map(|()| true),
+        Located::At(pane) => backend.kill_pane_oneshot(&pane).map(|()| true),
         // Already gone, or never this session's to begin with.
         Located::Absent => Ok(false),
-        Located::Unknown if backend.transport.uses_psmux() && !pane_id.is_empty() => {
-            backend.kill(pane_id).map(|()| true)
+        Located::Unknown if backend.transport.uses_psmux() && !psmux_fallback.is_empty() => {
+            backend.kill_pane_oneshot(psmux_fallback).map(|()| true)
         }
         Located::Unknown => {
-            debug!(
-                "not killing a window on {}: '{session_name}' is ambiguous there",
-                host.name
-            );
+            debug!("not killing a window on {host_name}: '{session_name}' is ambiguous there");
             Ok(false)
         }
     }
@@ -2791,6 +2920,21 @@ pub fn kill_pane_remote(
 /// reaped, and `kill-window -t tb-<name>` matches an arbitrary one of them.
 pub fn kill_window(session_id: &str, session_name: &str) -> Result<()> {
     match agent_target(session_id, session_name) {
+        Some(target) => kill_window_at(&target),
+        None => Ok(()),
+    }
+}
+
+/// Kill the session's companion shell window (`tbs-`), if the local server
+/// still holds one.
+///
+/// The other half of [`kill_window`]: a session owns two windows, and a
+/// teardown that takes only the agent leaves a `tbs-` shell running for a row
+/// that no longer exists. Resolved by the same stamp, so a NULL
+/// `shell_backend_id` — the usual state, since the column is written only when
+/// the interface opens the shell — costs nothing.
+pub fn kill_shell_window(session_id: &str, session_name: &str) -> Result<()> {
+    match owned_target(session_id, session_name, WindowRole::Shell) {
         Some(target) => kill_window_at(&target),
         None => Ok(()),
     }
@@ -3411,6 +3555,41 @@ mod tests {
         assert_eq!(backend.session, "sess-vm");
     }
 
+    #[test]
+    fn a_shareable_host_that_has_not_said_which_socket_it_uses_is_refused() {
+        // A remote teardown used to fall back on this build's own socket name.
+        // On a host running its own thurbox that is a guess about somebody
+        // else's machine — a dev build aims at `thurbox-dev` while the host's
+        // release binary runs `thurbox`, and a relocated data dir derives a
+        // name of its own — so the teardown acted on an empty server, and
+        // `ensure_ready` created one there while it was at it.
+        let host = crate::session::HostDef {
+            name: "devbox".into(),
+            destination: "me@devbox".into(),
+            ..Default::default()
+        };
+        let refusal = format!("{:#}", known_host_socket(&host).unwrap_err());
+        assert!(
+            refusal.contains("socket unknown for host 'devbox'"),
+            "{refusal}"
+        );
+
+        // Sharing off: nothing but this thurbox writes there, so its own socket
+        // is the host's by construction.
+        let solo = crate::session::HostDef {
+            share_sessions: false,
+            ..host.clone()
+        };
+        assert_eq!(known_host_socket(&solo).unwrap(), TMUX_SOCKET);
+
+        // And a pinned socket answers without asking anyone.
+        let pinned = crate::session::HostDef {
+            socket: Some("thurbox".into()),
+            ..host
+        };
+        assert_eq!(known_host_socket(&pinned).unwrap(), "thurbox");
+    }
+
     // Compile-time check: channel capacity must be large enough to buffer heavy output.
     const _: () = assert!(PANE_CHANNEL_CAPACITY >= 1024);
 
@@ -3590,6 +3769,29 @@ mod tests {
     fn a_sessions_shell_window_is_not_its_agent() {
         let index = WindowIndex::from_listing([listed("%5", "tbs-fleet", ONE, WindowRole::Shell)]);
         assert_eq!(index.agent_window(ONE, "fleet"), Located::Absent);
+        assert_eq!(index.shell_window(ONE, "fleet"), Located::At("%5".into()));
+    }
+
+    /// The rule a teardown reads the companion shell by. `shell_backend_id` is
+    /// written only once the interface has opened one, so most rows carry no id
+    /// for their shell at all and the stamp is the whole answer — including the
+    /// answer that a namesake's shell is *not* this session's to kill.
+    #[test]
+    fn a_shell_window_is_owned_by_its_stamp_the_way_an_agent_window_is() {
+        let theirs = WindowIndex::from_listing([listed("%5", "tbs-fleet", TWO, WindowRole::Shell)]);
+        assert_eq!(theirs.shell_window(ONE, "fleet"), Located::Absent);
+
+        // Unstamped and alone: the pre-ADR-25 shape, and psmux's permanent one.
+        let legacy = WindowIndex::from_listing([listed("%5", "tbs-fleet", "", WindowRole::Shell)]);
+        assert_eq!(legacy.shell_window(ONE, "fleet"), Located::At("%5".into()));
+
+        // Two of them, neither stamped: nobody can say, and a teardown that
+        // guessed would take a live session's shell down.
+        let ambiguous = WindowIndex::from_listing([
+            listed("%5", "tbs-fleet", "", WindowRole::Shell),
+            listed("%6", "tbs-fleet", "", WindowRole::Shell),
+        ]);
+        assert_eq!(ambiguous.shell_window(ONE, "fleet"), Located::Unknown);
     }
 
     /// `remain-on-exit` keeps a failed agent's window in place so the error is
@@ -3719,8 +3921,10 @@ mod tests {
         // Without `=`, tmux treats the window name as a pattern and will
         // resolve `tb-foo` ambiguously when both `tb-foo` and
         // `tb-foo-bar` exist. The `=` prefix forces exact-match lookup.
-        let t = window_target("foo");
+        let t = window_target(&agent_window_name("foo"));
         assert!(t.ends_with(":=tb-foo"), "got {t}");
+        let shell = window_target(&shell_window_name("foo"));
+        assert!(shell.ends_with(":=tbs-foo"), "got {shell}");
     }
 
     #[test]

--- a/src/cli/automations.rs
+++ b/src/cli/automations.rs
@@ -4,6 +4,8 @@
 //! loop is what actually fires them. `run` just marks an automation due so the
 //! TUI picks it up on its next tick.
 
+use std::collections::HashMap;
+
 use clap::Subcommand;
 use serde_json::{json, Value};
 
@@ -555,17 +557,20 @@ fn poll_local_pane_states(db: &Database) -> usize {
     written
 }
 
-/// Let go of the agents of local sessions soft-deleted longer ago than the
-/// interface's undo window, when the row still owns its window. Returns the ids
-/// reaped. Only rows with a window of their *own* are touched, so a row reaped
+/// Let go of the agents of sessions soft-deleted longer ago than the
+/// interface's undo window, when the row still owns a window. Returns the ids
+/// reaped. Only rows with windows of their *own* are touched, so a row reaped
 /// once costs nothing on every later tick — and a stale row is never reported as
 /// reaped on the strength of a live namesake's window. The gate is
-/// `session_ops::delete::owned_agent_pane_in`, the same and only ownership test
+/// `session_ops::delete::owned_windows_in`, the same and only ownership test
 /// the reap itself applies.
 ///
-/// The listing is taken once and only when a row has actually come due: a
-/// sweep that finds nothing overdue — which is nearly every one — costs no tmux
-/// round trip at all.
+/// A remote row is gated the same way, against its host's own listing rather
+/// than this machine's: a session soft-deleted on a host has no interface there
+/// to collect it, and leaving it was how every headless delete of a remote
+/// session leaked its `tb-`/`tbs-` pair for good. That costs one
+/// `list-windows` per host, and only for a host with a row actually overdue —
+/// the same shape as the remote status poll two steps above.
 ///
 /// Window ownership is the whole gate, so a row that owns none is skipped
 /// entirely and its metrics file and symlink workspace are left in place —
@@ -581,17 +586,15 @@ fn reap_overdue_soft_deletes(db: &Database) -> Vec<String> {
     let now = current_time_millis();
     let window = crate::kernel::reaper::UNDO_WINDOW.as_millis() as u64;
     let mut reaped = Vec::new();
-    let mut windows: Option<crate::agent::tmux::WindowIndex> = None;
+    let mut windows: HashMap<String, crate::agent::tmux::WindowIndex> = HashMap::new();
     for row in rows {
-        if row.force_deleted
-            || crate::session::is_remote_backend(&row.backend_type)
-            || now.saturating_sub(row.deleted_at) < window
-        {
+        if row.force_deleted || now.saturating_sub(row.deleted_at) < window {
             continue;
         }
         let index = windows
-            .get_or_insert_with(|| crate::agent::tmux::local_window_index().unwrap_or_default());
-        if crate::session_ops::delete::owned_agent_pane_in(index, &row).is_none() {
+            .entry(row.backend_type.clone())
+            .or_insert_with(|| window_index_on(&row.backend_type));
+        if crate::session_ops::delete::owned_windows_in(index, &row).is_empty() {
             continue;
         }
         match crate::session_ops::reap_soft_deleted(db, row.id) {
@@ -601,6 +604,22 @@ fn reap_overdue_soft_deletes(db: &Database) -> Vec<String> {
         }
     }
     reaped
+}
+
+/// Every thurbox window on the server `backend_type` names. An empty index for
+/// a host that is unconfigured or unreachable, which reads as "owns nothing" —
+/// the conservative answer a teardown gate wants.
+fn window_index_on(backend_type: &str) -> crate::agent::tmux::WindowIndex {
+    if !crate::session::is_remote_backend(backend_type) {
+        return crate::agent::tmux::local_window_index().unwrap_or_default();
+    }
+    match crate::session_ops::resolve_host(backend_type).flatten() {
+        Some(host) => crate::agent::tmux::remote_window_index(&host).unwrap_or_else(|e| {
+            tracing::debug!("could not list the windows of '{}': {e:#}", host.name);
+            crate::agent::tmux::WindowIndex::default()
+        }),
+        None => crate::agent::tmux::WindowIndex::default(),
+    }
 }
 
 /// Execute one automation's action without a TUI, returning the run outcome.

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -2038,12 +2038,13 @@ fn render_mirror_report(r: &crate::session_ops::mirror::MirrorReport) -> String 
     match &r.error {
         Some(error) => format!("{}: not mirrored — {error}", r.host),
         None => format!(
-            "{}: {} adopted, {} updated, {} deleted, {} restored{}{}",
+            "{}: {} adopted, {} updated, {} deleted, {} restored, {} tombstoned{}{}",
             r.host,
             r.adopted.len(),
             r.updated.len(),
             r.deleted.len(),
             r.restored.len(),
+            r.tombstoned.len(),
             match r.unknown_local.len() {
                 0 => String::new(),
                 n => format!(", {n} local session(s) the host does not know (use --adopt)"),

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -165,11 +165,13 @@ pub enum Action {
     /// Soft-delete a session. (`remove` is an alias.)
     #[command(alias = "remove")]
     ///
-    /// By default only the DB row is soft-deleted (the TUI cleans up the
-    /// tmux window and worktree on next sync). Pass `--force` to also
-    /// kill the tmux window, remove worktrees, and cancel pending
-    /// scheduled commands — useful for headless cleanup when the TUI
-    /// isn't running.
+    /// By default only the DB row is soft-deleted, and `session restore`
+    /// brings it back. The session's tmux windows come down once the undo
+    /// window closes — by a running interface, by the `automation tick`
+    /// heartbeat, or on demand with `session reap` — while the worktrees
+    /// stay, which is what makes the undo lossless. Pass `--force` to kill
+    /// the windows, remove the worktrees thurbox created, and cancel pending
+    /// scheduled commands in this call.
     Delete {
         /// Session UUID.
         uuid: String,
@@ -188,6 +190,18 @@ pub enum Action {
         /// state comes back (uncommitted/untracked work was lost on delete).
         #[arg(long)]
         best_effort: bool,
+    },
+    /// Let go of a soft-deleted session's agent, the way the interface does
+    /// once its undo window has closed.
+    ///
+    /// The row and its worktrees stay — reaping is not deleting — but the
+    /// windows the row still owns come down. What a peer calls on a host that
+    /// has no interface of its own to do it (ADR-24).
+    Reap {
+        /// Session name, UUID, or unique id prefix — resolved against the
+        /// deleted rows, since that is where a reapable session is.
+        #[arg(value_name = "SESSION")]
+        session: String,
     },
     /// Restart a session in-place (kills the window, re-spawns with --resume).
     Restart {
@@ -556,6 +570,7 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, CommandError>
                 .collect();
             let facts = SessionFacts::load(db);
             let bases = db.load_base_branches().unwrap_or_default();
+            let updated = db.load_updated_at().unwrap_or_default();
             let registry = crate::agent::agent_config::load_or_seed();
             let assessments: Vec<crate::session::Assessment> = sessions
                 .iter()
@@ -570,6 +585,7 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, CommandError>
                             s,
                             hook,
                             bases.get(&s.id).map(String::as_str),
+                            updated.get(&s.id).copied(),
                         )
                     })
                     .collect(),
@@ -607,6 +623,10 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, CommandError>
                     &session,
                     &hook,
                     bases.get(&session.id).map(String::as_str),
+                    db.load_updated_at()
+                        .unwrap_or_default()
+                        .get(&session.id)
+                        .copied(),
                 ),
                 render_session_detail(&session, &hook),
             ))
@@ -743,6 +763,26 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, CommandError>
             session,
             best_effort,
         } => restore_deleted(db, &session, best_effort),
+        Action::Reap { session } => {
+            let row = super::session_ref::resolve_deleted(db, &session)?;
+            let reaped = crate::session_ops::reap_soft_deleted(db, row.id)?;
+            let human = if reaped {
+                format!("Reaped session '{}' ({})", row.name, row.id)
+            } else {
+                format!(
+                    "Nothing to reap for '{}' ({}): it came back, or was force-deleted",
+                    row.name, row.id
+                )
+            };
+            Ok(CommandOutput::new(
+                json!({
+                    "reaped": reaped,
+                    "id": row.id.to_string(),
+                    "name": row.name,
+                }),
+                human,
+            ))
+        }
         Action::Restart { uuid, if_missing } => {
             let session = resolve(db, &uuid)?;
             let report = crate::session_ops::restart::restart_session_headless_with(
@@ -1050,6 +1090,9 @@ fn delete_session(db: &Database, uuid: &str, force: bool) -> Result<CommandOutpu
     let session = resolve(db, uuid)?;
     let report = crate::session_ops::delete_session_headless(db, session.id, force)?;
     let mut human = format!("Deleted session '{}' ({})", session.name, session.id);
+    if let Some(note) = &report.host_unknown {
+        human.push_str(&format!("\n  {note}"));
+    }
     if force {
         for line in output::kv(&force_delete_detail(&report)).lines() {
             human.push_str(&format!("\n  {line}"));
@@ -1068,6 +1111,7 @@ fn delete_session(db: &Database, uuid: &str, force: bool) -> Result<CommandOutpu
             "worktree_errors": report.worktree_errors,
             "disabled_automations": report.disabled_automations,
             "remote_teardown_error": report.remote_teardown_error,
+            "host_unknown": report.host_unknown,
             "hook_failures": report.hook_failures,
         }),
         human,

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -2136,6 +2136,20 @@ mod tests {
     }
 
     #[test]
+    fn mirror_report_mentions_a_pushed_tombstone() {
+        let report = crate::session_ops::mirror::MirrorReport {
+            host: "debian-hp".to_string(),
+            tombstoned: vec![SessionId::default()],
+            ..Default::default()
+        };
+        let rendered = render_mirror_report(&report);
+        assert!(
+            rendered.contains("1 tombstoned"),
+            "a sync pass that only pushed a delete must say so: {rendered:?}"
+        );
+    }
+
+    #[test]
     fn list_empty_returns_array() {
         let db = db();
         let v = run(

--- a/src/kernel/terminal/mod.rs
+++ b/src/kernel/terminal/mod.rs
@@ -841,12 +841,13 @@ impl Terminals {
                 .insert(done.backend.clone(), std::time::Instant::now() + interval);
             match done.report {
                 Ok(report) if report.changed() => tracing::info!(
-                    "mirrored {}: {} adopted, {} updated, {} deleted, {} restored",
+                    "mirrored {}: {} adopted, {} updated, {} deleted, {} restored, {} tombstoned",
                     done.backend,
                     report.adopted.len(),
                     report.updated.len(),
                     report.deleted.len(),
-                    report.restored.len()
+                    report.restored.len(),
+                    report.tombstoned.len()
                 ),
                 Ok(_) => {}
                 Err(e) => tracing::debug!("mirror of {} skipped: {e}", done.backend),

--- a/src/session_ops/delete.rs
+++ b/src/session_ops/delete.rs
@@ -23,6 +23,13 @@ pub struct ForceDeleteReport {
     /// unreachable host is expected (that's often *why* someone force-deletes),
     /// so this is recorded rather than aborting the delete.
     pub remote_teardown_error: Option<String>,
+    /// Set when the host was asked to delete the session and answered that it
+    /// has no such row — a fork minted here, a row from before ADR-24, or one
+    /// a peer already deleted there. The delete is then taken from here
+    /// instead of failing, and this says so: the alternative was an error that
+    /// left the local row active and attached, which reads as "delete does
+    /// nothing".
+    pub host_unknown: Option<String>,
     /// `session.post_delete` hooks that failed. The delete stands regardless.
     pub hook_failures: Vec<String>,
 }
@@ -63,7 +70,22 @@ pub fn delete_session_headless(
             if force {
                 args.push("--force");
             }
-            let answer = super::host_cli::run(&host, &cli, &args)?;
+            let answer = match super::host_cli::run(&host, &cli, &args) {
+                Ok(answer) => answer,
+                // The host does not know this row, so there is nothing there to
+                // delegate to — but the row here is real and the caller asked
+                // for it to go. Take the delete from here instead: the teardown
+                // is addressed by uuid, so it still reaches exactly this
+                // session's windows on that host if they are there at all.
+                Err(e) if is_unknown_session(&e) => {
+                    report.host_unknown = Some(format!(
+                        "'{}' does not know this session ({e}); deleted from here",
+                        host.name
+                    ));
+                    return finish_locally(db, &session, force, report, &hook_ctx);
+                }
+                Err(e) => return Err(e),
+            };
             report.killed_window = answer
                 .get("killed_window")
                 .and_then(serde_json::Value::as_bool)
@@ -85,18 +107,40 @@ pub fn delete_session_headless(
         }
     }
 
+    finish_locally(db, &session, force, report, &hook_ctx)
+}
+
+/// The delete taken from here: tear down what `force` asks for, mark the row,
+/// fire the post hooks. Shared by the plain path and by a delegated delete the
+/// host could not take (see [`is_unknown_session`]).
+fn finish_locally(
+    db: &Database,
+    session: &crate::sync::SharedSession,
+    force: bool,
+    mut report: ForceDeleteReport,
+    hook_ctx: &crate::session::HookContext,
+) -> Result<ForceDeleteReport, String> {
     if force {
-        teardown_runtime_resources(&session, &mut report);
+        teardown_runtime_resources(session, &mut report);
         report.disabled_automations = db
-            .disable_send_automations_for_session(session_id)
+            .disable_send_automations_for_session(session.id)
             .map_err(|e| format!("disable_send_automations_for_session: {e}"))?;
     }
 
-    delete_row(db, session_id, force)?;
+    delete_row(db, session.id, force)?;
 
-    report.hook_failures = super::fire_post(crate::session::HookEvent::PostDelete, &hook_ctx);
+    report.hook_failures = super::fire_post(crate::session::HookEvent::PostDelete, hook_ctx);
 
     Ok(report)
+}
+
+/// Whether a host CLI's refusal means "no such session here".
+///
+/// The host resolves the id against its *active* rows, so it answers this for
+/// a session it never knew and for one it has already deleted alike — both of
+/// which are cases where the local row still has to go.
+fn is_unknown_session(error: &str) -> bool {
+    error.contains("Session not found")
 }
 
 /// Mark the row gone. A force delete says so in the same statement rather than
@@ -195,10 +239,14 @@ pub fn teardown_runtime_resources(
 ///
 /// Worktrees are deliberately untouched: they are what makes the undo lossless.
 ///
+/// A session on a remote host is reaped *there* rather than left running: a
+/// host has no interface of its own to collect it, so "left alone" meant
+/// forever.
+///
 /// Returns whether the row was processed — `false` when it came back (the user
 /// undid it) or was force-deleted (already torn down), both of which are
 /// ordinary races rather than failures. It is not a claim that a window came
-/// down: a row that owns none (see [`owned_agent_pane`]) still releases its
+/// down: a row that owns none (see [`owned_windows_in`]) still releases its
 /// derived artifacts and reports `true`.
 pub fn reap_soft_deleted(db: &Database, id: SessionId) -> Result<bool, String> {
     let Some(row) = db
@@ -213,38 +261,36 @@ pub fn reap_soft_deleted(db: &Database, id: SessionId) -> Result<bool, String> {
         return Ok(false);
     }
 
-    // A remote session's window lives on its host, and a best-effort reap is
-    // not the place to be resolving hosts and dialing ssh. Left running and
-    // reported rather than half-killed.
+    // A remote session's windows live on its host, so the reap goes there.
+    // Leaving them was the old answer, and it meant every soft delete of a
+    // remote session leaked a `tb-`/`tbs-` pair forever — recreating the name
+    // then put a second agent beside the first.
     if crate::session::is_remote_backend(&row.backend_type) {
-        tracing::warn!(
-            "'{}' was soft-deleted on {}; its remote window is left running",
-            row.name,
-            row.backend_type
-        );
-        return Ok(false);
-    }
-
-    // Strict: kill only the window this row still owns. A reap must not resolve
-    // a pane id or a `tb-<name>` target another row answers to — that is how
-    // deleting a frozen session came to kill its replacement 30-60s later, and
-    // why each delete-and-recreate made the next one die sooner.
-    match owned_agent_pane(&row) {
-        // Not worth failing a cleanup over if the window went away underneath.
-        Some(target) => {
+        reap_remote(&row);
+    } else {
+        // Strict: kill only the windows this row still owns. A reap must not
+        // resolve a pane id or a `tb-<name>` target another row answers to —
+        // that is how deleting a frozen session came to kill its replacement
+        // 30-60s later, and why each delete-and-recreate made the next one die
+        // sooner.
+        let owned = owned_windows(&row);
+        if owned.is_empty() {
+            // The windows may already be gone — the agent exited, or a previous
+            // reap got there first. Logged rather than silent: owning nothing is
+            // also the shape a misdirected kill used to take.
+            tracing::debug!(
+                "reap of '{}': pane {:?} owns no window it may kill; \
+                 leaving any same-named window alone",
+                row.name,
+                row.backend_id
+            );
+        }
+        for target in owned {
+            // Not worth failing a cleanup over if the window went away underneath.
             if let Err(e) = crate::agent::tmux::kill_window_at(&target) {
                 tracing::debug!("kill_window_at({target}) during reap: {e}");
             }
         }
-        // The window may already be gone — the agent exited, or a previous reap
-        // got there first. Logged rather than silent: owning nothing is also
-        // the shape a misdirected kill used to take.
-        None => tracing::debug!(
-            "reap of '{}': pane {:?} owns no window it may kill; \
-             leaving any same-named window alone",
-            row.name,
-            row.backend_id
-        ),
     }
 
     // Derived per-session artifacts, both rebuilt on restore.
@@ -259,30 +305,91 @@ pub fn reap_soft_deleted(db: &Database, id: SessionId) -> Result<bool, String> {
     Ok(true)
 }
 
-/// The window a soft-deleted row still owns, if any — the sole target its reap
-/// may kill, and the answer to whether it has anything left to release.
+/// The windows a soft-deleted row still owns — its agent and its companion
+/// shell — the only targets its reap may kill, and the answer to whether it has
+/// anything left to release.
 ///
 /// The one place ownership is decided, so the reap and the headless sweep that
 /// gates on it cannot drift apart. It is the window's own stamp that settles
 /// it (ADR-25): the row's remembered pane id proves nothing after a tmux
 /// server has reissued it, and the `tb-<name>` a namesake shares proves less.
+/// The shell is included for the same reason it is included in every other
+/// teardown — `shell_backend_id` is written only once the interface has opened
+/// one, so the column is no guide to whether the window is there.
 ///
 /// Conservatively owns nothing when the listing fails or cannot tell: leaking a
 /// window costs a stale agent, killing the wrong one costs live work.
-pub fn owned_agent_pane(row: &DeletedSessionInfo) -> Option<String> {
-    owned_agent_pane_in(&crate::agent::tmux::local_window_index().ok()?, row)
+fn owned_windows(row: &DeletedSessionInfo) -> Vec<String> {
+    match crate::agent::tmux::local_window_index() {
+        Ok(index) => owned_windows_in(&index, row),
+        Err(_) => Vec::new(),
+    }
 }
 
-/// [`owned_agent_pane`] against a listing the caller already holds, so a sweep
-/// over several rows pays for one `list-windows` instead of one each.
+/// The windows a soft-deleted row owns, against a listing the caller already
+/// holds — so a sweep over several rows pays for one `list-windows` instead of
+/// one each.
 ///
 /// A window whose pane has already exited still counts: `remain-on-exit` keeps
 /// it on the server, and leaving it there is the leak the reap exists to stop.
-pub fn owned_agent_pane_in(
+pub fn owned_windows_in(
     index: &crate::agent::tmux::WindowIndex,
     row: &DeletedSessionInfo,
-) -> Option<String> {
-    index.agent_window(&row.id.to_string(), &row.name).pane()
+) -> Vec<String> {
+    let id = row.id.to_string();
+    [
+        index.agent_window(&id, &row.name),
+        index.shell_window(&id, &row.name),
+    ]
+    .into_iter()
+    .filter_map(crate::agent::tmux::Located::pane)
+    .collect()
+}
+
+/// Let go of a soft-deleted remote session's windows on the host they run on.
+///
+/// A host that runs a thurbox of its own is asked to reap the row itself
+/// (`session reap`): its database holds the same row, and only the host can
+/// mark it there. Otherwise the windows are killed from here, resolved by the
+/// stamp exactly as the local branch does.
+///
+/// Best-effort and silent about the ordinary cases: an unreachable host is
+/// often *why* the session was deleted, and the reap runs on a timer.
+fn reap_remote(row: &DeletedSessionInfo) {
+    let Some(Some(host)) = super::resolve_host(&row.backend_type) else {
+        tracing::warn!(
+            "'{}' was soft-deleted on {}, which is not in hosts.toml; \
+             its windows are left running there",
+            row.name,
+            row.backend_type
+        );
+        return;
+    };
+    if let Some(cli) = super::host_cli::delegated(&host) {
+        let id = row.id.to_string();
+        match super::host_cli::run(&host, &cli, &["session", "reap", &id]) {
+            Ok(_) => return,
+            // The host has no row to reap — the delete was taken here while it
+            // was unreachable, and the mirror has not pushed it yet. Its
+            // windows are still there, so they come down from here.
+            Err(e) if e.contains("not found") => {
+                tracing::debug!("'{}' is unknown on '{}': {e}", row.name, host.name);
+            }
+            Err(e) => {
+                tracing::warn!("reap of '{}' on '{}': {e}", row.name, host.name);
+                return;
+            }
+        }
+    }
+    let panes = crate::agent::tmux::SessionPanes {
+        agent: &row.backend_id,
+        shell: row.shell_backend_id.as_deref().unwrap_or_default(),
+    };
+    if let Err(e) =
+        crate::agent::tmux::kill_remote_windows(&host, &row.id.to_string(), &row.name, panes)
+    {
+        tracing::warn!("reap of '{}' on '{}': {e}", row.name, host.name);
+    }
 }
 
 /// Kill the session's window on the local tmux server, reaping the pane's child
@@ -302,6 +409,13 @@ fn kill_local_window(session: &crate::sync::SharedSession, report: &mut ForceDel
         Err(e) => tracing::warn!("kill_window({}) failed: {e}", session.name),
     }
 
+    // The companion shell is the session's second window and nothing else ever
+    // takes it down — leaving it is how a force-deleted session kept a live
+    // `tbs-` window on the server for good.
+    if let Err(e) = crate::agent::tmux::kill_shell_window(&session.id.to_string(), &session.name) {
+        tracing::warn!("kill_shell_window({}) failed: {e}", session.name);
+    }
+
     // `kill-window` returns before the OS reaps the pane's child process; wait
     // for it (force-terminating as a backstop) before the rmdir steps below.
     // NOTE: this only handles a handle held by the *pane child*. psmux ALSO holds
@@ -316,17 +430,29 @@ fn kill_local_window(session: &crate::sync::SharedSession, report: &mut ForceDel
     }
 }
 
-/// Kill the session's pane on a remote host by its persisted pane id (`%N`) —
-/// the addressable unit remotely (there's no cheap "window by thurbox name"
-/// lookup over the wire). Best-effort: a blank pane id or an unreachable host
-/// is recorded in `report.remote_teardown_error`, never aborts.
+/// Kill the session's windows — agent and companion shell — on a remote host,
+/// resolved by the stamp each carries. Best-effort: an unreachable host, or one
+/// whose socket is not known, is recorded in `report.remote_teardown_error` and
+/// never aborts the delete.
 fn kill_remote_window(
     host: &crate::session::HostDef,
     session: &crate::sync::SharedSession,
     report: &mut ForceDeleteReport,
 ) {
-    let pane = session.backend_id.trim();
-    match crate::agent::tmux::kill_pane_remote(host, &session.id.to_string(), &session.name, pane) {
+    let panes = crate::agent::tmux::SessionPanes {
+        agent: session.backend_id.trim(),
+        shell: session
+            .shell_backend_id
+            .as_deref()
+            .map(str::trim)
+            .unwrap_or_default(),
+    };
+    match crate::agent::tmux::kill_remote_windows(
+        host,
+        &session.id.to_string(),
+        &session.name,
+        panes,
+    ) {
         Ok(true) => report.killed_window = true,
         // Nothing there the row could claim: already gone, or a window the
         // host's listing attributes to somebody else. Not an error, and not a
@@ -546,8 +672,8 @@ mod tests {
 
     // The resolved-remote-host kill/worktree path (a configured, reachable
     // host) is not unit-tested here: it needs a live SSH/WSL host and
-    // `kill_pane_remote` would issue a real connection. The routing is thin —
-    // `remove_worktree_on` / `kill_pane_remote` are exercised where they live —
+    // `kill_remote_windows` would issue a real connection. The routing is thin —
+    // `remove_worktree_on` / `kill_remote_windows` are exercised where they live —
     // so these tests cover the two host-resolution failure modes instead.
     // (cfg(test) sandboxes the config dir, so `load_all` sees an empty
     // `hosts.toml` and never touches the real network.)
@@ -574,6 +700,46 @@ mod tests {
                 .unwrap()
                 .force_deleted
         );
+    }
+
+    #[test]
+    fn force_delete_on_a_host_whose_socket_is_unknown_records_the_refusal() {
+        // The teardown used to build a backend on this build's own socket name
+        // and `ensure_ready` it, which *creates* the server and the thurbox
+        // session on the host — a teardown leaving an empty server behind on
+        // somebody else's machine, while the host's own thurbox ran on another
+        // socket entirely. It refuses instead, and says so.
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let path = crate::agent::host_config::hosts_config_path().unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            "[[hosts]]\nname = \"devbox\"\ndestination = \"me@devbox\"\n",
+        )
+        .unwrap();
+
+        // Not delegated — no reachable CLI there — so the teardown is the
+        // local one, aimed at the host's tmux server. Forced rather than
+        // probed so the test never dials.
+        crate::session_ops::host_cli::fake::force_usable(crate::session_ops::host_cli::Usable::No(
+            "no cli".into(),
+        ));
+        let db = Database::open_in_memory().unwrap();
+        let id = insert_session_on(&db, "remote", "ssh:devbox", "%3");
+
+        let report = delete_session_headless(&db, id, true).unwrap();
+        crate::session_ops::host_cli::fake::clear();
+
+        assert!(!report.killed_window);
+        let err = report
+            .remote_teardown_error
+            .expect("remote teardown error recorded");
+        assert!(
+            err.contains("socket unknown for host 'devbox'"),
+            "got {err}"
+        );
+        assert!(db.get_session_by_id(id).unwrap().is_none());
     }
 
     #[test]

--- a/src/session_ops/delete.rs
+++ b/src/session_ops/delete.rs
@@ -1,5 +1,5 @@
 //! Headless session deletion — soft-delete by default, `force` also tears
-//! down the tmux window, worktrees, and pending scheduled commands so the
+//! down the tmux windows, worktrees, and pending scheduled commands so the
 //! filesystem and tmux server don't leak orphans when the TUI isn't
 //! running to observe the deletion.
 
@@ -35,7 +35,7 @@ pub struct ForceDeleteReport {
 }
 
 /// Soft-delete a session and (when `force`) also tear down its runtime
-/// resources: the tmux window, on-disk worktrees, and any pending
+/// resources: the tmux windows, on-disk worktrees, and any pending
 /// scheduled commands queued against it.
 ///
 /// Worktree and tmux cleanup are best-effort — individual failures are
@@ -172,17 +172,18 @@ fn string_list(answer: &serde_json::Value, key: &str) -> Vec<String> {
         .unwrap_or_default()
 }
 
-/// Tear down a session's slow runtime resources: kill the tmux window, remove
-/// worktrees + the symlink workspace. Touches no SQLite — safe to call from a
-/// background thread after the row has been soft-deleted on the UI thread, so
-/// the TUI's hard-delete confirmation can close without blocking on a remote
-/// `kill-window` or a `git worktree remove`. Best-effort: failures are logged
-/// into `report` (or `tracing::warn`), never abort.
+/// Tear down a session's slow runtime resources: kill the tmux windows (agent
+/// + companion shell), remove worktrees + the symlink workspace. Touches no
+/// SQLite — safe to call from a background thread after the row has been
+/// soft-deleted on the UI thread, so the TUI's hard-delete confirmation can
+/// close without blocking on a remote `kill-window` or a `git worktree
+/// remove`. Best-effort: failures are logged into `report` (or
+/// `tracing::warn`), never abort.
 ///
-/// **Backend-aware.** The window kill and each worktree removal run on the
+/// **Backend-aware.** The window kills and each worktree removal run on the
 /// server the session actually lives on, resolved from `session.backend_type`:
 /// a local backend uses the local tmux socket + local `git`; an `ssh:`/`wsl:`
-/// backend kills the pane and removes the worktrees over that host's launcher.
+/// backend kills the panes and removes the worktrees over that host's launcher.
 /// The symlink workspace is always local (a spawn-time process-cwd detail under
 /// the local data dir), so it is torn down regardless of backend.
 pub fn teardown_runtime_resources(
@@ -228,12 +229,12 @@ pub fn teardown_runtime_resources(
 }
 
 /// Release what a *soft*-deleted session is still holding: its agent, its
-/// metrics file and its symlink workspace.
+/// companion shell, its metrics file and its symlink workspace.
 ///
 /// Deleting softly is meant to be undoable, so the row is kept and the worktrees
 /// stay on disk — but the agent process is not part of what an undo restores, and
 /// leaving it running means a deleted session keeps working, keeps writing, and
-/// keeps its tmux window forever. v1 killed it once the undo window closed;
+/// keeps its tmux windows forever. v1 killed the agent's once the undo window closed;
 /// this is that, callable without a TUI. The TUI side is now
 /// `kernel::reaper::Reaper`, which watches the undo windows close.
 ///

--- a/src/session_ops/delete.rs
+++ b/src/session_ops/delete.rs
@@ -172,13 +172,13 @@ fn string_list(answer: &serde_json::Value, key: &str) -> Vec<String> {
         .unwrap_or_default()
 }
 
-/// Tear down a session's slow runtime resources: kill the tmux windows (agent
-/// + companion shell), remove worktrees + the symlink workspace. Touches no
-/// SQLite — safe to call from a background thread after the row has been
-/// soft-deleted on the UI thread, so the TUI's hard-delete confirmation can
-/// close without blocking on a remote `kill-window` or a `git worktree
-/// remove`. Best-effort: failures are logged into `report` (or
-/// `tracing::warn`), never abort.
+/// Tear down a session's slow runtime resources: kill the tmux windows
+/// (agent and companion shell), remove worktrees and the symlink workspace.
+/// Touches no SQLite — safe to call from a background thread after the row
+/// has been soft-deleted on the UI thread, so the TUI's hard-delete
+/// confirmation can close without blocking on a remote `kill-window` or a
+/// `git worktree remove`. Best-effort: failures are logged into `report`
+/// (or `tracing::warn`), never abort.
 ///
 /// **Backend-aware.** The window kills and each worktree removal run on the
 /// server the session actually lives on, resolved from `session.backend_type`:

--- a/src/session_ops/mirror.rs
+++ b/src/session_ops/mirror.rs
@@ -315,14 +315,17 @@ pub fn apply(
         .filter(|s| s.backend_type == backend_type)
         .map(|s| (s.id, s))
         .collect();
-    // Tombstones with the instant each was taken: the host's row only outranks
-    // one when the host wrote it *afterwards*.
-    let local_deleted: HashMap<SessionId, (u64, bool)> = db
+    // Tombstones with the instant each was taken, and the host's own
+    // `updated_at` as last known before that (schema v45): the host's row
+    // only outranks one when *the host's own clock* shows it was written
+    // after that snapshot. `deleted_at` is this machine's clock and cannot be
+    // compared to the host's `updated_at` directly — see `apply` below.
+    let local_deleted: HashMap<SessionId, (u64, bool, Option<u64>)> = db
         .list_deleted_sessions()
         .unwrap_or_default()
         .into_iter()
         .filter(|s| s.backend_type == backend_type)
-        .map(|s| (s.id, (s.deleted_at, s.force_deleted)))
+        .map(|s| (s.id, (s.deleted_at, s.force_deleted, s.host_updated_at)))
         .collect();
     let hook_rows = db.load_hook_states().unwrap_or_default();
     let bases = db.load_base_branches().unwrap_or_default();
@@ -337,15 +340,27 @@ pub fn apply(
                     continue;
                 }
                 report.updated.push(id);
+                record_host_clock(db, id, row.updated_at);
             }
-        } else if let Some(&(deleted_at, _)) = local_deleted.get(&id) {
+        } else if let Some(&(deleted_at, _, host_updated_at)) = local_deleted.get(&id) {
             // A tombstone here is a decision, not a gap. The host listing the
-            // row as active only outranks it when the host wrote the row
-            // *after* the delete — that is a restore taken there. Otherwise the
+            // row as active only outranks it when the host itself wrote the
+            // row *after* the last state this database knew from that host —
+            // that is a restore taken there. Comparing two readings of the
+            // host's own clock, rather than the host's `updated_at` against
+            // this machine's `deleted_at` (two different, possibly skewed
+            // clocks — see schema v45). When this database never held a
+            // reading from the host for this row (never mirrored before the
+            // delete), there is nothing to compare against, so this machine's
+            // own clock is the best available approximation. Otherwise the
             // delete simply has not reached the host (its CLI was in backoff,
             // or sharing was off when it was taken), and restoring would undo
             // it on every pass for as long as both sides disagree.
-            if !row.updated_at.is_some_and(|at| at > deleted_at) {
+            let host_has_moved = match host_updated_at {
+                Some(known) => row.updated_at.is_some_and(|at| at > known),
+                None => row.updated_at.is_some_and(|at| at > deleted_at),
+            };
+            if !host_has_moved {
                 report.tombstoned.push(id);
                 continue;
             }
@@ -357,6 +372,7 @@ pub fn apply(
                 continue;
             }
             report.restored.push(id);
+            record_host_clock(db, id, row.updated_at);
         } else {
             // Adopted, not spawned: the host launched it and this database is
             // taking it on, which is what a watcher's `registered` reason says.
@@ -367,6 +383,7 @@ pub fn apply(
                 continue;
             }
             report.adopted.push(id);
+            record_host_clock(db, id, row.updated_at);
         }
         // Status is the host's: its hooks wrote it. Only a *different* value is
         // written, so an acknowledged `done` is not re-reported as new, and a
@@ -401,7 +418,7 @@ pub fn apply(
                 continue;
             }
             report.deleted.push(id);
-        } else if let Some((_, false)) = local_deleted.get(&id) {
+        } else if let Some((_, false, _)) = local_deleted.get(&id) {
             if gone.force_deleted {
                 let _ = db.mark_session_force_deleted(id);
             }
@@ -421,6 +438,17 @@ pub fn apply(
     report.unknown_local.sort_by_key(|id| id.to_string());
     report.tombstoned.sort_by_key(|id| id.to_string());
     report
+}
+
+/// Snapshot the host's self-reported `updated_at` on the row this pass just
+/// wrote, best-effort. Only called after an actual local write, so an idle
+/// pass still writes nothing (see the module doc).
+fn record_host_clock(db: &Database, id: SessionId, host_updated_at: Option<u64>) {
+    if let Some(at) = host_updated_at {
+        if let Err(e) = db.set_host_updated_at(id, at) {
+            tracing::warn!("mirror: could not record host clock for {id}: {e}");
+        }
+    }
 }
 
 /// The host's facts on top of what is the observer's own. The pane id is the
@@ -867,6 +895,46 @@ mod tests {
         assert_eq!(report.restored, vec![id]);
         assert!(report.tombstoned.is_empty());
         assert!(db.get_session_by_id(id).unwrap().is_some());
+    }
+
+    #[test]
+    fn a_host_restore_survives_a_slower_host_clock() {
+        // The host's `updated_at` and this machine's `deleted_at` are two
+        // different clocks. Comparing them directly means a host whose clock
+        // merely runs behind this machine's can write a genuine restore whose
+        // `updated_at` still reads below `deleted_at` — and a comparison that
+        // trusted that ordering would push the delete right back, destroying
+        // the very session the host's user just restored. Ordering the
+        // restore against the host's own last-known reading instead (schema
+        // v45) is immune to the offset between the two clocks.
+        let db = Database::open_in_memory().unwrap();
+        let id = SessionId::default();
+
+        let mut adopted = host_row(id, "foo");
+        adopted.updated_at = Some(100);
+        apply(&db, BACKEND, &[adopted], &[]);
+        assert!(db.get_session_by_id(id).unwrap().is_some());
+
+        db.soft_delete_session(id).unwrap();
+        let deleted_at = db
+            .get_deleted_session_by_id(id)
+            .unwrap()
+            .unwrap()
+            .deleted_at;
+
+        // The host's clock is far behind this one: its new reading for the
+        // restore is only just past its own last-known value, nowhere near
+        // `deleted_at` (a real wall-clock timestamp).
+        let mut restored = host_row(id, "foo");
+        restored.updated_at = Some(101);
+        assert!(restored.updated_at.unwrap() < deleted_at);
+
+        let report = apply(&db, BACKEND, &[restored], &[]);
+
+        assert_eq!(report.restored, vec![id]);
+        assert!(report.tombstoned.is_empty());
+        assert!(db.get_session_by_id(id).unwrap().is_some());
+        assert!(db.get_deleted_session_by_id(id).unwrap().is_none());
     }
 
     #[test]

--- a/src/session_ops/mirror.rs
+++ b/src/session_ops/mirror.rs
@@ -36,6 +36,10 @@ pub struct MirrorReport {
     pub unknown_local: Vec<SessionId>,
     /// Of `unknown_local`, the ones `--adopt` registered this pass.
     pub registered: Vec<SessionId>,
+    /// Rows the host still lists as active that were deleted here first — the
+    /// local tombstone stands, and the delete is pushed to the host. The
+    /// symmetric counterpart of `unknown_local`/[`register_unknown`].
+    pub tombstoned: Vec<SessionId>,
     /// Why the host could not be mirrored, when it could not.
     pub error: Option<String>,
 }
@@ -46,7 +50,8 @@ impl MirrorReport {
             && self.updated.is_empty()
             && self.deleted.is_empty()
             && self.restored.is_empty()
-            && self.registered.is_empty())
+            && self.registered.is_empty()
+            && self.tombstoned.is_empty())
     }
 
     pub fn to_json(&self) -> Value {
@@ -60,6 +65,7 @@ impl MirrorReport {
             "restored": ids(&self.restored),
             "unknown_local": ids(&self.unknown_local),
             "registered": ids(&self.registered),
+            "tombstoned": ids(&self.tombstoned),
             "error": self.error,
         })
     }
@@ -71,6 +77,11 @@ pub struct HostRow {
     pub session: SharedSession,
     pub hook_state: Option<String>,
     pub base_branch: Option<String>,
+    /// When the host last wrote this row (millis since epoch), when it says.
+    /// `None` from a host older than the field — every such row then loses to a
+    /// local tombstone, which is the reading that stops a delete from being
+    /// undone on the next pass.
+    pub updated_at: Option<u64>,
 }
 
 /// A deleted session as the host lists it.
@@ -82,13 +93,19 @@ pub struct HostDeletedRow {
 
 /// The one JSON shape of a session: what `session list`/`get` print, what a
 /// peer's mirror reads, and what `session register` accepts.
+///
+/// `updated_at` is when this database last wrote the row. A peer reads it
+/// against its own tombstones (see [`apply`]), which is the only ordering the
+/// two sides share.
 pub fn session_to_json(
     s: &SharedSession,
     hook_state: Option<&str>,
     base_branch: Option<&str>,
+    updated_at: Option<u64>,
 ) -> Value {
     json!({
         "id": s.id.to_string(),
+        "updated_at": updated_at,
         "name": s.name,
         "agent": s.agent,
         "backend_type": s.backend_type,
@@ -122,8 +139,9 @@ pub fn session_to_json_assessed(
     s: &SharedSession,
     hook: &Assessment,
     base_branch: Option<&str>,
+    updated_at: Option<u64>,
 ) -> Value {
-    let mut value = session_to_json(s, hook.hook_state.as_deref(), base_branch);
+    let mut value = session_to_json(s, hook.hook_state.as_deref(), base_branch, updated_at);
     let Some(obj) = value.as_object_mut() else {
         return value;
     };
@@ -237,6 +255,7 @@ pub fn session_from_json(value: &Value, backend_type: &str) -> Result<HostRow, S
         },
         hook_state: string("hook_state"),
         base_branch: string("base_branch"),
+        updated_at: value.get("updated_at").and_then(Value::as_u64),
     })
 }
 
@@ -296,12 +315,14 @@ pub fn apply(
         .filter(|s| s.backend_type == backend_type)
         .map(|s| (s.id, s))
         .collect();
-    let local_deleted: HashMap<SessionId, bool> = db
+    // Tombstones with the instant each was taken: the host's row only outranks
+    // one when the host wrote it *afterwards*.
+    let local_deleted: HashMap<SessionId, (u64, bool)> = db
         .list_deleted_sessions()
         .unwrap_or_default()
         .into_iter()
         .filter(|s| s.backend_type == backend_type)
-        .map(|s| (s.id, s.force_deleted))
+        .map(|s| (s.id, (s.deleted_at, s.force_deleted)))
         .collect();
     let hook_rows = db.load_hook_states().unwrap_or_default();
     let bases = db.load_base_branches().unwrap_or_default();
@@ -317,9 +338,17 @@ pub fn apply(
                 }
                 report.updated.push(id);
             }
-        } else if local_deleted.contains_key(&id) {
-            // The host restored it (or the delete here never reached the host);
-            // a row the host lists as active is active.
+        } else if let Some(&(deleted_at, _)) = local_deleted.get(&id) {
+            // A tombstone here is a decision, not a gap. The host listing the
+            // row as active only outranks it when the host wrote the row
+            // *after* the delete — that is a restore taken there. Otherwise the
+            // delete simply has not reached the host (its CLI was in backoff,
+            // or sharing was off when it was taken), and restoring would undo
+            // it on every pass for as long as both sides disagree.
+            if !row.updated_at.is_some_and(|at| at > deleted_at) {
+                report.tombstoned.push(id);
+                continue;
+            }
             if let Err(e) = db
                 .restore_session(id)
                 .and_then(|()| db.upsert_session(&row.session))
@@ -372,7 +401,7 @@ pub fn apply(
                 continue;
             }
             report.deleted.push(id);
-        } else if let Some(false) = local_deleted.get(&id) {
+        } else if let Some((_, false)) = local_deleted.get(&id) {
             if gone.force_deleted {
                 let _ = db.mark_session_force_deleted(id);
             }
@@ -390,6 +419,7 @@ pub fn apply(
         .copied()
         .collect();
     report.unknown_local.sort_by_key(|id| id.to_string());
+    report.tombstoned.sort_by_key(|id| id.to_string());
     report
 }
 
@@ -424,12 +454,41 @@ pub fn mirror_host(db: &Database, host: &HostDef, cli: &CliInfo) -> Result<Mirro
     let backend = host.backend_name();
     let active = host_cli::run(host, cli, &["session", "list"])?;
     let deleted = host_cli::run(host, cli, &["session", "list", "--deleted"])?;
-    Ok(apply(
+    let report = apply(
         db,
         &backend,
         &parse_active(&active, &backend),
         &parse_deleted(&deleted),
-    ))
+    );
+    push_tombstones(db, host, cli, &report.tombstoned);
+    Ok(report)
+}
+
+/// Tell the host about the deletes it has not heard: the rows it still lists as
+/// active that were deleted here first.
+///
+/// The counterpart of [`register_unknown`], and unconditional where that one is
+/// opt-in — a delete the host never hears is a window left running there
+/// forever, and the local row cannot express it any other way. Soft, so the
+/// host's own undo window still applies. Best-effort per row: an unreachable
+/// host is retried next pass, since the tombstone does not go away.
+///
+/// Forced as it was taken here: a force delete has already torn the worktrees
+/// down on its side, and pushing it softly would leave the host holding a
+/// restorable row for a session whose checkouts are gone.
+fn push_tombstones(db: &Database, host: &HostDef, cli: &CliInfo, ids: &[SessionId]) {
+    for id in ids {
+        let forced =
+            matches!(db.get_deleted_session_by_id(*id), Ok(Some(row)) if row.force_deleted);
+        let id = id.to_string();
+        let mut args = vec!["session", "delete", &id];
+        if forced {
+            args.push("--force");
+        }
+        if let Err(e) = host_cli::run(host, cli, &args) {
+            tracing::warn!("could not push the delete of {id} to '{}': {e}", host.name);
+        }
+    }
 }
 
 /// Register the local rows the host does not know (`unknown_local`) in the
@@ -443,6 +502,7 @@ pub fn register_unknown(
 ) -> Vec<SessionId> {
     let hooks = db.load_hook_states().unwrap_or_default();
     let bases = db.load_base_branches().unwrap_or_default();
+    let updated = db.load_updated_at().unwrap_or_default();
     let mut registered = Vec::new();
     for id in ids {
         let Ok(Some(row)) = db.get_session_by_id(*id) else {
@@ -452,6 +512,7 @@ pub fn register_unknown(
             &row,
             hooks.get(id).and_then(|r| r.state.as_deref()),
             bases.get(id).map(String::as_str),
+            updated.get(id).copied(),
         )
         .to_string();
         match host_cli::run(host, cli, &["session", "register", "--json-row", &body]) {
@@ -538,6 +599,10 @@ mod tests {
                 "display_order": 3,
                 "base_branch": "main",
                 "hook_state": "blocked",
+                // Later than any tombstone a test here could take, so the
+                // fixture reads as "the host has touched this since". The
+                // tests about that ordering set their own value.
+                "updated_at": u64::MAX,
                 "worktrees": [{
                     "repo_path": "/srv/repo",
                     "worktree_path": "/home/me/.local/share/thurbox/worktrees/repo/feat",
@@ -577,6 +642,7 @@ mod tests {
                 &row.session,
                 row.hook_state.as_deref(),
                 row.base_branch.as_deref(),
+                row.updated_at,
             ),
             BACKEND,
         )
@@ -609,6 +675,7 @@ mod tests {
                 &row.session,
                 row.hook_state.as_deref(),
                 row.base_branch.as_deref(),
+                row.updated_at,
             ),
             BACKEND,
         )
@@ -736,6 +803,70 @@ mod tests {
         );
         assert!(!report.changed());
         assert!(db.list_deleted_sessions().unwrap().is_empty());
+    }
+
+    /// A tombstone taken here, with the host still listing the row as active
+    /// and nothing written there since.
+    fn tombstoned_locally(db: &Database, id: SessionId) -> HostRow {
+        db.upsert_session(&local_row(id, "foo")).unwrap();
+        db.soft_delete_session(id).unwrap();
+        let deleted_at = db
+            .get_deleted_session_by_id(id)
+            .unwrap()
+            .unwrap()
+            .deleted_at;
+        let mut row = host_row(id, "foo");
+        row.updated_at = Some(deleted_at - 1);
+        row
+    }
+
+    #[test]
+    fn a_local_tombstone_beats_a_host_row_the_host_has_not_touched_since() {
+        // The delete landed here while the host's CLI was unusable, so the host
+        // still lists the row as active. Reading that as "restore me" undid the
+        // delete on every pass for as long as the two disagreed.
+        let db = Database::open_in_memory().unwrap();
+        let id = SessionId::default();
+        let row = tombstoned_locally(&db, id);
+
+        let report = apply(&db, BACKEND, &[row], &[]);
+
+        assert_eq!(report.tombstoned, vec![id]);
+        assert!(report.restored.is_empty());
+        assert!(db.get_session_by_id(id).unwrap().is_none());
+        assert!(db.get_deleted_session_by_id(id).unwrap().is_some());
+    }
+
+    #[test]
+    fn a_host_that_reports_no_timestamp_does_not_outrank_a_tombstone() {
+        // A peer older than the field says nothing about when it wrote the row,
+        // and "I cannot tell" must not be the answer that resurrects a session.
+        let db = Database::open_in_memory().unwrap();
+        let id = SessionId::default();
+        let mut row = tombstoned_locally(&db, id);
+        row.updated_at = None;
+
+        let report = apply(&db, BACKEND, &[row], &[]);
+
+        assert_eq!(report.tombstoned, vec![id]);
+        assert!(db.get_session_by_id(id).unwrap().is_none());
+    }
+
+    #[test]
+    fn a_host_row_written_after_the_tombstone_is_a_restore() {
+        // The other half of the ordering: a peer that restored the session on
+        // the host wrote its row after the delete here, and that outranks the
+        // tombstone — otherwise the mirror would just re-delete it.
+        let db = Database::open_in_memory().unwrap();
+        let id = SessionId::default();
+        let mut row = tombstoned_locally(&db, id);
+        row.updated_at = row.updated_at.map(|at| at + 2);
+
+        let report = apply(&db, BACKEND, &[row], &[]);
+
+        assert_eq!(report.restored, vec![id]);
+        assert!(report.tombstoned.is_empty());
+        assert!(db.get_session_by_id(id).unwrap().is_some());
     }
 
     #[test]

--- a/src/session_ops/restart.rs
+++ b/src/session_ops/restart.rs
@@ -109,6 +109,15 @@ pub(crate) fn build_restart_plan(
     })
 }
 
+/// The pane ids a row remembers for its two windows — the psmux tiebreaker a
+/// remote teardown falls back on when nothing there is stamped.
+fn session_panes(session: &SharedSession) -> crate::agent::tmux::SessionPanes<'_> {
+    crate::agent::tmux::SessionPanes {
+        agent: &session.backend_id,
+        shell: session.shell_backend_id.as_deref().unwrap_or_default(),
+    }
+}
+
 /// Park a session: kill its pane, keep everything else.
 ///
 /// The row, the checkout, the branch, the agent's own conversation on disk all
@@ -132,11 +141,11 @@ pub fn stop_session_headless(db: &Database, session_id: SessionId) -> Result<boo
 
     let killed = if crate::session::is_remote_backend(&session.backend_type) {
         match super::resolve_host(&session.backend_type).flatten() {
-            Some(host) => crate::agent::tmux::kill_pane_remote(
+            Some(host) => crate::agent::tmux::kill_remote_windows(
                 &host,
                 &session.id.to_string(),
                 &session.name,
-                &session.backend_id,
+                session_panes(&session),
             )
             .unwrap_or(false),
             // An unreachable host is not a reason to refuse: the mark is what
@@ -145,7 +154,14 @@ pub fn stop_session_headless(db: &Database, session_id: SessionId) -> Result<boo
             _ => false,
         }
     } else {
-        crate::agent::tmux::kill_window(&session.id.to_string(), &session.name).is_ok()
+        let killed =
+            crate::agent::tmux::kill_window(&session.id.to_string(), &session.name).is_ok();
+        if let Err(e) =
+            crate::agent::tmux::kill_shell_window(&session.id.to_string(), &session.name)
+        {
+            tracing::debug!("no shell window to kill for '{}': {e:#}", session.name);
+        }
+        killed
     };
 
     Ok(killed)
@@ -298,6 +314,13 @@ pub fn restart_session_headless_with(
             {
                 tracing::debug!("no window to kill for '{}': {e:#}", plan.window_name);
             }
+            // The companion shell goes with it: it was opened beside the agent
+            // this restart replaces, and the interface reopens one on demand.
+            if let Err(e) =
+                crate::agent::tmux::kill_shell_window(&session.id.to_string(), &plan.window_name)
+            {
+                tracing::debug!("no shell window to kill for '{}': {e:#}", plan.window_name);
+            }
             let pane = crate::agent::tmux::spawn_window(
                 &session.id.to_string(),
                 &plan.window_name,
@@ -319,18 +342,24 @@ pub fn restart_session_headless_with(
                 .map_err(|e| format!("Failed to record the new pane: {e}"))?;
         }
         Some(host) => {
-            // By pane id, not window name: the host's tmux server is shared with
-            // whatever else runs there, and a name is not ours to claim. A pane
-            // that is already gone is not an error — the restart is what the
-            // caller wanted, and it can still happen.
-            if let Err(e) = crate::agent::tmux::kill_pane_remote(
+            // Before anything is killed or spawned: acting on a socket the host
+            // has not vouched for would tear down nothing and then put a second
+            // agent on a server of our own guessing.
+            crate::agent::tmux::known_host_socket(host)
+                .map_err(|e| format!("cannot restart '{}': {e:#}", session.name))?;
+            // By the window's own stamp, exactly as the local branch: the
+            // host's tmux server is shared with whatever else runs there, so a
+            // name is not ours to claim. A window that is already gone is not
+            // an error — the restart is what the caller wanted, and it can
+            // still happen.
+            if let Err(e) = crate::agent::tmux::kill_remote_windows(
                 host,
                 &session.id.to_string(),
                 &session.name,
-                &session.backend_id,
+                session_panes(&session),
             ) {
                 tracing::warn!(
-                    "could not kill the remote window of '{}': {e:#}",
+                    "could not kill the remote windows of '{}': {e:#}",
                     session.name
                 );
             }

--- a/src/session_ops/restart.rs
+++ b/src/session_ops/restart.rs
@@ -1,10 +1,12 @@
-//! Headless session restart — tears down the tmux window and re-launches
-//! the agent CLI, resuming the existing conversation when the agent supports
-//! it and a transcript exists, starting fresh otherwise.
+//! Headless session restart — tears down the tmux windows (agent + companion
+//! shell) and re-launches the agent CLI, resuming the existing conversation
+//! when the agent supports it and a transcript exists, starting fresh
+//! otherwise.
 //!
-//! And its two halves on their own: [`stop_session_headless`] kills the window
-//! and leaves everything else standing, [`start_session_headless`] puts a
-//! window back. A restart is those two in a row, which is why they live here.
+//! And its two halves on their own: [`stop_session_headless`] kills the
+//! windows and leaves everything else standing, [`start_session_headless`]
+//! puts the agent's window back. A restart is those two in a row, which is
+//! why they live here.
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -189,8 +191,8 @@ pub struct RestartReport {
     pub hook_failures: Vec<String>,
 }
 
-/// Restart an existing session in-place — kills its tmux window and
-/// re-spawns the agent CLI.
+/// Restart an existing session in-place — kills its tmux windows (agent +
+/// companion shell) and re-spawns the agent CLI.
 ///
 /// For the `claude` agent, uses its resume group when a transcript for the
 /// session id exists on disk, otherwise pins the same id for a fresh start.

--- a/src/session_ops/shared_tests.rs
+++ b/src/session_ops/shared_tests.rs
@@ -100,17 +100,27 @@ fn rig() -> Rig {
             ["session", "list"] => Ok(Value::Array(
                 host.active
                     .iter()
-                    .map(|s| mirror::session_to_json(s, Some("working"), None))
+                    .map(|s| mirror::session_to_json(s, Some("working"), None, Some(1)))
                     .collect(),
             )),
             ["session", "delete", id, rest @ ..] => {
                 let id: SessionId = id.parse().unwrap();
+                if !host.active.iter().any(|s| s.id == id) {
+                    // Word for word what the host's own resolver answers for a
+                    // row it does not hold — see `cli::session_ref::resolve`.
+                    return Err(format!("Session not found: {id}"));
+                }
                 host.active.retain(|s| s.id != id);
                 let force = rest.contains(&"--force");
                 host.deleted.push((id, force));
                 Ok(
                     json!({ "deleted": true, "killed_window": true, "removed_worktrees": ["/srv/wt"] }),
                 )
+            }
+            ["session", "reap", id] => {
+                let id: SessionId = id.parse().unwrap();
+                let known = host.deleted.iter().any(|(gone, _)| *gone == id);
+                Ok(json!({ "reaped": known, "id": id.to_string() }))
             }
             ["session", "restart", _id, ..] => Ok(json!({ "restarted": true })),
             ["session", "restore", id, ..] => {
@@ -368,4 +378,120 @@ fn a_host_with_sharing_off_is_used_the_old_way() {
     assert_eq!(host_cli::delegated(host), None);
     let reports = mirror::sync(&rig.db, None, false).unwrap();
     assert!(reports.is_empty(), "{reports:?}");
+}
+
+#[test]
+fn a_delete_the_host_does_not_know_is_taken_here_rather_than_failing() {
+    // A fork minted locally on a shareable host, a row from before ADR-24, or
+    // one a peer already deleted there: the host answers "Session not found",
+    // and the delete used to abort on it — leaving the local row active and
+    // attached, which reads as "delete does nothing".
+    let rig = rig();
+    let id = SessionId::default();
+    let mut row = host_session(id, "unknown-there");
+    row.backend_type = BACKEND.into();
+    rig.db.upsert_session(&row).unwrap();
+
+    let report = super::delete_session_headless(&rig.db, id, true).unwrap();
+
+    assert_eq!(
+        fake::calls()[0],
+        vec!["session", "delete", &id.to_string(), "--force"]
+    );
+    let note = report.host_unknown.expect("the fall-through is reported");
+    assert!(note.contains(HOST), "{note}");
+    assert!(
+        rig.db.get_session_by_id(id).unwrap().is_none(),
+        "the local row must go regardless"
+    );
+    assert!(
+        rig.db
+            .get_deleted_session_by_id(id)
+            .unwrap()
+            .unwrap()
+            .force_deleted
+    );
+}
+
+#[test]
+fn any_other_refusal_from_the_host_still_aborts_the_delete() {
+    // The counterpart: only "not found" falls through. A host that failed for
+    // some other reason may still be holding the session, and deleting the
+    // local row would strand it there.
+    let rig = rig();
+    let id = SessionId::default();
+    let mut row = host_session(id, "wedged");
+    row.backend_type = BACKEND.into();
+    rig.db.upsert_session(&row).unwrap();
+    fake::install_runner(Box::new(|_, _| Err("worktree is locked".into())));
+
+    let err = super::delete_session_headless(&rig.db, id, true).unwrap_err();
+    assert_eq!(err, "worktree is locked");
+    assert!(rig.db.get_session_by_id(id).unwrap().is_some());
+}
+
+#[test]
+fn a_soft_deleted_row_on_a_shareable_host_is_reaped_there() {
+    // The host's row is soft-deleted too, and a host running only `thurbox-cli`
+    // has no interface to collect it once the undo window closes. Nothing here
+    // asked it to, so every remote soft delete leaked its windows for good.
+    let rig = rig();
+    let id = SessionId::default();
+    let mut row = host_session(id, "doomed");
+    row.backend_type = BACKEND.into();
+    rig.db.upsert_session(&row).unwrap();
+    rig.host
+        .borrow_mut()
+        .active
+        .push(host_session(id, "doomed"));
+
+    super::delete_session_headless(&rig.db, id, false).unwrap();
+    let reaped = super::reap_soft_deleted(&rig.db, id).unwrap();
+
+    assert!(reaped, "the row was processed");
+    let reap = fake::calls()
+        .into_iter()
+        .find(|c| c.get(1).map(String::as_str) == Some("reap"))
+        .expect("the host was asked to reap it");
+    assert_eq!(reap, vec!["session", "reap", &id.to_string()]);
+}
+
+#[test]
+fn a_delete_taken_while_the_host_was_unusable_is_pushed_on_the_next_pass() {
+    // The delete lands locally (the host's CLI is in backoff), so the host
+    // still lists the row as active. The mirror used to read that as "restore
+    // me" and undo the delete within one interval, forever.
+    let rig = rig();
+    let id = SessionId::default();
+    let mut row = host_session(id, "deleted-here");
+    row.backend_type = BACKEND.into();
+    rig.db.upsert_session(&row).unwrap();
+    rig.host
+        .borrow_mut()
+        .active
+        .push(host_session(id, "deleted-here"));
+
+    fake::force_usable(Usable::No("ssh timed out".into()));
+    super::delete_session_headless(&rig.db, id, false).unwrap();
+    assert!(rig.db.get_session_by_id(id).unwrap().is_none());
+
+    fake::force_usable(Usable::Yes(fake::cli()));
+    let reports = mirror::sync(&rig.db, Some(HOST), false).unwrap();
+
+    assert_eq!(reports[0].tombstoned, vec![id]);
+    assert!(reports[0].restored.is_empty(), "the tombstone stands");
+    assert!(
+        rig.db.get_session_by_id(id).unwrap().is_none(),
+        "the row must not come back"
+    );
+    // And the host is told, so the two sides converge instead of disagreeing
+    // for as long as the row exists.
+    assert!(
+        fake::calls()
+            .iter()
+            .any(|c| c.as_slice() == ["session", "delete", &id.to_string()]),
+        "the delete was pushed to the host: {:?}",
+        fake::calls()
+    );
+    assert!(rig.host.borrow().active.is_empty());
 }

--- a/src/session_ops/spawn.rs
+++ b/src/session_ops/spawn.rs
@@ -418,7 +418,12 @@ pub fn spawn_session_headless_with_progress(
         // sessions share destroys a live one. Leaking the window we already
         // leaked is the cheap failure; killing someone else's is not.
         let cleanup = match host.as_ref() {
-            Some(h) => crate::agent::tmux::kill_pane_remote(h, &stamp, &req.name, &backend_id),
+            Some(h) => crate::agent::tmux::kill_remote_windows(
+                h,
+                &stamp,
+                &req.name,
+                crate::agent::tmux::SessionPanes::agent(&backend_id),
+            ),
             None => crate::agent::tmux::kill_window(&stamp, &req.name).map(|()| true),
         };
         match cleanup {

--- a/src/storage/schema/migrations.rs
+++ b/src/storage/schema/migrations.rs
@@ -905,3 +905,13 @@ pub(super) fn migrate_v43_session_events(conn: &Connection) -> rusqlite::Result<
 pub(super) fn migrate_v44_reports_as(conn: &Connection) -> rusqlite::Result<()> {
     add_column_if_absent(conn, "sessions", "reports_as", "TEXT")
 }
+
+/// See [`super::SCHEMA_VERSION`] v45: the host's own last-reported
+/// `updated_at`, snapshotted on this row whenever a mirror pass adopts or
+/// updates it. Deliberately not part of `upsert_session` for the same reason
+/// `reports_as` is not: a peer mirroring this machine round-trips rows
+/// through that upsert, and one on an older release would clear the column on
+/// every tick.
+pub(super) fn migrate_v45_host_updated_at(conn: &Connection) -> rusqlite::Result<()> {
+    add_column_if_absent(conn, "sessions", "host_updated_at", "INTEGER")
+}

--- a/src/storage/schema/mod.rs
+++ b/src/storage/schema/mod.rs
@@ -34,8 +34,15 @@ use rusqlite::Connection;
 /// rather than one sampled diff. v44 adds `reports_as` to `sessions`: the
 /// agent a driver actually launched inside a pane thurbox opened for
 /// something else, which is what hook coverage has to be read against.
+/// v45 adds `host_updated_at` to `sessions`: the host's own last-reported
+/// `updated_at` for the row, snapshotted whenever a mirror pass adopts or
+/// updates it from that host. `deleted_at` is stamped on this machine's clock
+/// and a host's `updated_at` on its own, so ordering a tombstone against a
+/// live restore by comparing those two directly conflates two clocks that can
+/// be skewed against each other; comparing the host's new `updated_at`
+/// against this snapshot instead orders two readings of the *same* clock.
 /// Gaps in the step table are fine (there is no v18 step either).
-pub const SCHEMA_VERSION: u32 = 44;
+pub const SCHEMA_VERSION: u32 = 45;
 
 /// A single migration step: applied when the stored version is below `target`.
 type MigrationStep = (u32, fn(&Connection) -> rusqlite::Result<()>);
@@ -108,6 +115,7 @@ pub fn initialize(conn: &Connection) -> rusqlite::Result<()> {
             launch_env        TEXT,
             stopped_at        INTEGER,
             reports_as        TEXT,
+            host_updated_at   INTEGER,
             created_at        INTEGER NOT NULL,
             updated_at        INTEGER NOT NULL,
             deleted_at        INTEGER
@@ -349,6 +357,7 @@ fn migrate(conn: &Connection) -> rusqlite::Result<()> {
         (42, migrate_v42_worktree_provenance),
         (43, migrate_v43_session_events),
         (44, migrate_v44_reports_as),
+        (45, migrate_v45_host_updated_at),
     ];
 
     for &(target, step) in steps {

--- a/src/storage/sessions.rs
+++ b/src/storage/sessions.rs
@@ -64,6 +64,11 @@ pub struct DeletedSessionInfo {
     /// window's own `@thurbox_session` stamp instead (ADR-25). Empty for rows
     /// persisted before local spawns recorded an id.
     pub backend_id: String,
+    /// The companion shell's pane id (`%N`), when the interface ever opened
+    /// one. Read for the same reason as [`Self::backend_id`] and with the same
+    /// caveat: a teardown resolves the shell window by its stamp, and this is
+    /// only the tiebreaker for a multiplexer that carries no stamps (psmux).
+    pub shell_backend_id: Option<String>,
     pub deleted_at: u64,
     /// Whether this row was hard-deleted (tmux window + worktrees torn down). A
     /// force-deleted session is shown in the restore list and normally cannot be
@@ -770,7 +775,7 @@ impl Database {
         let sql = format!(
             "SELECT s.id, s.name, s.agent, s.agent_session_id, \
              s.cwd, s.parent_session_id, s.deleted_at, s.backend_type, \
-             s.force_deleted, s.backend_id, \
+             s.force_deleted, s.backend_id, s.shell_backend_id, \
              w.repo_path, w.worktree_path, w.branch, w.created_by_thurbox \
              FROM sessions s \
              LEFT JOIN worktrees w ON s.id = w.session_id \
@@ -789,10 +794,11 @@ impl Database {
             let backend_type: String = row.get(7)?;
             let force_deleted: i64 = row.get(8)?;
             let backend_id: String = row.get(9)?;
-            let wt_repo: Option<String> = row.get(10)?;
-            let wt_path: Option<String> = row.get(11)?;
-            let wt_branch: Option<String> = row.get(12)?;
-            let wt_mine: Option<bool> = row.get(13)?;
+            let shell_backend_id: Option<String> = row.get(10)?;
+            let wt_repo: Option<String> = row.get(11)?;
+            let wt_path: Option<String> = row.get(12)?;
+            let wt_branch: Option<String> = row.get(13)?;
+            let wt_mine: Option<bool> = row.get(14)?;
 
             let worktree = worktree_from_cols(wt_repo, wt_path, wt_branch, wt_mine);
 
@@ -806,6 +812,7 @@ impl Database {
                     parent_session_id: parent_str.and_then(|s| s.parse().ok()),
                     backend_type,
                     backend_id,
+                    shell_backend_id,
                     deleted_at: deleted_at as u64,
                     force_deleted: force_deleted != 0,
                     worktrees: Vec::new(),
@@ -1094,6 +1101,33 @@ impl Database {
     /// does not carry it cannot describe what it diffed. Rows with no base are
     /// omitted rather than mapped to an empty string — "never recorded" is a
     /// real answer, and the caller shows uncommitted changes instead.
+    /// When each active session's row was last written (millis since epoch).
+    ///
+    /// The ordering a peer needs to read a `session list` answer against its own
+    /// tombstones: a host row touched *after* a local delete is a restore that
+    /// happened there, while an untouched one is a delete that has not reached
+    /// the host yet. Loaded in one statement beside the other per-row facts the
+    /// listing carries.
+    pub fn load_updated_at(&self) -> rusqlite::Result<HashMap<SessionId, u64>> {
+        let mut stmt = self
+            .conn
+            .prepare_cached("SELECT id, updated_at FROM sessions WHERE deleted_at IS NULL")?;
+        let rows = stmt.query_map([], |row| {
+            let id_str: String = row.get(0)?;
+            let at: i64 = row.get(1)?;
+            Ok((id_str, at))
+        })?;
+
+        let mut map = HashMap::new();
+        for row in rows {
+            let (id_str, at) = row?;
+            if let Ok(id) = id_str.parse::<SessionId>() {
+                map.insert(id, at as u64);
+            }
+        }
+        Ok(map)
+    }
+
     pub fn load_base_branches(&self) -> rusqlite::Result<HashMap<SessionId, String>> {
         let mut stmt = self.conn.prepare_cached(
             "SELECT id, base_branch FROM sessions \

--- a/src/storage/sessions.rs
+++ b/src/storage/sessions.rs
@@ -70,6 +70,13 @@ pub struct DeletedSessionInfo {
     /// only the tiebreaker for a multiplexer that carries no stamps (psmux).
     pub shell_backend_id: Option<String>,
     pub deleted_at: u64,
+    /// The host's own last-reported `updated_at` for this row as of the last
+    /// mirror pass before it was deleted here, or `None` if it was never
+    /// mirrored from a host. Ordering a tombstone against a host's row is a
+    /// same-clock comparison against this value (schema v45); `deleted_at`
+    /// above is stamped on this machine's clock and cannot be compared to a
+    /// host's `updated_at` directly.
+    pub host_updated_at: Option<u64>,
     /// Whether this row was hard-deleted (tmux window + worktrees torn down). A
     /// force-deleted session is shown in the restore list and normally cannot be
     /// restored — its worktrees, and any uncommitted work in them, are gone. See
@@ -776,7 +783,8 @@ impl Database {
             "SELECT s.id, s.name, s.agent, s.agent_session_id, \
              s.cwd, s.parent_session_id, s.deleted_at, s.backend_type, \
              s.force_deleted, s.backend_id, s.shell_backend_id, \
-             w.repo_path, w.worktree_path, w.branch, w.created_by_thurbox \
+             w.repo_path, w.worktree_path, w.branch, w.created_by_thurbox, \
+             s.host_updated_at \
              FROM sessions s \
              LEFT JOIN worktrees w ON s.id = w.session_id \
              WHERE {condition} \
@@ -799,6 +807,7 @@ impl Database {
             let wt_path: Option<String> = row.get(12)?;
             let wt_branch: Option<String> = row.get(13)?;
             let wt_mine: Option<bool> = row.get(14)?;
+            let host_updated_at: Option<i64> = row.get(15)?;
 
             let worktree = worktree_from_cols(wt_repo, wt_path, wt_branch, wt_mine);
 
@@ -814,6 +823,7 @@ impl Database {
                     backend_id,
                     shell_backend_id,
                     deleted_at: deleted_at as u64,
+                    host_updated_at: host_updated_at.map(|at| at as u64),
                     force_deleted: force_deleted != 0,
                     worktrees: Vec::new(),
                 },
@@ -922,6 +932,24 @@ impl Database {
         self.conn.execute(
             "UPDATE sessions SET base_branch = ?1 WHERE id = ?2",
             params![base, id.to_string()],
+        )?;
+        Ok(())
+    }
+
+    /// Snapshot a host's self-reported `updated_at` for a row a mirror pass
+    /// just adopted or updated from it (schema v45).
+    ///
+    /// Read back by [`Self::list_deleted_sessions`]/[`Self::get_deleted_session_by_id`]
+    /// once the row is later tombstoned, so ordering that tombstone against a
+    /// fresh report from the same host compares two readings of the host's own
+    /// clock instead of this machine's `deleted_at` against the host's
+    /// `updated_at` — two different clocks that can be skewed against each
+    /// other. Left untouched by `deleted_at`/`restore`, so it survives a
+    /// soft-delete unharmed.
+    pub fn set_host_updated_at(&self, id: SessionId, host_updated_at: u64) -> rusqlite::Result<()> {
+        self.conn.execute(
+            "UPDATE sessions SET host_updated_at = ?1 WHERE id = ?2",
+            params![host_updated_at as i64, id.to_string()],
         )?;
         Ok(())
     }

--- a/tests/reap_e2e.rs
+++ b/tests/reap_e2e.rs
@@ -52,6 +52,41 @@ fn windows() -> Vec<String> {
         .collect()
 }
 
+/// Open a session's companion shell window, stamped the way the interface
+/// stamps the one it spawns. Raw tmux because nothing headless opens a shell:
+/// it is created lazily by `Session::ensure_shell_pane` when the user asks for
+/// it, which is exactly why so many rows have no `shell_backend_id` and the
+/// window has to be found by its stamp.
+fn open_shell_window(session_id: &str, name: &str) -> String {
+    let sessions = tmux(&["list-sessions", "-F", "#{session_name}"]);
+    let target = String::from_utf8_lossy(&sessions.stdout)
+        .lines()
+        .next()
+        .expect("a thurbox tmux session")
+        .to_string();
+    let out = tmux(&[
+        "new-window",
+        "-d",
+        "-t",
+        &target,
+        "-n",
+        &format!("tbs-{name}"),
+        "-P",
+        "-F",
+        "#{pane_id}",
+        "sh",
+    ]);
+    let pane = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    assert!(pane.starts_with('%'), "new-window said {pane:?}");
+    for (option, value) in [
+        (thurbox::agent::tmux::WINDOW_SESSION_OPTION, session_id),
+        (thurbox::agent::tmux::WINDOW_ROLE_OPTION, "shell"),
+    ] {
+        tmux(&["set-option", "-w", "-t", &pane, option, value]);
+    }
+    pane
+}
+
 /// Whether `pane_id` (`%N`) still exists.
 fn pane_alive(pane_id: &str) -> bool {
     let out = tmux(&["list-panes", "-a", "-F", "#{pane_id}"]);
@@ -685,4 +720,127 @@ fn restoring_a_session_never_adopts_a_live_namesakes_window() {
          its own agent; windows left: {windows_after:?}",
         live.backend_id
     );
+}
+
+/// The companion shell (`tbs-`) is the second window a session owns, and until
+/// now no teardown path read it: `Session::kill_shell_pane` has no headless
+/// caller, and `shell_backend_id` is written only once the interface opens one,
+/// so even a kill by pane id would have missed most of them. The result was a
+/// `tbs-` window per force-deleted or reaped session, alive for as long as the
+/// server was — the orphans seen on the operator's own machine and on the
+/// remote host.
+///
+/// Both teardowns are walked here, each on its own session, because the second
+/// would be vacuous if the first had already taken the window down.
+#[test]
+fn force_delete_and_reap_both_collect_the_companion_shell() {
+    if !have_tmux() {
+        eprintln!("skipping: tmux is not installed");
+        return;
+    }
+
+    let repo = repo();
+    let db = thurbox::storage::Database::open_in_memory().expect("db");
+    let _tmux_dir = isolate_tmux();
+    let home = tempfile::tempdir().expect("tempdir");
+    isolate_paths(home.path());
+
+    let Some(forced) = spawn(&db, repo.path(), "forced") else {
+        return;
+    };
+    let forced_shell = open_shell_window(&forced.session_id.to_string(), "forced");
+    let Some(reaped) = spawn(&db, repo.path(), "reaped") else {
+        return;
+    };
+    let reaped_shell = open_shell_window(&reaped.session_id.to_string(), "reaped");
+
+    thurbox::session_ops::delete_session_headless(&db, forced.session_id, true).expect("delete");
+    let forced_shell_alive = pane_alive(&forced_shell);
+
+    thurbox::session_ops::delete_session_headless(&db, reaped.session_id, false).expect("delete");
+    thurbox::session_ops::reap_soft_deleted(&db, reaped.session_id).expect("reap");
+    let reaped_shell_alive = pane_alive(&reaped_shell);
+    let windows_after = windows();
+    cleanup();
+
+    assert!(
+        !forced_shell_alive,
+        "force delete left the shell pane {forced_shell} running; windows: {windows_after:?}"
+    );
+    assert!(
+        !reaped_shell_alive,
+        "the reap left the shell pane {reaped_shell} running; windows: {windows_after:?}"
+    );
+}
+
+/// And the shell is held to the same ownership rule as the agent: `tbs-<name>`
+/// is no more unique than `tb-<name>`, so a teardown that reached for the name
+/// would take a live namesake's shell down with it.
+#[test]
+fn a_teardown_spares_a_live_namesakes_companion_shell() {
+    if !have_tmux() {
+        eprintln!("skipping: tmux is not installed");
+        return;
+    }
+
+    let repo = repo();
+    let db = thurbox::storage::Database::open_in_memory().expect("db");
+    let _tmux_dir = isolate_tmux();
+    let home = tempfile::tempdir().expect("tempdir");
+    isolate_paths(home.path());
+
+    let Some(stale) = spawn(&db, repo.path(), "fleet") else {
+        return;
+    };
+    // Its own windows go: the row is left owning nothing, which is when a
+    // teardown used to fall through to the name.
+    let _ = tmux(&["kill-pane", "-t", &stale.backend_id]);
+
+    let Some(live) = spawn(&db, repo.path(), "fleet") else {
+        return;
+    };
+    let live_shell = open_shell_window(&live.session_id.to_string(), "fleet");
+
+    thurbox::session_ops::delete_session_headless(&db, stale.session_id, true).expect("delete");
+    let survived = pane_alive(&live_shell);
+    let windows_after = windows();
+    cleanup();
+
+    assert!(
+        survived,
+        "force-deleting the stale 'fleet' row killed the live one's shell pane \
+         {live_shell}; windows left: {windows_after:?}"
+    );
+}
+
+/// A teardown asks the server what it holds; it must not bring one into being.
+///
+/// The remote path used to call `ensure_ready` first, which starts the server
+/// *and* creates the thurbox session on the host — so a one-shot `thurbox-cli`
+/// tearing a session down left an empty server on somebody else's machine,
+/// often on a socket the host's own thurbox does not even use. Both paths read
+/// the same one-shot listing now, and this pins the property where it can be
+/// observed: on a socket with nothing running.
+#[test]
+fn a_teardown_never_brings_a_tmux_server_into_being() {
+    if !have_tmux() {
+        eprintln!("skipping: tmux is not installed");
+        return;
+    }
+
+    let db = thurbox::storage::Database::open_in_memory().expect("db");
+    let _tmux_dir = isolate_tmux();
+    let home = tempfile::tempdir().expect("tempdir");
+    isolate_paths(home.path());
+    // Nothing was spawned, so there is no server on this socket.
+    assert!(!tmux(&["has-session"]).status.success());
+
+    let id = thurbox::session::SessionId::default();
+    let _ = thurbox::agent::tmux::kill_window(&id.to_string(), "ghost");
+    let _ = thurbox::agent::tmux::kill_shell_window(&id.to_string(), "ghost");
+    let _ = thurbox::session_ops::reap_soft_deleted(&db, id);
+
+    let started = tmux(&["has-session"]).status.success();
+    cleanup();
+    assert!(!started, "a teardown started a tmux server on the socket");
 }

--- a/tests/shared_sessions.rs
+++ b/tests/shared_sessions.rs
@@ -86,7 +86,7 @@ fn the_json_a_host_prints_is_the_json_a_peer_reads() {
     let id = SessionId::default();
     let mut s = row(id, "shape", "local-tmux");
     s.additional_dirs = vec![PathBuf::from("/srv/extra")];
-    let printed = mirror::session_to_json(&s, Some("done"), Some("main"));
+    let printed = mirror::session_to_json(&s, Some("done"), Some("main"), Some(1));
     let read = mirror::session_from_json(&printed, BACKEND).unwrap();
     assert_eq!(read.session.id, id);
     assert_eq!(
@@ -105,7 +105,7 @@ fn register_records_only_a_window_that_is_running() {
     // launches, and it will not invent a row for a window that is not there.
     let db = Database::open_in_memory().unwrap();
     let id = SessionId::default();
-    let body = mirror::session_to_json(&row(id, "elsewhere", "local-tmux"), None, None);
+    let body = mirror::session_to_json(&row(id, "elsewhere", "local-tmux"), None, None, None);
     let err = run(
         Action::Register {
             json_row: body.to_string(),
@@ -131,7 +131,7 @@ fn register_refuses_an_id_or_a_name_already_here() {
     let db = Database::open_in_memory().unwrap();
     let id = SessionId::default();
     db.upsert_session(&row(id, "taken", "local-tmux")).unwrap();
-    let same_id = mirror::session_to_json(&row(id, "other", "local-tmux"), None, None);
+    let same_id = mirror::session_to_json(&row(id, "other", "local-tmux"), None, None, None);
     let err = run(
         Action::Register {
             json_row: same_id.to_string(),
@@ -142,6 +142,7 @@ fn register_refuses_an_id_or_a_name_already_here() {
     assert!(err.contains("already registered"), "{err}");
     let same_name = mirror::session_to_json(
         &row(SessionId::default(), "taken", "local-tmux"),
+        None,
         None,
         None,
     );
@@ -176,8 +177,16 @@ fn sync_with_no_shareable_host_configured_is_an_empty_report() {
 fn the_mirror_reconciles_a_real_database_both_ways() {
     let db = Database::open_in_memory().unwrap();
     let theirs = SessionId::default();
+    // `updated_at` later than any tombstone this test takes: the restore leg
+    // below is the host having written the row *after* the local delete, which
+    // is the only reading that outranks a local tombstone.
     let host_rows = vec![mirror::session_from_json(
-        &mirror::session_to_json(&row(theirs, "theirs", "local-tmux"), Some("working"), None),
+        &mirror::session_to_json(
+            &row(theirs, "theirs", "local-tmux"),
+            Some("working"),
+            None,
+            Some(u64::MAX),
+        ),
         BACKEND,
     )
     .unwrap()];

--- a/tests/shared_sessions.rs
+++ b/tests/shared_sessions.rs
@@ -177,15 +177,16 @@ fn sync_with_no_shareable_host_configured_is_an_empty_report() {
 fn the_mirror_reconciles_a_real_database_both_ways() {
     let db = Database::open_in_memory().unwrap();
     let theirs = SessionId::default();
-    // `updated_at` later than any tombstone this test takes: the restore leg
-    // below is the host having written the row *after* the local delete, which
-    // is the only reading that outranks a local tombstone.
+    // A low `updated_at` for the adopt: the restore leg below needs a *later*
+    // reading of the host's own clock to outrank the local tombstone (schema
+    // v45 orders a restore against the host's last-known value, not against
+    // this machine's `deleted_at` — see `mirror::apply`).
     let host_rows = vec![mirror::session_from_json(
         &mirror::session_to_json(
             &row(theirs, "theirs", "local-tmux"),
             Some("working"),
             None,
-            Some(u64::MAX),
+            Some(1),
         ),
         BACKEND,
     )
@@ -213,7 +214,19 @@ fn the_mirror_reconciles_a_real_database_both_ways() {
             .force_deleted
     );
 
-    // The host restores it; so does the peer.
+    // The host restores it; so does the peer. A restore only outranks the
+    // tombstone when the host's own clock reads past its last-known value, so
+    // this leg needs a fresh, later `updated_at`.
+    let host_rows = vec![mirror::session_from_json(
+        &mirror::session_to_json(
+            &row(theirs, "theirs", "local-tmux"),
+            Some("working"),
+            None,
+            Some(2),
+        ),
+        BACKEND,
+    )
+    .unwrap()];
     let report = mirror::apply(&db, BACKEND, &host_rows, &[]);
     assert_eq!(report.restored, vec![theirs]);
     assert!(db.get_session_by_id(theirs).unwrap().is_some());

--- a/website/docs/features.html
+++ b/website/docs/features.html
@@ -1685,8 +1685,13 @@ thurbox-cli message inbox --for flow --claim</code></pre>
             <code>session delete &lt;uuid&gt;</code>
             is a
             <strong>soft-delete</strong>
-            by default: it only marks the database row deleted. A running TUI kills the tmux window
-            once the 10-second undo window closes; the worktrees stay, which is what makes
+            by default: it only marks the database row deleted. Its tmux windows &mdash; the agent's
+            and the companion shell's &mdash; come down once the 10-second undo window closes: a
+            running TUI does it, the
+            <code>automation tick</code>
+            heartbeat does it with no TUI open, and
+            <code>session reap &lt;session&gt;</code>
+            does it on demand. The worktrees stay, which is what makes
             <code>session restore &lt;uuid&gt;</code>
             &mdash; or
             <code>Ctrl+Z</code>


### PR DESCRIPTION
## Intent

Make a delete of a remote thurbox session actually stick, on both machines. The user handed me a code review (session E of a multi-session split) naming five root causes and asked me to write the failing test first for each, then implement, gate and ship.

Live evidence behind it: orphan tbs-* shell windows for force-deleted sessions on the operator's own machine and ~15 on the remote host linux-host, plus two live tb-test claude windows there with no local row.

The five things asked for, in order, and what I did:

1. Every teardown (force delete, reap, stop, restart, --on-existing replace) must also kill the row's companion shell pane, resolved by the window's @thurbox_session uuid + @thurbox_role=shell stamp so a NULL shell_backend_id column does not matter, and verified never to be another session's pane. Done: WindowIndex::shell_window + kill_shell_window (local) and kill_remote_windows (remote, one listing serving both roles). --on-existing replace is a force delete, so it inherits it. I also added shell_backend_id to DeletedSessionInfo's SELECT as asked, and it is used - as the psmux tiebreaker in the new SessionPanes struct, since a stamped window never needs it.

2. reap_soft_deleted must handle remote backends instead of returning early, and the delegated path must ask the host to reap once the undo window closes. Done: a shareable host is asked via a new `thurbox-cli session reap <ref>` verb (it owns the host's own row, and resolves against the deleted rows the way `session restore` does); a non-shareable host's windows are killed from here through the stamp. If the host answers "not found" - the delete was taken here while it was unreachable and the mirror has not pushed it yet - the reap falls through to killing the windows directly. Driven by the interface's kernel::reaper and by reap_overdue_soft_deletes on the heartbeat, which now builds a WindowIndex per backend (one list-windows per host, only when a row on that host is actually overdue) and gates a remote row on the host's own listing exactly as it gates a local one on this machine's. That per-host round trip is a deliberate cost, matching the remote status poll that already runs in the same tick; the alternative was an "already reaped" marker on the row, which is a second store.

3. Mirror must honour tombstones. Done: session_to_json (the one wire shape) gained updated_at, backed by a new Database::load_updated_at; HostRow carries it; mirror::apply lets a local tombstone win unless the host wrote the row after the local deleted_at, reports the winners in MirrorReport.tombstoned, and mirror_host pushes each as `session delete` to the host - the counterpart of register_unknown, and unconditional where that one is opt-in. Pushed with --force when the local tombstone was a force delete, so the host does not keep a restorable row for a session whose checkouts are gone. A host that reports no updated_at (an older peer) loses to the tombstone: "I cannot tell" must not be the answer that resurrects a session. The two timestamps come from two clocks; documented in ADR-24 as tolerable because the comparison orders two user actions minutes apart and its skew failure mode is a delete pushed twice, not a session destroyed.

4. Delegated delete: host "not found" must fall through to local teardown by uuid + local soft-delete instead of erroring, and record what happened. Done: ForceDeleteReport.host_unknown, surfaced in the CLI JSON and human output. Any *other* host error still aborts on purpose - the session may still be running there - and there is a test pinning that.

5. Non-delegated remote kill/discover must never ensure_ready (which creates the server and the thurbox session on the host as a side effect of tearing one down); use a read-only existence check and refuse with "socket unknown for host" rather than creating a server. Done: TmuxBackend::kill_pane_oneshot replaces the control-mode kill, discover's has-session guard is the read-only check, and known_host_socket resolves hosts.toml socket -> what the host's CLI reported -> for a share_sessions=false host only, this build's default. A *shareable* host that has reported nothing is refused. That last carve-out is a judgment call the reviewer should see: refusing unconditionally would have broken every non-shared ssh host, where this thurbox is the only writer and its own socket is correct by construction. The remote restart branch now checks the same thing before killing-and-spawning, so it cannot spawn beside a window it failed to kill.

Tests, each verified to fail on the pre-fix code first (I neutered each fix in turn and re-ran):
- tests/reap_e2e.rs (real tmux): force delete and reap both collect the companion shell; a teardown spares a live namesake's shell; a teardown never brings a tmux server into being.
- src/session_ops/shared_tests.rs (scripted host, no ssh): the host's "not found" delete is taken here; any other refusal still aborts; a soft-deleted row on a shareable host is reaped there; a delete taken while the host was unusable is pushed on the next mirror pass instead of being resurrected.
- src/session_ops/mirror.rs: the three ordering cases (tombstone wins, no timestamp still loses to the tombstone, a row written after the tombstone is a restore).
- src/agent/tmux.rs: shell-window ownership by stamp (theirs / lone unstamped / ambiguous), and the socket refusal with its two exceptions.

Deliberately not done: there is no remote-transport test double in this repo (TmuxTransport is Local/Ssh/Wsl, and the host_cli fake only stands in for the host's CLI, not for tmux over ssh), so the remote *shell* kill is covered at the seam - the WindowIndex resolution that decides which pane it targets is unit-tested, and the identical local path is end-to-end tested against real tmux. The vestigial SharedSession.tombstone/tombstone_at fields were left alone; they are never written from the database and belong to another cleanup.

Docs updated in the same commit: the thurbox-remote-hosts and thurbox-cli skills, ADR-24 (three new rules: tombstone direction, the not-found fall-through, reaping on the host) and ADR-25 (the role stamp made the companion shell reachable), docs/FEATURES.md, the website's delete section, and the `session delete` help text, which still claimed "the TUI cleans up the tmux window and worktree on next sync".

Local gate before this run: cargo nextest run --all = 2418 passed, just lint clean, clippy -D warnings clean, RUSTDOCFLAGS=-D warnings cargo doc clean, cargo test --test architecture_rules 12 passed. Note the machine's disk hit 100% mid-session; I freed it by deleting target/debug/incremental caches in sibling worktrees whose PRs are already merged (build cache only, no source touched).

## What Changed

- Every teardown path (force delete, reap, stop, restart, `--on-existing` replace) now also kills the session's companion shell tmux window, resolved via `@thurbox_session`/`@thurbox_role=shell` window stamps instead of relying on a possibly-null `shell_backend_id` column, with ownership verified so another session's pane is never touched (`src/agent/tmux.rs`, `src/session_ops/delete.rs`, `src/session_ops/restart.rs`, `src/session_ops/spawn.rs`).
- `reap_soft_deleted` and the heartbeat's overdue-reap path now handle remote backends: a shareable host is asked to reap via a new `thurbox-cli session reap` verb, a non-shareable host has its windows killed directly, and mirror sync now compares a new `updated_at` column so a local tombstone wins over a stale remote row and is pushed to the host as a `session delete` instead of being silently overwritten on the next sync (`src/session_ops/mirror.rs`, `src/storage/schema/migrations.rs`, `src/storage/schema/mod.rs`, `src/storage/sessions.rs`).
- Delegated delete falls through to local teardown when the host reports the session unknown (recorded in `ForceDeleteReport.host_unknown` and surfaced in CLI output), and non-delegated remote kill/discover now use a read-only existence check instead of `ensure_ready`, so tearing down a session can no longer create a tmux server on the host as a side effect (`src/session_ops/delete.rs`, `src/agent/tmux.rs`, `src/cli/sessions.rs`, `src/cli/automations.rs`).

## Risk Assessment

⚠️ Medium: The two auto-fix findings from round 1 (missing tombstoned count in the CLI report and background mirror log) are correctly resolved, and the v45 host-clock-snapshot fix closes the primary scenario from round 1's ask-user finding (a genuine host-side restore surviving a slower host clock, now covered by a passing test); but the snapshot the fix relies on is only refreshed on an incidental content diff rather than on every mirror observation, so the same class of clock-skew misbehavior — this time making a fresh local delete silently undo itself rather than destroying a host-side restore — remains reachable for the common case of an already-stable or pre-upgrade session, which is a real gap against the commit's own stated goal but requires clock skew as a precondition and is not a guaranteed-every-time break.

## Testing

Baseline `cargo nextest run --all` already passed. On top of that I ran the mirror-ordering unit tests (17/17, including the new clock-skew regression test), the shared_sessions integration test (8/8, including the one updated in the follow-up commit for the same-clock ordering change), session_ops::shared_tests + agent::tmux (102/102), and the real-tmux reap_e2e suite (13/13) — all passing. For the two round-1 auto-fix findings about the tombstoned count missing from output, I found no existing test covering `render_mirror_report`'s formatting, so I added one asserting it reports a pushed tombstone; the symmetric log-line change in `collect_mirrored` is a one-line mechanical change with no tracing-capture test infra in this repo, so I verified it by inspection only. I also manually drove the actual `thurbox-cli` binary against a real (sandboxed) tmux server end-to-end — created a session, gave it a stamped companion shell window, force-deleted it through the real delete command, and confirmed via `tmux list-windows` that both the agent and companion shell windows were gone — directly reproducing the fix for the orphan `tbs-*` window bug described in the intent. No test or environment issues found; transient sandbox/tmux state and the throwaway evidence repo were cleaned up afterward, leaving only the one new test as a working-tree change.

<details>
<summary>Evidence: Manual CLI transcript: force-delete kills both the agent window and its orphaned companion shell window</summary>

```text
Manual end-to-end verification: force-deleting a thurbox session through the
real thurbox-cli, over a real tmux server, also kills its companion shell
window — the orphan tbs-* window bug described in the user intent.

Setup: isolated dev sandbox (scripts/dev/sandbox.sh, persistent "default"
profile, TMUX_TMPDIR=$XDG_RUNTIME_DIR/thurbox-sbx-default, socket
"thurbox-dev"), a throwaway git repo at /tmp/tbx-evidence-repo.

1) Created a session via the real CLI (no mocks):

$ thurbox-cli session create --name ev-demo --repo-path /tmp/tbx-evidence-repo \
    --command /bin/sh --arg -c --arg "sleep 600"
agent: sh
backend_id: %1
created: true
id: 00000000-0000-4000-8000-000000000001
name: ev-demo
tmux_socket: thurbox-dev

2) Opened its companion shell window the way the interface lazily does
   (raw tmux, stamped with @thurbox_session / @thurbox_role=shell — there is
   no headless CLI path to open one, matching tests/reap_e2e.rs's own
   open_shell_window helper):

$ tmux -L thurbox-dev new-window -d -n tbs-ev-demo sh   # -> pane %3
$ tmux -L thurbox-dev set-option -w -t %3 @thurbox_session ac07d91d-...
$ tmux -L thurbox-dev set-option -w -t %3 @thurbox_role shell

Windows before delete:
thurbox-dev:0 zsh pane=%0
thurbox-dev:1 tb-ev-demo pane=%1
thurbox-dev:2 automation-heartbeat pane=%2
thurbox-dev:3 tbs-ev-demo pane=%3

3) Force-deleted through the real CLI:

$ thurbox-cli session delete 00000000-0000-4000-8000-000000000001 --force
deleted: true
forced: true
killed_window: true
name: ev-demo

Windows after delete:
thurbox-dev:0 zsh pane=%0
thurbox-dev:2 automation-heartbeat pane=%2

Both the agent window (tb-ev-demo) and its companion shell window
(tbs-ev-demo) are gone — no orphan tbs-* window survives the delete, which is
exactly the live bug ("orphan tbs-* shell windows for force-deleted
sessions") the user intent describes and root cause #1 claims to fix.
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (8m26s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"84a2326ff5c1fd66329a75cdad20c10abce94076","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

- ⚠️ `src/session_ops/mirror.rs:348` - The ADR-24 tombstone-vs-restore ordering in mirror::apply (src/session_ops/mirror.rs, the `else if let Some(&amp;(deleted_at, _)) = local_deleted.get(&amp;id)` branch, ~line 348) compares the host&#39;s self-reported `updated_at` against the local `deleted_at` — two different clocks. The intent text and docs/ARCHITECTURE.md&#39;s ADR-24 explicitly claim &#39;its failure mode under skew is a delete pushed again rather than a session destroyed&#39;, but that claim does not hold. Concrete sequence: (1) local deletes session S at local time T0 while the host&#39;s CLI is in backoff, so the delete never reaches the host; (2) before the next mirror pass, a user genuinely restores S directly on the host at true time T1 &gt; T0, so the host writes `updated_at = T1` on its own (slower) clock; (3) if the host&#39;s clock lags the local clock by more than T1_true - T0_true, the host-reported `updated_at` ends up &lt;= the local `deleted_at`; (4) `apply()` then reads the fresh restore as &#39;host hasn&#39;t touched it since the delete&#39;, keeps the local tombstone, and `push_tombstones` sends `session delete &lt;id&gt;` to the host, deleting the session the user just explicitly restored there. That is a session destroyed, not merely a delete resent, contradicting the documented risk analysis for this otherwise deliberate, disclosed tradeoff. Worth the author&#39;s judgment call (e.g. a monotonic/logical counter per row instead of wall-clock timestamps would close the gap) rather than a silent fix.
- ⚠️ `src/cli/sessions.rs:2023` - `render_mirror_report` (src/cli/sessions.rs:2023) formats `session sync`&#39;s human-readable summary from `adopted`/`updated`/`deleted`/`restored`/`unknown_local`/`registered`, but never mentions `report.tombstoned` even though `MirrorReport::to_json` and `changed()` were both updated to include it in this diff. A sync pass that only pushes a tombstoned delete to a host now prints a summary line with no indication a delete happened, unlike every other kind of change the same command reports.
- ⚠️ `src/kernel/terminal/mod.rs:844` - The background mirror worker&#39;s log line in `collect_mirrored` (src/kernel/terminal/mod.rs:843-849) logs `{adopted} adopted, {updated} updated, {deleted} deleted, {restored} restored` only when `report.changed()` is true. Since `changed()` now also returns true when `tombstoned` alone is non-empty, a pass whose only effect is pushing a tombstoned delete to the host now logs a line reading &#39;0 adopted, 0 updated, 0 deleted, 0 restored&#39; — which looks like nothing happened despite the log firing because something did. The tombstoned count should be included in this line too.

🔧 Fix: fix(core): order mirror tombstones on the host&#39;s own clock
1 warning still open:

- ⚠️ `src/session_ops/mirror.rs:337` - The v45 fix orders a tombstone against `sessions.host_updated_at` — a snapshot of the host&#39;s own clock — instead of against this machine&#39;s `deleted_at`, but that snapshot is only taken in two of three places where a row&#39;s active state is observed: unconditionally when a session is first adopted (line 386) or restored (line 375), but in the common &#39;session already known on both sides&#39; path (line 333-344) only `if merged != *local`, i.e. only when some other field (name/agent/cwd/agent_session_id/worktrees/…) visibly changed on that tick. A session that just sits there quietly between mirror passes — the normal case once an agent is attached and its state stops changing — never re-triggers `record_host_clock`, so `host_updated_at` freezes at whatever value it last got (possibly `None`, since the `add_column_if_absent` migration does not backfill it for rows that existed before the v45 upgrade and have not had an observable diff since). Concretely: session S predates this build (or has simply been idle since upgrading), so `sessions.host_updated_at` is still NULL for it. The user deletes S locally; `deleted_at` is stamped on this machine&#39;s clock. linux-host&#39;s clock is skewed ahead of this machine&#39;s by more than the gap to the next mirror pull (the exact kind of skew ADR-24 already treats as real) and still lists S as active with an `updated_at` from its own clock. The next mirror pass hits the `None` fallback (mirror.rs:361): `row.updated_at.is_some_and(|at| at &gt; deleted_at)` compares the host&#39;s clock directly against this machine&#39;s, is `true` purely from skew, and `apply()` calls `restore_session`, silently undoing the user&#39;s own delete with no host-side action at all — the opposite of this commit&#39;s stated goal (&#39;make a delete of a remote session actually stick&#39;). This is a materially different, narrower failure than the one flagged in round 1 (that one required a genuine host-side restore and destroyed it; this one needs no host action and instead makes a fresh local delete fail to stick), and it is reachable for what is likely the majority of real deletes — an already-established session, not a brand-new one. The cheapest fix consistent with the rest of this design: call `record_host_clock` unconditionally whenever an active row is observed from the host in the merged branch (not gated on `merged != *local`), so any row that has been through at least one mirror tick since upgrading carries a valid same-clock reading before it can ever be deleted.
</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- 🚨 tests failed with exit code 100
- `cargo nextest run --all`

🔧 Fix: fix(test): mirror test needs increasing updated_at for restore ordering
✅ Re-checked - no issues remain.
- `cargo nextest run --all`
- <code>`cargo nextest run --lib session_ops::mirror` (17/17 passed, including the new `a_host_restore_survives_a_slower_host_clock` regression test for the tombstone-clock-skew fix)</code>
- <code>`cargo nextest run --test shared_sessions` (8/8 passed, including `the_mirror_reconciles_a_real_database_both_ways` which needed the same-clock ordering fix from f7509c41)</code>
- <code>`cargo nextest run --lib session_ops::shared_tests agent::tmux` (102/102 passed)</code>
- <code>`cargo nextest run --test reap_e2e` against a real isolated tmux server (13/13 passed, including `force_delete_and_reap_both_collect_the_companion_shell`)</code>
- <code>Added and ran `cli::sessions::tests::mirror_report_mentions_a_pushed_tombstone`, a new focused test asserting `render_mirror_report` surfaces a pushed tombstone (round-1 finding `mirror-report-omits-tombstoned-cli` had no prior test coverage)</code>
- <code>Manual end-to-end CLI verification in an isolated dev sandbox: created a session via `thurbox-cli session create`, stamped a companion `tbs-*` shell window the way the interface lazily does, then ran the real `thurbox-cli session delete --force` and confirmed via `tmux list-windows` that both the agent window and the companion shell window were killed</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 101)

🔧 Fix: {&#34;summary&#34;: &#34;fix(core): avoid doc-list-item lint by rewording teardown_runtime_resources comment&#34;}
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
