### PR TITLE
fix(core): stop the reap sweep from flickering the status band

### DIFF
--- a/.claude/skills/thurbox-cli/SKILL.md
+++ b/.claude/skills/thurbox-cli/SKILL.md
@@ -437,7 +437,9 @@ session shape thurbox advertises for drivers.
 deleted, and `session restore` revives it. The windows are torn down once the
 undo window closes (`UNDO_WINDOW`, 10s) by the one sweep,
 `session_ops::reap_overdue_soft_deletes` — driven by the TUI's loop on a slow
-cadence (`REAP_INTERVAL`) and by the heartbeat's tick, or on demand with
+cadence (`REAP_INTERVAL`, as background housekeeping the bus keeps no in-flight
+record of, so it never captions the message band) and by the heartbeat's tick,
+or on demand with
 `session reap <ref>` — which is how a peer collects a row on a host that has no
 interface of its own (ADR-24), and resolves against the *deleted* rows the way
 `session restore` does. Only the **windows** (agent and companion shell, both

--- a/.claude/skills/thurbox-performance/SKILL.md
+++ b/.claude/skills/thurbox-performance/SKILL.md
@@ -21,7 +21,13 @@ frame is agent output. Applying the tight floor to both made a chatty agent driv
 (ADR-P17). What marks the screen dirty:
 any input, a resize, a reload, a worker result, and **new agent output** —
 `Terminals::output_generation` is summed each iteration, which is what stops a
-printing agent being drawn at 4 fps. A **reflow** — the arrangement placing a
+printing agent being drawn at 4 fps. What does **not**: background housekeeping.
+A command answering `Command::is_housekeeping()` (the 5-second deleted-session
+sweep, and nothing else) is dispatched to a worker with no in-flight record at
+all, so it reaches neither `thurbox.commands`, nor the message band, nor the
+animation clock — recorded like a command someone pressed, the sweep reserved a
+band row and gave it back every five seconds, and a band row appearing is a
+reflow (ADR-P22). A **reflow** — the arrangement placing a
 slot at a new rect, so a column opened or closed — additionally forces one *full*
 repaint: the cell diff is only correct while ratatui and the terminal agree on a
 glyph's width, and where they cannot (a flag, an emoji presentation sequence) the
@@ -96,8 +102,9 @@ This is ADR-P16 closed out by ADR-P18, and it all rests on one rule: a signal is
 mutation and only when the value actually changed — writing an unchanged value
 counts as no change, which is the difference between the gate saving 27% and
 saving nothing. The **animation clock** obeys it too: it lives in the epoch and
-the loop advances it only while something is actually animating, because a
-free-running one invalidated every pure pane on every idle frame. It is also
+the loop advances it only while something is actually animating — a `working`
+session, a *user's* command in flight, a repo read — because a free-running one
+invalidated every pure pane on every idle frame. It is also
 **scoped to its readers**: `ctx.elapsed` is served through the render context's
 metatable rather than set as a field, so the kernel can see which panes asked for
 it, and a pure tree is keyed on the animation tick only if the render that built

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1435,7 +1435,10 @@ rather than through a column that is usually NULL.
 `deleted_at` is older than `UNDO_WINDOW` and that still owns a window by its
 ADR-25 stamp — and both drivers call it: the interface's loop on a slow cadence
 (`REAP_INTERVAL`, a `Command::Reap` that names no session) and `thurbox-cli`'s
-heartbeat on its tick. Alongside it, a caller that changes **one column** of a
+heartbeat on its tick. `Command::Reap` is the one command the bus keeps no
+in-flight record of — it recurs forever with nobody waiting on it, and a row
+there is drawn, captioned and counted as activity (ADR-P22 in
+`docs/PERFORMANCE.md`). Alongside it, a caller that changes **one column** of a
 session row uses a targeted setter (`set_backend_id`, `set_session_shell`,
 `set_display_order`) rather than the full-row `upsert_session`.
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -963,7 +963,8 @@ interface. Three fixes:
   `ctx.elapsed` as `floor(elapsed * 8)`, so it advanced 8 times a second whether
   or not anything was moving — and at the 4fps idle floor that invalidated every
   pure pane on every frame. It now lives in `Epoch::animation`, advanced by the
-  loop only while something animates (a `working` session, a command in flight).
+  loop only while something animates (a `working` session, a command in flight —
+  background housekeeping is not one, ADR-P22).
   This was a bug against this capability's own requirement that an idle
   interface rebuild nothing, not a tuning choice.
 - **An adaptive poll timeout.** The loop blocked in `event::poll(10ms)`
@@ -1438,6 +1439,51 @@ context); both are stated for plugin authors in `docs/PLUGINS.md`, which owns
 that contract, along with the rule the mechanism creates: reading `ctx.elapsed`
 is what subscribes a tree to the animation tick, so read it where you animate and
 not at the top of a render that usually draws nothing moving.
+
+---
+
+## ADR-P22: Background housekeeping is invisible to the interface (2026-09-04)
+
+**Context**: the deleted-session sweep is dispatched on the command bus every
+`REAP_INTERVAL` (5s) for as long as thurbox runs (ADR-26). The bus records every
+command it accepts, and three things read that record: `status_rows` reserves a
+message-band row while anything is in flight, the band captions it with the
+command's kind, and `advance_animation` counts it as something moving. So the
+sweep flashed "reap" through the band and reflowed every pane twice every five
+seconds — and a reflow forces a *full* repaint (ADR-P1), which is the most
+expensive frame there is. Its completion also went through `poll_command_bus`,
+re-reading the snapshot and marking a data change 12 times a minute on an
+interface nobody was touching.
+
+**Decision**: a command answers `is_housekeeping()`, true for `Reap` alone, and
+the bus keeps **no in-flight record** of one. Not a filter at each reader — a
+single `dispatch` branch, so the sweep is absent from `inflight()`,
+`has_inflight()`, `first_running()`, `is_busy()` and therefore from
+`thurbox.commands`, the band, the arrangement and the animation clock at once.
+The work still runs on its own worker thread, unchanged; a failure is reported
+through `tracing` rather than the band, which is where the rest of the sweep
+already speaks.
+
+**Rejected**:
+
+- *Excluding it in `status_rows`* — the cheapest edit and the wrong one: the
+  same row still reaches plugins through `thurbox.commands` and still animates
+  the clock, so the flicker would come back through whichever reader was not
+  patched. There are four.
+- *Slowing `REAP_INTERVAL`* — makes the flash rarer, not absent, and the cadence
+  is the undo window's business, not the render loop's.
+- *Moving the sweep back onto the UI thread* — it opens the database and can
+  reach a multiplexer; that is exactly what the bus exists to keep off the frame.
+
+**Consequences**: a reaped row leaves the list on the next due snapshot refresh
+rather than the instant the sweep finishes. That is the right trade — nobody is
+waiting on a sweep, and the row it collects has been invisible for the whole undo
+window already. Anything a *person* dispatched is unaffected: it still takes the
+band, still captions it, still animates. Pinned by
+`kernel::command::tests::housekeeping_is_never_reported_in_flight` and
+`chrome::a_housekeeping_sweep_neither_captions_the_band_nor_reflows_the_frame`,
+which asserts both halves — the sweep placing no `status` slot and moving no
+pane, a delete still doing both.
 
 ---
 

--- a/src/kernel/command/bus.rs
+++ b/src/kernel/command/bus.rs
@@ -110,6 +110,9 @@ impl CommandBus {
     /// Accept a command. Returns immediately, always.
     pub fn dispatch(&self, command: Command) -> u64 {
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        if command.is_housekeeping() {
+            return self.dispatch_housekeeping(command, id);
+        }
         let entry = InFlight {
             id,
             kind: command.kind(),
@@ -135,6 +138,22 @@ impl CommandBus {
             }
             let error = execute(&command, id, &progress).err();
             let _ = finished.send(Done { id, error });
+        });
+        id
+    }
+
+    /// Run background housekeeping on a worker, unrecorded.
+    ///
+    /// Deliberately touches neither the in-flight list nor the completion
+    /// channel: a row there is drawn, captioned and counted as activity, and
+    /// this work recurs forever with nobody waiting on it — see
+    /// [`Command::is_housekeeping`]. Its failures go to the log.
+    fn dispatch_housekeeping(&self, command: Command, id: u64) -> u64 {
+        let progress = self.progress_tx.clone();
+        std::thread::spawn(move || {
+            if let Err(e) = execute(&command, id, &progress) {
+                tracing::warn!(command = command.kind(), "housekeeping failed: {e}");
+            }
         });
         id
     }

--- a/src/kernel/command/mod.rs
+++ b/src/kernel/command/mod.rs
@@ -420,6 +420,21 @@ impl Command {
         )
     }
 
+    /// Whether this is background housekeeping rather than work someone is
+    /// waiting on.
+    ///
+    /// The bus keeps no in-flight record of one, so it appears nowhere the
+    /// interface reads: no published `thurbox.commands` row, no message-band
+    /// caption, and nothing for the redraw loop to call activity. The reap
+    /// sweep is dispatched every few seconds for as long as thurbox runs —
+    /// reported like a command someone pressed, it reserved the band and gave
+    /// it back on that cadence, reflowing every pane twice every five seconds.
+    /// A failure is reported through `tracing` instead, which is where the rest
+    /// of the sweep already speaks.
+    pub fn is_housekeeping(&self) -> bool {
+        matches!(self, Command::Reap)
+    }
+
     /// What this command concerns when it names no session.
     ///
     /// For a creation that is the repository, which is what lets the session
@@ -1059,6 +1074,23 @@ mod tests {
         let found = bus.first_running().expect("the dispatched command");
         assert_eq!(found.id, id);
         assert_eq!(found.kind, "restore");
+    }
+
+    #[test]
+    fn housekeeping_is_never_reported_in_flight() {
+        // The reap sweep is dispatched every few seconds for as long as thurbox
+        // runs. Recorded like a command someone pressed, it reserves the message
+        // band and gives it back on that cadence — the whole frame reflowing
+        // twice every five seconds, captioned "reap".
+        let bus = CommandBus::new();
+        bus.dispatch(Command::Reap);
+        assert!(
+            bus.inflight().is_empty(),
+            "the sweep must not be published: {:?}",
+            bus.inflight()
+        );
+        assert!(!bus.has_inflight(), "nor counted as work the loop is doing");
+        assert!(bus.first_running().is_none(), "nor drawn as progress");
     }
 
     #[test]

--- a/tests/chrome.rs
+++ b/tests/chrome.rs
@@ -11,6 +11,7 @@ use ratatui::Terminal;
 
 use ratatui::style::Color;
 use thurbox::kernel::bands::BandState;
+use thurbox::kernel::command::{Command, CommandBus, InFlight};
 use thurbox::kernel::host::{LuaHost, Published, RenderContext};
 use thurbox::kernel::layout::{resolve, SlotRect};
 use thurbox::kernel::node::ClickVerb;
@@ -80,6 +81,18 @@ fn world(automations: usize) -> Snapshot {
 }
 
 fn publish(host: &LuaHost, snapshot: &Snapshot, themes: &Themes) {
+    publish_with(host, snapshot, themes, &[], 0);
+}
+
+/// [`publish`], with the two inputs the message band moves with: what is in
+/// flight, and the row `App::status_rows` reserved for it.
+fn publish_with(
+    host: &LuaHost,
+    snapshot: &Snapshot,
+    themes: &Themes,
+    inflight: &[InFlight],
+    status_rows: u16,
+) {
     let mut registry = Registry::default();
     let (bindings, settings) = host.declarations();
     registry.declare(bindings, settings);
@@ -89,7 +102,7 @@ fn publish(host: &LuaHost, snapshot: &Snapshot, themes: &Themes) {
         epoch: thurbox::kernel::host::Epoch::always_fresh(),
         snapshot,
         attach_errors: &Default::default(),
-        inflight: &[],
+        inflight,
         themes,
         registry: &registry,
         diffs: &diffs,
@@ -97,7 +110,7 @@ fn publish(host: &LuaHost, snapshot: &Snapshot, themes: &Themes) {
         content: &Default::default(),
         meta: &Default::default(),
         metrics: &Default::default(),
-        status_rows: 0,
+        status_rows,
         can_open: true,
         inventory: &[],
         ui_dir: "ui",
@@ -188,7 +201,19 @@ fn screen(
 }
 
 fn slots(host: &LuaHost, snapshot: &Snapshot, width: u16, height: u16) -> Vec<SlotRect> {
-    publish(host, snapshot, &Themes::load(None));
+    slots_with(host, snapshot, &[], 0, width, height)
+}
+
+/// [`slots`] for a frame the message band is reporting work on.
+fn slots_with(
+    host: &LuaHost,
+    snapshot: &Snapshot,
+    inflight: &[InFlight],
+    status_rows: u16,
+    width: u16,
+    height: u16,
+) -> Vec<SlotRect> {
+    publish_with(host, snapshot, &Themes::load(None), inflight, status_rows);
     let area = Rect {
         x: 0,
         y: 0,
@@ -623,6 +648,97 @@ fn a_band_is_placed_by_the_arrangement_and_omitting_it_is_not_an_error() {
     assert!(
         short_names.contains(&"center"),
         "the panes survive: {short_names:?}"
+    );
+}
+
+/// The progress line `App::draw` builds from the bus, mirrored so the label a
+/// command would put on screen is the one asserted here.
+fn progress_label(bus: &CommandBus) -> Option<String> {
+    bus.first_running().map(|item| match &item.subject {
+        Some(subject) => format!("{} {subject}…", item.kind),
+        None => format!("{}…", item.kind),
+    })
+}
+
+#[test]
+fn a_housekeeping_sweep_neither_captions_the_band_nor_reflows_the_frame() {
+    // The reap sweep is dispatched every few seconds forever. Reported like a
+    // command someone pressed, it flashed "reap" through the message band and
+    // reflowed every pane on that cadence, twice.
+    //
+    // Isolated by environment variable, process-wide: the dispatched command
+    // runs on a thread of its own and would otherwise open — and sweep — the
+    // developer's real database. nextest runs a process per test.
+    let home = tempfile::tempdir().expect("tempdir");
+    std::env::set_var("THURBOX_CONFIG_DIR", home.path().join("config"));
+    std::env::set_var("THURBOX_DATA_DIR", home.path().join("data"));
+
+    let host = host();
+    let themes = Themes::load(None);
+    let registry = Registry::default();
+    let quiet = rect_of(&slots(&host, &world(0), 160, 40), "sessions").expect("a session column");
+
+    let bus = CommandBus::new();
+    bus.dispatch(Command::Reap);
+    assert!(
+        !bus.inflight().iter().any(|item| item.kind == "reap"),
+        "the sweep must not be published to plugins: {:?}",
+        bus.inflight()
+    );
+
+    // What `App::status_rows` derives from, with no live message to say.
+    let placed = slots_with(
+        &host,
+        &world(0),
+        &bus.inflight(),
+        u16::from(bus.has_inflight()),
+        160,
+        40,
+    );
+    assert!(
+        !placed.iter().any(|s| s.slot == "status"),
+        "the sweep must not reserve the message band"
+    );
+    assert_eq!(
+        rect_of(&placed, "sessions"),
+        Some(quiet),
+        "the panes must not move while housekeeping runs"
+    );
+
+    let mut state = band_state(&registry, &themes, None);
+    let label = progress_label(&bus);
+    state.progress = label.as_deref();
+    assert_eq!(
+        band_row(thurbox::kernel::bands::Band::Message, &state, 60),
+        "",
+        "and there is nothing to caption"
+    );
+
+    // The other half: a command someone pressed still takes its row.
+    bus.dispatch(Command::Delete {
+        session: "not-a-uuid".into(),
+        force: false,
+    });
+    assert!(
+        bus.has_inflight(),
+        "a user command is work someone waits on"
+    );
+    let busy = slots_with(
+        &host,
+        &world(0),
+        &bus.inflight(),
+        u16::from(bus.has_inflight()),
+        160,
+        40,
+    );
+    assert!(
+        busy.iter().any(|s| s.slot == "status"),
+        "a delete still reserves the band"
+    );
+    assert_eq!(
+        rect_of(&busy, "sessions").expect("a session column").height,
+        quiet.height - 1,
+        "and the panes give it the row"
     );
 }
 


### PR DESCRIPTION
## Intent

Fix a UX regression the user reported on the live TUI after PR #1067 merged: a 'reap' message appears in the status bar every few seconds for a fraction of a second and the whole frame resizes each time.

Cause: #1067 collapsed the in-memory reaper into a Command::Reap dispatched on the command bus every REAP_INTERVAL (5s). The bus records every command it accepts, and three readers consume that record: coordinator/draw.rs status_rows() reserves a message-band row while has_inflight(), the band captions it with the command kind ('reap'), and advance_animation() counts it as something moving. A band row appearing/disappearing is a reflow, which forces a full repaint — so every pane resized twice every five seconds. Its completion also drove poll_command_bus into a snapshot refresh + note_data_change twelve times a minute on an idle interface.

The user prescribed the fix and its constraints explicitly: give Command a notion of background housekeeping (is_housekeeping(), true for Reap only) and make the bus report such work nowhere the interface reads — not has_inflight(), not the published in-flight list, not status_rows, not loop activity. The reap must still run on the worker and still log via tracing. Do NOT change REAP_INTERVAL and do NOT move the reap back onto the UI thread. Tests were to be written first and to fail for the right reason.

Deliberate decisions: one branch in CommandBus::dispatch that keeps no InFlight row at all, rather than a filter at each of the four readers — a filter would let the flicker return through whichever reader was not patched. The housekeeping worker sends no Done either, so poll() no longer reports a completion every five seconds; a reaped row therefore leaves the session list on the next due snapshot refresh instead of instantly, which is the accepted trade (nobody waits on a sweep, and the row has been invisible for the whole undo window). Failures go to tracing::warn instead of the message band.

Two tests, both written first and confirmed failing on the old code: kernel::command::tests::housekeeping_is_never_reported_in_flight (unit, beside work_in_flight_is_reported_as_running) and chrome::a_housekeeping_sweep_neither_captions_the_band_nor_reflows_the_frame (asserts the sweep places no 'status' slot and moves no pane rect, and that a user delete still reserves the band and shrinks the panes by a row). The chrome test sets THURBOX_CONFIG_DIR/THURBOX_DATA_DIR process-wide because the dispatched command runs on its own thread and would otherwise sweep the developer's real database — the same pattern tests/repo_memory.rs documents.

Docs updated in the same PR per the repo rule: new ADR-P22 in docs/PERFORMANCE.md, the animation-clock parenthetical there, ADR-26 in docs/ARCHITECTURE.md, and the thurbox-performance and thurbox-cli skills.

Not in scope: REAP_INTERVAL, the reaper's cadence or placement, and any other command's in-flight reporting.

## What Changed

- Added `Command::is_housekeeping()` (true only for `Command::Reap`) and a new `CommandBus::dispatch_housekeeping` path in `src/kernel/command/bus.rs` / `mod.rs`: housekeeping commands run on their own worker thread but are never added to the in-flight list and send no completion, so `has_inflight()`, the published in-flight list, `status_rows()`, and the animation clock never see them. Failures are logged via `tracing::warn` instead of surfacing in the message band.
- Added `kernel::command::tests::housekeeping_is_never_reported_in_flight`, asserting a dispatched `Command::Reap` leaves `inflight()` empty, `has_inflight()` false, and `first_running()` none.
- Added `tests/chrome.rs::a_housekeeping_sweep_neither_captions_the_band_nor_reflows_the_frame`, asserting a reap sweep reserves no status slot and moves no pane rect, while a user-initiated delete still reserves the band and shrinks the panes by a row; the test pins `THURBOX_CONFIG_DIR`/`THURBOX_DATA_DIR` process-wide since the dispatched command runs on its own thread.
- Updated `docs/ARCHITECTURE.md` (ADR-26) and `docs/PERFORMANCE.md` (new ADR-P22 plus an animation-clock parenthetical), and refreshed the `thurbox-cli` and `thurbox-performance` skills to describe the housekeeping/in-flight distinction.

## Risk Assessment

✅ Low: A small, well-isolated change (one dispatch branch in CommandBus plus a new Command::is_housekeeping predicate) that I traced through all four readers (inflight(), has_inflight(), status_rows(), advance_animation()) and confirmed none of them observe the reap sweep anymore, while REAP_INTERVAL, worker-thread placement, and tracing-based failure reporting are all left untouched as required; both prescribed tests exist, exercise real behavior (bus state and rendered layout), and match the intent's described trade-off (delayed row removal via poll_command_bus's non-immediate-refresh branch).

## Testing

Baseline `cargo nextest run --all` already passed. I ran the two tests the PR added first (kernel::command::tests::housekeeping_is_never_reported_in_flight and chrome::a_housekeeping_sweep_neither_captions_the_band_nor_reflows_the_frame) on the target commit and both pass, directly asserting the constraints from the intent: Command::Reap is never recorded in-flight, published, captioned in the message band, or counted as loop activity, while a real user command (Delete) still reserves the band row and reflows the panes. To confirm these aren't vacuously-passing tests, I reproduced the pre-fix failure by applying only the new unit test (not the is_housekeeping/dispatch_housekeeping implementation) onto the base commit in an isolated temp worktree; it failed exactly as the regression describes, with Command::Reap showing up as a published InFlight row. Overall result: the fix is verified end-to-end at the unit and interface-publish level; no findings to report.

<details>
<summary>Evidence: Pre-fix failure of the new unit regression test on base commit f8614b03</summary>

```text
test kernel::command::tests::housekeeping_is_never_reported_in_flight ... FAILED
panicked at src/kernel/command/mod.rs:1072:9:
the sweep must not be published: [InFlight { id: 1, kind: "reap", session: "", subject: None, phase: Queued, error: None }]
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"b052bcad6f0d3d629f523bd0ea89a722f3dad03e","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `cargo nextest run --all`
- `cargo nextest run --lib kernel::command::tests::housekeeping_is_never_reported_in_flight (target commit b052bcad) — PASS`
- `cargo nextest run --test chrome a_housekeeping_sweep_neither_captions_the_band_nor_reflows_the_frame (target commit b052bcad) — PASS`
- `Manual repro: transplanted housekeeping_is_never_reported_in_flight onto base commit f8614b03 (unmodified CommandBus::dispatch/is_housekeeping) in an isolated /tmp git worktree and ran it — FAILED with 'the sweep must not be published: [InFlight { kind: "reap", ... }]', confirming the regression and that the test fails for the right reason pre-fix`
</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/PERFORMANCE.md:1445` - ADR-P22 has no &#39;Measured&#39; section (harness invocation, terminal size, session count, paired before/after), unlike every other ADR-PNN in this file, which the repo&#39;s own stated rule requires for a performance ADR. Producing one needs an actual scripts/dev/perf-run.sh (or `just perf`) run to compare reflow/repaint behavior before vs. after this fix — that&#39;s a measurement task outside a docs-only phase, so flagging as a follow-up rather than fabricating numbers.

🔧 Fix: No stale docs found; ADR-P22 measurement still requires a human perf run
1 info still open:

- ℹ️ `docs/PERFORMANCE.md:1445` - ADR-P22 still has no &#39;Measured&#39; section (harness invocation, terminal size, session count, paired before/after) that every other ADR-PNN in this file carries. The only tool that produces one, scripts/dev/perf-run.sh, refuses to run here by design: it checks NO_MISTAKES_GATE (set to 1 in this session) and exits, explaining that a gate is a busy machine so its reading would be meaningless, and citing a prior incident where an agent ran it inside a gate step anyway and timed out at 30 minutes. This is not fixable from a document-only phase; someone needs to run `just perf -n 19 -p 3 -s 255x62` (idle vs. reap-enabled, paired) by hand on a quiet machine and paste the table into the ADR.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
