### PR TITLE
feat(ui): type the plugin API so a typo fails lint

### DIFF
--- a/.claude/skills/thurbox-kernel/SKILL.md
+++ b/.claude/skills/thurbox-kernel/SKILL.md
@@ -170,6 +170,23 @@ examples to read and copy from, not a catalogue thurbox maintains for anyone —
 `check` fails on a pane that **loaded but which no arrangement places** — the only
 failure with no symptom — and prints the `layout.lua` line to add.
 
+`ui/lib/thurbox.d.lua` is the API as lua-language-server types — node props and
+their allowed values, `ctx`, the `hit`/`key`/`wheel` payloads, the declaration
+table, every published `thurbox.*` row shape, every `command` verb's options, and
+the theme roles. It is declarations only; nothing loads it into the VM (which is
+why `selene.toml` excludes it — describing a global means assigning one, and that
+is the one thing the sandbox forbids). Keep it in step with `node.rs`/`convert.rs`,
+`host/load.rs`, `host/publish.rs`, `command/mod.rs` and `theme.rs`, the same way
+`thurbox.yml` is kept in step with `LuaHost::publish`.
+
+Two shapes do the catching, because lua-language-server does **not** flag an extra
+key in a table constructor: every kind and every verb declares the field it cannot
+work without (a misspelt one reads as `missing-fields`), and every field drawn from
+a fixed set is spelled as that set (a misspelt value is `assign-type-mismatch`).
+`tests/fixtures/lua_types/` holds three panes that each make one of those mistakes
+and `scripts/ci/check-lua-types.sh` fails when any of them stops being reported —
+the counterpart to `--check ui`, which only proves the bundled panes are clean.
+
 The directory ships its own guidance for whoever edits it: `README.md` is the
 reference, and **`AGENTS.md`** is the operational half a coding CLI loads as context
 without being asked — which is what stops "install this plugin" being read as a

--- a/.claude/skills/thurbox-testing/SKILL.md
+++ b/.claude/skills/thurbox-testing/SKILL.md
@@ -38,8 +38,14 @@ kernel over the real `ui/`** rather than a harness that imitates either:
 - **`tests/kernel_limits.rs`** — instruction and memory ceilings, in their own file
   because they mutate process-wide limits.
 - **Lua statics** — `selene ui` (undefined names + the sandbox, via `thurbox.yml`),
-  `lua-language-server --check` (types + withheld libraries), `stylua` (format).
-  The three cover different halves; see **Linting & Formatting**.
+  `lua-language-server --check` (types + withheld libraries, via
+  `ui/lib/thurbox.d.lua`), `stylua` (format). The three cover different halves;
+  see **Linting & Formatting**.
+- **`scripts/ci/check-lua-types.sh`** — the definitions' own test. Three panes in
+  `tests/fixtures/lua_types/` each misspell one thing the plugin API otherwise
+  drops in silence (a node prop, a command option, a theme role) and each must
+  still be reported. `--check ui` proves the panes are clean; this proves the
+  types have teeth. Runs in the Lua Lint job and in `just lint`.
 - **`tests/frames.rs`** — the bundled panes' frames pinned cell for cell, as
   literals in the file (no snapshot tool): the session list grouped, nested,
   windowed, narrow and under double-width names; the selection as a *style*;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,10 @@ jobs:
               - 'thurbox.yml'
               - 'stylua.toml'
               - '.luarc.json'
+              # The probes that hold the type definitions to their job, and the
+              # script that runs them.
+              - 'tests/fixtures/lua_types/**'
+              - 'scripts/ci/check-lua-types.sh'
               - '.github/workflows/ci.yml'
             website:
               - 'website/**'
@@ -398,6 +402,11 @@ jobs:
         # silently not found and every injected global reads as undefined — 79
         # phantom findings rather than an error saying the config was missed.
         run: lua-language-server --check ui --configpath "$PWD/.luarc.json" --checklevel=Warning
+      - name: Check the type definitions still catch a typo
+        # The complement to the step above: `--check ui` proves the bundled
+        # panes are clean, which definitions describing nothing would also
+        # achieve. These probes prove the definitions have teeth.
+        run: scripts/ci/check-lua-types.sh
 
   website-lint:
     name: Website Lint

--- a/.luarc.json
+++ b/.luarc.json
@@ -16,14 +16,17 @@
       "state",
       "store",
       "files",
-      "require"
+      "require",
+      "run"
     ],
     "disable": [
       "lowercase-global"
     ]
   },
   "workspace": {
-    "library": [],
+    "library": [
+      "ui/lib/thurbox.d.lua"
+    ],
     "checkThirdParty": false
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,7 @@ stylua ui                            # Lua format (stylua.toml); --check in CI
 # silently not found, and then reports every injected global as undefined (79
 # phantom findings). `just lint` passes an absolute one:
 lua-language-server --check ui --configpath "$PWD/.luarc.json" --checklevel=Warning
+scripts/ci/check-lua-types.sh        # the definitions' own test (see below)
 ```
 
 Three tools on `ui/`, chosen to match what the Lua ecosystem actually gates on —
@@ -129,6 +130,28 @@ The split is not redundancy: selene's `removed:` works on plain functions but no
 on a table's fields, and luals' `runtime.builtin` disables whole libraries but
 cannot drop a single base function. Verified by probing every withheld capability
 against both.
+
+**`ui/lib/thurbox.d.lua` is the API as types**, and is what gives luals something
+to check names against: node props and their allowed values, `ctx`, the
+`hit`/`key`/`wheel` payloads, the declaration table, every published `thurbox.*`
+row, every `command` verb's options, and the theme roles. Declarations only —
+nothing loads it into the VM, which is why `selene.toml` excludes it (describing a
+global means assigning one, the single thing the sandbox forbids a plugin).
+
+`.luarc.json` names it in `workspace.library` for an editor opened at the
+repository root. `--check ui` does not need that entry — luals loads a `---@meta`
+file that is inside the workspace it is checking — which is also why the file
+ships in `BUNDLED` and works in a user's own interface directory with no config
+at all. The relative library path resolves against the workspace ROOT, not the
+working directory, so it is spelled for the root the repository is opened at.
+
+luals will **not** flag an extra key in a table constructor, so the file catches a
+typo the other way round: each kind and each verb declares the field it cannot work
+without, so a misspelt one reads as `missing-fields`, and each field drawn from a
+fixed set is spelled as that set, so a misspelt value is `assign-type-mismatch`.
+`scripts/ci/check-lua-types.sh` runs three panes from `tests/fixtures/lua_types/`
+that each make one of those mistakes and fails if any stops being reported —
+`--check ui` alone would also pass against a file describing nothing.
 
 **`thurbox.yml` is the plugin sandbox, checked statically.** It is selene's
 standard library for `ui/`, and it deliberately declares **no `base:`** — it lists

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -343,6 +343,43 @@ them every withheld capability is declared absent, so reaching for one is a lint
 error rather than a nil-index at the moment someone opens your pane. `stylua ui`
 formats. All three run in CI; selene and stylua also run on commit.
 
+## Names, checked before you run
+
+Absence is the loud half. The quiet half is everything that *is* there and is
+simply misspelt: `convert.rs` drops a node key it does not know (deliberately —
+that is how you carry your own bookkeeping on the node table), `command` reads a
+fixed list of option names and collects the rest into an event payload, and a
+theme role no palette defines is nil. All three render something plausible and
+report nothing.
+
+`ui/lib/thurbox.d.lua` is those names written down as lua-language-server types:
+every node prop and the values it accepts, `ctx`, the `hit`/`key`/`wheel`
+payloads, the declaration table, every published `thurbox.*` row, every command
+verb's options, and the theme roles. `.luarc.json` loads it, so an editor opened
+on the repository — or on your own interface directory — has it already.
+
+lua-language-server will not flag an **extra** key in a table constructor, so the
+file is written to catch a typo the other way round:
+
+```lua
+---@type thurbox.TextNode
+local row = { type = "text", txet = "hello" }
+-- Missing required fields in type `thurbox.TextNode`: `text`
+
+command("open", { url = "https://example.com" })
+-- Missing required fields in type `thurbox.cmd.Open`: `text`
+
+local colour = theme.warning
+-- Undefined field `warning`.
+```
+
+The first needs the `---@type` line: without an annotation there is no type to
+check the table against. The second and third need nothing — `command` and
+`lib/theme.lua` are typed already.
+
+Those three examples are literally `tests/fixtures/lua_types/`, and
+`scripts/ci/check-lua-types.sh` fails if any of them stops being reported.
+
 ## The four node kinds
 
 `text`, `box`, `input`, `surface`. That is the whole vocabulary, and it is meant

--- a/justfile
+++ b/justfile
@@ -52,6 +52,9 @@ lint:
     # server's install dir, and a missed config reports every injected global as
     # undefined instead of erroring.
     lua-language-server --check ui --configpath "{{ justfile_directory() }}/.luarc.json" --checklevel=Warning
+    # The other direction: three panes that each misspell something, which must
+    # each still come back as a finding.
+    scripts/ci/check-lua-types.sh
 
 # Format the Lua interface in place (the counterpart to `cargo fmt`).
 fmt-lua:

--- a/scripts/ci/check-lua-types.sh
+++ b/scripts/ci/check-lua-types.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# Prove `ui/lib/thurbox.d.lua` still catches the mistakes it exists to catch.
+#
+# `lua-language-server --check ui` only proves the bundled panes are clean,
+# which a definitions file describing nothing would also achieve. These probes
+# are the other direction: three panes that each make one of the silent failures
+# the plugin API allows — a node prop the kernel drops (`convert.rs` ignores an
+# unknown key), a command option no verb reads (`command/mod.rs` reads a fixed
+# list), and a theme role no palette defines (`theme.lua`'s `__index` answers
+# nil) — and each must come back as a finding rather than as a pane that draws
+# the wrong thing and says nothing.
+#
+# The probes run in a throwaway copy of `ui/` rather than in the tree, because
+# lua-language-server resolves both `require("lib.…")` and the relative entries
+# of `workspace.library` against the workspace ROOT — a probe checked from
+# anywhere else would type-check against no definitions and pass for the wrong
+# reason. Copying also keeps them out of `--check ui`, which must stay clean.
+#
+# Usage: check-lua-types.sh
+set -euo pipefail
+
+root=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+probes="$root/tests/fixtures/lua_types"
+
+if ! command -v lua-language-server > /dev/null 2>&1; then
+    printf 'lua-language-server not found — install it (see scripts/install-dev-tools.sh)\n' >&2
+    exit 1
+fi
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+cp -R "$root/ui/." "$work/"
+cp "$root/.luarc.json" "$work/.luarc.json"
+mkdir -p "$work/probes"
+cp "$probes"/*.lua "$work/probes/"
+
+# Read the findings from the machine-readable report rather than the progress
+# output: only it names the diagnostic code, and only it is not line-wrapped.
+report="$work/check.json"
+lua-language-server --check "$work" \
+    --configpath "$work/.luarc.json" \
+    --checklevel=Warning \
+    --logpath "$work/log" \
+    --check_out_path "$report" > /dev/null 2>&1 || true
+
+if [ ! -s "$report" ]; then
+    printf 'no findings at all — every probe type-checked clean, so the\n' >&2
+    printf 'definitions in ui/lib/thurbox.d.lua are not being loaded.\n' >&2
+    exit 1
+fi
+
+# The report is one JSON object of file -> findings, pretty-printed one key per
+# line. `codes_for` cuts the block belonging to one file and lists its codes,
+# which is all this needs and costs no JSON parser in CI.
+codes_for() {
+    awk -v want="probes/$1\"" '
+        /^    "file:/ { inside = (index($0, want) > 0); next }
+        inside && /"code"/ { gsub(/[",]/, ""); print $2 }
+    ' "$report"
+}
+
+expect() {
+    local file=$1 code=$2
+    if ! codes_for "$file" | grep -qx "$code"; then
+        printf 'probes/%s: expected a %s finding, got none —\n' "$file" "$code" >&2
+        printf '  thurbox.d.lua no longer describes what this probe misspells.\n' >&2
+        return 1
+    fi
+    printf 'probes/%s: %s\n' "$file" "$code"
+}
+
+failed=0
+expect prop.lua missing-fields || failed=1
+expect command.lua missing-fields || failed=1
+expect theme.lua undefined-field || failed=1
+
+# The bundled interface travels in the same workspace, so a finding there is a
+# real regression. Reported here rather than tolerated, even though `just
+# lint-lua` would catch it too.
+if grep -q '"file:.*/\(lib\|plugins\)/' "$report"; then
+    printf 'the bundled interface reported a finding — run "just lint"\n' >&2
+    failed=1
+fi
+
+exit "$failed"

--- a/selene.toml
+++ b/selene.toml
@@ -6,6 +6,13 @@
 # things at once: that the Lua is sound, and that it stays inside the sandbox.
 std = "thurbox"
 
+# The type definitions are declarations, not code: nothing loads
+# `lib/thurbox.d.lua` into the VM, and describing a global means *assigning* it,
+# which is the one thing the sandbox forbids of a plugin. Linting it against the
+# sandbox would therefore reject the file for saying exactly what the sandbox
+# is. `lua-language-server` checks it instead — see `scripts/ci/check-lua-types.sh`.
+exclude = ["ui/lib/thurbox.d.lua"]
+
 [lints]
 # A plugin is one file returning one table; the kernel calls its fields. Nothing
 # else references them, which is not "unused".

--- a/src/kernel/bundled.rs
+++ b/src/kernel/bundled.rs
@@ -45,6 +45,15 @@ pub const BUNDLED: &[(&str, &str)] = &[
     ("CLAUDE.md", include_str!("../../ui/CLAUDE.md")),
     ("GEMINI.md", include_str!("../../ui/GEMINI.md")),
     ("layout.lua", include_str!("../../ui/layout.lua")),
+    // Not code either: the API as lua-language-server types. It ships because a
+    // pane is edited in the user's own interface directory, and luals loads a
+    // `---@meta` file that is simply *in* the workspace — so delivering it is
+    // what gives an author (or an agent) `lua-language-server --check .` there
+    // with no config to write. Nothing requires it; the VM never sees it.
+    (
+        "lib/thurbox.d.lua",
+        include_str!("../../ui/lib/thurbox.d.lua"),
+    ),
     ("lib/theme.lua", include_str!("../../ui/lib/theme.lua")),
     ("lib/widgets.lua", include_str!("../../ui/lib/widgets.lua")),
     ("lib/tree.lua", include_str!("../../ui/lib/tree.lua")),

--- a/tests/fixtures/lua_types/command.lua
+++ b/tests/fixtures/lua_types/command.lua
@@ -1,0 +1,13 @@
+-- A pane that names a command option the verb does not read.
+--
+-- `command("open", …)` takes its url in `text`; `url` is collected into the
+-- payload and ignored, so the link never opens and nothing is reported.
+return {
+  name = "command_probe",
+  render = function()
+    return { text = "" }
+  end,
+  on_action = function()
+    command("open", { url = "https://example.invalid" })
+  end,
+}

--- a/tests/fixtures/lua_types/prop.lua
+++ b/tests/fixtures/lua_types/prop.lua
@@ -1,0 +1,13 @@
+-- A pane that misspells a node prop: `txet` where the kind needs `text`.
+--
+-- `convert.rs` drops a key it does not know — that is how a plugin carries its
+-- own bookkeeping on the node table — so this renders an empty line at runtime
+-- and says nothing. The type definitions are what turn it into a finding.
+return {
+  name = "prop_probe",
+  render = function()
+    ---@type thurbox.TextNode
+    local row = { type = "text", txet = "hello" }
+    return row
+  end,
+}

--- a/tests/fixtures/lua_types/theme.lua
+++ b/tests/fixtures/lua_types/theme.lua
@@ -1,0 +1,12 @@
+-- A pane that asks the theme for a role no palette defines.
+--
+-- `lib/theme.lua`'s `__index` returns nil for an unknown shorthand, so the run
+-- is drawn in the terminal's default colour and looks deliberate.
+local theme = require("lib.theme")
+
+return {
+  name = "theme_probe",
+  render = function()
+    return { text = "warning", style = { fg = theme.warning } }
+  end,
+}

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -68,6 +68,18 @@ the one that looks like success:
   It compiles, declares its keys, appears in listings, and is absent from the
   screen. `check` prints the `layout.lua` line to add.
 
+`check` loads; it does not read names. The mistakes it cannot see are the quiet
+ones — a node prop the kernel drops, a command option no verb reads, a theme role
+no palette defines — and `lib/thurbox.d.lua` is what turns those into findings:
+
+```bash
+lua-language-server --check . --checklevel=Warning
+```
+
+Annotate the node you build (`---@type thurbox.TextNode` above the table) so a
+misspelt prop reads back as a missing required field. An **extra** key is never
+reported, so the annotation is what does the work.
+
 ## Adding a pane is two edits
 
 The plugin file, **and** its slot in `layout.lua`. A pane names a slot; the

--- a/ui/README.md
+++ b/ui/README.md
@@ -14,6 +14,9 @@ layout.lua      the arrangement: which slots exist, and where
 lib/            shared helpers — widgets, theme roles, fuzzy match, text input,
                 border chrome, modal shells, scrolling, and the session-list
                 and repo-picker models
+lib/thurbox.d.lua   the API as types: node props, ctx, the event payloads, every
+                published `thurbox.*` row, every command verb's options, and the
+                theme roles. Declarations only — nothing loads it at runtime
 plugins/        the panes themselves, loaded in filename order
 ```
 
@@ -185,6 +188,35 @@ interactive program pane is asked for through `command`, which every plugin has.
 they are *missing* — `os.time()` is an `attempt to index a nil value`, not a
 permission error. `selene` catches this at lint time via `thurbox.yml`, which is
 the sandbox written down; run `selene ui` if it is installed.
+
+## Names, checked before you run
+
+The other half of the API fails quietly rather than loudly: `convert.rs` drops a
+node key it does not know (that is how you carry your own bookkeeping on the node
+table), `command` reads a fixed list of option names, and an undefined theme role
+is nil. Each of those draws something plausible and reports nothing.
+
+`lib/thurbox.d.lua` is what turns those into findings. Point an editor at the
+repository (it reads `.luarc.json`) or run the checker over your own directory:
+
+```bash
+lua-language-server --check . --checklevel=Warning
+```
+
+No config to write: `lib/thurbox.d.lua` ships beside the panes, and the checker
+loads a `---@meta` file that is simply in the directory it is checking.
+
+Two habits make it earn its keep:
+
+- **Annotate the node you build**: `---@type thurbox.TextNode` above a table is
+  what lets `txet = "…"` read back as "missing required field `text`". Without
+  an annotation there is no type to check against.
+- **Name a verb's options as the verb spells them.** `command("open", { url = u })`
+  is the classic: the url goes in `text`, and `url` is collected and ignored.
+
+Extra keys in a table are never reported — lua-language-server does not flag
+them — which is why each kind and each verb declares the field it cannot work
+without, so a misspelling reads as that field missing.
 
 ## Traps
 

--- a/ui/lib/theme.lua
+++ b/ui/lib/theme.lua
@@ -10,6 +10,25 @@
 -- never heard of your theme. A plugin that hardcodes "#5fafff" opts out of all
 -- of that, which is why nothing here hands one out.
 
+--- Declared so the shorthands the metatable serves are checkable: `__index`
+--- answers nil for a name it does not know, so without this a misspelt one is a
+--- run that renders in the terminal's default colour and looks deliberate. The
+--- full role vocabulary is `thurbox.Role` in `thurbox.d.lua`; these are the
+--- short names, and the two are kept in step by SHORTHAND below.
+---@class thurbox.ThemeLib
+---@field accent thurbox.Color?
+---@field accent_bright thurbox.Color?
+---@field muted thurbox.Color?
+---@field text thurbox.Color?
+---@field secondary thurbox.Color?
+---@field ok thurbox.Color?
+---@field warn thurbox.Color?
+---@field bad thurbox.Color?
+---@field info thurbox.Color?
+---@field border thurbox.Color?
+---@field border_focused thurbox.Color?
+---@field branch thurbox.Color?
+---@field hint thurbox.Color?
 local theme = {}
 
 -- Resolved on access so a theme change is picked up on the next frame, and
@@ -34,6 +53,8 @@ end
 ---
 --- nil is deliberate: an undefined role must render as "no colour", never as an
 --- arbitrary one that looks deliberate.
+---@param name thurbox.Role
+---@return thurbox.Color?
 function theme.role(name)
   return roles()[name]
 end
@@ -89,6 +110,8 @@ local STATUS_ROLES = {
 ---
 --- Colour comes from the theme's own status roles, so a theme that recolours
 --- "blocked" recolours it here without this file changing.
+---@param name thurbox.Status
+---@return { glyph: string, color: thurbox.Color? }
 function theme.status(name)
   return {
     glyph = STATUS_GLYPHS[name] or STATUS_GLYPHS.idle,
@@ -115,20 +138,27 @@ theme.spinner = { "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇",
 --- and only while something is animating, so a spinner advancing faster than the
 --- clock would skip frames and one advancing slower would be re-rendered for no
 --- visible change.
+---@param elapsed number?
+---@return string
 function theme.spinner_frame(elapsed)
   local frame = math.floor((elapsed or 0) * 8) % #theme.spinner + 1
   return theme.spinner[frame]
 end
 
+---@param text string
+---@return thurbox.Span
 function theme.dim(text)
   return { text = text, style = { fg = theme.muted } }
 end
 
+---@param text string
+---@return thurbox.Span
 function theme.heading(text)
   return { text = text, style = { fg = theme.accent, bold = true } }
 end
 
 --- The active theme's identifier, for anything that wants to show it.
+---@return string
 function theme.name()
   return (thurbox and thurbox.theme and thurbox.theme.name) or "default"
 end

--- a/ui/lib/thurbox.d.lua
+++ b/ui/lib/thurbox.d.lua
@@ -1,0 +1,792 @@
+---@meta
+--
+-- The plugin API, as types. Loaded by lua-language-server through
+-- `.luarc.json`'s `workspace.library`; never loaded by the plugin VM.
+--
+-- It exists because every mistake the API allows is silent. `convert.rs` drops
+-- a node key it does not know (that is how a plugin carries its own bookkeeping
+-- on the node table), `command` reads a fixed list of option names and ignores
+-- the rest, and `lib/theme.lua`'s `__index` answers nil for a role no palette
+-- defines. Each of those renders something plausible and reports nothing, so
+-- the only place a typo can be caught is before it runs.
+--
+-- Two shapes do the catching, because lua-language-server will not flag an
+-- *extra* key in a table constructor:
+--
+--   * every kind and every verb declares the field it cannot work without, so
+--     a misspelt one reads as that field missing (`missing-fields`);
+--   * every field whose value is drawn from a fixed set is that set, so a
+--     misspelt value is a type mismatch (`assign-type-mismatch`).
+--
+-- `tests/fixtures/lua_types` + `scripts/ci/check-lua-types.sh` hold this to it.
+--
+-- Keep in step with `src/kernel/node.rs` and `src/kernel/convert.rs` (nodes),
+-- `src/kernel/host/load.rs` (the declaration), `src/kernel/host/publish.rs`
+-- (`thurbox.*`), `src/kernel/command/mod.rs` (verbs) and `src/kernel/theme.rs`
+-- (roles) — and with `thurbox.yml`, which is the same contract for selene.
+
+---@alias thurbox.Color string A role's colour, `#rrggbb`, a name, or a 0-255 index.
+
+--- A style: a bare colour is shorthand for a foreground.
+---@class thurbox.Style
+---@field fg? thurbox.Color
+---@field bg? thurbox.Color
+---@field bold? boolean
+---@field dim? boolean
+---@field italic? boolean
+---@field underline? boolean
+---@field reversed? boolean
+---@field crossed_out? boolean
+
+---@alias thurbox.StyleSpec thurbox.Color|thurbox.Style
+
+--- One styled run within a line.
+---@class thurbox.Span
+---@field text string|number|boolean
+---@field style? thurbox.StyleSpec
+
+--- One line: a bare string, one span, or a list of spans.
+---@alias thurbox.Line string|number|boolean|thurbox.Span|thurbox.Span[]
+
+--- What a `text` node or a frame title accepts: one line, or a list of them.
+---@alias thurbox.Text thurbox.Line|thurbox.Line[]
+
+--- A frame drawn around a node. `borders` is all-or-none and the border type is
+--- fixed; there is no `title_align`.
+---@class thurbox.Frame
+---@field title? thurbox.Text
+---@field borders? "all"|"none"
+---@field border_style? thurbox.StyleSpec
+---@field style? thurbox.StyleSpec
+---@field padding? integer
+
+--- What every node may say about its space and its identity.
+---
+--- Sizing resolves exact → percentage → share, each clamped by `min`/`max`; a
+--- node that asks for nothing takes an equal share of the remainder. `role`
+--- carries the kernel's own click verbs (`action:`, `key:`, `focus:`, `url:`,
+--- and the bare `drag`); any other role hands the click to the plugin.
+---@class thurbox.NodeCommon
+---@field len? integer
+---@field pct? number
+---@field fill? number
+---@field min? integer
+---@field max? integer
+---@field id? string
+---@field class? string|string[]
+---@field role? string
+---@field frame? thurbox.Frame|string|boolean
+---@field block? thurbox.Frame|string|boolean The POC's spelling of `frame`.
+
+--- Text. Carries no style of its own — style the spans.
+---@class (exact) thurbox.TextNode : thurbox.NodeCommon
+---@field type? "text"|"paragraph"|"line"
+---@field text thurbox.Text
+---@field align? "left"|"center"|"centre"|"right"
+---@field wrap? boolean
+---@field scroll? integer
+
+--- A row or a column. Children live under `children`, or in the array part.
+---@class thurbox.BoxNode : thurbox.NodeCommon
+---@field type? "box"|"vstack"|"hstack"|"column"|"row"|"stack"
+---@field axis? "vertical"|"horizontal"|"column"|"row"|"v"|"h"
+---@field gap? integer
+---@field children? thurbox.Node[]
+
+--- A text field. `focused` claims the one caret, and `cursor` counts characters.
+---@class (exact) thurbox.InputNode : thurbox.NodeCommon
+---@field type? "input"|"field"
+---@field value string
+---@field cursor? integer
+---@field placeholder? string
+---@field focused? boolean
+---@field style? thurbox.StyleSpec
+
+--- Pre-rendered cells: a live session's terminal, a program this plugin asked
+--- to run, or lines the plugin produced itself. Exactly one source.
+---@class thurbox.SurfaceNode : thurbox.NodeCommon
+---@field type? "surface"|"terminal"
+---@field session? string
+---@field program? string
+---@field cells? thurbox.Line[]
+---@field scroll? integer
+
+---@alias thurbox.Node thurbox.TextNode|thurbox.BoxNode|thurbox.InputNode|thurbox.SurfaceNode
+
+--- How big a floating pane asks to be: a share of the screen, or exact cells.
+---@class (exact) thurbox.Float
+---@field width? number
+---@field height? number
+---@field cols? integer
+---@field rows? integer
+
+--- What a render is told. `elapsed` is served through a metatable, so reading it
+--- is what marks a `pure` pane as depending on the animation clock.
+---@class (exact) thurbox.Ctx
+---@field width integer
+---@field height integer
+---@field focused boolean
+---@field frame integer
+---@field name string
+---@field slot string
+---@field elapsed number
+
+--- What a decorator is told. Smaller than a render's: it is handed the tree it
+--- is transforming, not a slot of its own.
+---@class (exact) thurbox.DecorateCtx
+---@field width integer
+---@field height integer
+
+--- What `ui/layout.lua` is told. Smaller than a render's: an arrangement sees
+--- the screen and which slots are occupied, and no plugin.
+---@class (exact) thurbox.LayoutCtx
+---@field width integer
+---@field height integer
+---@field slots table<string, boolean>
+
+--- A key offered to `on_key`. Return true to consume it.
+---@class (exact) thurbox.Key
+---@field key string
+---@field char? string
+---@field ctrl boolean
+---@field alt boolean
+---@field shift boolean
+---@field cmd boolean
+
+--- A click on a node this plugin painted, with the rect it landed in.
+--- Reached only for identity the kernel has no verb for.
+---@class (exact) thurbox.Hit
+---@field id? string
+---@field class string
+---@field role? string
+---@field x integer
+---@field y integer
+---@field w integer
+---@field h integer
+---@field dragging boolean
+
+--- A wheel tick over this plugin's pane. Declining puts it back on the key path.
+---@class (exact) thurbox.Wheel
+---@field up boolean
+---@field x integer
+---@field y integer
+
+---@alias thurbox.Event
+---| "session.created"
+---| "session.deleted"
+---| "session.status"
+---| "session.changed"
+---| "session.post_create"
+---| "session.post_delete"
+---| "session.post_restart"
+---| "session.post_restore"
+---| "focus.session"
+---| "focus.pane"
+---| "command.done"
+---| "command.failed"
+---| "interface.reloaded"
+---| string A `user.<name>` a plugin emits.
+
+--- A key a plugin declares. Declared as data so the registry can enumerate,
+--- conflict-check and rebind it without calling the plugin.
+---@class (exact) thurbox.Binding
+---@field key string
+---@field action string
+---@field desc? string
+---@field scope? "global"|"plugin"
+---@field passthrough? boolean
+---@field group? string
+
+--- A palette row: an action reachable without a chord.
+---@class (exact) thurbox.CommandDecl
+---@field action string
+---@field desc? string
+
+--- An entry in the action band.
+---@class (exact) thurbox.Pill
+---@field action string
+---@field label string
+---@field priority? integer
+
+--- A switch in the settings panel, owned by the declaring plugin.
+---@class (exact) thurbox.SettingDecl
+---@field id string
+---@field desc? string
+---@field default boolean|number|string
+
+--- What a plugin file returns.
+---
+--- `render` is required unless the plugin `decorates` another, which draws
+--- nothing of its own. A returned tree may carry `float` on its root.
+---@class thurbox.Plugin
+---@field name? string Defaults to the filename, minus a numeric ordering prefix.
+---@field slot? string Defaults to `"center"`.
+---@field slot_mode? "stack"|"switch"
+---@field order? number Defaults to 100.
+---@field focusable? boolean
+---@field pure? boolean Cache the tree until an input changes.
+---@field floats? boolean
+---@field input? "session"
+---@field size? thurbox.Size
+---@field decorates? string A slot whose tree this plugin transforms.
+---@field keys? thurbox.Binding[]
+---@field pills? thurbox.Pill[]
+---@field settings? thurbox.SettingDecl[]
+---@field commands? thurbox.CommandDecl[]
+---@field events? thurbox.Event[]
+---@field capabilities? ("run"|"program")[]
+---@field render? fun(ctx: thurbox.Ctx): thurbox.Node
+---@field decorate? fun(node: thurbox.Node, ctx: thurbox.DecorateCtx): thurbox.Node
+---@field on_key? fun(key: thurbox.Key): boolean
+---@field on_action? fun(action: string): boolean
+---@field on_click? fun(hit: thurbox.Hit): boolean
+---@field on_scroll? fun(wheel: thurbox.Wheel): boolean
+---@field on_event? fun(name: string, payload: table<string, any>)
+
+--- What a pane asks of its slot, in the same vocabulary a node uses.
+---@class (exact) thurbox.Size
+---@field len? integer
+---@field pct? number
+---@field fill? number
+---@field min? integer
+---@field max? integer
+
+---@alias thurbox.Role
+---| "accent"
+---| "accent_bright"
+---| "status_working"
+---| "status_blocked"
+---| "status_done"
+---| "status_idle"
+---| "status_error"
+---| "status_unreachable"
+---| "text_primary"
+---| "text_secondary"
+---| "text_muted"
+---| "border_focused"
+---| "border_unfocused"
+---| "role_name"
+---| "branch_name"
+---| "search_bar"
+---| "keybind_hint"
+---| "tool_allowed"
+---| "tool_disallowed"
+---| "danger"
+---| "selection_bg"
+---| "selection_fg"
+---| "modal_dim_bg"
+---| "modal_bg"
+---| "modal_border"
+---| "inverted_fg"
+---| "diff_added"
+---| "diff_removed"
+---| "diff_added_bg"
+---| "diff_removed_bg"
+---| "app_bg"
+
+--- A session's derived status, as `SessionState::as_str` spells it.
+--- `lib/theme.lua` has a glyph and a role for `working`, `blocked`, `done`,
+--- `idle` and `unreachable`, and falls back to `idle` for the rest — which is
+--- why `theme.status` accepts the whole vocabulary.
+---@alias thurbox.Status
+---| "working"
+---| "blocked"
+---| "done"
+---| "idle"
+---| "unreachable"
+---| "stopped"
+---| "running"
+---| "uncovered"
+---| "unreported"
+
+--- Uncommitted work in a session's tree. Absent until it has been measured,
+--- which a plugin must be able to tell apart from a clean tree.
+---@class (exact) thurbox.GitStats
+---@field files integer
+---@field insertions integer
+---@field deletions integer
+---@field untracked integer
+---@field dirty boolean
+---@field ahead integer
+---@field behind integer
+---@field merged? boolean Absent when nobody could say.
+
+---@class (exact) thurbox.Session
+---@field id string
+---@field name string
+---@field agent string
+---@field status thurbox.Status
+---@field backend string
+---@field repo? string
+---@field branch? string
+---@field base_branch? string What a diff is taken against.
+---@field host? string
+---@field parent? string
+---@field cwd? string
+---@field worktrees integer
+---@field repos string[]
+---@field activity? string What the agent said about itself.
+---@field notification? string
+---@field display_order integer
+---@field git? thurbox.GitStats
+---@field attach_error? string Why this session's terminal is not live.
+
+---@class (exact) thurbox.DeletedSession
+---@field id string
+---@field name string
+---@field agent string
+---@field deleted_at integer Epoch millis, against `thurbox.taken_at_ms`.
+---@field worktrees integer
+---@field partial boolean Restoring recovers committed work only.
+---@field restore_refusal? string Set when the restore would refuse, and why.
+
+---@class (exact) thurbox.Repo
+---@field path string
+---@field name string
+
+---@class (exact) thurbox.Agent
+---@field name string
+---@field command string
+
+---@class (exact) thurbox.Host
+---@field name string
+---@field detail string
+---@field backend string
+
+---@class (exact) thurbox.Task
+---@field id integer
+---@field title string
+---@field description? string
+---@field status string
+---@field source string
+---@field url? string
+---@field created_at integer Epoch seconds.
+---@field updated_at integer
+
+---@class (exact) thurbox.AutomationRun
+---@field started_at integer
+---@field status string
+---@field detail string
+
+---@class (exact) thurbox.Automation
+---@field id integer
+---@field name string
+---@field schedule string
+---@field action string
+---@field enabled boolean
+---@field last_outcome? string
+---@field last_detail? string
+---@field runs thurbox.AutomationRun[]
+
+--- A command this interface accepted but has not finished.
+---@class (exact) thurbox.InFlight
+---@field id integer
+---@field kind string
+---@field session string
+---@field phase string
+---@field subject? string
+---@field error? string
+
+---@class (exact) thurbox.DiffFile
+---@field path string
+---@field added integer
+---@field removed integer
+---@field status string
+---@field old_path? string
+
+--- A session's diff. Branch on `state`.
+---@class (exact) thurbox.Diff
+---@field state "pending"|"ready"|"failed"
+---@field error? string
+---@field truncated? boolean
+---@field raw_bytes? integer
+---@field untracked_omitted? integer
+---@field files? thurbox.DiffFile[]
+---@field body? string[]
+
+--- A link found in a session's terminal, at the cell it starts on.
+---@class (exact) thurbox.Link
+---@field url string
+---@field row integer
+---@field col integer
+
+--- An answer to a program this plugin asked to run. Branch on `state`: a
+--- program that has not answered is not one that answered with nothing.
+---@class (exact) thurbox.Run
+---@field state "pending"|"done"|"failed"
+---@field error? string
+---@field stdout? string
+---@field stderr? string
+---@field status? integer
+---@field truncated? boolean
+---@field timed_out? boolean
+---@field ok? boolean
+
+---@class (exact) thurbox.Features
+---@field tasks boolean
+---@field automations boolean
+---@field file_viewer boolean
+---@field global_search boolean
+---@field info_panel boolean
+---@field shell_pane boolean
+---@field code_review boolean
+---@field perf_hud boolean
+---@field mouse boolean
+---@field notifications boolean
+---@field soft_delete boolean
+---@field version_check boolean
+---@field auto_update boolean
+
+--- The settings in force. Read your own switch and decline to draw when it is
+--- off — the kernel gates only what it owns.
+---@class (exact) thurbox.Settings
+---@field features thurbox.Features
+---@field two_panel_min_cols integer
+---@field three_panel_min_cols integer
+---@field scrollback_lines integer
+
+---@class (exact) thurbox.BookmarkRow
+---@field path string
+---@field name string
+---@field parent? string
+---@field label? string
+---@field is_parent boolean
+---@field offered boolean
+---@field worktrees integer
+
+--- Remembered repositories, served only while `store.want_bookmarks` asks.
+---@class (exact) thurbox.Bookmarks
+---@field host string
+---@field loading boolean
+---@field rows thurbox.BookmarkRow[]
+
+---@class (exact) thurbox.BrowseEntry
+---@field name string
+---@field is_git boolean
+
+--- A directory listing, served only while `store.want_browse` asks.
+---@class (exact) thurbox.Browse
+---@field host string
+---@field dir string
+---@field loading boolean
+---@field error? string
+---@field entries thurbox.BrowseEntry[]
+
+--- Base branches, served only while `store.want_branches` asks.
+---@class (exact) thurbox.Branches
+---@field host string
+---@field repo string
+---@field loading boolean
+---@field error? string
+---@field list string[]
+
+---@class (exact) thurbox.WorktreeEntry
+---@field path string
+---@field branch string
+
+--- The worktrees a repo already has, served while `store.want_worktrees` asks.
+---@class (exact) thurbox.Worktrees
+---@field host string
+---@field repo string
+---@field loading boolean
+---@field error? string
+---@field list thurbox.WorktreeEntry[]
+
+---@class (exact) thurbox.SystemMetrics
+---@field cpu_percent number
+---@field memory_used integer
+---@field memory_total integer
+
+---@class thurbox.SessionMetrics
+---@field cpu_percent? number
+---@field memory_bytes? integer
+---@field agent? table<string, any>
+---@field usage? table<string, any>
+
+---@class (exact) thurbox.Metrics
+---@field system thurbox.SystemMetrics
+---@field sessions table<string, thurbox.SessionMetrics>
+
+--- The machine this is running on, from the values the binary was built for.
+---@class (exact) thurbox.Platform
+---@field os string
+---@field arch string
+
+--- What the pointer is over, as whichever of the two the affordance was marked
+--- with. Empty when nothing is hovered.
+---@class (exact) thurbox.Hover
+---@field id? string
+---@field role? string
+
+---@class (exact) thurbox.ThemeChoice
+---@field name string
+---@field display_name string
+---@field light boolean
+---@field custom boolean
+
+---@class (exact) thurbox.ThemeSnapshot
+---@field name string
+---@field roles table<thurbox.Role, thurbox.Color>
+---@field choices thurbox.ThemeChoice[]
+
+---@class (exact) thurbox.RegistryKey
+---@field plugin string
+---@field action string
+---@field key string
+---@field default_key string
+---@field desc string
+---@field scope "global"|"plugin"
+---@field rebound boolean
+---@field group string
+
+---@class (exact) thurbox.RegistrySetting
+---@field plugin string
+---@field id string
+---@field desc string
+---@field type string
+---@field value boolean|number|string
+---@field default boolean|number|string
+
+--- What every plugin declared, so help and settings render from it.
+---@class (exact) thurbox.RegistrySnapshot
+---@field keys thurbox.RegistryKey[]
+---@field settings thurbox.RegistrySetting[]
+---@field sections string[] The order help renders its sections in.
+
+--- One of the interface's own files: where it came from, and whether it runs.
+---@class (exact) thurbox.PluginRow
+---@field path string
+---@field name string
+---@field kind string
+---@field slot string
+---@field source string
+---@field state string
+---@field error? string
+
+--- What the arrangement needs to know about the bands, and no more.
+---@class (exact) thurbox.Chrome
+---@field status_rows integer
+
+--- Capabilities THIS plugin has been granted. A boolean about a decision the
+--- user already made; it grants nothing.
+---@class (exact) thurbox.Granted
+---@field run? boolean
+---@field program? boolean
+
+--- Everything readable. Rebuilt each publish; a group whose inputs did not move
+--- is handed back as the same table, which is what `lib/theme.lua` memoizes on.
+---@class (exact) thurbox.Api
+---@field sessions thurbox.Session[]
+---@field deleted thurbox.DeletedSession[]
+---@field repos thurbox.Repo[]
+---@field agents thurbox.Agent[]
+---@field agent_default string What a bare launch would use.
+---@field settings thurbox.Settings
+---@field bookmarks thurbox.Bookmarks
+---@field browse thurbox.Browse
+---@field branches thurbox.Branches
+---@field worktrees thurbox.Worktrees
+---@field hosts thurbox.Host[]
+---@field tasks thurbox.Task[]
+---@field automations thurbox.Automation[]
+---@field commands thurbox.InFlight[]
+---@field diffs table<string, thurbox.Diff>
+---@field links table<string, thurbox.Link[]>
+---@field content table<string, string> Served while `store.want_content` asks.
+---@field runs table<string, thurbox.Run> Answers to THIS plugin's runs.
+---@field granted thurbox.Granted
+---@field metrics thurbox.Metrics
+---@field platform thurbox.Platform
+---@field version string
+---@field reloads integer
+---@field can_open_links boolean
+---@field taken_at_ms integer When these rows were read.
+---@field error? string
+---@field focus string Which pane holds focus, by name.
+---@field hover thurbox.Hover
+---@field plugins thurbox.PluginRow[]
+---@field ui_dir string
+---@field chrome thurbox.Chrome
+---@field theme thurbox.ThemeSnapshot
+---@field registry thurbox.RegistrySnapshot
+thurbox = {}
+
+--- Persistent, shared by every plugin — the bus between them. Survives a
+--- reload, not a restart.
+---@type table<string, any>
+store = {}
+
+--- Persistent and private to the declaring plugin. Same lifetime as `store`.
+---@type table<string, any>
+state = {}
+
+---@class (exact) thurbox.FileEntry
+---@field name string
+---@field dir boolean
+
+--- Directory entries and file text, rooted at a session's working directory.
+--- Not a filesystem: a path outside the root is refused.
+---@class thurbox.Files
+files = {}
+
+---@param session string
+---@param path? string Relative to the session's root; defaults to the root.
+---@return thurbox.FileEntry[]
+function files.list(session, path) end
+
+---@param session string
+---@param path string
+---@return string
+function files.read(session, path) end
+
+---@class (exact) thurbox.RunOpts
+---@field session? string Run in this session's directory.
+---@field ttl? number Seconds an answer stays fresh.
+---@field timeout? number Seconds before the program is given up on.
+---@field refresh? boolean Ask again even if a fresh answer is held.
+
+--- Ask for a program and read the answer later, from `thurbox.runs[key]`.
+---
+--- Queued, never executed here — a plugin cannot call anything that waits.
+--- Absent unless this plugin declares `capabilities = { "run" }` AND the user
+--- has trusted it, so `if not run then` is the honest check.
+---@param key string
+---@param program string
+---@param opts? thurbox.RunOpts
+function run(key, program, opts) end
+
+--- Loads any `.lua` under the interface directory, and nothing outside it.
+---@param name string
+---@return any
+function require(name) end
+
+--- A user event. Not exact: every other scalar on the table travels as the
+--- event's payload, which is the one place an unknown key is meaningful.
+---@class thurbox.cmd.Emit
+---@field text string The event's name; subscribers see `user.<name>`.
+
+---@class (exact) thurbox.cmd.Plugin
+---@field file string A path within the interface directory.
+---@field action "restore"|"remove"
+
+---@class (exact) thurbox.cmd.Set
+---@field text string A `plugin.setting` key.
+---@field flag? boolean
+---@field number? number
+---@field reset? boolean Put the setting back to its default.
+
+---@class (exact) thurbox.cmd.Task
+---@field text? string A title: creates when there is no `number`.
+---@field number? integer An existing task's id.
+---@field status? string
+---@field reset? boolean Delete it.
+
+---@class (exact) thurbox.cmd.Dispatch
+---@field number integer The task to dispatch.
+---@field session? string
+
+---@class (exact) thurbox.cmd.Automation
+---@field number integer
+---@field flag? boolean Enable or disable it.
+---@field force? boolean Run it now.
+---@field reset? boolean Delete it.
+
+---@class (exact) thurbox.cmd.ExtraMember
+---@field path string
+---@field worktree? boolean
+
+---@class (exact) thurbox.cmd.Create
+---@field repo string
+---@field text? string The session's name.
+---@field branch? string
+---@field base? string
+---@field worktree_path? string An existing worktree to open rather than make.
+---@field agent? string
+---@field host? string
+---@field extras? thurbox.cmd.ExtraMember[] Further repositories to span.
+
+---@class (exact) thurbox.cmd.Bookmark
+---@field repo string The path to remember or forget.
+---@field action "add"|"remove"|"parent"
+---@field host? string
+
+---@class (exact) thurbox.cmd.Focus
+---@field text string The plugin to focus.
+---@field toggle? boolean Return to the previous pane when it already has focus.
+
+---@class (exact) thurbox.cmd.Open
+---@field text string The url. `url` is not read.
+
+---@class (exact) thurbox.cmd.Theme
+---@field text string The theme's name.
+
+---@class (exact) thurbox.cmd.Order
+---@field list string[] Every session id, in the order wanted.
+
+---@class (exact) thurbox.cmd.Program
+---@field text? string This plugin's name for the pane.
+---@field repo? string The program to run; required unless closing.
+---@field args? string[]
+---@field action? "close"|"stop"
+
+---@class (exact) thurbox.cmd.Delete
+---@field session string
+---@field force? boolean Skip the undo window.
+
+---@class (exact) thurbox.cmd.Restore
+---@field session string
+---@field force? boolean Restore what can be restored.
+
+---@class (exact) thurbox.cmd.Session
+---@field session string
+
+---@class (exact) thurbox.cmd.Send
+---@field session string
+---@field text string
+
+---@class (exact) thurbox.cmd.Reorder
+---@field session string
+---@field delta integer Non-zero.
+
+---@class (exact) thurbox.cmd.Fork
+---@field session string
+---@field text? string The new session's name.
+
+---@alias thurbox.Verb
+---| "emit" | "plugin" | "set" | "task" | "dispatch" | "automation"
+---| "create" | "bookmark" | "focus" | "open" | "theme" | "order" | "program"
+---| "delete" | "restore" | "restart" | "send" | "reorder" | "fork"
+---| "sync" | "copy" | "diff" | "shell" | "editor"
+
+--- The only way a plugin changes anything. Enqueues and returns; it never runs
+--- the operation, which is why a plugin cannot stall the loop.
+---
+--- An option name no verb reads is collected and ignored, so the overloads
+--- below name what each verb actually requires.
+---@overload fun(verb: "emit", opts: thurbox.cmd.Emit)
+---@overload fun(verb: "plugin", opts: thurbox.cmd.Plugin)
+---@overload fun(verb: "set", opts: thurbox.cmd.Set)
+---@overload fun(verb: "task", opts: thurbox.cmd.Task)
+---@overload fun(verb: "dispatch", opts: thurbox.cmd.Dispatch)
+---@overload fun(verb: "automation", opts: thurbox.cmd.Automation)
+---@overload fun(verb: "create", opts: thurbox.cmd.Create)
+---@overload fun(verb: "bookmark", opts: thurbox.cmd.Bookmark)
+---@overload fun(verb: "focus", opts: thurbox.cmd.Focus)
+---@overload fun(verb: "open", opts: thurbox.cmd.Open)
+---@overload fun(verb: "theme", opts: thurbox.cmd.Theme)
+---@overload fun(verb: "order", opts: thurbox.cmd.Order)
+---@overload fun(verb: "program", opts: thurbox.cmd.Program)
+---@overload fun(verb: "delete", opts: thurbox.cmd.Delete)
+---@overload fun(verb: "restore", opts: thurbox.cmd.Restore)
+---@overload fun(verb: "restart", opts: thurbox.cmd.Session)
+---@overload fun(verb: "send", opts: thurbox.cmd.Send)
+---@overload fun(verb: "reorder", opts: thurbox.cmd.Reorder)
+---@overload fun(verb: "fork", opts: thurbox.cmd.Fork)
+---@overload fun(verb: "sync", opts: thurbox.cmd.Session)
+---@overload fun(verb: "copy", opts: thurbox.cmd.Session)
+---@overload fun(verb: "diff", opts: thurbox.cmd.Session)
+---@overload fun(verb: "shell", opts: thurbox.cmd.Session)
+---@overload fun(verb: "editor", opts: thurbox.cmd.Session)
+---@param verb thurbox.Verb
+---@param opts? table
+function command(verb, opts) end

--- a/ui/lib/thurbox.d.lua
+++ b/ui/lib/thurbox.d.lua
@@ -87,7 +87,7 @@
 ---@field scroll? integer
 
 --- A row or a column. Children live under `children`, or in the array part.
----@class thurbox.BoxNode : thurbox.NodeCommon
+---@class (exact) thurbox.BoxNode : thurbox.NodeCommon
 ---@field type? "box"|"vstack"|"hstack"|"column"|"row"|"stack"
 ---@field axis? "vertical"|"horizontal"|"column"|"row"|"v"|"h"
 ---@field gap? integer
@@ -104,7 +104,7 @@
 
 --- Pre-rendered cells: a live session's terminal, a program this plugin asked
 --- to run, or lines the plugin produced itself. Exactly one source.
----@class thurbox.SurfaceNode : thurbox.NodeCommon
+---@class (exact) thurbox.SurfaceNode : thurbox.NodeCommon
 ---@field type? "surface"|"terminal"
 ---@field session? string
 ---@field program? string
@@ -452,7 +452,7 @@
 ---@field label? string
 ---@field is_parent boolean
 ---@field offered boolean
----@field worktrees integer
+---@field is_git? boolean
 
 --- Remembered repositories, served only while `store.want_bookmarks` asks.
 ---@class (exact) thurbox.Bookmarks
@@ -724,7 +724,7 @@ function require(name) end
 ---@field list string[] Every session id, in the order wanted.
 
 ---@class (exact) thurbox.cmd.Program
----@field text? string This plugin's name for the pane.
+---@field text string This plugin's name for the pane.
 ---@field repo? string The program to run; required unless closing.
 ---@field args? string[]
 ---@field action? "close"|"stop"


### PR DESCRIPTION
## Intent

Step 1 of a six-step series from a read-only review of thurbox's Lua interface layer (review section 2 problem 7, section 5 step 1). The reviewer's finding: everything in the plugin API fails silently. convert.rs drops a node key it does not know (deliberately - that is how a plugin carries its own bookkeeping on the node table), command reads a fixed list of option names and ignores extras, lib/theme.lua's __index answers nil for a role no palette defines, and nothing catches any of it statically because .luarc.json declared the globals with no shape at all. The reviewer called this the single highest-leverage change for an LLM plugin author, who currently gets no feedback on a hallucinated prop name.

The task as given: add ui/lib/thurbox.d.lua (a ---@meta file) describing the node table (types text/box/input/surface and their aliases; len/pct/fill/min/max; id/class/role; frame; text props; box axis/gap/children; input value/cursor/placeholder/focused/style; surface session/program/cells/scroll; root float), the render ctx and layout ctx, the hit/key/wheel payloads, the plugin declaration table, the published thurbox.* snapshot row shapes, every command(verb, opts) verb and its option keys, the theme role names, and the store/state/files/run globals - all read from the Rust sources (node.rs, convert.rs, host/mod.rs, host/load.rs, host/publish.rs, command/mod.rs, theme.rs). Wire it into .luarc.json workspace.library and add the missing 'run' global there. Prove it works: a scratch plugin with a misspelt prop, a bad command option and an unknown theme role must each produce a lua-language-server warning; the bundled ui/ must pass clean.

Deliberate decisions made while doing the work, which a reviewer reading only the diff would not know:

- REQUIRED to be no runtime change. ui/lib/theme.lua gains annotation comments only; tests/frames.rs and tests/session_list.rs frames are byte-identical (verified, 2425 tests pass).

- I first wrote the test, then the fix. tests/fixtures/lua_types/ (three probe panes) plus scripts/ci/check-lua-types.sh were written before thurbox.d.lua existed and confirmed failing for the right reason ('no findings at all'), then made to pass.

- Empirically established that lua-language-server does NOT flag an extra key in a table constructor - not with ---@class (exact), not with type.checkTableShape, not through a typed parameter; only assignment injection (x.field = v) is caught. So the naive 'describe every optional prop' approach could not catch a misspelt prop at all. The file is therefore written the other way round: every node kind and every command verb declares the field it cannot work without, so a misspelt one reads back as missing-fields, and every field drawn from a fixed set is spelled as that set, so a misspelt value is assign-type-mismatch. This inversion is the load-bearing design decision and is documented in the file header, CLAUDE.md, docs/PLUGINS.md and the thurbox-kernel skill.

- The three probes produce: prop.lua -> missing-fields, command.lua -> missing-fields, theme.lua -> undefined-field. The gate asserts each by diagnostic code and also fails if any bundled pane reports a finding.

- The probes run in a throwaway copy of ui/ because lua-language-server resolves both require("lib.…") and relative workspace.library entries against the workspace ROOT; a probe checked from anywhere else would type-check against no definitions and pass for the wrong reason. Copying also keeps the deliberately-broken probes out of --check ui, which must stay clean.

- selene.toml excludes ui/lib/thurbox.d.lua. Describing a global means assigning one, which is the single thing the sandbox forbids a plugin, so linting the declarations against the sandbox rejects the file for saying exactly what the sandbox is. This exclusion is deliberate, explained in selene.toml, and is not a hole in the sandbox check.

- The file ships in BUNDLED (src/kernel/bundled.rs). Verified that luals loads a ---@meta file merely by it being in the workspace being checked - no config needed - so shipping it is what gives a plugin author 'lua-language-server --check .' in their own ~/.config/thurbox/ui with nothing to configure. It is a lib/ module by inventory's rules, so it lists as a module that nothing loads, which is accurate.

- .luarc.json gets one library entry, 'ui/lib/thurbox.d.lua', spelled for an editor opened at the repository root. --check ui does not need it (in-workspace pickup), and I deliberately did not add a second 'lib/thurbox.d.lua' spelling for that case: two near-identical entries invite a cleanup that breaks one. Explained in CLAUDE.md.

- 'run' added to .luarc.json diagnostics.globals as asked. thurbox.yml already declared it for selene, so no thurbox.yml change was needed - I added no new global, prop or lib function, which is why thurbox.yml is untouched.

- Two accuracy corrections found while reading the sources: decorate's ctx carries only width/height (not the full render ctx), so it has its own thurbox.DecorateCtx; and session.status is the nine SessionState strings, not the six theme.lua has glyphs for - theme.status falls back to idle for the rest, which the alias now records. Noted but NOT changed: theme.lua still carries an 'error' status glyph/role for a status the kernel no longer publishes; fixing that is a runtime change and out of scope for a types-only step.

- Wired into just lint and the CI Lua Lint job, with the ci.yml path filter extended to cover the probes and the script. Docs updated in the same PR per the repo rule: ui/README.md, ui/AGENTS.md, docs/PLUGINS.md, CLAUDE.md, .claude/skills/thurbox-kernel/SKILL.md and .claude/skills/thurbox-testing/SKILL.md.

Out of scope by design (each is a later step in the series): text.style in the kernel, widgets.list fixes, text measurement globals, frame parity props, and the ui/lib/ui.lua component layer. Do not propose them here.

## What Changed

- Added `ui/lib/thurbox.d.lua`, a `---@meta` file describing the full plugin surface (node kinds and their required props, render/layout ctx, decorate ctx, hit/key/wheel payloads, the plugin declaration table, `thurbox.*` snapshot row shapes, every `command(verb, opts)` and its options, theme roles, and the `store`/`state`/`files`/`run` globals) — deliberately written so each node kind and command verb declares only the field it cannot work without, since lua-language-server flags a missing required field but not an extra/misspelt one.
- Wired the new file into `.luarc.json` (`workspace.library`, plus the previously-missing `run` global) and excluded it from `selene.toml` (describing a global there would mean assigning one, the one thing the plugin sandbox forbids); shipped it via `src/kernel/bundled.rs` so it's present in every installed interface directory with no user config.
- Added `scripts/ci/check-lua-types.sh` with three deliberately-broken probe panes (`tests/fixtures/lua_types/{prop,command,theme}.lua`) that assert lua-language-server reports the expected diagnostic for a misspelt prop, command option, and theme role, and that the bundled `ui/` stays clean; wired into `just lint` and the CI Lua Lint job. Corrected `theme.lua`'s decorate-ctx and `session.status` shapes against the Rust sources during the annotation pass (comments/docs only — no runtime behavior change) and updated `ui/README.md`, `ui/AGENTS.md`, `docs/PLUGINS.md`, `CLAUDE.md`, and the `thurbox-kernel`/`thurbox-testing` skills accordingly.

## Risk Assessment

✅ Low: The fix round made exactly the three targeted, narrowly-scoped edits to ui/lib/thurbox.d.lua (Program.text required, BookmarkRow fields corrected, BoxNode/SurfaceNode marked exact); each was independently verified against the Rust sources (command/mod.rs, terminal/programs.rs, repos.rs, publish.rs, convert.rs) and is now accurate, with no other files touched.

## Testing

Baseline `cargo nextest run --all` already passed per the harness. For this targeted phase I confirmed all three review-round-1 fixes (Program.text required, BookmarkRow field correction, exact BoxNode/SurfaceNode) are correctly present in ui/lib/thurbox.d.lua and verified them against the Rust source of truth by reading the relevant code. I then ran the PR's own end-to-end evidence mechanism, scripts/ci/check-lua-types.sh, which is exactly the product-level proof the user intent calls for: it runs lua-language-server against three deliberately-broken probe panes plus the bundled ui/ tree. All three probes produced their expected diagnostics and the bundled interface reported zero findings — the plugin-API typing still catches the class of silent failures it was built to catch. No transient artifacts remained (the script self-cleans via mktemp), working tree is clean, and no issues were found.

<details>
<summary>Evidence: check-lua-types.sh output</summary>

```text
probes/prop.lua: missing-fields
probes/command.lua: missing-fields
probes/theme.lua: undefined-field
EXIT:0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"69796aa46052cc5e87d6888bd482c099decd0e50","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- 🚨 `ui/lib/thurbox.d.lua:727` - thurbox.cmd.Program.text is marked optional (`text?`), but src/kernel/command/mod.rs:643-645 calls `validate_program_name(&amp;text.unwrap_or_default())` unconditionally — before the close/stop check — and terminal/programs.rs:66-69 errors &#39;a program pane needs a name&#39; when it&#39;s empty. So `text` is required for every use of the `&#34;program&#34;` verb, including a close. Since thurbox.cmd.Program is `(exact)` with `text` as the pane&#39;s only name, `command(&#34;program&#34;, { repo = &#34;top&#34;, action = &#34;close&#34; })` (or any create with no text) type-checks cleanly but always fails at runtime — exactly the silent-failure class this file exists to catch, now reintroduced for this one verb. Fix: change to `---@field text string`.
- 🚨 `ui/lib/thurbox.d.lua:448` - thurbox.BookmarkRow declares a required `worktrees: integer` that src/kernel/repos.rs&#39;s BookmarkRow struct and src/kernel/host/publish.rs&#39;s build_bookmarks (lines 458-486) never define or publish (a plugin reading `row.worktrees` gets nil despite the type guaranteeing an integer), and omits `is_git` (Option&lt;bool&gt;), which IS published at publish.rs:478-484. Because the class is `(exact)`, any plugin code that legitimately reads `row.is_git` would be flagged `undefined-field` — a false positive. `--check ui` stays clean only because no bundled pane (ui/lib/repo_picker.lua) happens to read `is_git` or construct a BookmarkRow literal. Looks like a copy-paste of `worktrees` from thurbox.Session (line 326). Fix: drop `worktrees`, add `is_git? boolean`.
- ⚠️ `ui/lib/thurbox.d.lua:90` - thurbox.TextNode and thurbox.InputNode are declared `(exact)` but thurbox.BoxNode and thurbox.SurfaceNode are not, even though convert.rs&#39;s Fields::read/convert_table enumerate box&#39;s (axis/gap/children) and surface&#39;s (session/program/cells/scroll) fields just as exhaustively as text/input&#39;s. Since none of a box or surface node&#39;s fields are required, a typo in any of them (e.g. `sesion` for `session`, `axsis` for `axis`) is neither caught by missing-fields nor by exact-class extra-key detection — the exact silent-drop failure mode this PR exists to close, uncaught for two of the four node kinds.

🔧 Fix: fix(ui): correct Program.text, BookmarkRow fields, exact box/surface nodes
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `cargo nextest run --all`
- `bash scripts/ci/check-lua-types.sh — exercised the actual product-level proof mechanism the user intent specifies: three deliberately-broken probe panes (prop.lua, command.lua, theme.lua) type-checked with lua-language-server against ui/lib/thurbox.d.lua, confirming each still produces its expected diagnostic (missing-fields, missing-fields, undefined-field) and the bundled ui/ interface stays clean`
- <code>grep/read verification: ui/lib/thurbox.d.lua thurbox.cmd.Program.text is now `---@field text string` (no longer optional), matching src/kernel/command/mod.rs:644-645 which calls validate_program_name unconditionally on text.unwrap_or_default()</code>
- <code>grep/read verification: ui/lib/thurbox.d.lua thurbox.BookmarkRow now omits `worktrees` and adds `is_git? boolean`, matching src/kernel/repos.rs BookmarkRow struct and src/kernel/host/publish.rs build_bookmarks (lines 441-490), which sets is_git (nilable) and never sets worktrees</code>
- <code>grep/read verification: ui/lib/thurbox.d.lua thurbox.BoxNode and thurbox.SurfaceNode are now declared `(exact)`, matching thurbox.TextNode/thurbox.InputNode</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
