### PR TITLE
feat(core): add a style prop to text nodes

### DIFF
--- a/.claude/skills/thurbox-kernel/SKILL.md
+++ b/.claude/skills/thurbox-kernel/SKILL.md
@@ -18,6 +18,12 @@ deleted when the kernel took the binary name — v1 lives on the `v1.x` branch.
 
 1. **Four node kinds, forever** — `text`, `box`, `input`, `surface`. Everything
    else composes in `ui/lib/widgets.lua`. `tests/kernel_mvp.rs` asserts the count.
+   A new appearance arrives as a **prop** on one of the four: `text` takes a
+   `style` the kernel paints across its whole rect before the spans go on top,
+   which is what a selection bar or hover band is — no pane pads a row with a
+   spacer span, and a span naming its own colour keeps it (a search hit stays
+   visible under the bar). `widgets.list` exposes it as `selected_style` /
+   `hover_style`.
 2. **Layout resolves before render** — rects are computed first, then each plugin
    is called with its own. Plugins declare size *statically*, in their declaration
    table, which is what breaks the circularity.

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -402,7 +402,23 @@ widgets.gauge(0.7, { width = 20 })
 `widgets.list` sizes itself — pass `len` or `fill` alongside the rows rather
 than patching the returned table — and windows itself: when the rows outrun
 `height` it spends a line of its own on an `↑ N more` / `↓ N more` marker, so
-the count is exactly what you cannot see and no row is drawn over.
+the count is exactly what you cannot see and no row is drawn over. Give it
+`selected_style` and `hover_style` and it puts them on the row itself, which is
+the `text` style below.
+
+A `text` node takes a **`style` of its own**, painted across its whole rect
+before the spans go on top:
+
+```lua
+{ type = "text", style = { bg = theme.role("selection_bg"), bold = true },
+  text = { spans } }
+```
+
+That is what a selection bar or a hover band is. The style reaches the right
+edge of the rect whatever the spans say, so nothing has to append a spacer span
+sized by hand — and a span that names a colour keeps it, because the node style
+only supplies what a span left unsaid. A search highlight therefore stays
+visible on the selected row with the bar painting through it.
 
 `input` carries one thing the other three do not: a claim on the **caret**. A
 screen can hold several fields and the terminal has one cursor, so the field

--- a/src/kernel/convert.rs
+++ b/src/kernel/convert.rs
@@ -203,6 +203,7 @@ fn convert_table(
             align: read_align(&fields, path)?,
             wrap: val_bool(fields.wrap.as_ref(), "wrap", path)?.unwrap_or(false),
             scroll: val_u16(fields.scroll.as_ref(), "scroll", path)?.unwrap_or(0),
+            style: read_style_value(fields.style.as_ref(), "style", path)?,
             frame,
             size,
             identity,
@@ -836,6 +837,7 @@ pub fn to_lua(lua: &mlua::Lua, node: &Node) -> Result<Value, String> {
             align,
             wrap,
             scroll,
+            style,
             ..
         } => {
             let out = lua.create_table().map_err(|e| e.to_string())?;
@@ -874,6 +876,12 @@ pub fn to_lua(lua: &mlua::Lua, node: &Node) -> Result<Value, String> {
             )?;
             table.set("wrap", *wrap).map_err(|e| e.to_string())?;
             table.set("scroll", *scroll).map_err(|e| e.to_string())?;
+            // Round-trips for the same reason a run's style does: a decorator
+            // is handed the tree and returns one, so a selection bar dropped
+            // here is a selection bar dropped from the pane.
+            if let Some(style) = style_to_lua(lua, style)? {
+                table.set("style", style).map_err(|e| e.to_string())?;
+            }
         }
         Node::Box {
             axis,

--- a/src/kernel/node.rs
+++ b/src/kernel/node.rs
@@ -239,6 +239,15 @@ pub enum Node {
         align: Align,
         wrap: bool,
         scroll: u16,
+        /// The node's base style, painted over its whole rect before the runs
+        /// are drawn on top.
+        ///
+        /// This is what a selection bar is: a background that reaches the right
+        /// edge without the pane appending a spacer span sized by hand, and a
+        /// foreground every run that names none inherits. A run that DOES name
+        /// one keeps it — which is what lets a search hit stay accent-coloured
+        /// on the row the cursor is on, with the bar painting through it.
+        style: Style,
         frame: Option<Frame>,
         size: Size,
         identity: Identity,
@@ -386,6 +395,7 @@ impl Node {
             align: Align::Left,
             wrap: false,
             scroll: 0,
+            style: Style::default(),
             frame: None,
             size: Size::default(),
             identity: Identity::default(),
@@ -402,6 +412,7 @@ impl Node {
             align: Align::Left,
             wrap: true,
             scroll: 0,
+            style: Style::default(),
             frame: None,
             size: Size::default(),
             identity: Identity::default(),

--- a/src/kernel/paint.rs
+++ b/src/kernel/paint.rs
@@ -194,10 +194,14 @@ pub fn render_recording(
             align,
             wrap,
             scroll,
+            style,
             ..
         } => {
             let text: Vec<Line> = lines.iter().map(|runs| to_line(runs)).collect();
-            let mut paragraph = Paragraph::new(text).scroll((*scroll, 0));
+            // The node's style is the paragraph's base: ratatui fills the rect
+            // with it and each run patches over, so a bar reaches the right
+            // edge and a run that names a colour keeps it.
+            let mut paragraph = Paragraph::new(text).style(*style).scroll((*scroll, 0));
             paragraph = match align {
                 Align::Left => paragraph.left_aligned(),
                 Align::Center => paragraph.centered(),

--- a/tests/decoration.rs
+++ b/tests/decoration.rs
@@ -25,6 +25,7 @@ fn styled_tree() -> Node {
             role: Some("row".into()),
         },
         size: Default::default(),
+        style: Style::default(),
         frame: None,
         lines: vec![vec![
             Run {
@@ -80,6 +81,32 @@ fn a_style_survives_the_trip_out_to_a_decorator_and_back() {
 }
 
 #[test]
+fn a_node_style_survives_the_trip_out_to_a_decorator_and_back() {
+    // The selection bar lives on the node now rather than on every span, so the
+    // boundary has to carry it there too — a decorator that returns its input
+    // untouched must not flatten the row the cursor is on.
+    let mut before = styled_tree();
+    let Node::Text { style, .. } = &mut before else {
+        unreachable!("styled_tree is a text node");
+    };
+    *style = Style::default()
+        .fg(Color::White)
+        .bg(Color::Indexed(24))
+        .add_modifier(Modifier::BOLD);
+
+    let after = round_trip(&before);
+    let Node::Text { style, .. } = &after else {
+        panic!("expected a text node, got {after:?}");
+    };
+    assert_eq!(style.bg, Some(Color::Indexed(24)), "the bar lost its band");
+    assert_eq!(style.fg, Some(Color::White), "the bar lost its fg");
+    assert!(
+        style.add_modifier.contains(Modifier::BOLD),
+        "the bar lost its bold"
+    );
+}
+
+#[test]
 fn an_untouched_tree_comes_back_unchanged() {
     // The strongest form of the rule, and the case that actually broke: a
     // decorator that changes nothing must cost nothing.
@@ -94,6 +121,7 @@ fn an_unstyled_run_stays_unstyled() {
     let node = Node::Text {
         identity: Identity::default(),
         size: Default::default(),
+        style: Style::default(),
         frame: None,
         lines: vec![vec![Run {
             text: "plain".into(),
@@ -141,6 +169,7 @@ fn every_field_survives_the_trip_out_and_back() {
             Node::Text {
                 identity: Identity::default(),
                 size: Default::default(),
+                style: Style::default(),
                 frame: None,
                 lines: vec![vec![Run {
                     text: "scrolled".into(),

--- a/tests/frames.rs
+++ b/tests/frames.rs
@@ -24,7 +24,7 @@ use std::collections::HashMap;
 use ratatui::backend::TestBackend;
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
-use ratatui::style::Style;
+use ratatui::style::{Color, Modifier, Style};
 use ratatui::Frame;
 use ratatui::Terminal;
 
@@ -64,7 +64,24 @@ fn publish(host: &LuaHost, snapshot: &Snapshot) {
     publish_with(host, snapshot, &HashMap::new());
 }
 
+fn publish_hovered(
+    host: &LuaHost,
+    snapshot: &Snapshot,
+    hovered: Option<&thurbox::kernel::node::Identity>,
+) {
+    publish_inner(host, snapshot, &HashMap::new(), hovered);
+}
+
 fn publish_with(host: &LuaHost, snapshot: &Snapshot, attach_errors: &HashMap<String, String>) {
+    publish_inner(host, snapshot, attach_errors, None);
+}
+
+fn publish_inner(
+    host: &LuaHost,
+    snapshot: &Snapshot,
+    attach_errors: &HashMap<String, String>,
+    hovered: Option<&thurbox::kernel::node::Identity>,
+) {
     let themes = themes();
     let registry = registry(host);
     let diffs = thurbox::kernel::diff::DiffStore::new();
@@ -89,7 +106,7 @@ fn publish_with(host: &LuaHost, snapshot: &Snapshot, attach_errors: &HashMap<Str
         repos: &repos,
         wants: &Default::default(),
         focus: None,
-        hovered: None,
+        hovered,
     })
     .expect("publish");
 }
@@ -394,6 +411,138 @@ fn the_selection_is_a_style_and_moves_with_j() {
             "⟨LightCyan/Reset/NONE⟩│⟨White/Indexed(24)/BOLD⟩ ○ └ ⑂ fix-osc52-tests                ⟨LightCyan/Reset/NONE⟩│",
         ],
     );
+}
+
+// --- node props -------------------------------------------------------------
+
+/// Convert a Lua node table the way a plugin's return value is converted, then
+/// paint it alone into a fresh buffer.
+fn paint_lua_node(source: &str, width: u16, height: u16) -> Buffer {
+    let lua = mlua::Lua::new();
+    let value: mlua::Value = lua.load(source).eval().expect("the table evaluates");
+    let node = thurbox::kernel::convert::to_node(&value, "plugins/90_test.lua")
+        .expect("the table converts");
+    let mut terminal = Terminal::new(TestBackend::new(width, height)).expect("terminal");
+    terminal
+        .draw(|frame| render(frame, frame.area(), &node, &PlaceholderSurfaces))
+        .expect("draw");
+    terminal.backend().buffer().clone()
+}
+
+#[test]
+fn a_styled_text_node_paints_its_style_across_its_whole_rect() {
+    // What a selection bar is: the row's style covers the rect, so it reaches
+    // the right edge without the pane appending a spacer span sized by hand.
+    let buffer = paint_lua_node(
+        r#"{ text = "hi", style = { fg = "white", bg = 24, bold = true } }"#,
+        10,
+        1,
+    );
+    for x in 0..10 {
+        let cell = &buffer[(x, 0)];
+        assert_eq!(
+            cell.bg,
+            Color::Indexed(24),
+            "cell {x} should carry the band"
+        );
+        assert_eq!(cell.fg, Color::Gray, "cell {x} should carry the band's fg");
+        assert!(cell.modifier.contains(Modifier::BOLD), "cell {x} bold");
+    }
+}
+
+#[test]
+fn a_span_keeps_the_colour_it_names_over_the_node_style() {
+    // The other half of the same contract, and why the pane no longer needs a
+    // `keep_fg` exception list: a search hit names its own foreground and the
+    // bar underneath it supplies only what the span left unsaid.
+    let buffer = paint_lua_node(
+        r#"{
+             style = { fg = "white", bg = 24 },
+             text = { { { text = "ab" }, { text = "cd", style = "green" } } },
+           }"#,
+        6,
+        1,
+    );
+    assert_eq!(buffer[(1, 0)].fg, Color::Gray);
+    assert_eq!(buffer[(2, 0)].fg, Color::Green);
+    assert_eq!(
+        buffer[(2, 0)].bg,
+        Color::Indexed(24),
+        "the band paints through"
+    );
+}
+
+/// A one-off pane in a materialized copy of the bundled interface, so a `lib/`
+/// widget can be held to its painted output without a bundled pane adopting it.
+fn paint_probe(render_body: &str, hovered: Option<&str>, width: u16, height: u16) -> Buffer {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let report = thurbox::kernel::bundled::materialize(dir.path());
+    assert!(report.errors.is_empty(), "{:?}", report.errors);
+    std::fs::write(
+        dir.path().join("plugins").join("95_probe.lua"),
+        format!(
+            "local widgets = require(\"lib.widgets\")\n\
+             return {{ name = \"probe\", slot = \"center\", focusable = true,\n\
+             render = function(ctx) {render_body} end }}"
+        ),
+    )
+    .expect("write the probe");
+
+    let host = LuaHost::new(dir.path());
+    assert!(host.error.is_none(), "{:?}", host.error);
+    let identity = hovered.map(|id| thurbox::kernel::node::Identity {
+        id: Some(id.to_string()),
+        classes: Vec::new(),
+        role: Some("row".to_string()),
+    });
+    publish_hovered(&host, &snapshot(Vec::new()), identity.as_ref());
+
+    let node = host
+        .render(index_of(&host, "probe"), ctx(width, height, true))
+        .expect("the probe renders")
+        .node;
+    let mut terminal = Terminal::new(TestBackend::new(width, height)).expect("terminal");
+    terminal
+        .draw(|frame| render(frame, frame.area(), &node, &PlaceholderSurfaces))
+        .expect("draw");
+    terminal.backend().buffer().clone()
+}
+
+const PROBE_LIST: &str = r#"
+    return widgets.list({
+      rows = { { spans = "one", id = "a" }, { spans = "two", id = "b" } },
+      selected = 1,
+      height = ctx.height,
+      selected_style = { bg = 24, fg = "white" },
+      hover_style = { bg = 17 },
+    })
+"#;
+
+#[test]
+fn a_list_paints_its_selected_and_hovered_rows_edge_to_edge() {
+    // The two props that replace hand-padding a spacer span and merging a style
+    // into every span: the row's own style covers its rect, so the bar reaches
+    // the right edge whatever the row says.
+    let buffer = paint_probe(PROBE_LIST, Some("b"), 12, 2);
+    for x in 0..12 {
+        assert_eq!(buffer[(x, 0)].bg, Color::Indexed(24), "selected cell {x}");
+        assert_eq!(buffer[(x, 1)].bg, Color::Indexed(17), "hovered cell {x}");
+    }
+}
+
+#[test]
+fn a_list_without_the_style_props_paints_no_band() {
+    // They are opt-in: a pane that asks for neither gets the marker it always
+    // had and no background at all.
+    let buffer = paint_probe(
+        r#"return widgets.list({ rows = { "one" }, selected = 1, height = ctx.height })"#,
+        None,
+        12,
+        1,
+    );
+    for x in 0..12 {
+        assert_eq!(buffer[(x, 0)].bg, Color::Reset, "cell {x}");
+    }
 }
 
 // --- the agent pane ---------------------------------------------------------

--- a/tests/mouse.rs
+++ b/tests/mouse.rs
@@ -198,6 +198,7 @@ fn a_pane_url_node_becomes_a_link_over_the_cells_it_drew() {
         align: Default::default(),
         wrap: false,
         scroll: 0,
+        style: ratatui::style::Style::default(),
         frame: None,
         size: Size::default(),
         identity: Identity {
@@ -293,6 +294,7 @@ fn a_parent_is_recorded_before_its_children() {
         align: Default::default(),
         wrap: false,
         scroll: 0,
+        style: ratatui::style::Style::default(),
         frame: None,
         size: Size::default(),
         identity: Identity {
@@ -349,6 +351,7 @@ fn a_framed_node_is_clickable_on_its_border() {
         align: Default::default(),
         wrap: false,
         scroll: 0,
+        style: ratatui::style::Style::default(),
         frame: Some(Frame::default()),
         size: Size::default(),
         identity: Identity {

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -7,6 +7,12 @@ file reloads it; there is no build step.
 `README.md` beside this file is the reference — the node kinds, the sizing rules,
 what you can read and write. This file is the part that is easy to get wrong.
 
+One habit it pays to have before you write a row: a highlight is a **node
+style**, not a loop over spans. `{ type = "text", style = { bg = … } }` covers
+the whole rect, so a bar reaches the right edge without a padding span and a
+span that names its own colour survives it. `widgets.list` exposes the same
+thing as `selected_style` / `hover_style`.
+
 ## "Install a plugin" means `thurbox-cli plugin install`
 
 A *plugin* here is a thurbox interface pane, not a package from a language

--- a/ui/README.md
+++ b/ui/README.md
@@ -62,7 +62,11 @@ said out loud.
 1. **Four node kinds, forever**: `text`, `box`, `input`, `surface`. Lists,
    panels, tables and gauges are *not* node kinds — they compose from these in
    `lib/widgets.lua`. If you find yourself wanting a fifth kind, you want a
-   widget.
+   widget. New *appearances* arrive as props on these four: a `text` node takes
+   a `style` painted across its whole rect before the spans go on top, which is
+   what a selection bar or a hover band is — nothing pads a row with a spacer
+   span, and a span that names its own colour keeps it. `widgets.list` takes
+   `selected_style` / `hover_style` and puts them there for you.
 2. **Layout resolves before render.** Size is declared *statically* in the
    plugin's table, never returned from `render`. That is what lets the kernel
    tell your `render` the rect it is drawing into.

--- a/ui/lib/thurbox.d.lua
+++ b/ui/lib/thurbox.d.lua
@@ -78,13 +78,16 @@
 ---@field frame? thurbox.Frame|string|boolean
 ---@field block? thurbox.Frame|string|boolean The POC's spelling of `frame`.
 
---- Text. Carries no style of its own — style the spans.
+--- Text. `style` paints across the whole rect before the spans go on top, so a
+--- span that names its own colour keeps it — that is a selection bar or a
+--- hover band, and `widgets.list` exposes it as `selected_style`/`hover_style`.
 ---@class (exact) thurbox.TextNode : thurbox.NodeCommon
 ---@field type? "text"|"paragraph"|"line"
 ---@field text thurbox.Text
 ---@field align? "left"|"center"|"centre"|"right"
 ---@field wrap? boolean
 ---@field scroll? integer
+---@field style? thurbox.StyleSpec
 
 --- A row or a column. Children live under `children`, or in the array part.
 ---@class (exact) thurbox.BoxNode : thurbox.NodeCommon

--- a/ui/lib/widgets.lua
+++ b/ui/lib/widgets.lua
@@ -13,6 +13,7 @@
 -- So: when you need a new appearance, add it HERE. Adding a node kind to the
 -- kernel is a design decision, not a shortcut.
 
+local hover = require("lib.hover")
 local theme = require("lib.theme")
 
 local widgets = {}
@@ -251,7 +252,15 @@ end
 --- onto the table after the call was reaching for the one prop the widget could
 --- not express.
 ---
---- opts: rows, selected, height, frame, empty, len, fill
+--- `selected_style` and `hover_style` are the row's own `style`, which the
+--- kernel paints across its whole rect before the spans go on top. That is a
+--- full-width bar with no spacer span to pad it and no style merged into every
+--- span by hand — and a span that names its own colour keeps it, so a search
+--- highlight stays visible under the bar. `hover_style` is matched on `row.id`
+--- and skipped on the selected row, which already wears the stronger one.
+---
+--- opts: rows, selected, height, frame, empty, len, fill, selected_style,
+--- hover_style
 function widgets.list(opts)
   local rows = opts.rows or {}
   local height = opts.height or #rows
@@ -303,15 +312,25 @@ function widgets.list(opts)
       spans[#spans + 1] = span
     end
 
+    -- Addressable by default. `index` is the row's position in the FULL list,
+    -- not the visible window, so a click resolves to the same index j/k moves
+    -- through -- which is what lets a pane answer a click with one line instead
+    -- of repeating the window arithmetic. Hover is matched on the very id the
+    -- node carries, so the highlight and the click can never disagree.
+    local id = row.id or tostring(index)
+    local style = nil
+    if is_selected then
+      style = opts.selected_style
+    elseif hover.id(id) then
+      style = opts.hover_style
+    end
+
     children[#children + 1] = {
       type = "text",
       len = 1,
       text = { spans },
-      -- Addressable by default. `index` is the row's position in the FULL
-      -- list, not the visible window, so a click resolves to the same index
-      -- j/k moves through -- which is what lets a pane answer a click with
-      -- one line instead of repeating the window arithmetic.
-      id = row.id or tostring(index),
+      style = style,
+      id = id,
       class = table.concat(classes, " "),
       role = "row",
     }

--- a/ui/plugins/10_sessions.lua
+++ b/ui/plugins/10_sessions.lua
@@ -31,46 +31,6 @@ local session_model = require("lib.session_model")
 local theme = require("lib.theme")
 local widgets = require("lib.widgets")
 
--- ── Text helpers the contract needs and widgets.lua does not have ───────────
-
---- Append a raw-space span so a styled run covers the full width — how v1 makes
---- the selection background reach the right edge.
-local function pad_spans(spans, width)
-  local short = width - chrome.spans_len(spans)
-  if short > 0 then
-    spans[#spans + 1] = { text = string.rep(" ", short) }
-  end
-  return spans
-end
-
---- ratatui's `Style::patch` over every span: the overlay wins for the fields it
---- sets, the span keeps the rest.
----
---- `keep_fg` names spans whose COLOUR is a signal of its own — the characters a
---- search query matched. They still take everything else the overlay sets, so the
---- selection bar paints through them (a bar with a gap in it is not a bar), but
---- their foreground survives it. v1 layered the same two the same way round:
---- `highlight_style` was built ON TOP of the row's base style
---- (`src/ui/highlight.rs`), so an accent match stayed accent on the selected row.
---- Patching over it left the match wearing the selection's own colour with only
---- its underline showing — on the one row the strip was pointing at, since
---- previewing a result moves this list's cursor onto it.
-local function patch_spans(spans, style, keep_fg)
-  for index, span in ipairs(spans) do
-    local merged = {}
-    for key, value in pairs(span.style or {}) do
-      merged[key] = value
-    end
-    for key, value in pairs(style) do
-      if not (keep_fg and keep_fg[index] and key == "fg") then
-        merged[key] = value
-      end
-    end
-    span.style = merged
-  end
-  return spans
-end
-
 -- ── The model, the border chrome and the ordering algebra live in lib/ ──────
 --
 -- `lib.session_model` builds the item list (one selectable unit per row, with
@@ -192,17 +152,22 @@ local function name_hits(session, search)
   return nil
 end
 
+--- The spans of one session row, and the style the whole row wears.
+---
+--- The second return is the node's own `style`: the kernel paints it across the
+--- row's whole rect before the spans go on top, which is what a selection bar
+--- and a hover band are. Nothing here pads the spans to the right edge or merges
+--- a style into each of them by hand.
 local function session_line(item, inner_width, elapsed, is_selected, work, search)
   local session = item.session
   local glyph, glyph_color = status_glyph(session.status, elapsed)
-  local status_style = { fg = glyph_color }
   -- A blocked row's text is an attention message, so it keeps the dot's colour;
   -- plain activity is muted, leaving the name the row's visual anchor. v1 draws
   -- the same split.
   local trailing = agent_status_text(session)
-  local trailing_style = status_style
+  local trailing_color = glyph_color
   if session.status ~= "blocked" then
-    trailing_style = { fg = theme.muted }
+    trailing_color = theme.muted
   end
 
   -- Work already accepted but not yet in the snapshot is the more recent truth,
@@ -210,77 +175,85 @@ local function session_line(item, inner_width, elapsed, is_selected, work, searc
   -- geometry is v1's, the signal is v2's.
   if work then
     if work.phase == "failed" then
-      glyph, status_style = "✗", { fg = theme.role("status_error") }
+      glyph, glyph_color = "✗", theme.role("status_error")
       trailing = work.error and ("failed: " .. work.error) or "failed"
-      trailing_style = { fg = theme.role("status_error") }
+      trailing_color = theme.role("status_error")
     else
-      glyph, status_style = "◌", { fg = theme.muted }
-      trailing, trailing_style = work.kind, { fg = theme.muted }
+      glyph, glyph_color = "◌", theme.muted
+      trailing, trailing_color = work.kind, theme.muted
     end
   end
 
-  local spans = { { text = " " .. glyph .. " ", style = status_style } }
+  local hits = name_hits(session, search)
+
+  --- The colour a span wears, unless the ROW speaks for all of them.
+  ---
+  --- Selected: nothing names a foreground, so every cell takes the bar's —
+  --- a span that named one would poke a hole in it. Unmatched: v1 keeps a
+  --- non-matching row on screen and lets the contrast do the filtering, so the
+  --- list never jumps around under a cursor you are still moving.
+  local function tone(color)
+    if is_selected then
+      return nil
+    end
+    if search and hits == nil then
+      return { fg = theme.muted }
+    end
+    return { fg = color }
+  end
+
+  local spans = { { text = " " .. glyph .. " ", style = tone(glyph_color) } }
 
   -- Nesting prefix: a tree mark for a child inside the group, a lone mark for
   -- one whose parent renders elsewhere in the list.
   if item.depth > 0 then
     spans[#spans + 1] = {
       text = string.rep("  ", item.depth - 1) .. "└ ",
-      style = { fg = theme.muted },
+      style = tone(theme.muted),
     }
   elseif item.cross_group then
-    spans[#spans + 1] = { text = "↳ ", style = { fg = theme.muted } }
+    spans[#spans + 1] = { text = "↳ ", style = tone(theme.muted) }
   end
 
   -- An agent running on another machine, then a session that owns a worktree.
   if session.host then
-    spans[#spans + 1] = { text = "⇅ ", style = { fg = theme.accent } }
+    spans[#spans + 1] = { text = "⇅ ", style = tone(theme.accent) }
   end
   if (session.worktrees or 0) > 0 then
-    spans[#spans + 1] = { text = "⑂ ", style = { fg = theme.branch } }
+    spans[#spans + 1] = { text = "⑂ ", style = tone(theme.branch) }
   end
 
   -- Never truncated: the name is the row's anchor, and overflow clips.
-  local hits = name_hits(session, search)
-  local name_style = is_selected and { fg = theme.role("selection_fg"), bold = true }
-    or { fg = theme.text }
-  -- Which spans the search highlight owns, by position in `spans`. The overlays
-  -- below are told, so the selection bar cannot repaint a match — see
-  -- `patch_spans`. Identity on the style table is what marks one: `fuzzy.spans`
-  -- hands back the very table it was given for a matched run.
-  local matched_spans = nil
+  local name_style = tone(theme.text)
   if hits then
+    -- A matched run is the one thing that keeps its colour on a selected row:
+    -- it names a foreground, and the bar underneath supplies only what a span
+    -- left unsaid. v1 layered the same two the same way round —
+    -- `highlight_style` was built ON TOP of the row's base style
+    -- (`src/ui/highlight.rs`) — and previewing a result moves this list's
+    -- cursor onto the row, so the selected row is exactly the one whose marks
+    -- would otherwise disappear.
     local hit_style = { fg = theme.accent, bold = true, underline = true }
-    matched_spans = {}
     for _, span in ipairs(fuzzy.spans(session.name or "?", hits, name_style, hit_style)) do
       spans[#spans + 1] = span
-      if span.style == hit_style then
-        matched_spans[#spans] = true
-      end
     end
   else
     spans[#spans + 1] = { text = session.name or "?", style = name_style }
   end
 
-  push_status(spans, trailing, trailing_style, inner_width)
+  push_status(spans, trailing, tone(trailing_color), inner_width)
 
-  -- A row nothing matched is dimmed rather than hidden: v1 keeps every row on
-  -- screen and lets the contrast do the filtering, so the list never jumps
-  -- around under a cursor you are still moving.
-  if search and hits == nil then
-    patch_spans(spans, { fg = theme.muted, bold = false, underline = false })
-  end
-
-  -- The selection bar is painted here rather than by a list-wide highlight,
-  -- which would bleed onto the group header glued above a group's first row.
+  -- The bar is the row's own style rather than a list-wide highlight, which
+  -- would bleed onto the group header glued above a group's first row.
   if is_selected then
-    pad_spans(spans, inner_width)
-    patch_spans(spans, {
-      bg = theme.role("selection_bg"),
-      fg = theme.role("selection_fg"),
-      bold = true,
-    }, matched_spans)
-  elseif hover.id(session.id) then
+    return spans,
+      {
+        bg = theme.role("selection_bg"),
+        fg = theme.role("selection_fg"),
+        bold = true,
+      }
+  end
+  if hover.id(session.id) then
     -- v1's row hover: a subtle band marking what a click would hit. Only the
     -- BACKGROUND is tinted — each cell keeps its own fg, so the status dot and
     -- the branch colour survive being hovered. A button gets the stronger
@@ -288,8 +261,7 @@ local function session_line(item, inner_width, elapsed, is_selected, work, searc
     --
     -- Skipped on the selected row because v1 tints it to the colour it already
     -- has, which is no change at all.
-    pad_spans(spans, inner_width)
-    patch_spans(spans, { bg = theme.role("selection_bg") })
+    return spans, { bg = theme.role("selection_bg") }
   end
 
   return spans
@@ -712,7 +684,8 @@ return {
     -- identical within a frame, and building two four-deep tables per row was
     -- pure churn (the agent pane's `edge` upvalue is the same pattern).
     local edge = { type = "text", len = 1, text = { { { text = "│", style = frame_style } } } }
-    local function row(spans, id, class)
+    local function row(line)
+      line = line or {}
       return {
         type = "box",
         axis = "horizontal",
@@ -722,13 +695,17 @@ return {
           {
             type = "text",
             fill = 1,
-            text = { spans },
-            id = id,
-            class = class,
+            text = { line.spans or {} },
+            -- The row's own style covers this rect and this rect only: the
+            -- edges are siblings, so a selection bar reaches the border and
+            -- never paints over it.
+            style = line.style,
+            id = line.id,
+            class = line.class,
             -- Decoration (the search plugin) finds rows by this role, and only
             -- the content is inside it — so a highlight can never repaint the
             -- border cells.
-            role = id and "row" or nil,
+            role = line.id and "row" or nil,
           },
           edge,
         },
@@ -784,15 +761,17 @@ return {
               class = "pending-row",
             }
           else
+            local spans, style = session_line(
+              item,
+              inner_width,
+              ctx.elapsed,
+              index == cursor,
+              busy[item.session.id],
+              search
+            )
             lines[#lines + 1] = {
-              spans = session_line(
-                item,
-                inner_width,
-                ctx.elapsed,
-                index == cursor,
-                busy[item.session.id],
-                search
-              ),
+              spans = spans,
+              style = style,
               id = item.session.id,
               class = "session-row",
             }
@@ -820,9 +799,7 @@ return {
     children[#children + 1] = { type = "text", len = 1, text = { chrome.cells_to_spans(top) } }
 
     for index = 1, inner_height do
-      local line = lines[index]
-      children[#children + 1] =
-        row(line and line.spans or {}, line and line.id, line and line.class)
+      children[#children + 1] = row(lines[index])
     end
 
     local bottom = chrome.new_cells(width, "─", frame_style)

--- a/ui/plugins/10_sessions.lua
+++ b/ui/plugins/10_sessions.lua
@@ -160,12 +160,14 @@ end
 --- a style into each of them by hand.
 local function session_line(item, inner_width, elapsed, is_selected, work, search)
   local session = item.session
-  local glyph, glyph_color = status_glyph(session.status, elapsed)
+  local glyph, glyph_color
+  glyph, glyph_color = status_glyph(session.status, elapsed)
   -- A blocked row's text is an attention message, so it keeps the dot's colour;
   -- plain activity is muted, leaving the name the row's visual anchor. v1 draws
   -- the same split.
   local trailing = agent_status_text(session)
-  local trailing_color = glyph_color
+  local trailing_color
+  trailing_color = glyph_color
   if session.status ~= "blocked" then
     trailing_color = theme.muted
   end


### PR DESCRIPTION
## Intent

Step 3 of a six-step series making thurbox's Lua interface layer cheap to write a clean pane in (from the 2026-09-04 Lua UI review, section 2 problem 1 and section 5 step 3).

Goal: Node::Text had no style, so any selected/hovered/dimmed row had to be synthesised in Lua — append a spacer span sized by hand so the background reaches the right edge, then merge a style table into every span, with a keep_fg exception list so the selection bar did not repaint the characters a search query matched. That was 35 lines of pad_spans/patch_spans in ui/plugins/10_sessions.lua.

What was asked for: add a 'style' prop to Node::Text (node.rs), read it in convert.rs's Fields, apply it as the Paragraph base style in paint.rs so the whole rect takes it; give widgets.list selected_style/hover_style props; delete pad_spans/patch_spans from 10_sessions.lua. Tests: a frames test that a styled text node paints its background to the full width, and the sessions-list frames must stay byte-identical after the pane switches over.

Deliberate decisions made while doing the work:
- The failing test was written first (tests/frames.rs, a_styled_text_node_paints_its_style_across_its_whole_rect) and confirmed to fail because the style prop was ignored entirely, before any kernel change.
- ratatui composes Paragraph::style as buf.set_style over the rect and then patches each run over it, so a run that names a colour keeps it. That is why the keep_fg exception list could be deleted outright rather than reimplemented: a search hit names its own fg and survives the bar for free.
- To keep the sessions frames byte-identical, the pane's spans must NOT name a foreground on a selected row (the old code force-patched every span to selection_fg). This is expressed as one 'tone' helper in session_line that returns nil when selected and theme.muted when the row matched no search hit, instead of two after-the-fact patch passes. tests/frames.rs the_selection_is_a_style_and_moves_with_j pins the style runs cell-for-cell and is unchanged.
- The node style is round-tripped through convert::to_lua. Without that, a decorator returning its input untouched (the search plugin decorates the session list) would flatten the highlighted row — the same class of bug tests/decoration.rs already documents for run styles. A new decoration test covers it.
- widgets.list's new props default to nil so no bundled pane changes appearance; they are covered by a probe pane written into a materialized copy of the interface (tests/frames.rs paint_probe), not left untested. Adopting them in 65_search / 80_restore would be a visible change to those panes and belongs to step 6 of the series.
- 20_agent.lua:653-663 was NOT converted. The review lists it as 'the same idea ad hoc', but it bands two runs inside one hand-composed border line, not a whole node, so a node-level style cannot express it without banding the entire border row. Left as is on purpose.
- thurbox.yml was NOT changed: it is selene's standard library and declares globals only (thurbox, command, store, state, require, files, run) — it carries no node-table schema, so there is nothing there to declare for a node prop. The typed entry for text.style belongs in ui/lib/thurbox.d.lua, which is step 1 of the series and still in flight on PR #1070; it will be added there.
- Docs updated in the same PR per the repo rule: docs/PLUGINS.md (the node-kinds reference), ui/README.md, ui/AGENTS.md and .claude/skills/thurbox-kernel/SKILL.md.

Verified locally: just lint clean, just test 2431/2431 passing, commit signed.

## What Changed

- Added a `style` field to `Node::Text` (`src/kernel/node.rs`), read from the Lua `style` field in `convert.rs`'s `Fields`, and applied in `paint.rs` as the `Paragraph`'s base style so it fills the whole rect while individual runs that name a colour still patch over it; the style is also round-tripped back out through `convert::to_lua` so a decorator that returns its input untouched doesn't drop it.
- Added `selected_style`/`hover_style` props to `widgets.list` (`ui/lib/widgets.lua`), defaulting to `nil` so no bundled pane's appearance changes.
- Removed the `pad_spans`/`patch_spans` span-patching helpers from `ui/plugins/10_sessions.lua`, replacing the hand-built spacer span and per-span foreground overrides with the new node-level `style` prop and a single `tone` helper in `session_line`.
- Added `tests/frames.rs::a_styled_text_node_paints_its_style_across_its_whole_rect` (and a `paint_probe` pane exercising the new `widgets.list` props), a decoration test in `tests/decoration.rs` covering the style round-trip through a pass-through decorator, and updated `tests/mouse.rs` for the changed node shape.
- Updated `ui/lib/thurbox.d.lua` types, `docs/PLUGINS.md`, `ui/README.md`, `ui/AGENTS.md`, and `.claude/skills/thurbox-kernel/SKILL.md` to document the new `text.style` prop.

## Risk Assessment

✅ Low: Self-contained, well-tested addition of a style prop to Node::Text (kernel + convert + paint), consumed by widgets.list and 10_sessions.lua; all Node::Text construction sites, round-trip/decoration, and paint semantics were traced and are correct, the deleted pad_spans/patch_spans helpers have no leftover references, docs are updated consistently, and the claimed byte-identical selection-frame test was left untouched, confirming the refactor preserves output.

## Testing

Ran `cargo nextest run --test frames --test decoration --test mouse` (29/29 passed), including the two new frames tests proving a styled text node paints its background/fg/bold across its whole rect while a span naming its own colour survives the bar, the two new widgets.list probe tests proving selected_style/hover_style paint edge-to-edge and are no-ops when unset, the new decoration round-trip test proving a decorator that returns its input untouched no longer flattens a styled row, and the pre-existing `the_selection_is_a_style_and_moves_with_j` sessions-list frame test confirming the pane's selection frame is unchanged after the pad_spans/patch_spans removal. No test failures, no leftover artifacts (git status clean).

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"9b99eb0133c435c42c89e8f1231769954368e270","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `cargo nextest run --all`
- `cargo nextest run --test frames --test decoration --test mouse`
- `cargo nextest run --test frames --test decoration -E 'test(a_styled_text_node_paints_its_style_across_its_whole_rect) or test(a_span_keeps_the_colour_it_names_over_the_node_style) or test(a_list_paints_its_selected_and_hovered_rows_edge_to_edge) or test(a_list_without_the_style_props_paints_no_band) or test(a_node_style_survives_the_trip_out_to_a_decorator_and_back) or test(the_selection_is_a_style_and_moves_with_j)'`
- `git status --porcelain (confirmed no transient artifacts left behind)`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: fix(ui): split glyph/trailing_color declarations to satisfy luals
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
