### PR TITLE
fix(ui): stop widgets.list overflow markers from eating a row

### DIFF
--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -362,6 +362,11 @@ widgets.panel("title", ctx.focused)
 widgets.gauge(0.7, { width = 20 })
 ```
 
+`widgets.list` sizes itself — pass `len` or `fill` alongside the rows rather
+than patching the returned table — and windows itself: when the rows outrun
+`height` it spends a line of its own on an `↑ N more` / `↓ N more` marker, so
+the count is exactly what you cannot see and no row is drawn over.
+
 `input` carries one thing the other three do not: a claim on the **caret**. A
 screen can hold several fields and the terminal has one cursor, so the field
 being typed into says so with `focused = true` and the others say nothing — and

--- a/src/paths/tests.rs
+++ b/src/paths/tests.rs
@@ -678,18 +678,25 @@ fn no_unit_test_temp_dir_outlives_the_test_process() {
         String::from_utf8_lossy(&out.stderr)
     );
 
+    // Scanned as a substring rather than line-by-line: with --nocapture the
+    // harness's own "test <name> ... " / "ok" progress text shares stdout
+    // with the test's println! on the same fd, unsynchronized, so a marker
+    // can land mid-line (e.g. "...okTEMP_SANDBOX=/tmp/..." or "... ...
+    // TEMP_SANDBOX=/tmp/...\nok") rather than as a line of its own.
+    const MARKER: &str = "TEMP_SANDBOX=";
     let mut reported = 0;
-    for line in stdout.lines() {
-        let Some(path) = line.strip_prefix("TEMP_SANDBOX=") else {
-            continue;
-        };
-        let path = Path::new(path.trim_end());
+    let mut rest: &str = &stdout;
+    while let Some(start) = rest.find(MARKER) {
+        let after = &rest[start + MARKER.len()..];
+        let end = after.find(char::is_whitespace).unwrap_or(after.len());
+        let path = Path::new(&after[..end]);
         assert!(
             !path.exists(),
             "a temp dir outlived the test process that made it: {}",
             path.display()
         );
         reported += 1;
+        rest = &after[end..];
     }
     assert_eq!(
         reported,

--- a/tests/restore.rs
+++ b/tests/restore.rs
@@ -243,6 +243,38 @@ fn esc_closes_without_restoring_anything() {
 }
 
 #[test]
+fn an_overflowing_list_hides_only_the_rows_its_marker_counts() {
+    // The overflow marker is a ROW, not an overlay: it used to be written over
+    // `children[1]`/`children[#children]`, so the window's own first or last row
+    // vanished under it while the count reported one fewer hidden than there
+    // were. Twelve rows in a ten-line window: nine rows fit beside the marker,
+    // and the marker says three.
+    let host = host();
+    let snapshot = Snapshot {
+        deleted: (1..=12)
+            .map(|n| deleted(&format!("id{n}"), &format!("row-{n:02}"), false))
+            .collect(),
+        taken_at_ms: 7_200_000,
+        ..Snapshot::default()
+    };
+    press_in(&host, &snapshot, PLUGIN, "ctrl+u");
+    let (_, tree) = rendered(&host, &snapshot, PLUGIN);
+
+    let shown: Vec<u32> = (1..=12)
+        .filter(|n| tree.contains(&format!("row-{n:02} (claude)")))
+        .collect();
+    assert_eq!(
+        shown,
+        (1..=9).collect::<Vec<_>>(),
+        "the marker takes a line of its own, it does not eat a row: {tree}"
+    );
+    assert!(
+        tree.contains(&format!("\u{2193} {} more", 12 - shown.len())),
+        "the count is what is actually hidden: {tree}"
+    );
+}
+
+#[test]
 fn a_force_deleted_row_is_tagged_and_asks_before_a_best_effort_restore() {
     // v1 gates this behind `ConfirmRestore`: force-delete removed the worktree
     // directory, so only committed work on the branch comes back. The tag is on

--- a/ui/lib/widgets.lua
+++ b/ui/lib/widgets.lua
@@ -207,30 +207,76 @@ local function span_list(spans)
   return spans
 end
 
+--- An overflow marker: a row of its own, never drawn over one.
+local function overflow_marker(text)
+  return { type = "text", len = 1, text = theme.dim(text), role = "overflow" }
+end
+
+--- The visible window, plus which overflow markers fit beside it.
+---
+--- A marker is a row, so it costs a line the rows would otherwise have had —
+--- and giving up that line can push a further row out of view, which calls for
+--- the second marker too. Hence two passes rather than one subtraction.
+---
+--- What comes back is always a sub-range of `widgets.window` for the same
+--- height, which is what lets a pane build spans against that wider window and
+--- know the list reads no row it skipped.
+---
+--- A list with no line to spare — one or two rows with both ends hidden —
+--- shows rows and no markers: a strip made entirely of "N more" says nothing.
+local function marked_window(count, height, selected)
+  if count <= height then
+    return 1, count, false, false
+  end
+  for markers = 1, 2 do
+    if height - markers < 1 then
+      break
+    end
+    local first, last, above, below = widgets.window(count, height - markers, selected)
+    if (above and 1 or 0) + (below and 1 or 0) <= markers then
+      return first, last, above, below
+    end
+  end
+  local first, last = widgets.window(count, height, selected)
+  return first, last, false, false
+end
+
 --- A scrollable list of rows.
 ---
 --- Each row is `{ spans = <text>, id =, class =, role = }` or a plain string.
 --- Rows get identity by default (`role = "row"`), so decoration and event
 --- targeting work without every pane opting in.
 ---
---- opts: rows, selected, height, focused, frame, empty
+--- `len` and `fill` size the returned box. A caller that had to patch a size
+--- onto the table after the call was reaching for the one prop the widget could
+--- not express.
+---
+--- opts: rows, selected, height, frame, empty, len, fill
 function widgets.list(opts)
   local rows = opts.rows or {}
   local height = opts.height or #rows
   local count = #rows
+  local children = {}
 
   if count == 0 then
+    children[1] = { type = "text", text = theme.dim(opts.empty or "  nothing here") }
     return {
       type = "box",
       frame = opts.frame,
-      children = { { type = "text", text = theme.dim(opts.empty or "  nothing here") } },
+      len = opts.len,
+      fill = opts.fill,
+      children = children,
     }
   end
 
   local selected = widgets.clamp(opts.selected, count)
-  local first, last, more_above, more_below = widgets.window(count, height, selected)
+  local first, last, more_above, more_below = marked_window(count, height, selected)
 
-  local children = {}
+  -- The markers bracket the rows and their counts are exact: everything before
+  -- `first` and everything after `last` is hidden, and no row is drawn over.
+  if more_above then
+    children[1] = overflow_marker("  ↑ " .. (first - 1) .. " more")
+  end
   for index = first, last do
     local row = rows[index]
     if type(row) == "string" then
@@ -271,25 +317,17 @@ function widgets.list(opts)
     }
   end
 
-  -- Overflow markers, so a windowed list never silently hides rows.
-  if more_above then
-    children[1] = {
-      type = "text",
-      len = 1,
-      text = theme.dim("  ↑ " .. (first - 1) .. " more"),
-      role = "overflow",
-    }
-  end
   if more_below then
-    children[#children] = {
-      type = "text",
-      len = 1,
-      text = theme.dim("  ↓ " .. (count - last) .. " more"),
-      role = "overflow",
-    }
+    children[#children + 1] = overflow_marker("  ↓ " .. (count - last) .. " more")
   end
 
-  return { type = "box", frame = opts.frame, children = children }
+  return {
+    type = "box",
+    frame = opts.frame,
+    len = opts.len,
+    fill = opts.fill,
+    children = children,
+  }
 end
 
 --- A horizontal bar. Composed from text — not a node kind.

--- a/ui/plugins/65_search.lua
+++ b/ui/plugins/65_search.lua
@@ -377,10 +377,10 @@ end
 local function result_rows(rows, cursor, width, height)
   -- Line numbers are assigned arithmetically first, then spans are built only
   -- for the visible window: every result used to be fully rendered — fuzzy
-  -- spans, truncation and all — for a strip that shows a handful. The window
-  -- is the same `widgets.window` call the list itself makes over the same
-  -- (count, height, selected), so the two agree on which lines are on screen;
-  -- an off-window entry is a placeholder whose spans the list never reads.
+  -- spans, truncation and all — for a strip that shows a handful. The list's
+  -- own window is a sub-range of this one (it shrinks to make room for the
+  -- overflow markers) over the same (count, height, selected), so every line it
+  -- draws has spans; an off-window entry is a placeholder it never reads.
   local entries, selected_line = {}, 1
   local scope = nil
   for index, row in ipairs(rows) do
@@ -500,14 +500,13 @@ return {
     local list_height = math.max(0, height - consumed)
     local lines, selected_line =
       result_rows(rows, search.cursor, math.max(0, width - 4), list_height)
-    local list = widgets.list({
+    children[#children + 1] = widgets.list({
       rows = lines,
       selected = selected_line,
       height = list_height,
+      fill = 1,
       empty = "  nothing matches",
     })
-    list.fill = 1
-    children[#children + 1] = list
 
     return {
       type = "box",

--- a/ui/plugins/80_restore.lua
+++ b/ui/plugins/80_restore.lua
@@ -165,10 +165,11 @@ return {
     local cols = math.min(MODAL_COLS, math.max(4, ctx.width or MODAL_COLS))
     local list = deleted()
     local cursor = cursor_in(list)
-    -- Spans only for the visible window — the same `widgets.window` call the
-    -- list itself makes, so the two agree; off-window entries are placeholders
-    -- whose spans the list never reads. The deleted list can be long after an
-    -- unpurged week, and it shows ten rows.
+    -- Spans only for the visible window — the list's own window is a sub-range
+    -- of this one (it shrinks to make room for the overflow markers), so every
+    -- row it reads has spans; off-window entries are placeholders whose spans
+    -- the list never reads. The deleted list can be long after an unpurged
+    -- week, and it shows ten rows.
     local height = math.max(1, math.min(#list, LIST_MAX))
     local first, last = widgets.window(#list, height, cursor)
     local rows = {}
@@ -183,9 +184,9 @@ return {
       rows = rows,
       selected = cursor,
       height = height,
+      len = height,
       empty = "  No deleted sessions",
     })
-    body.len = height
 
     return modal.frame("Restore Deleted Sessions", {
       cols = cols,


### PR DESCRIPTION
## Intent

Step 2 of a six-step series improving thurbox's Lua interface layer (from the 2026-09-04 Lua UI review, §2 problem 2 and §5 step 2). Goal: a plugin author, human or LLM, can produce a clean, consistent pane with little code.

This step fixes two defects in ui/lib/widgets.lua's list widget that made it unusable for a serious pane:

1. The overflow markers were written into children[1] / children[#children], REPLACING the first or last visible row, and the counts reported first-1 / count-last, which then undercounted by one. A ten-line restore list of twelve rows showed nine rows and said '2 more' while hiding three. The user asked for a failing end-to-end/interface test FIRST that reproduces this, then the fix: markers become rows of their own (the window shrinks so all remaining rows stay visible) and the counts are exact.
2. widgets.list carried no size of its own, so callers patched the returned table: 80_restore.lua wrote body.len = height and 65_search.lua wrote list.fill = 1. The widget now accepts len/fill opts and both callers pass them in.

Deliberate decisions made while doing the work:
- marked_window is a two-pass loop rather than one subtraction, because giving up a line to one marker can push a further row out of view and call for the second marker too.
- The window it returns is provably a sub-range of widgets.window for the same height, which is what keeps 80_restore.lua and 65_search.lua correct: both build spans only for their own wider window and pass placeholders for the rest, so every row the list actually draws still has spans. Their comments were updated to say this instead of 'the same widgets.window call'.
- A list with no line to spare (one or two rows with both ends hidden) shows rows and no markers, rather than spending every line on 'N more'.
- Kept to pure Lua; no kernel/Rust change, and the four node kinds are untouched.
- The review's optional 'remove the dead widgets' was NOT done and this is deliberate: hints, pad and divider are used by examples/ (examples/lua/plugin.lua, examples/lua/composite.lua, examples/panes/top/top.lua, examples/panes/tasks/tasks.lua) and gauge is documented in docs/PLUGINS.md, so none of the four are dead.
- Only this step of the series was done; the other five steps are separate sessions.

Verification: new test tests/restore.rs::an_overflowing_list_hides_only_the_rows_its_marker_counts failed for the right reason before the fix (rows 1-9 shown, row-10 overwritten, marker said '2 more') and passes after. Full 'just test' is green at 2426/2426 - the pinned frames in tests/frames.rs, tests/session_list.rs and tests/render_props.rs are byte-identical, which was the intent since the search and restore panes' visible output only changes when a list actually overflows. 'just lint' (fmt, clippy, deny, rumdl, shellcheck, selene, stylua, lua-language-server) is green.

Note for the pipeline: the pre-commit hook's nextest hit a pre-existing flake in src/paths/tests.rs::no_unit_test_temp_dir_outlives_the_test_process (it greps child stdout for lines starting with TEMP_SANDBOX=, and the child's two parallel libtest threads interleave so one marker lands mid-line). It is unrelated to this change and passed on retry.

## What Changed

- `widgets.list` in `ui/lib/widgets.lua` no longer overwrites `children[1]`/`children[#children]` with an overflow marker; a new two-pass `marked_window` helper shrinks the visible window so each `↑ N more` / `↓ N more` marker gets its own row and reports an exact hidden-row count, falling back to showing rows with no marker when there's no spare line.
- `widgets.list` now accepts `len`/`fill` options and sizes its returned box directly; `ui/plugins/80_restore.lua` and `ui/plugins/65_search.lua` were updated to pass `len`/`fill` instead of patching the returned table afterward, and their window-related comments and `docs/PLUGINS.md` were updated to match the new windowing behavior. A new end-to-end test (`tests/restore.rs::an_overflowing_list_hides_only_the_rows_its_marker_counts`) covers the fix.
- Fixed a flaky assertion in `src/paths/tests.rs::no_unit_test_temp_dir_outlives_the_test_process`: it now scans the child process's captured stdout for `TEMP_SANDBOX=` as a substring instead of line-by-line, since interleaved test-thread output could land a marker mid-line.

## Risk Assessment

✅ Low: Pure-Lua fix confined to widgets.lua and its two callers, backed by a real end-to-end test (LuaHost render) that fails before the fix and passes after; traced the marked_window two-pass algorithm through boundary cases (top/bottom/middle selection, height 0/1/2, count<=height) and it produces exact, non-overlapping overflow counts in every case, with the sub-range-of-widgets.window claim holding by monotonicity of the centering formula.

## Testing

Baseline `cargo nextest run --all` already passed. I additionally reproduced the reported bug against the base commit (marker overwrites the last visible row and undercounts), confirmed the new regression test and all pinned rendering snapshots pass on the target commit, confirmed the previously-flaky temp-dir marker test is now stable across repeated runs, and captured a real painted terminal buffer of the 12-row restore modal showing 9 intact rows plus a correctly-counted "↓ 3 more" marker row as end-user-visible evidence. No issues found.

<details>
<summary>Evidence: Rendered restore modal (12 rows) after fix — ASCII terminal buffer</summary>

```text
Rendered terminal buffer (60x16) of the Restore Deleted Sessions modal with
12 deleted sessions, produced by painting the real Node tree returned by
ui/plugins/80_restore.lua through thurbox::kernel::paint::render (the same
path production frames go through), captured via a temporary test appended
to tests/restore.rs and reverted afterward.

╭ Restore Deleted Sessions ────────────────────────────────╮
│▸ row-01 (claude) 1h ago [wt]                             │
│  row-02 (claude) 1h ago [wt]                             │
│  row-03 (claude) 1h ago [wt]                             │
│  row-04 (claude) 1h ago [wt]                             │
│  row-05 (claude) 1h ago [wt]                             │
│  row-06 (claude) 1h ago [wt]                             │
│  row-07 (claude) 1h ago [wt]                             │
│  row-08 (claude) 1h ago [wt]                             │
│  row-09 (claude) 1h ago [wt]                             │
│  ↓ 3 more                                                │
│j/k navigate  esc close              [ Restore ] [ Close ]│
│                                                          │
│                                                          │
│                                                          │
╰──────────────────────────────────────────────────────────╯

Rows 1-9 are all fully visible (none overwritten by the marker), and the
marker's own row correctly reads "3 more" for the 3 rows actually hidden
(10, 11, 12) — matching the fix description. Before the fix (base commit
4d0a8dea), the same 12-row snapshot rendered row 9 replaced by "↓ 2 more"
(undercounting by one and hiding row 9's content).
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (13m7s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"530c7d93d50ee9e2a05f7a866d48f449a6d8e8c5","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- 🚨 tests failed with exit code 100
- `cargo nextest run --all`

🔧 Fix: fix(core): stop temp-dir marker scan from breaking on interleaved stdout
✅ Re-checked - no issues remain.
- `cargo nextest run --all`
- <code>`cargo nextest run --test restore an_overflowing_list_hides_only_the_rows_its_marker_counts` on target commit 530c7d93 — passes</code>
- `Same test against base commit 4d0a8dea's ui/lib/widgets.lua (temporarily checked out) — fails for the described reason: rows 1-9 shown, marker overwrote row 9 and undercounted ('2 more' vs 3 actually hidden)`
- <code>`cargo nextest run --test frames --test session_list --test render_props --test restore` on target commit — all 42 tests pass, pinned frames byte-identical</code>
- <code>`cargo nextest run --lib paths::tests::no_unit_test_temp_dir_outlives_the_test_process` x3 — consistently passes (previously flaky test fixed in this commit)</code>
- `Manual visual verification: temporarily added a test that paints the real restore-modal Node tree via thurbox::kernel::paint::render into a ratatui TestBackend with 12 deleted sessions, captured the rendered 60x16 terminal buffer, then reverted the temporary test (git checkout -- tests/restore.rs, worktree left clean)`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
