### PR TITLE
feat(ui): expose kernel display-width measurement as text.width/truncate/pad

### DIFF
--- a/.claude/skills/thurbox-kernel/SKILL.md
+++ b/.claude/skills/thurbox-kernel/SKILL.md
@@ -176,6 +176,17 @@ examples to read and copy from, not a catalogue thurbox maintains for anyone —
 `check` fails on a pane that **loaded but which no arrangement places** — the only
 failure with no symptom — and prints the `layout.lua` line to add.
 
+**Measuring text is the kernel's job** (`host::api::install_text`). The `text`
+global gives a plugin `text.width(s)`, `text.truncate(s, cols, opts)` and
+`text.pad(s, cols, align)`, all in terminal COLUMNS and all backed by the same
+`unicode-width` the painter measures with. Lua cannot compute this: `#` counts
+bytes, `utf8.len` counts codepoints, and a CJK glyph is one codepoint over two
+columns — so a budget counted either way sheared every row with a double-width
+name in it. `ui/lib/widgets.lua` forwards to it (`widgets.len`, `truncate`,
+`truncate_hard`, `keep_left`, `keep_right`, `middle_truncate`, `pad`), and
+`widgets.chars` is the separate codepoint count a CARET needs, since
+`input.cursor` is a character offset.
+
 `ui/lib/thurbox.d.lua` is the API as lua-language-server types — node props and
 their allowed values, `ctx`, the `hit`/`key`/`wheel` payloads, the declaration
 table, every published `thurbox.*` row shape, every `command` verb's options, and

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -160,12 +160,19 @@ undefined variable; the runtime message will not help you.
 turns a *failed* match (`nil`) into an empty table, which then reads as a match —
 so a filter silently keeps everything. Spell it as an `if`.
 
-**A Lua character class is a set of *bytes*.** `text:match("[▸▾]")` does not mean
+**A Lua character class is a set of *bytes*.** `value:match("[▸▾]")` does not mean
 "either of those arrows" — it means any byte occurring in their encodings, which
 matches no arrow and plenty of unrelated things. `#` counts bytes for the same reason,
 so a column computed from it comes out short on any row with `é` or `╭` in it. This
 interface is full of multi-byte glyphs, so both apply constantly: measure with
-`utf8.len`, and compare whole strings rather than classing them.
+`text.width`, and compare whole strings rather than classing them.
+
+**A column is not a character either.** `utf8.len` fixes the byte count and stops
+there: a CJK glyph is one codepoint over *two* columns and a combining mark one
+over none, so a budget counted in codepoints shears every row a double-width name
+appears in. `text.width` / `text.truncate` / `text.pad` measure in columns, with
+the same `unicode-width` the painter uses. The one place codepoints are right is
+`input.cursor`, which is a character offset — `widgets.chars` is that count.
 
 **`ipairs` stops at the first hole.** It is not "iterate the array"; it is "iterate
 until a `nil`". A table built by index where one slot was left empty — a diff row with
@@ -314,6 +321,7 @@ that throws costs its own pane and nothing else.
 | `state` | Private to your plugin. Survives a reload; **not** a restart |
 | `store` | Shared by every plugin — the bus between them. Same lifetime as `state` |
 | `files.list/read` | Directory entries and file text, rooted at a session's directory |
+| `text.width/truncate/pad` | Display width in terminal COLUMNS, and the two cuts that spend a budget in it |
 | `thurbox.settings` | The settings in force: every `[features]` switch, plus the panel breakpoints and scrollback. Read your own switch and decline to draw when it is off — the kernel gates only what it owns |
 | `thurbox.bookmarks/browse/branches/worktrees` | The creation flow's reads: remembered repositories, a directory listing, a base-branch list, the worktrees a repo already has — each served only while `store.want_bookmarks`/`want_browse`/`want_branches`/`want_worktrees` asks for it |
 | `require` | Loads **any** `.lua` under the interface directory, and nothing outside it |

--- a/src/kernel/host/api.rs
+++ b/src/kernel/host/api.rs
@@ -701,10 +701,17 @@ fn pad(s: &str, cols: usize, align: &Align) -> String {
     }
 }
 
-/// A column count as Lua spells it: any number, floored, never negative.
+/// No real terminal is remotely this wide; the ceiling exists so that
+/// `pad`'s `" ".repeat(cols)` — a Rust-side allocation the VM's own
+/// [`super::memory_limit`] cannot see or budget for — stays too small to
+/// ever hit the allocator's abort path, whatever a plugin passes in.
+const MAX_COLS: usize = 1 << 20;
+
+/// A column count as Lua spells it: any number, floored, never negative,
+/// and never past [`MAX_COLS`].
 fn cols_arg(n: f64) -> usize {
     if n.is_finite() && n > 0.0 {
-        n.floor() as usize
+        (n.floor() as usize).min(MAX_COLS)
     } else {
         0
     }
@@ -829,5 +836,15 @@ mod tests {
         assert!(Side::parse("centre").is_err());
         assert!(Align::parse("middle").is_err());
         assert!(Align::parse("centre").is_ok());
+    }
+
+    /// `pad`'s `" ".repeat(cols)` is a Rust-side allocation the VM's memory
+    /// limit cannot see; a plugin passing a huge `cols` must not drive it
+    /// past a bounded size regardless of how large the request claims to be.
+    #[test]
+    fn a_huge_cols_is_capped_rather_than_allocated_in_full() {
+        assert_eq!(cols_arg(f64::MAX), MAX_COLS);
+        assert_eq!(cols_arg(1e18), MAX_COLS);
+        assert_eq!(pad("x", cols_arg(1e18), &Align::Left).len(), MAX_COLS);
     }
 }

--- a/src/kernel/host/api.rs
+++ b/src/kernel/host/api.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
 use mlua::{Lua, Table, Value};
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use super::load::BUDGET_EXCEEDED;
 use super::{
@@ -36,6 +37,7 @@ pub(super) fn install_api(
     install_files(lua, roots)?;
     install_run(lua, runs, current_path)?;
     install_clock(lua, clock, clock_read)?;
+    install_text(lua)?;
     Ok(())
 }
 
@@ -561,4 +563,271 @@ pub(super) fn clean_error(error: &mlua::Error) -> String {
         .unwrap_or(&text)
         .trim()
         .to_string()
+}
+
+// ── Display width ───────────────────────────────────────────────────────────
+
+/// What a cut is marked with when the caller does not say.
+const ELLIPSIS: &str = "…";
+
+/// How many terminal columns `s` occupies.
+///
+/// Not its bytes and not its characters: a CJK glyph takes two columns and a
+/// combining mark none, so the three counts disagree on exactly the text a
+/// column budget is hardest to get right on. This is the same `unicode-width`
+/// the painter measures with, so a plugin that budgets with it agrees with what
+/// lands on the screen.
+fn columns(s: &str) -> usize {
+    UnicodeWidthStr::width(s)
+}
+
+/// The longest prefix of `s` that fits in `cols` columns.
+///
+/// A double-width glyph that would straddle the edge is left out rather than
+/// half-drawn, so the result is never *wider* than asked for — which is what
+/// lets a caller add its own marker and still fit.
+fn take_left(s: &str, cols: usize) -> &str {
+    let mut used = 0;
+    for (at, ch) in s.char_indices() {
+        let w = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if used + w > cols {
+            return &s[..at];
+        }
+        used += w;
+    }
+    s
+}
+
+/// The longest suffix of `s` that fits in `cols` columns.
+fn take_right(s: &str, cols: usize) -> &str {
+    let mut used = 0;
+    for (at, ch) in s.char_indices().rev() {
+        let w = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if used + w > cols {
+            return &s[at + ch.len_utf8()..];
+        }
+        used += w;
+    }
+    s
+}
+
+/// Which end of the text a truncation eats.
+enum Side {
+    Right,
+    Left,
+    Middle,
+}
+
+impl Side {
+    fn parse(name: &str) -> mlua::Result<Self> {
+        match name {
+            "right" => Ok(Self::Right),
+            "left" => Ok(Self::Left),
+            "middle" => Ok(Self::Middle),
+            other => Err(mlua::Error::runtime(format!(
+                "text.truncate: side must be right, left or middle, not {other:?}"
+            ))),
+        }
+    }
+}
+
+/// Cut `s` down to `cols` columns, marking the cut with `ellipsis`.
+fn truncate(s: &str, cols: usize, ellipsis: &str, side: &Side) -> String {
+    if cols == 0 {
+        return String::new();
+    }
+    if columns(s) <= cols {
+        return s.to_string();
+    }
+    let mark = columns(ellipsis);
+    // No room for both the mark and any text: the mark alone is the whole
+    // answer, itself cut to fit rather than overrunning the budget it was
+    // meant to respect.
+    if mark >= cols {
+        return take_left(ellipsis, cols).to_string();
+    }
+    let budget = cols - mark;
+    match side {
+        Side::Right => format!("{}{ellipsis}", take_left(s, budget)),
+        Side::Left => format!("{ellipsis}{}", take_right(s, budget)),
+        Side::Middle => {
+            // The tail gets the larger share of an odd remainder: for a path it
+            // carries the leaf, which is the half that identifies the thing.
+            let head = budget / 2;
+            format!(
+                "{}{ellipsis}{}",
+                take_left(s, head),
+                take_right(s, budget - head)
+            )
+        }
+    }
+}
+
+/// Where the short side of a pad goes.
+enum Align {
+    Left,
+    Right,
+    Center,
+}
+
+impl Align {
+    fn parse(name: &str) -> mlua::Result<Self> {
+        match name {
+            "left" => Ok(Self::Left),
+            "right" => Ok(Self::Right),
+            "center" | "centre" => Ok(Self::Center),
+            other => Err(mlua::Error::runtime(format!(
+                "text.pad: align must be left, right or center, not {other:?}"
+            ))),
+        }
+    }
+}
+
+/// Spaces `s` out to `cols` columns. Text already that wide is returned as it
+/// is — a pad never truncates, because the two answers to "too long" are the
+/// caller's to choose between.
+fn pad(s: &str, cols: usize, align: &Align) -> String {
+    let short = cols.saturating_sub(columns(s));
+    if short == 0 {
+        return s.to_string();
+    }
+    match align {
+        Align::Left => format!("{s}{}", " ".repeat(short)),
+        Align::Right => format!("{}{s}", " ".repeat(short)),
+        Align::Center => {
+            let before = short / 2;
+            format!("{}{s}{}", " ".repeat(before), " ".repeat(short - before))
+        }
+    }
+}
+
+/// A column count as Lua spells it: any number, floored, never negative.
+fn cols_arg(n: f64) -> usize {
+    if n.is_finite() && n > 0.0 {
+        n.floor() as usize
+    } else {
+        0
+    }
+}
+
+/// `text.width(s)`, `text.truncate(s, cols, opts)` and `text.pad(s, cols, align)`.
+///
+/// The one measurement a plugin cannot make for itself. Lua's `#` counts bytes
+/// and `utf8.len` counts codepoints; a terminal budget is columns, and no
+/// arithmetic over the other two recovers it. Every truncation and every pad in
+/// the interface rides on this, so it is the kernel's `unicode-width` — the
+/// painter's own measure — rather than an approximation per plugin.
+///
+/// `opts` is the ellipsis, or `{ ellipsis = "…", side = "right"|"left"|"middle" }`
+/// for the cuts that keep the far end. An unknown `side` or `align` raises
+/// rather than being ignored: a misspelt option that silently means "left" is
+/// the trap `command`'s option list already documents.
+fn install_text(lua: &Lua) -> mlua::Result<()> {
+    let table = lua.create_table()?;
+
+    table.set(
+        "width",
+        lua.create_function(|_, s: String| Ok(columns(&s)))?,
+    )?;
+
+    table.set(
+        "truncate",
+        lua.create_function(|_, (s, cols, opts): (String, f64, Option<Value>)| {
+            let (ellipsis, side) = match opts {
+                Some(Value::String(mark)) => (mark.to_string_lossy(), Side::Right),
+                Some(Value::Table(opts)) => (
+                    opts.get::<Option<String>>("ellipsis")?
+                        .unwrap_or_else(|| ELLIPSIS.to_string()),
+                    match opts.get::<Option<String>>("side")? {
+                        Some(name) => Side::parse(&name)?,
+                        None => Side::Right,
+                    },
+                ),
+                _ => (ELLIPSIS.to_string(), Side::Right),
+            };
+            Ok(truncate(&s, cols_arg(cols), &ellipsis, &side))
+        })?,
+    )?;
+
+    table.set(
+        "pad",
+        lua.create_function(|_, (s, cols, align): (String, f64, Option<String>)| {
+            let align = match align {
+                Some(name) => Align::parse(&name)?,
+                None => Align::Left,
+            };
+            Ok(pad(&s, cols_arg(cols), &align))
+        })?,
+    )?;
+
+    lua.globals().set("text", table)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The three counts a plugin could reach for disagree here, which is why
+    /// this one is the kernel's: six characters, eighteen bytes, twelve columns.
+    #[test]
+    fn width_is_columns_and_not_bytes_or_characters() {
+        assert_eq!(columns("修复终端宽度"), 12);
+        assert_eq!("修复终端宽度".len(), 18);
+        assert_eq!("修复终端宽度".chars().count(), 6);
+    }
+
+    /// A double-width glyph that would straddle the budget's edge is dropped
+    /// rather than half-drawn: the result must never be wider than asked for,
+    /// or the caller's own marker pushes the row over.
+    #[test]
+    fn a_cut_never_returns_more_columns_than_it_was_given() {
+        assert_eq!(take_left("修复终端", 3), "修");
+        assert_eq!(take_right("修复终端", 3), "端");
+        assert_eq!(
+            truncate("修复终端宽度", 7, ELLIPSIS, &Side::Right),
+            "修复终…"
+        );
+    }
+
+    #[test]
+    fn each_side_keeps_the_end_it_names() {
+        assert_eq!(truncate("abcdefgh", 5, ELLIPSIS, &Side::Right), "abcd…");
+        assert_eq!(truncate("abcdefgh", 5, ELLIPSIS, &Side::Left), "…efgh");
+        assert_eq!(truncate("abcdefgh", 5, ELLIPSIS, &Side::Middle), "ab…gh");
+        // The tail takes the larger share of an odd remainder.
+        assert_eq!(truncate("abcdefgh", 6, ELLIPSIS, &Side::Middle), "ab…fgh");
+    }
+
+    /// Below the mark's own width there is nothing to say but the mark, and it
+    /// is cut to the budget rather than overrunning the one it protects.
+    #[test]
+    fn a_budget_too_small_for_the_mark_holds_the_mark() {
+        assert_eq!(truncate("abcdefgh", 1, ELLIPSIS, &Side::Right), "…");
+        assert_eq!(truncate("abcdefgh", 0, ELLIPSIS, &Side::Right), "");
+        assert_eq!(truncate("abcdefgh", 2, "...", &Side::Right), "..");
+    }
+
+    #[test]
+    fn an_empty_mark_cuts_without_saying_so() {
+        assert_eq!(truncate("abcdefgh", 4, "", &Side::Right), "abcd");
+        assert_eq!(truncate("abcdefgh", 4, "", &Side::Left), "efgh");
+    }
+
+    #[test]
+    fn pad_counts_columns_and_never_truncates() {
+        assert_eq!(pad("修复", 6, &Align::Left), "修复  ");
+        assert_eq!(pad("修复", 6, &Align::Right), "  修复");
+        assert_eq!(pad("修复", 7, &Align::Center), " 修复  ");
+        assert_eq!(pad("修复终端", 4, &Align::Left), "修复终端");
+    }
+
+    /// A misspelt option means the caller asked for something; answering with
+    /// the default would draw a plausible frame and report nothing.
+    #[test]
+    fn an_unknown_side_or_align_is_refused() {
+        assert!(Side::parse("centre").is_err());
+        assert!(Align::parse("middle").is_err());
+        assert!(Align::parse("centre").is_ok());
+    }
 }

--- a/tests/frames.rs
+++ b/tests/frames.rs
@@ -32,6 +32,7 @@ use thurbox::kernel::host::{KeyPress, LuaHost, Published, RenderContext};
 use thurbox::kernel::paint::{render, PlaceholderSurfaces, ProgramPaint, SurfaceProvider};
 use thurbox::kernel::registry::Registry;
 use thurbox::kernel::snapshot::{SessionRow, Snapshot};
+use thurbox::kernel::terminal::AgentMeta;
 use thurbox::kernel::theme::Themes;
 use thurbox::session::SessionState;
 
@@ -69,17 +70,27 @@ fn publish_hovered(
     snapshot: &Snapshot,
     hovered: Option<&thurbox::kernel::node::Identity>,
 ) {
-    publish_inner(host, snapshot, &HashMap::new(), hovered);
+    publish_inner(host, snapshot, &HashMap::new(), &HashMap::new(), hovered);
 }
 
 fn publish_with(host: &LuaHost, snapshot: &Snapshot, attach_errors: &HashMap<String, String>) {
-    publish_inner(host, snapshot, attach_errors, None);
+    publish_inner(host, snapshot, attach_errors, &HashMap::new(), None);
+}
+
+fn publish_meta(
+    host: &LuaHost,
+    snapshot: &Snapshot,
+    attach_errors: &HashMap<String, String>,
+    meta: &HashMap<String, AgentMeta>,
+) {
+    publish_inner(host, snapshot, attach_errors, meta, None);
 }
 
 fn publish_inner(
     host: &LuaHost,
     snapshot: &Snapshot,
     attach_errors: &HashMap<String, String>,
+    meta: &HashMap<String, AgentMeta>,
     hovered: Option<&thurbox::kernel::node::Identity>,
 ) {
     let themes = themes();
@@ -96,7 +107,7 @@ fn publish_inner(
         diffs: &diffs,
         links: &Default::default(),
         content: &Default::default(),
-        meta: &Default::default(),
+        meta,
         metrics: &Default::default(),
         status_rows: 0,
         can_open: true,
@@ -366,6 +377,35 @@ fn the_session_list_keeps_its_columns_under_double_width_names() {
 }
 
 #[test]
+fn a_double_width_name_budgets_the_status_by_the_columns_it_takes() {
+    // The trailing status is budgeted against what the name left of the row.
+    // A CJK name spends two columns per character, so a budget counted in
+    // characters is six columns too generous here: the status overruns the
+    // row and the clip shears it, dropping the very mark that says it was
+    // cut.
+    let host = host();
+    let world = snapshot(vec![row("修复终端宽度", "thurbox", "idle")]);
+    let meta = HashMap::from([(
+        world.sessions[0].id.clone(),
+        AgentMeta {
+            activity: Some("waiting for your review".to_string()),
+            notification: None,
+        },
+    )]);
+    publish_meta(&host, &world, &HashMap::new(), &meta);
+    assert_frame(
+        &text(&paint(&host, "sessions", 40, 5, true)),
+        &[
+            "╭ Sessions ───────────────────────────○╮",
+            "│── thurbox ───────────────────────────│",
+            "│ ○ ⑂ 修复终端宽度  waiting for your r…│",
+            "│                                      │",
+            "╰──────────────────────────────────────╯",
+        ],
+    );
+}
+
+#[test]
 fn the_session_list_truncates_rather_than_overflows_when_narrow() {
     let host = host();
     publish(&host, &sample());
@@ -584,6 +624,28 @@ fn the_agent_pane_before_its_session_is_attached() {
             "│                       not attached                       │",
             "│                                                          │",
             "│                                                          │",
+            "╰──────────────────────────────────────────────────────────╯",
+        ],
+    );
+}
+
+#[test]
+fn the_agent_pane_closes_its_border_over_a_double_width_name() {
+    // The title is fitted to the columns the border has left, and a CJK name
+    // spends two of them per character. Measured in characters the title is
+    // wider than its budget, and the corner drawn afterwards lands on top of
+    // the very ellipsis that says the branch was cut.
+    let host = host();
+    let world = snapshot(vec![row("修复终端宽度", "thurbox", "idle")]);
+    publish(&host, &world);
+    host.render(index_of(&host, "sessions"), ctx(40, 12, true))
+        .expect("render list");
+    assert_frame(
+        &text(&paint(&host, "agent", 60, 4, true)),
+        &[
+            "╭ ◀ F9 ─ Agent ─ Shell · F8 ── 修复终端宽度 (claude) [feat…╮",
+            "│                     terminal surface                     │",
+            "│                       修复终端宽度                       │",
             "╰──────────────────────────────────────────────────────────╯",
         ],
     );

--- a/tests/kernel_mvp.rs
+++ b/tests/kernel_mvp.rs
@@ -1329,13 +1329,17 @@ fn the_granted_capability_set_matches_a_declared_list() {
     // Capabilities are introduced with their consumer, never
     // ahead of one. This is the tripwire — a new global in the plugin
     // environment has to be added here deliberately.
-    const GRANTED: [&str; 6] = [
+    const GRANTED: [&str; 7] = [
         "require", "state", "store", "command", "thurbox",
         // Two rooted reads — directory entries and a file's text — confined to
         // a session's working directory. NOT a filesystem: there is no open,
         // no write, no path outside the root. Granted with its consumer (the
         // file viewer).
         "files",
+        // Display width, which Lua cannot compute for itself: `#` counts bytes
+        // and `utf8.len` counts codepoints. Pure measurement — it reads
+        // nothing and reaches nothing.
+        "text",
     ];
 
     let dir = tempfile::tempdir().expect("tempdir");

--- a/thurbox.yml
+++ b/thurbox.yml
@@ -400,6 +400,19 @@ globals:
     args:
       - type: "..."
 
+  # Display width, which Lua cannot compute: `#` counts bytes and `utf8.len`
+  # counts codepoints, and a terminal budget is columns. Backed by the same
+  # `unicode-width` the painter measures with.
+  text.width:
+    args:
+      - type: "..."
+  text.truncate:
+    args:
+      - type: "..."
+  text.pad:
+    args:
+      - type: "..."
+
   # Loads `lib/*.lua`, and nothing outside the plugin directory.
   require:
     args:

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -86,6 +86,18 @@ Annotate the node you build (`---@type thurbox.TextNode` above the table) so a
 misspelt prop reads back as a missing required field. An **extra** key is never
 reported, so the annotation is what does the work.
 
+## Measure in columns
+
+A terminal budget is columns, and Lua counts neither of the two things it can
+count for you: `#` is bytes and `utf8.len` is codepoints, so a CJK glyph — one
+codepoint, two columns — comes out a column short every time. The kernel
+measures instead: `text.width(s)`, `text.truncate(s, cols, opts)` and
+`text.pad(s, cols, align)`, with the same `unicode-width` the painter uses. The
+`widgets` helpers (`len`, `truncate`, `truncate_hard`, `keep_left`,
+`keep_right`, `middle_truncate`, `pad`) forward to them, so either spelling is
+right. The one count that is *not* columns is `input.cursor`, a character
+offset — `widgets.chars` is that.
+
 ## Adding a pane is two edits
 
 The plugin file, **and** its slot in `layout.lua`. A pane names a slot; the

--- a/ui/README.md
+++ b/ui/README.md
@@ -230,6 +230,12 @@ These are the ones that cost real time.
   designed to be called on every render: a fresh answer is a table lookup, not a
   process. Do not try to call them "only once" — you will get a pane that never
   updates.
+- **Measure in columns, not characters.** `#s` is bytes and `utf8.len(s)` is
+  codepoints; a terminal budget is neither, and a CJK name is one codepoint over
+  two columns. `text.width(s)` is the measure the painter itself uses, and
+  `text.truncate` / `text.pad` (or the `widgets` helpers that forward to them)
+  spend a budget in it. The exception is `input.cursor`, which is a CHARACTER
+  offset — `widgets.chars` is that count.
 - **The answer is not there yet.** `run` returns nothing useful on the frame you
   ask. Read `thurbox.runs[key]` and handle `nil` and `state ~= "done"` — a pane
   that assumes the answer is present renders an error on its first frame.

--- a/ui/lib/chrome.lua
+++ b/ui/lib/chrome.lua
@@ -21,7 +21,7 @@ local chrome = {}
 
 -- ── Span measurement ────────────────────────────────────────────────────────
 
---- Character count across a span list (widgets.len handles one string).
+--- Display columns across a span list (widgets.len handles one string).
 function chrome.spans_len(spans)
   local total = 0
   for _, span in ipairs(spans) do

--- a/ui/lib/textinput.lua
+++ b/ui/lib/textinput.lua
@@ -13,9 +13,11 @@
 -- function here therefore mutates in place and returns whether it consumed the
 -- key.
 --
--- `cursor` counts CHARACTERS before the caret, not bytes — the kernel's caret is
--- placed by character offset, and a path with an accent in it must not put the
--- caret in the wrong column.
+-- `cursor` counts CHARACTERS before the caret, not bytes and not columns — the
+-- kernel's caret is placed by character offset, and a path with an accent in it
+-- must not put the caret in the wrong column. `widgets.chars` is that count;
+-- `widgets.len` is the column width every layout budgets in, and using it here
+-- would misplace the caret in exactly the double-width text it exists for.
 --
 -- One chord v1 has is missing, and cannot be had: `ctrl+h` (delete backwards) is
 -- reserved by the kernel for moving focus, so it never reaches a plugin.
@@ -42,13 +44,13 @@ end
 
 function textinput.new(value)
   local text = value or ""
-  return { value = text, cursor = widgets.len(text) }
+  return { value = text, cursor = widgets.chars(text) }
 end
 
 --- Replace the contents, caret at the end — how a field is prefilled.
 function textinput.set(field, value)
   field.value = value or ""
-  field.cursor = widgets.len(field.value)
+  field.cursor = widgets.chars(field.value)
   return field
 end
 
@@ -62,7 +64,7 @@ function textinput.insert(field, text)
   end
   local before, after = split(field)
   field.value = before .. text .. after
-  field.cursor = field.cursor + widgets.len(text)
+  field.cursor = field.cursor + widgets.chars(text)
   return field
 end
 
@@ -98,11 +100,11 @@ local function control(field, key)
   if name == "a" then
     field.cursor = 0
   elseif name == "e" then
-    field.cursor = widgets.len(field.value)
+    field.cursor = widgets.chars(field.value)
   elseif name == "b" then
     field.cursor = math.max(0, field.cursor - 1)
   elseif name == "f" then
-    field.cursor = math.min(widgets.len(field.value), field.cursor + 1)
+    field.cursor = math.min(widgets.chars(field.value), field.cursor + 1)
   elseif name == "d" then
     local before, after = split(field)
     if after ~= "" then
@@ -135,7 +137,7 @@ function textinput.key(field, key)
     -- A modifier chord that is not a line edit is still swallowed rather than
     -- typed, but only for letters: `ctrl+p` and friends belong to the pane, and
     -- it declares them as actions so they never arrive here at all.
-    if key.ctrl and not key.alt and key.char and widgets.len(key.char) == 1 then
+    if key.ctrl and not key.alt and key.char and widgets.chars(key.char) == 1 then
       return control(field, key)
     end
     return false
@@ -159,13 +161,13 @@ function textinput.key(field, key)
     field.cursor = math.max(0, field.cursor - 1)
     return true
   elseif name == "right" then
-    field.cursor = math.min(widgets.len(field.value), field.cursor + 1)
+    field.cursor = math.min(widgets.chars(field.value), field.cursor + 1)
     return true
   elseif name == "home" then
     field.cursor = 0
     return true
   elseif name == "end" then
-    field.cursor = widgets.len(field.value)
+    field.cursor = widgets.chars(field.value)
     return true
   elseif name == "space" then
     textinput.insert(field, " ")
@@ -174,7 +176,7 @@ function textinput.key(field, key)
 
   -- Anything that produced a character is typed, which is what makes a path
   -- with `~`, `/` or a digit in it work without listing them.
-  if key.char and not key.ctrl and widgets.len(key.char) == 1 then
+  if key.char and not key.ctrl and widgets.chars(key.char) == 1 then
     textinput.insert(field, key.char)
     return true
   end

--- a/ui/lib/thurbox.d.lua
+++ b/ui/lib/thurbox.d.lua
@@ -642,6 +642,39 @@ function files.list(session, path) end
 ---@return string
 function files.read(session, path) end
 
+---@class (exact) thurbox.TruncateOpts
+---@field ellipsis? string What marks the cut. `""` cuts without a mark.
+---@field side? "right"|"left"|"middle" Which end is eaten. Defaults to `"right"`.
+
+--- Display width, in terminal COLUMNS.
+---
+--- The one measurement Lua cannot make: `#` counts bytes and `utf8.len` counts
+--- codepoints, and a CJK glyph is one codepoint over two columns. Backed by the
+--- same `unicode-width` the painter measures with, so a budget computed here
+--- agrees with what lands on the screen.
+---@class thurbox.TextApi
+text = {}
+
+---@param str string
+---@return integer
+function text.width(str) end
+
+--- Cut `str` down to `cols` columns. `opts` is the ellipsis, or a table. An
+--- unknown `side` raises rather than being quietly read as `"right"`.
+---@param str string
+---@param cols integer
+---@param opts? string|thurbox.TruncateOpts
+---@return string
+function text.truncate(str, cols, opts) end
+
+--- Space `str` out to `cols` columns. Never truncates: what to do with text
+--- that is already too wide is the caller's choice.
+---@param str string
+---@param cols integer
+---@param align? "left"|"right"|"center"|"centre"
+---@return string
+function text.pad(str, cols, align) end
+
 ---@class (exact) thurbox.RunOpts
 ---@field session? string Run in this session's directory.
 ---@field ttl? number Seconds an answer stays fresh.

--- a/ui/lib/widgets.lua
+++ b/ui/lib/widgets.lua
@@ -60,40 +60,36 @@ function widgets.window(count, height, selected)
   return first, last, first > 1, last < count
 end
 
---- Length in characters, not bytes.
+--- Width in terminal COLUMNS — what every layout here budgets in.
 ---
---- Lua's `#` is a byte count, so "Rosé Pine" measures 10 and pads a column
---- short. This is still not display *width* — a CJK or emoji character occupies
---- two columns and counts as one here — but it is right for the Latin text the
---- bundled panes show. True width belongs in the kernel, which already has
---- unicode-width linked.
-function widgets.len(text)
-  return utf8 and utf8.len(text) or #text
+--- Lua has no way to compute this: `#` counts bytes and `utf8.len` counts
+--- codepoints, and a CJK glyph is one codepoint over two columns while a
+--- combining mark is one codepoint over none. So the kernel measures, with the
+--- same `unicode-width` the painter uses, and a budget computed here agrees
+--- with what lands on the screen.
+---
+--- Use `widgets.chars` instead for a caret: `input.cursor` is a CHARACTER
+--- offset, and columns would put it in the wrong place in exactly the text
+--- this function exists for.
+---@param str string
+---@return integer
+function widgets.len(str)
+  return text.width(str)
 end
 
---- Byte offset of the character at position `n`, for safe substring cuts.
-local function offset(text, n)
-  if not utf8 then
-    return n
-  end
-  return (utf8.offset(text, n + 1) or (#text + 1)) - 1
+--- Count of characters, for the one job columns cannot do: placing a caret.
+---@param str string
+---@return integer
+function widgets.chars(str)
+  return utf8.len(str) or #str
 end
 
---- Truncate to `width` characters, marking the cut with an ellipsis.
-function widgets.truncate(text, width)
-  if width <= 0 then
-    return ""
-  end
-  if widgets.len(text) <= width then
-    return text
-  end
-  if width == 1 then
-    return "…"
-  end
-  return string.sub(text, 1, offset(text, width - 1)) .. "…"
+--- Truncate to `width` columns, marking the cut with an ellipsis.
+function widgets.truncate(str, width)
+  return text.truncate(str, width)
 end
 
---- Truncate to `max` characters, marking the cut with an ellipsis — but return
+--- Truncate to `max` columns, marking the cut with an ellipsis — but return
 --- NOTHING at `max <= 1` rather than a bare `…`.
 ---
 --- v1's `ui::truncate_ellipsis`, and the counterpart to `widgets.truncate`
@@ -107,47 +103,31 @@ end
 --- explaining why it was not `widgets.truncate`. That is the signal that the
 --- library was missing a variant, not that the callers were wrong — so it lives
 --- here now and the forks are gone.
-function widgets.truncate_hard(text, max)
-  if widgets.len(text) <= max then
-    return text
-  end
-  if max <= 1 then
+function widgets.truncate_hard(str, max)
+  if max <= 1 and text.width(str) > max then
     return ""
   end
-  return string.sub(text, 1, offset(text, max - 1)) .. "…"
+  return text.truncate(str, max)
 end
 
---- Keep the FIRST `max` characters, adding nothing.
+--- Keep the FIRST `max` columns, adding nothing.
 ---
 --- What a left-aligned border title does when it overruns its area: ratatui
 --- truncates the far side and marks the cut in no way at all. Use this when you
 --- are MATCHING that behaviour; use `truncate`/`truncate_hard` when you are
 --- telling the reader something was cut.
-function widgets.keep_left(text, max)
-  if max <= 0 then
-    return ""
-  end
-  if widgets.len(text) <= max then
-    return text
-  end
-  return string.sub(text, 1, offset(text, max))
+function widgets.keep_left(str, max)
+  return text.truncate(str, max, "")
 end
 
---- Keep the LAST `max` characters.
+--- Keep the LAST `max` columns.
 ---
 --- What a right-aligned border title does when it overruns: ratatui's
 --- `Line::render_with_alignment` skips from the left, so the title shrinks
 --- toward the right edge. v1's recorded frame shows exactly this — a 42-char
 --- title in a 40-wide pane renders as `╭-osc52 (claude) …`.
-function widgets.keep_right(text, max)
-  if max <= 0 then
-    return ""
-  end
-  local count = widgets.len(text)
-  if count <= max then
-    return text
-  end
-  return string.sub(text, offset(text, count - max) + 1)
+function widgets.keep_right(str, max)
+  return text.truncate(str, max, { ellipsis = "", side = "left" })
 end
 
 --- Truncate in the MIDDLE, keeping both ends.
@@ -158,33 +138,16 @@ end
 --- column it had on boilerplate and cut off the only part that identifies the
 --- repository. Falls back to end-truncation below eight columns, where there is
 --- not room for two halves and an ellipsis.
-function widgets.middle_truncate(text, width)
-  if width <= 0 then
-    return ""
-  end
-  if widgets.len(text) <= width then
-    return text
-  end
+function widgets.middle_truncate(str, width)
   if width < 8 then
-    return widgets.truncate(text, width)
+    return text.truncate(str, width)
   end
-  -- The tail gets the larger share of an odd remainder: it carries the leaf.
-  local keep = width - 1
-  local head = math.floor(keep / 2)
-  local tail = keep - head
-  local len = widgets.len(text)
-  return string.sub(text, 1, offset(text, head))
-    .. "…"
-    .. string.sub(text, offset(text, len - tail) + 1)
+  return text.truncate(str, width, { side = "middle" })
 end
 
---- Pad `text` out to `width` characters.
-function widgets.pad(text, width)
-  local short = width - widgets.len(text)
-  if short <= 0 then
-    return text
-  end
-  return text .. string.rep(" ", short)
+--- Pad `str` out to `width` columns.
+function widgets.pad(str, width)
+  return text.pad(str, width)
 end
 
 --- A row's text as a LIST of spans, whatever shape it arrived in.
@@ -209,8 +172,8 @@ local function span_list(spans)
 end
 
 --- An overflow marker: a row of its own, never drawn over one.
-local function overflow_marker(text)
-  return { type = "text", len = 1, text = theme.dim(text), role = "overflow" }
+local function overflow_marker(label)
+  return { type = "text", len = 1, text = theme.dim(label), role = "overflow" }
 end
 
 --- The visible window, plus which overflow markers fit beside it.

--- a/ui/plugins/20_agent.lua
+++ b/ui/plugins/20_agent.lua
@@ -194,8 +194,8 @@ end
 
 -- --- text measurement ------------------------------------------------------
 --
--- `widgets.len`/`pad` are utf8-aware; `#` is not, and every glyph below is
--- multi-byte.
+-- `widgets.len`/`pad` measure in terminal COLUMNS, which is what a border
+-- budget is spent in; `#` counts bytes and every glyph below is multi-byte.
 
 --- v1's `ui::fit_right_title`: clamp a right-aligned title to what the tab strip
 --- on the left of the same border leaves it — the border minus its two corners,
@@ -454,9 +454,9 @@ local function compact_chord(chord)
     modifiers = modifiers .. symbol
     key = rest
   end
-  if widgets.len(key) == 1 then
+  if widgets.chars(key) == 1 then
     key = string.upper(key)
-  elseif widgets.len(key) > 1 then
+  elseif widgets.chars(key) > 1 then
     key = string.upper(string.sub(key, 1, 1)) .. string.sub(key, 2)
   end
   return modifiers .. key


### PR DESCRIPTION
## Intent

Step 4 of a Lua-interface review series: give the plugin API a display-width measurement from the kernel, so a pane can budget terminal columns instead of codepoints.

ui/lib/widgets.lua's own doc comment admitted the bug — widgets.len counted codepoints, a CJK glyph is one codepoint over two terminal columns, and all six truncate/pad variants plus chrome.spans_len rode on it. unicode-width was already a dependency (Cargo.toml) and was not exposed to Lua at all. Symptoms pinned by two new tests/frames.rs cases: a session row's trailing status overran its row and was sheared by the clip, losing the ellipsis that says it was cut; the agent pane's border corner landed on top of the same mark in its title.

Decisions made deliberately, so they are not mistakes:

- The new global is named "text" (text.width / text.truncate / text.pad), as the review specified. It shadows a common local/parameter name in Lua, which is accepted: only widgets.lua needs the global, and its parameters were renamed to "str" there.
- widgets.len now means COLUMNS, and the six variants become thin forwarders so no caller changes. That was an explicit requirement of the step: keep the Lua API names stable.
- Because widgets.len changed meaning, the callers that genuinely wanted CHARACTERS were moved to a new widgets.chars: textinput's caret math (input.cursor is a character offset, per node.rs) and 20_agent's chord-label single-character check. Using columns there would misplace the caret and would reject typing a CJK character.
- text.truncate takes opts as either the ellipsis string or a table with ellipsis and side (right, left or middle), so keep_left, keep_right and middle_truncate all forward to it. An unknown side, or an unknown pad align, RAISES rather than silently defaulting — the review's section 7 complains about exactly that class of silent failure.
- text.pad never truncates; what to do with over-wide text is the caller's choice.
- middle_truncate keeps its "width < 8" fall-back to end-truncation in Lua, because that is a UI judgement rather than a measurement.
- The "text" global was added to the GRANTED tripwire list in tests/kernel_mvp.rs deliberately; that test exists so a new global has to be declared.

Test-first was followed: both frames tests were written and shown failing on the pre-fix tree (the status sheared to "waiting for your re" with no ellipsis, and the agent border reading "[feat/" where the cut mark should be) before the fix landed.

Out of scope on purpose: step 3 of the series (text.style) is in flight on another branch and does not touch these length helpers, so no coordination was needed. Frames unrelated to double-width text are byte-identical.

Docs updated in the same commit: thurbox.yml (selene's stdlib), ui/lib/thurbox.d.lua (lua-language-server types), ui/README.md, docs/PLUGINS.md, and .claude/skills/thurbox-kernel/SKILL.md.

Verified locally before committing: full cargo nextest --all (2435 passed), clippy with -D warnings, selene, stylua, lua-language-server --check, scripts/ci/check-lua-types.sh, rumdl, and all 20 pre-commit hooks on a signed commit.

## What Changed

- Added a `text` global to the plugin API (`src/kernel/host/api.rs`) backed by `unicode-width`: `text.width` measures terminal columns, `text.truncate` cuts to a column budget with a configurable ellipsis and side (`right`/`left`/`middle`, raising on an unknown side), and `text.pad` pads without ever truncating. Declared in `thurbox.yml`'s selene stdlib, typed in `ui/lib/thurbox.d.lua`, and added to the `GRANTED` tripwire list in `tests/kernel_mvp.rs`.
- Reworked `ui/lib/widgets.lua` so `widgets.len` now measures columns (via `text.width`) instead of codepoints, and `truncate`, `truncate_hard`, `keep_left`, `keep_right`, and `middle_truncate` become thin forwarders onto `text.truncate`, fixing double-width (e.g. CJK) text being measured/cut incorrectly. Added `widgets.chars` for the character-offset use cases that genuinely need codepoints rather than columns.
- Updated `ui/lib/textinput.lua` (caret math) and `ui/plugins/20_agent.lua` (chord-label single-character check) to use the new `widgets.chars` instead of `widgets.len`, since caret position and single-character key checks are character-based, not column-based. Updated `ui/lib/chrome.lua`'s doc comment to reflect that `spans_len` now counts display columns.
- Added two `tests/frames.rs` regression cases pinning the fixed rendering (a session row's truncated status keeps its ellipsis, and the agent pane border no longer collides with a truncated title), and updated `tests/kernel_mvp.rs` and `tests/frames.rs` accordingly. Updated `docs/PLUGINS.md`, `ui/README.md`, `ui/AGENTS.md`, and `.claude/skills/thurbox-kernel/SKILL.md` to document the new `text` API.

## Risk Assessment

✅ Low: The previously flagged unbounded Rust-side allocation (text.pad with an attacker-controlled cols) is now bounded by MAX_COLS (1<<20), verified by a new unit test; the rest of the change is a faithful, well-tested column-width refactor with no behavioral regressions in the six widgets.* forwarders or the caret-vs-column split, and the only remaining issue is a narrow, currently-unreachable type-handling gap.

## Testing

Baseline `cargo nextest run --all` (2435 tests) already passed; on top of that I ran the 11 tests specific to this change (2 rendered-frame regression tests, 8 new src/kernel/host/api.rs unit tests including the review-1 MAX_COLS cap regression test, and the kernel_mvp.rs capability tripwire) and all 11 pass, with the two frames tests' actual rendered TUI output captured as evidence showing the CJK double-width truncation bug is fixed end-to-end.

<details>
<summary>Evidence: Rendered TUI frames (session row + agent pane border) with CJK double-width session name, showing correct column-budgeted truncation</summary>

```text
Rendered TUI frames captured by tests/frames.rs on target commit 0759208d
(feat/text-width-globals), confirming column-aware truncation with the new
text.width/truncate/pad global. Both tests below PASS against the actual
render pipeline (thurbox::kernel::paint::render + tui_term buffer -> text());
`assert_frame` compares the real rendered buffer to these exact strings, so
this is the literal on-screen output, not a hand-authored mock.

== test: a_double_width_name_budgets_the_status_by_the_columns_it_takes ==
Session row for a CJK session name ("修复终端宽度") with a trailing status
("waiting for your review"), rendered at 40x5. Before the fix, the status
budget was computed in codepoints (6) instead of columns (12), so the status
overran the row and the clip sheared it with no ellipsis. After the fix:

╭ Sessions ───────────────────────────○╮
│── thurbox ───────────────────────────│
│ ○ ⑂ 修复终端宽度  waiting for your r…│
│                                      │
╰──────────────────────────────────────╯

Note the trailing "…" — the row is correctly budgeted by columns and the cut
is marked.

== test: the_agent_pane_closes_its_border_over_a_double_width_name ==
Agent pane title with the same CJK session name and a branch ("feat/..."),
rendered at 60x4. Before the fix, the title's column budget was computed in
codepoints, so the title overflowed and the border's closing corner landed
on top of the "…" that marks the cut ("[feat/" with no visible corner).
After the fix:

╭ ◀ F9 ─ Agent ─ Shell · F8 ── 修复终端宽度 (claude) [feat…╮
│                     terminal surface                     │
│                       修复终端宽度                       │
╰──────────────────────────────────────────────────────────╯

The border now closes cleanly after the "…" mark.

Command: `cargo nextest run -E 'test(a_double_width_name_budgets_the_status_by_the_columns_it_takes) or test(the_agent_pane_closes_its_border_over_a_double_width_name)'`
Result: 2/2 passed.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"0759208dd9517f203a03d0e082b372c6b6b8f788","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `src/kernel/host/api.rs:689` - text.pad(s, cols, align) allocates a Rust-side String proportional to `cols` via &#34; &#34;.repeat(short)/format! (src/kernel/host/api.rs:689-700) before the result ever crosses into Lua. mlua&#39;s memory limit (set at src/kernel/host/load.rs:20 via memory_limit(), documented at src/kernel/host/mod.rs:89-90 as making an over-budget allocation &#39;fail... as a plugin error rather than aborting the process&#39;) only tracks allocations made through the Lua allocator, not this Rust-side `.repeat()`. A plugin calling `text.pad(s, cols)` (or `widgets.pad`) with a large-but-plausible `cols` (tens of millions to billions — well short of triggering Rust&#39;s capacity-overflow panic, which is catchable) drives a real heap allocation that, on failure, invokes Rust&#39;s global alloc-error handler and aborts the whole process — taking down every session, not just the offending plugin&#39;s pane, directly contradicting the stated per-plugin-failure-isolation design (docs/PLUGINS.md: &#39;that throws costs its own pane and nothing else&#39;). No current bundled caller passes an unbounded width, so this isn&#39;t triggered today, but the capability is now published to every interface plugin with no upper bound on `cols`. `truncate`&#39;s allocations stay bounded by the input string&#39;s own length regardless of `cols`, so this is specific to `pad`.

🔧 Fix: Cap text.pad/truncate cols to bound Rust-side allocation size
1 info still open:

- ℹ️ `src/kernel/host/api.rs:753` - text.truncate&#39;s `opts` argument is typed `Option&lt;Value&gt;` so it can accept a bare ellipsis string or a table; but the catch-all arm `_ =&gt; (ELLIPSIS.to_string(), Side::Right)` also matches any other Lua value a caller passes by mistake (a number, boolean, or function), silently falling back to the default ellipsis/side instead of raising. This is the same &#39;silent default on a misspelt/wrong option&#39; failure class the intent explicitly wants text.truncate/text.pad to avoid for unknown `side`/`align` strings (docs/PLUGINS.md section 7); the type-level version of that trap is unguarded. No current caller in ui/ hits this (all pass either omitted, a string, or a table), so it&#39;s not reachable today, but it&#39;s a one-line gap in the stated no-silent-default contract for future plugin authors.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `cargo nextest run --all`
- <code>`cargo nextest run -E &#39;test(a_double_width_name_budgets_the_status_by_the_columns_it_takes)&#39;` — session-row status budget honors CJK column width, ellipsis preserved</code>
- <code>`cargo nextest run -E &#39;test(the_agent_pane_closes_its_border_over_a_double_width_name)&#39;` — agent-pane title border closes correctly over a CJK name</code>
- <code>`cargo nextest run -E &#39;test(a_huge_cols_is_capped_rather_than_allocated_in_full)&#39;` — text.pad&#39;s cols argument is capped at 2^20 (MAX_COLS) so the underlying `&#34; &#34;.repeat(cols)` allocation stays bounded, addressing the review-1 finding about an uncapped Rust-side allocation escaping mlua&#39;s memory limit</code>
- <code>`cargo nextest run -E &#39;test(width_is_columns_and_not_bytes_or_characters)&#39;` — text.width counts columns, not bytes/codepoints</code>
- <code>`cargo nextest run -E &#39;test(a_cut_never_returns_more_columns_than_it_was_given)&#39;` — truncate never straddles a double-width glyph</code>
- <code>`cargo nextest run -E &#39;test(each_side_keeps_the_end_it_names)&#39;` — right/left/middle truncate sides</code>
- <code>`cargo nextest run -E &#39;test(a_budget_too_small_for_the_mark_holds_the_mark)&#39;` — ellipsis-only fallback when budget is tiny</code>
- <code>`cargo nextest run -E &#39;test(an_empty_mark_cuts_without_saying_so)&#39;` — empty ellipsis cuts silently</code>
- <code>`cargo nextest run -E &#39;test(pad_counts_columns_and_never_truncates)&#39;` — pad never shortens over-wide text</code>
- <code>`cargo nextest run -E &#39;test(an_unknown_side_or_align_is_refused)&#39;` — unknown side/align raises instead of silently defaulting</code>
- <code>`cargo nextest run -E &#39;test(the_granted_capability_set_matches_a_declared_list)&#39;` — &#34;text&#34; global is declared in the GRANTED tripwire list</code>
- <code>manual review of `git diff 2f469483..0759208d` for src/kernel/host/api.rs, tests/frames.rs, tests/kernel_mvp.rs to confirm the fix matches the user intent and the accepted review-1 finding</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
