### PR TITLE
feat(core): add frame title alignment, border type, overlay slots, and run identity

### DIFF
--- a/.claude/skills/thurbox-kernel/SKILL.md
+++ b/.claude/skills/thurbox-kernel/SKILL.md
@@ -23,7 +23,15 @@ deleted when the kernel took the binary name — v1 lives on the `v1.x` branch.
    which is what a selection bar or hover band is — no pane pads a row with a
    spacer span, and a span naming its own colour keeps it (a search hit stays
    visible under the bar). `widgets.list` exposes it as `selected_style` /
-   `hover_style`.
+   `hover_style`. A `frame` takes `title_align`, `border_type`
+   (`rounded`/`square`) and an `overlay` — runs painted onto its own border
+   cells (`top_left`/`top_right`/`bottom_left`/`bottom_right`/`right_column`)
+   after the block, which is where the session list's dot strip and `▲ N`/`▼ N`
+   counts and the terminal pane's scrollbar live, at the cost of no content
+   cell. And a **run** takes `id`/`role`, so a chip inside a line is a click
+   target over its own columns without becoming a node; adjacent runs sharing an
+   identity coalesce into one hitbox, which is what makes ` ◀ F9 ` — an accent
+   chevron and a muted hint — a single button.
 2. **Layout resolves before render** — rects are computed first, then each plugin
    is called with its own. Plugins declare size *statically*, in their declaration
    table, which is what breaks the circularity.
@@ -110,7 +118,8 @@ already follow.
   these groups.
 - **`ui/`** (Lua, not Rust) — `layout.lua` is the arrangement; `lib/` holds
   widgets, theme roles, fuzzy match, text input, trees — plus the extracted
-  pane halves: `chrome` (borders/cells), `modal` (frame + footer), `scroll`,
+  pane halves: `chrome` (the two full-height panes' focus styling), `modal`
+  (frame + footer), `scroll`,
   `order` and `session_model` (the session list's model, with its memo),
   `pathpicker` and `repo_picker` (the creation flow's); `plugins/` holds the
   panes.

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -438,6 +438,30 @@ it already does the right thing; a raw `input` node that never sets the flag
 draws no caret at all, which is visible at once. A caret guessed from the value
 being non-empty is not: it wanders to whichever field happens to hold text.
 
+Every kind takes a **`frame`**, and a frame is the whole border vocabulary:
+
+```lua
+frame = {
+  title = { { text = " Sessions ", style = badge } },  -- styled runs, not a string
+  title_align = "right",                               -- left | center | right
+  border_type = "square",                              -- rounded (default) | square
+  border_style = { fg = theme.accent },
+  padding = 1,
+  overlay = {
+    top_right = dots,        -- painted leftward from before the top-right corner
+    right_column = bar,      -- one run per inner row, down the right border
+  },
+}
+```
+
+`overlay` paints runs onto the frame's *own* border cells, after the block draws
+them — `top_left` and `top_right` along the top border, `bottom_left` and
+`bottom_right` along the bottom, `right_column` down the right one. A status
+strip, a `▲ N` scroll count or a scrollbar there costs no content cell, which is
+the reason it exists: the session list's dot strip and the terminal pane's
+scrollbar are both border cells, and every row of the pane stays a row. Each slot
+clips between the corners, which are never painted over.
+
 `surface` is the exception that proves the rule: it carries **cells**, for
 content positioned by character measurement rather than by structure — a live
 terminal, or a diff body. You place and frame it; the kernel fills it.
@@ -664,6 +688,23 @@ verb and the kernel answers it without calling you at all:
   view is brought forward.
 - `url:<link>` opens the link, and is the one verb that also changes how the
   node is *painted* — see below.
+
+A **run inside a line** carries `id`/`role` of its own, and becomes a target over
+the columns it is laid out at:
+
+```lua
+{ type = "text", text = { {
+  { text = " ◀ ", style = accent, role = "action:sessions.toggle_panel" },
+  { text = "F9 ", style = muted,  role = "action:sessions.toggle_panel" },
+} } }
+```
+
+so a chip inside a row needs no node of its own with a hand-counted `len`.
+Adjacent runs carrying the **same** identity coalesce into one hitbox — which is
+what makes that two-colour button one button rather than two halves the pointer
+has to find. It applies to a frame's overlay runs too: the terminal pane's
+scrollbar is one target the length of its column because every row of it names
+the same role.
 
 ### `url:` is a link, not just a click
 

--- a/src/kernel/convert.rs
+++ b/src/kernel/convert.rs
@@ -10,7 +10,8 @@ use mlua::{Table, Value};
 use ratatui::style::Style;
 
 use super::node::{
-    parse_color, Align, Axis, Borders, Frame, Identity, Node, Run, Size, SurfaceSource,
+    parse_color, Align, Axis, BorderKind, Borders, Frame, Identity, Node, Overlay, Run, Size,
+    SurfaceSource,
 };
 
 /// Where in the tree an error happened, built as a borrowed chain rather than a
@@ -337,10 +338,12 @@ fn read_lines(value: &Value, path: Crumb<'_>, depth: usize) -> Result<Vec<Vec<Ru
         Value::String(s) => Ok(vec![vec![Run {
             text: s.to_string_lossy(),
             style: Style::default(),
+            identity: None,
         }]]),
         Value::Integer(_) | Value::Number(_) | Value::Boolean(_) => Ok(vec![vec![Run {
             text: scalar_to_string(value),
             style: Style::default(),
+            identity: None,
         }]]),
         Value::Table(table) => {
             // `{ text = ..., style = ... }` is one line, not a list of lines.
@@ -375,10 +378,12 @@ fn read_runs(value: &Value, path: Crumb<'_>, depth: usize) -> Result<Vec<Run>, S
         Value::String(s) => Ok(vec![Run {
             text: s.to_string_lossy(),
             style: Style::default(),
+            identity: None,
         }]),
         Value::Integer(_) | Value::Number(_) | Value::Boolean(_) => Ok(vec![Run {
             text: scalar_to_string(value),
             style: Style::default(),
+            identity: None,
         }]),
         Value::Nil => Ok(Vec::new()),
         Value::Table(table) => {
@@ -396,6 +401,7 @@ fn read_runs(value: &Value, path: Crumb<'_>, depth: usize) -> Result<Vec<Run>, S
                 return Ok(vec![Run {
                     text,
                     style: read_style_field(table, "style", path)?,
+                    identity: read_run_identity(table, path)?,
                 }]);
             }
             let mut runs = Vec::new();
@@ -414,6 +420,24 @@ fn read_runs(value: &Value, path: Crumb<'_>, depth: usize) -> Result<Vec<Run>, S
             type_name(other)
         )),
     }
+}
+
+/// A run's own `id`/`role`, when it names either.
+///
+/// `class` is deliberately absent: a run is a click target, not a selector
+/// surface, and every read here costs a crossing into the VM per span per
+/// frame — the hottest leaf in the renderer.
+fn read_run_identity(table: &Table, path: Crumb<'_>) -> Result<Option<Box<Identity>>, String> {
+    let id = opt_string(table, "id", path)?;
+    let role = opt_string(table, "role", path)?;
+    if id.is_none() && role.is_none() {
+        return Ok(None);
+    }
+    Ok(Some(Box::new(Identity {
+        id,
+        classes: Vec::new(),
+        role,
+    })))
 }
 
 fn read_size(fields: &Fields, path: Crumb<'_>) -> Result<Size, String> {
@@ -490,12 +514,30 @@ fn read_frame(fields: &Fields, path: Crumb<'_>) -> Result<Option<Frame>, String>
                 )?),
                 Err(e) => return Err(format!("{path}.frame.title: {e}")),
             };
+            let border_type = match opt_string(&spec, "border_type", path)?.as_deref() {
+                Some("rounded") | None => BorderKind::Rounded,
+                // Two spellings for one shape: `square` is what the panes call
+                // it, `plain` is ratatui's name for the same corners.
+                Some("square") | Some("plain") => BorderKind::Square,
+                Some(other) => {
+                    return Err(format!(
+                    "{path}.frame.border_type: expected \"rounded\" or \"square\", found {other:?}"
+                ))
+                }
+            };
             Ok(Some(Frame {
                 title,
+                title_align: align_named(
+                    opt_string(&spec, "title_align", path)?.as_deref(),
+                    Crumb::Field(&path, "frame"),
+                    "title_align",
+                )?,
                 borders,
+                border_type,
                 border_style: read_style_field(&spec, "border_style", path)?,
                 style: read_style_field(&spec, "style", path)?,
                 padding: opt_u16(&spec, "padding", path)?.unwrap_or(0),
+                overlay: read_overlay(&spec, path)?,
             }))
         }
         ref other => Err(format!(
@@ -505,13 +547,52 @@ fn read_frame(fields: &Fields, path: Crumb<'_>) -> Result<Option<Frame>, String>
     }
 }
 
+/// The runs a frame paints onto its own border cells.
+fn read_overlay(spec: &Table, path: Crumb<'_>) -> Result<Option<Box<Overlay>>, String> {
+    let raw: Value = spec
+        .raw_get("overlay")
+        .map_err(|e| lua_err(path, "overlay", &e))?;
+    let Value::Table(table) = raw else {
+        return match raw {
+            Value::Nil => Ok(None),
+            ref other => Err(format!(
+                "{path}.frame.overlay: expected a table, found {}",
+                type_name(other)
+            )),
+        };
+    };
+    let crumb = Crumb::Field(&path, "frame");
+    let slot = |key: &'static str| -> Result<Vec<Run>, String> {
+        match table.raw_get::<Value>(key) {
+            Ok(Value::Nil) => Ok(Vec::new()),
+            Ok(value) => read_runs(&value, Crumb::Field(&crumb, key), 0),
+            Err(e) => Err(format!("{path}.frame.overlay.{key}: {e}")),
+        }
+    };
+    Ok(Some(Box::new(Overlay {
+        top_left: slot("top_left")?,
+        top_right: slot("top_right")?,
+        bottom_left: slot("bottom_left")?,
+        bottom_right: slot("bottom_right")?,
+        right_column: slot("right_column")?,
+    })))
+}
+
 fn read_align(fields: &Fields, path: Crumb<'_>) -> Result<Align, String> {
-    match val_string(fields.align.as_ref(), "align", path)?.as_deref() {
+    align_named(
+        val_string(fields.align.as_ref(), "align", path)?.as_deref(),
+        path,
+        "align",
+    )
+}
+
+fn align_named(value: Option<&str>, path: Crumb<'_>, key: &str) -> Result<Align, String> {
+    match value {
         Some("center") | Some("centre") => Ok(Align::Center),
         Some("right") => Ok(Align::Right),
         Some("left") | None => Ok(Align::Left),
         Some(other) => Err(format!(
-            "{path}.align: expected \"left\", \"center\" or \"right\", found {other:?}"
+            "{path}.{key}: expected \"left\", \"center\" or \"right\", found {other:?}"
         )),
     }
 }
@@ -769,6 +850,48 @@ fn style_to_lua(lua: &mlua::Lua, style: &Style) -> Result<Option<Table>, String>
     Ok(any.then_some(table))
 }
 
+/// One run as the table a plugin would have written, identity included.
+///
+/// Everything a run carries MUST round-trip, for the reason the styles below
+/// do: a decorator is handed the tree and returns one, so a field dropped here
+/// is dropped from the pane.
+fn run_to_lua(lua: &mlua::Lua, run: &Run) -> Result<Table, String> {
+    let entry = lua.create_table().map_err(|e| e.to_string())?;
+    entry
+        .set("text", run.text.clone())
+        .map_err(|e| e.to_string())?;
+    if let Some(style) = style_to_lua(lua, &run.style)? {
+        entry.set("style", style).map_err(|e| e.to_string())?;
+    }
+    if let Some(identity) = &run.identity {
+        if let Some(id) = &identity.id {
+            entry.set("id", id.clone()).map_err(|e| e.to_string())?;
+        }
+        if let Some(role) = &identity.role {
+            entry.set("role", role.clone()).map_err(|e| e.to_string())?;
+        }
+    }
+    Ok(entry)
+}
+
+/// A run list as the sequence of run tables `read_runs` reads back.
+fn runs_to_lua(lua: &mlua::Lua, runs: &[Run]) -> Result<Table, String> {
+    let out = lua.create_table().map_err(|e| e.to_string())?;
+    for (index, run) in runs.iter().enumerate() {
+        out.set(index + 1, run_to_lua(lua, run)?)
+            .map_err(|e| e.to_string())?;
+    }
+    Ok(out)
+}
+
+fn align_name(align: Align) -> &'static str {
+    match align {
+        Align::Left => "left",
+        Align::Center => "center",
+        Align::Right => "right",
+    }
+}
+
 pub fn to_lua(lua: &mlua::Lua, node: &Node) -> Result<Value, String> {
     let table = lua.create_table().map_err(|e| e.to_string())?;
     let set = |key: &str, value: Value| -> Result<(), String> {
@@ -809,9 +932,15 @@ pub fn to_lua(lua: &mlua::Lua, node: &Node) -> Result<Value, String> {
     }
     if let Some(frame) = node.frame() {
         let spec = lua.create_table().map_err(|e| e.to_string())?;
-        if let Some(text) = frame.title_text() {
-            spec.set("title", text).map_err(|e| e.to_string())?;
+        if let Some(title) = &frame.title {
+            // The runs, not `title_text()`: a title carries styled runs (the
+            // session list's badge, the agent pane's status word) and
+            // flattening it here would hand every decorated pane a plain one.
+            spec.set("title", runs_to_lua(lua, title)?)
+                .map_err(|e| e.to_string())?;
         }
+        spec.set("title_align", align_name(frame.title_align))
+            .map_err(|e| e.to_string())?;
         spec.set(
             "borders",
             match frame.borders {
@@ -820,6 +949,30 @@ pub fn to_lua(lua: &mlua::Lua, node: &Node) -> Result<Value, String> {
             },
         )
         .map_err(|e| e.to_string())?;
+        spec.set(
+            "border_type",
+            match frame.border_type {
+                BorderKind::Rounded => "rounded",
+                BorderKind::Square => "square",
+            },
+        )
+        .map_err(|e| e.to_string())?;
+        if let Some(overlay) = &frame.overlay {
+            let out = lua.create_table().map_err(|e| e.to_string())?;
+            for (key, runs) in [
+                ("top_left", &overlay.top_left),
+                ("top_right", &overlay.top_right),
+                ("bottom_left", &overlay.bottom_left),
+                ("bottom_right", &overlay.bottom_right),
+                ("right_column", &overlay.right_column),
+            ] {
+                if !runs.is_empty() {
+                    out.set(key, runs_to_lua(lua, runs)?)
+                        .map_err(|e| e.to_string())?;
+                }
+            }
+            spec.set("overlay", out).map_err(|e| e.to_string())?;
+        }
         spec.set("padding", frame.padding)
             .map_err(|e| e.to_string())?;
         if let Some(style) = style_to_lua(lua, &frame.border_style)? {
@@ -844,10 +997,6 @@ pub fn to_lua(lua: &mlua::Lua, node: &Node) -> Result<Value, String> {
             for (index, runs) in lines.iter().enumerate() {
                 let line = lua.create_table().map_err(|e| e.to_string())?;
                 for (span, run) in runs.iter().enumerate() {
-                    let entry = lua.create_table().map_err(|e| e.to_string())?;
-                    entry
-                        .set("text", run.text.clone())
-                        .map_err(|e| e.to_string())?;
                     // The style MUST round-trip. A decorator is handed the
                     // tree and returns one, so anything dropped here is
                     // dropped from the pane -- and a decorator that returns
@@ -855,25 +1004,13 @@ pub fn to_lua(lua: &mlua::Lua, node: &Node) -> Result<Value, String> {
                     // empty) would silently strip every colour the pane drew.
                     // That is exactly what happened: the session list rendered
                     // colourless because search decorates its slot.
-                    if let Some(style) = style_to_lua(lua, &run.style)? {
-                        entry.set("style", style).map_err(|e| e.to_string())?;
-                    }
-                    line.set(span + 1, entry).map_err(|e| e.to_string())?;
+                    line.set(span + 1, run_to_lua(lua, run)?)
+                        .map_err(|e| e.to_string())?;
                 }
                 out.set(index + 1, line).map_err(|e| e.to_string())?;
             }
             table.set("text", out).map_err(|e| e.to_string())?;
-            set(
-                "align",
-                string_value(
-                    lua,
-                    match align {
-                        Align::Left => "left",
-                        Align::Center => "center",
-                        Align::Right => "right",
-                    },
-                )?,
-            )?;
+            set("align", string_value(lua, align_name(*align))?)?;
             table.set("wrap", *wrap).map_err(|e| e.to_string())?;
             table.set("scroll", *scroll).map_err(|e| e.to_string())?;
             // Round-trips for the same reason a run's style does: a decorator
@@ -945,18 +1082,8 @@ pub fn to_lua(lua: &mlua::Lua, node: &Node) -> Result<Value, String> {
                     // the moment any decorator touches the pane.
                     let out = lua.create_table().map_err(|e| e.to_string())?;
                     for (index, runs) in lines.iter().enumerate() {
-                        let line = lua.create_table().map_err(|e| e.to_string())?;
-                        for (span, run) in runs.iter().enumerate() {
-                            let entry = lua.create_table().map_err(|e| e.to_string())?;
-                            entry
-                                .set("text", run.text.clone())
-                                .map_err(|e| e.to_string())?;
-                            if let Some(style) = style_to_lua(lua, &run.style)? {
-                                entry.set("style", style).map_err(|e| e.to_string())?;
-                            }
-                            line.set(span + 1, entry).map_err(|e| e.to_string())?;
-                        }
-                        out.set(index + 1, line).map_err(|e| e.to_string())?;
+                        out.set(index + 1, runs_to_lua(lua, runs)?)
+                            .map_err(|e| e.to_string())?;
                     }
                     table.set("cells", out).map_err(|e| e.to_string())?;
                 }

--- a/src/kernel/node.rs
+++ b/src/kernel/node.rs
@@ -162,6 +162,44 @@ impl ClickVerb {
     }
 }
 
+/// Runs painted onto a frame's own border cells, after the block is drawn.
+///
+/// The border row is chrome a pane wants to *layer* — the session list puts its
+/// status-dot strip on the top border and a `▲ N` count over the right end of
+/// it, the agent pane puts a tab strip on the left of the same row and a
+/// scrollbar down the right border column. Every one of those costs zero
+/// content cells, which is the whole reason they live on the border; expressing
+/// them without this meant composing the border out of `text` nodes and
+/// re-drawing what a block already knows how to draw.
+///
+/// Each slot is clipped to the cells between the corners, so an over-long strip
+/// loses its tail rather than eating the corner that makes a pane read as one.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Overlay {
+    /// Painted rightward from the cell after the top-left corner.
+    pub top_left: Vec<Run>,
+    /// Painted leftward from the cell before the top-right corner.
+    pub top_right: Vec<Run>,
+    pub bottom_left: Vec<Run>,
+    pub bottom_right: Vec<Run>,
+    /// One run per inner row, down the right border column. A shorter list
+    /// leaves the rows below it as border.
+    pub right_column: Vec<Run>,
+}
+
+/// Which glyphs a frame's border is drawn with.
+///
+/// Two, because two is what the bundled panes distinguish: rounded is the
+/// program's normal chrome and square is what the agent pane's empty state
+/// draws. `Square` is what the panes call it; `Plain` is ratatui's name for the
+/// same corners and is accepted as a second spelling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum BorderKind {
+    #[default]
+    Rounded,
+    Square,
+}
+
 /// A frame drawn around a node.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct Frame {
@@ -174,10 +212,16 @@ pub struct Frame {
     /// the list uses for *blocked*. `Run` and `to_line` already existed for text
     /// nodes; this is the same treatment.
     pub title: Option<Vec<Run>>,
+    /// Where the title sits along the top border.
+    pub title_align: Align,
     pub borders: Borders,
+    pub border_type: BorderKind,
     pub border_style: Style,
     pub style: Style,
     pub padding: u16,
+    /// Boxed because a frame is carried by every node that has one and almost
+    /// none of them overlay anything, and [`Node`] is built afresh every frame.
+    pub overlay: Option<Box<Overlay>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -198,6 +242,21 @@ pub enum Axis {
 pub struct Run {
     pub text: String,
     pub style: Style,
+    /// What this run alone can be targeted as, when it is not the whole node.
+    ///
+    /// Identity used to hang off [`Node`] only, so a clickable chip inside a
+    /// line had to become a `text` node of its own with a hand-computed `len` —
+    /// and a two-colour button (` ◀ F9 `: an accent chevron, a muted hint) came
+    /// out as two hitboxes with the pointer having to find one of them. The
+    /// paint walk already knows every run's column offset, so this is that
+    /// offset kept: adjacent runs sharing an identity coalesce into one [`Hit`],
+    /// which is what makes the two halves of that button one target.
+    ///
+    /// Boxed because it is absent from nearly every run, and a run is the
+    /// hottest allocation in the renderer — one per span per plugin per frame.
+    ///
+    /// [`Hit`]: super::paint::Hit
+    pub identity: Option<Box<Identity>>,
 }
 
 impl Run {
@@ -206,7 +265,14 @@ impl Run {
         Run {
             text: text.into(),
             style: Style::default(),
+            identity: None,
         }
+    }
+
+    /// The columns this run occupies when painted.
+    pub fn width(&self) -> u16 {
+        use unicode_width::UnicodeWidthStr;
+        u16::try_from(self.text.width()).unwrap_or(u16::MAX)
     }
 }
 
@@ -408,6 +474,7 @@ impl Node {
             lines: vec![vec![Run {
                 text: text.into(),
                 style,
+                identity: None,
             }]],
             align: Align::Left,
             wrap: true,

--- a/src/kernel/paint.rs
+++ b/src/kernel/paint.rs
@@ -716,7 +716,7 @@ fn record_run_hits(lines: &[Vec<Run>], area: Rect, align: Align, scroll: u16, hi
         let mut cursor = left
             + match align {
                 Align::Left => 0,
-                Align::Center => (i32::from(area.width) - width).max(0) / 2,
+                Align::Center => (i32::from(area.width) / 2 - width / 2).max(0),
                 Align::Right => (i32::from(area.width) - width).max(0),
             };
         let mut group: Option<(&Identity, i32, i32)> = None;

--- a/src/kernel/paint.rs
+++ b/src/kernel/paint.rs
@@ -8,14 +8,15 @@
 //! rect among children ([`super::node::divide`]) and recurses.
 
 use ratatui::buffer::{Buffer, CellDiffOption};
-use ratatui::layout::{Position, Rect};
+use ratatui::layout::{Alignment, Position, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::Line;
 use ratatui::widgets::{Block, BorderType, Borders as RatBorders, Clear, Paragraph, Wrap};
 use ratatui::Frame;
 
 use super::node::{
-    divide, to_line, Align, Axis, Borders, Frame as NodeFrame, Identity, Node, SurfaceSource,
+    divide, to_line, Align, Axis, BorderKind, Borders, Frame as NodeFrame, Identity, Node, Overlay,
+    Run, SurfaceSource,
 };
 
 /// A painted node that carried identity, and the rect it went into.
@@ -180,6 +181,9 @@ pub fn render_recording(
             let block = build_block(spec);
             let inner = block.inner(area);
             frame.render_widget(block, area);
+            if let (Some(overlay), Borders::All) = (spec.overlay.as_deref(), spec.borders) {
+                paint_overlay(frame.buffer_mut(), area, overlay, hits);
+            }
             pad(inner, spec.padding)
         }
         None => area,
@@ -211,6 +215,9 @@ pub fn render_recording(
                 paragraph = paragraph.wrap(Wrap { trim: false });
             }
             frame.render_widget(paragraph, inner);
+            if !*wrap {
+                record_run_hits(lines, inner, *align, *scroll, hits);
+            }
         }
 
         Node::Box {
@@ -445,7 +452,10 @@ fn build_block(spec: &NodeFrame) -> Block<'_> {
     block = match spec.borders {
         Borders::All => block
             .borders(RatBorders::ALL)
-            .border_type(BorderType::Rounded)
+            .border_type(match spec.border_type {
+                BorderKind::Rounded => BorderType::Rounded,
+                BorderKind::Square => BorderType::Plain,
+            })
             .border_style(spec.border_style),
         Borders::None => block.borders(RatBorders::NONE),
     };
@@ -472,9 +482,255 @@ fn build_block(spec: &NodeFrame) -> Block<'_> {
                 ratatui::text::Span::styled(run.text.as_str(), style)
             })
             .collect();
-        block = block.title(Line::from(spans));
+        block = block
+            .title(Line::from(spans))
+            .title_alignment(match spec.title_align {
+                Align::Left => Alignment::Left,
+                Align::Center => Alignment::Center,
+                Align::Right => Alignment::Right,
+            });
     }
     block
+}
+
+/// Paint a frame's overlay onto the border cells it just drew, recording a
+/// [`Hit`] for every run that names one.
+///
+/// After the block, because that is what "overlay" means: the strip, the counts
+/// and the scrollbar sit ON the cells the border occupies, so they cost no
+/// content column. Only a bordered frame has such cells, so a frame with
+/// `borders = "none"` overlays nothing.
+fn paint_overlay(buf: &mut Buffer, area: Rect, overlay: &Overlay, hits: &mut Vec<Hit>) {
+    if area.width < 2 || area.height < 1 {
+        return;
+    }
+    // The corners are never painted over: they are what makes a pane read as a
+    // pane, and v1's strips stop one cell short of each.
+    let left = i32::from(area.x) + 1;
+    let right = i32::from(area.right()) - 1;
+    let top = area.y;
+    paint_row(buf, top, left, right, &overlay.top_left, Align::Left, hits);
+    paint_row(
+        buf,
+        top,
+        left,
+        right,
+        &overlay.top_right,
+        Align::Right,
+        hits,
+    );
+    let bottom = area.bottom() - 1;
+    if bottom > top {
+        let slots = [
+            (&overlay.bottom_left, Align::Left),
+            (&overlay.bottom_right, Align::Right),
+        ];
+        for (runs, align) in slots {
+            paint_row(buf, bottom, left, right, runs, align, hits);
+        }
+    }
+    if area.height > 2 {
+        paint_column(
+            buf,
+            area.right() - 1,
+            area.y + 1,
+            bottom,
+            &overlay.right_column,
+            hits,
+        );
+    }
+}
+
+/// Paint `runs` along row `y`, clipped to the columns `[left, right)`.
+///
+/// Columns are `i32` because a right-aligned strip that does not fit starts
+/// left of the frame: keeping the arithmetic signed is what makes it lose its
+/// HEAD rather than its tail, which is what right-aligned means.
+fn paint_row(
+    buf: &mut Buffer,
+    y: u16,
+    left: i32,
+    right: i32,
+    runs: &[Run],
+    align: Align,
+    hits: &mut Vec<Hit>,
+) {
+    if runs.is_empty() || left >= right {
+        return;
+    }
+    let total: i32 = runs.iter().map(|run| i32::from(run.width())).sum();
+    let mut cursor = match align {
+        Align::Right => right - total,
+        _ => left,
+    };
+    let mut group: Option<(&Identity, i32, i32)> = None;
+    for run in runs {
+        let start = cursor;
+        cursor += i32::from(run.width());
+        let from = start.max(left);
+        let to = cursor.min(right);
+        if from < to {
+            let text = clip_left(&run.text, (from - start) as u16);
+            buf.set_stringn(from as u16, y, text, (to - from) as usize, run.style);
+        }
+        group = extend(group, run, start, cursor, |identity, from, to| {
+            push_hit(hits, identity, from.max(left), to.min(right), y, 1);
+        });
+    }
+    if let Some((identity, from, to)) = group {
+        push_hit(hits, identity, from.max(left), to.min(right), y, 1);
+    }
+}
+
+/// Paint one run per row down column `x`, from `top` up to (not including)
+/// `bottom`. A shorter list leaves the rows under it as border.
+fn paint_column(
+    buf: &mut Buffer,
+    x: u16,
+    top: u16,
+    bottom: u16,
+    runs: &[Run],
+    hits: &mut Vec<Hit>,
+) {
+    let mut group: Option<(&Identity, i32, i32)> = None;
+    for (index, run) in runs.iter().enumerate() {
+        let Ok(offset) = u16::try_from(index) else {
+            break;
+        };
+        let y = top.saturating_add(offset);
+        if y >= bottom {
+            break;
+        }
+        buf.set_stringn(x, y, &run.text, 1, run.style);
+        group = extend(
+            group,
+            run,
+            i32::from(y),
+            i32::from(y) + 1,
+            |identity, from, to| {
+                push_hit(
+                    hits,
+                    identity,
+                    i32::from(x),
+                    i32::from(x) + 1,
+                    from as u16,
+                    (to - from) as u16,
+                );
+            },
+        );
+    }
+    if let Some((identity, from, to)) = group {
+        push_hit(
+            hits,
+            identity,
+            i32::from(x),
+            i32::from(x) + 1,
+            from as u16,
+            (to - from) as u16,
+        );
+    }
+}
+
+/// Grow the open group of adjacent runs sharing an identity, flushing it
+/// through `emit` when this run starts a different one.
+///
+/// Adjacency is what makes ` ◀ F9 ` — an accent chevron and a muted hint, two
+/// runs because a run carries one style — a single hitbox rather than two with
+/// the pointer having to find one of them.
+fn extend<'a>(
+    group: Option<(&'a Identity, i32, i32)>,
+    run: &'a Run,
+    start: i32,
+    end: i32,
+    emit: impl FnOnce(&Identity, i32, i32),
+) -> Option<(&'a Identity, i32, i32)> {
+    let identity = run.identity.as_deref();
+    match (group, identity) {
+        (Some((open, from, to)), Some(next)) if open == next && to == start => {
+            Some((open, from, end))
+        }
+        (open, next) => {
+            if let Some((open, from, to)) = open {
+                emit(open, from, to);
+            }
+            next.map(|next| (next, start, end))
+        }
+    }
+}
+
+fn push_hit(hits: &mut Vec<Hit>, identity: &Identity, from: i32, to: i32, y: u16, height: u16) {
+    if from >= to || height == 0 {
+        return;
+    }
+    hits.push(Hit {
+        rect: Rect {
+            x: from as u16,
+            y,
+            width: (to - from) as u16,
+            height,
+        },
+        identity: identity.clone(),
+    });
+}
+
+/// Drop the first `columns` display columns of `text`.
+///
+/// A wide character straddling the cut goes whole, which is what the cell
+/// buffer this replaces did with an out-of-range cell.
+fn clip_left(text: &str, columns: u16) -> &str {
+    if columns == 0 {
+        return text;
+    }
+    use unicode_width::UnicodeWidthChar;
+    let mut used = 0u16;
+    for (index, ch) in text.char_indices() {
+        if used >= columns {
+            return &text[index..];
+        }
+        used = used.saturating_add(u16::try_from(ch.width().unwrap_or(0)).unwrap_or(0));
+    }
+    ""
+}
+
+/// Record a [`Hit`] for every run that names an identity, at the columns the
+/// paragraph will lay it out at.
+///
+/// Only for an unwrapped node: with `wrap` on, ratatui decides where a line
+/// breaks, and a hitbox computed from the unwrapped columns would sit over
+/// cells the run never reached.
+fn record_run_hits(lines: &[Vec<Run>], area: Rect, align: Align, scroll: u16, hits: &mut Vec<Hit>) {
+    let left = i32::from(area.x);
+    let right = i32::from(area.right());
+    for (index, runs) in lines.iter().enumerate().skip(usize::from(scroll)) {
+        if runs.iter().all(|run| run.identity.is_none()) {
+            continue;
+        }
+        let Ok(row) = u16::try_from(index - usize::from(scroll)) else {
+            break;
+        };
+        if row >= area.height {
+            break;
+        }
+        let y = area.y + row;
+        let width: i32 = runs.iter().map(|run| i32::from(run.width())).sum();
+        let mut cursor = left
+            + match align {
+                Align::Left => 0,
+                Align::Center => (i32::from(area.width) - width).max(0) / 2,
+                Align::Right => (i32::from(area.width) - width).max(0),
+            };
+        let mut group: Option<(&Identity, i32, i32)> = None;
+        for run in runs {
+            let start = cursor;
+            cursor += i32::from(run.width());
+            group = extend(group, run, start, cursor, |identity, from, to| {
+                push_hit(hits, identity, from.max(left), to.min(right), y, 1);
+            });
+        }
+        if let Some((identity, from, to)) = group {
+            push_hit(hits, identity, from.max(left), to.min(right), y, 1);
+        }
+    }
 }
 
 /// Shrink a rect by `padding` on every side, never past zero.

--- a/tests/decoration.rs
+++ b/tests/decoration.rs
@@ -31,6 +31,7 @@ fn styled_tree() -> Node {
             Run {
                 text: "○ ".into(),
                 style: Style::default().fg(Color::Green),
+                identity: None,
             },
             Run {
                 text: "fix-osc52".into(),
@@ -38,6 +39,7 @@ fn styled_tree() -> Node {
                     .fg(Color::White)
                     .bg(Color::Indexed(24))
                     .add_modifier(Modifier::BOLD),
+                identity: None,
             },
         ]],
         align: Default::default(),
@@ -126,6 +128,7 @@ fn an_unstyled_run_stays_unstyled() {
         lines: vec![vec![Run {
             text: "plain".into(),
             style: Style::default(),
+            identity: None,
         }]],
         align: Default::default(),
         wrap: false,
@@ -145,7 +148,9 @@ fn an_unstyled_run_stays_unstyled() {
 /// flattened to plain text.
 #[test]
 fn every_field_survives_the_trip_out_and_back() {
-    use thurbox::kernel::node::{Align, Axis, Borders, Frame, Size, SurfaceSource};
+    use thurbox::kernel::node::{
+        Align, Axis, BorderKind, Borders, Frame, Overlay, Size, SurfaceSource,
+    };
 
     let framed = Node::Box {
         axis: Axis::Horizontal,
@@ -159,11 +164,35 @@ fn every_field_survives_the_trip_out_and_back() {
             max: Some(9),
         },
         frame: Some(Frame {
-            title: Some(vec![thurbox::kernel::node::Run::plain("Panel")]),
+            title: Some(vec![Run {
+                text: "Panel".into(),
+                style: Style::default().fg(Color::Cyan),
+                identity: None,
+            }]),
+            title_align: Align::Right,
             borders: Borders::All,
+            border_type: BorderKind::Square,
             border_style: Style::default().fg(Color::Magenta),
             style: Style::default().bg(Color::Indexed(17)),
             padding: 1,
+            // The border overlay round-trips too, and a run's identity with it:
+            // the session list's dot strip and the agent pane's tab chips live
+            // here, and the search pane decorates both.
+            overlay: Some(Box::new(Overlay {
+                top_left: vec![Run {
+                    text: " ◀ F9 ".into(),
+                    style: Style::default().fg(Color::Blue),
+                    identity: Some(Box::new(Identity {
+                        id: None,
+                        classes: Vec::new(),
+                        role: Some("action:sessions.toggle_panel".into()),
+                    })),
+                }],
+                top_right: vec![Run::plain("●")],
+                bottom_left: Vec::new(),
+                bottom_right: vec![Run::plain("▼ 2 ")],
+                right_column: vec![Run::plain("█")],
+            })),
         }),
         children: vec![
             Node::Text {
@@ -174,6 +203,7 @@ fn every_field_survives_the_trip_out_and_back() {
                 lines: vec![vec![Run {
                     text: "scrolled".into(),
                     style: Style::default(),
+                    identity: None,
                 }]],
                 align: Align::Right,
                 wrap: true,
@@ -198,10 +228,12 @@ fn every_field_survives_the_trip_out_and_back() {
                     Run {
                         text: "+ added".into(),
                         style: Style::default().fg(Color::Green),
+                        identity: None,
                     },
                     Run {
                         text: " tail".into(),
                         style: Style::default().fg(Color::Red),
+                        identity: None,
                     },
                 ]]),
             },

--- a/tests/frames.rs
+++ b/tests/frames.rs
@@ -713,6 +713,34 @@ fn the_agent_pane_with_nothing_selected() {
 }
 
 #[test]
+fn the_no_session_title_takes_the_borders_muted_colour_not_the_terminals_default() {
+    // The one deliberate visible change of the frame-parity work: this title
+    // used to go through chrome.lua's hand-drawn cell buffer, which never
+    // passed it a colour, so it painted in the terminal's own default
+    // foreground. Routed through frame.title instead, build_block's existing
+    // "an unstyled run takes the border's colour" rule now reaches it, so the
+    // 'N' of "No Session" carries the same fg as the border it sits in rather
+    // than Color::Reset.
+    let host = host();
+    publish(&host, &snapshot(Vec::new()));
+    let buffer = paint(&host, "agent", 50, 8, true);
+    let row = text(&buffer);
+    let title_x = row[0].find('N').expect("the title is on the top border") as u16;
+    let border_x = row[0].find('─').expect("the border has a horizontal rule") as u16;
+    let title_fg = buffer[(title_x, 0)].fg;
+    assert_ne!(
+        title_fg,
+        Color::Reset,
+        "the title must not fall back to the terminal's own default"
+    );
+    assert_eq!(
+        title_fg,
+        buffer[(border_x, 0)].fg,
+        "the title and the border it sits in share one colour"
+    );
+}
+
+#[test]
 fn the_agent_pane_before_its_session_is_attached() {
     // Nothing live behind the surface, so it draws the detached notice — the
     // frame a fresh boot shows before the first attach lands.

--- a/tests/frames.rs
+++ b/tests/frames.rs
@@ -512,6 +512,112 @@ fn a_span_keeps_the_colour_it_names_over_the_node_style() {
     );
 }
 
+#[test]
+fn a_frame_title_takes_the_alignment_it_asks_for() {
+    // The reason two panes drew their borders by hand: a title could only sit at
+    // the left, so a right-aligned session title meant composing the row out of
+    // `text` nodes.
+    let left = paint_lua_node(r#"{ text = "", frame = { title = "T" } }"#, 8, 3);
+    let centre = paint_lua_node(
+        r#"{ text = "", frame = { title = "T", title_align = "center" } }"#,
+        8,
+        3,
+    );
+    let right = paint_lua_node(
+        r#"{ text = "", frame = { title = "T", title_align = "right" } }"#,
+        8,
+        3,
+    );
+    assert_frame(
+        &[
+            text(&left)[0].clone(),
+            text(&centre)[0].clone(),
+            text(&right)[0].clone(),
+        ],
+        &[
+            "\u{256d}T\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{256e}",
+            "\u{256d}\u{2500}\u{2500}T\u{2500}\u{2500}\u{2500}\u{256e}",
+            "\u{256d}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}T\u{256e}",
+        ],
+    );
+}
+
+#[test]
+fn a_frame_draws_the_border_type_it_asks_for() {
+    // `square` is what the panes call it and `plain` is ratatui's name for the
+    // same corners; the agent pane's empty state is the one that wants them.
+    assert_frame(
+        &text(&paint_lua_node(r#"{ text = "", frame = true }"#, 4, 3)),
+        &[
+            "\u{256d}\u{2500}\u{2500}\u{256e}",
+            "\u{2502}  \u{2502}",
+            "\u{2570}\u{2500}\u{2500}\u{256f}",
+        ],
+    );
+    for spelling in ["square", "plain"] {
+        assert_frame(
+            &text(&paint_lua_node(
+                &format!(r#"{{ text = "", frame = {{ border_type = "{spelling}" }} }}"#),
+                4,
+                3,
+            )),
+            &[
+                "\u{250c}\u{2500}\u{2500}\u{2510}",
+                "\u{2502}  \u{2502}",
+                "\u{2514}\u{2500}\u{2500}\u{2518}",
+            ],
+        );
+    }
+}
+
+const OVERLAY_NODE: &str = r#"{
+    text = "",
+    frame = {
+      overlay = {
+        top_left = { { text = "ab" } },
+        top_right = { { text = "cd" } },
+        bottom_left = { { text = "ef" } },
+        bottom_right = { { text = "gh" } },
+        right_column = { { text = "x" }, { text = "y" } },
+      },
+    },
+  }"#;
+
+#[test]
+fn a_frame_overlay_paints_onto_the_border_cells() {
+    // The other half of what the hand-drawn chrome was for: the session list's
+    // dot strip and its scroll counts, and the agent pane's scrollbar in the
+    // border column, all of which cost zero content cells.
+    assert_frame(
+        &text(&paint_lua_node(OVERLAY_NODE, 10, 4)),
+        &[
+            "\u{256d}ab\u{2500}\u{2500}\u{2500}\u{2500}cd\u{256e}",
+            "\u{2502}        x",
+            "\u{2502}        y",
+            "\u{2570}ef\u{2500}\u{2500}\u{2500}\u{2500}gh\u{256f}",
+        ],
+    );
+}
+
+#[test]
+fn an_overlay_never_paints_over_a_corner() {
+    // An over-long strip clips at the corner rather than eating it: the corners
+    // are what makes a pane read as a pane.
+    let buffer = paint_lua_node(
+        r#"{ text = "", frame = { overlay = { top_left = { { text = "abcdefgh" } } } } }"#,
+        6,
+        3,
+    );
+    assert_frame(
+        &text(&buffer),
+        &[
+            "\u{256d}abcd\u{256e}",
+            "\u{2502}    \u{2502}",
+            "\u{2570}\u{2500}\u{2500}\u{2500}\u{2500}\u{256f}",
+        ],
+    );
+}
+
 /// A one-off pane in a materialized copy of the bundled interface, so a `lib/`
 /// widget can be held to its painted output without a bundled pane adopting it.
 fn paint_probe(render_body: &str, hovered: Option<&str>, width: u16, height: u16) -> Buffer {

--- a/tests/mouse.rs
+++ b/tests/mouse.rs
@@ -250,13 +250,10 @@ fn only_identified_nodes_become_targets() {
 
 #[test]
 fn the_collapse_toggle_is_one_target_covering_its_chevron_and_its_hint() {
-    // The label is ` ◀ F9 ` and it is ONE button. It has to be two nodes — a node
+    // The label is ` ◀ F9 ` and it is ONE button. It has to be two runs — a run
     // carries one style, and the chevron reads accent while the hint reads muted
-    // — so both carry the same role, and the click registry answers either.
-    //
-    // Before this, only the three-cell chevron was a target: the pointer had to
-    // find the arrow inside a six-cell label, which is the "increased click size"
-    // this fixes.
+    // — so both carry the same role, and the paint walk coalesces them into one
+    // hitbox over the whole label.
     let hits = hits_of("agent", 113, 10);
     let toggle: Vec<&Hit> = hits
         .iter()
@@ -267,20 +264,107 @@ fn the_collapse_toggle_is_one_target_covering_its_chevron_and_its_hint() {
 
     assert_eq!(
         toggle.len(),
-        2,
-        "the chevron and its hint are both targets: {:?}",
+        1,
+        "the chevron and its hint are one target: {:?}",
         toggle.iter().map(|hit| hit.rect).collect::<Vec<_>>()
     );
-    let covered: u16 = toggle.iter().map(|hit| hit.rect.width).sum();
-    assert_eq!(covered, 6, "` ◀ F9 ` is six cells wide: {covered}");
-    // Adjacent, so there is no dead cell between the halves.
-    let mut rects: Vec<Rect> = toggle.iter().map(|hit| hit.rect).collect();
-    rects.sort_by_key(|rect| rect.x);
     assert_eq!(
-        rects[0].x + rects[0].width,
-        rects[1].x,
-        "the two halves must touch: {rects:?}"
+        toggle[0].rect.width, 6,
+        "` ◀ F9 ` is six cells wide: {:?}",
+        toggle[0].rect
     );
+}
+
+/// Convert a Lua node table and record the hits painting it declares.
+fn hits_for(source: &str, width: u16, height: u16) -> Vec<Hit> {
+    let lua = mlua::Lua::new();
+    let value: mlua::Value = lua.load(source).eval().expect("the table evaluates");
+    let node = thurbox::kernel::convert::to_node(&value, "plugins/90_test.lua")
+        .expect("the table converts");
+    let mut hits = Vec::new();
+    let mut terminal = Terminal::new(TestBackend::new(width, height)).expect("terminal");
+    terminal
+        .draw(|frame| render_recording(frame, frame.area(), &node, &PlaceholderSurfaces, &mut hits))
+        .expect("draw");
+    hits
+}
+
+#[test]
+fn a_run_that_names_a_role_is_a_target_over_its_own_columns() {
+    // Identity used to hang off the node alone, so a clickable chip inside a
+    // line forced the row to be exploded into one sized node per run. The paint
+    // walk already knows each run's column offset; this is that offset kept.
+    let hits = hits_for(
+        r#"{ text = { { { text = "ab" }, { text = "cd", role = "action:go" }, { text = "ef" } } } }"#,
+        10,
+        1,
+    );
+    assert_eq!(hits.len(), 1, "only the run carries identity: {hits:#?}");
+    assert_eq!(
+        hits[0].identity.click_verb(),
+        Some(ClickVerb::Action("go".into()))
+    );
+    assert_eq!(hits[0].rect, Rect::new(2, 0, 2, 1));
+}
+
+#[test]
+fn adjacent_runs_sharing_an_identity_are_one_target() {
+    // ` ◀ F9 ` is one button in two colours — a run carries one style, so it has
+    // to be two runs — and a hitbox per run gave it a hole in the middle.
+    let hits = hits_for(
+        r#"{ text = { { { text = " ◀ ", role = "action:go" }, { text = "F9 ", role = "action:go" } } } }"#,
+        10,
+        1,
+    );
+    assert_eq!(hits.len(), 1, "one button, one target: {hits:#?}");
+    assert_eq!(hits[0].rect, Rect::new(0, 0, 6, 1));
+}
+
+#[test]
+fn a_run_hit_stops_at_the_edge_of_the_node_that_holds_it() {
+    // A row wider than its rect clips rather than declaring a target over cells
+    // it never painted.
+    let hits = hits_for(
+        r#"{ text = { { { text = "ab" }, { text = "cdef", role = "action:go" } } } }"#,
+        4,
+        1,
+    );
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].rect, Rect::new(2, 0, 2, 1));
+}
+
+#[test]
+fn an_overlay_run_is_a_target_on_the_border_it_paints_on() {
+    // The chips the agent pane puts on its top border, and the scrollbar it
+    // puts in the right border column: the column is ONE target, so a press
+    // arrives with `y` the row of the bar and `h` its length.
+    let hits = hits_for(
+        r#"{
+             text = "",
+             frame = {
+               overlay = {
+                 top_left = { { text = "ab", role = "action:go" } },
+                 right_column = {
+                   { text = "x", role = "drag" },
+                   { text = "y", role = "drag" },
+                 },
+               },
+             },
+           }"#,
+        8,
+        4,
+    );
+    let chip = hits
+        .iter()
+        .find(|hit| hit.identity.click_verb() == Some(ClickVerb::Action("go".into())))
+        .expect("the chip is a target");
+    assert_eq!(chip.rect, Rect::new(1, 0, 2, 1));
+
+    let bar = hits
+        .iter()
+        .find(|hit| hit.identity.is_drag_handle())
+        .expect("the bar is a target");
+    assert_eq!(bar.rect, Rect::new(7, 1, 1, 2));
 }
 
 #[test]

--- a/tests/mouse.rs
+++ b/tests/mouse.rs
@@ -334,6 +334,34 @@ fn a_run_hit_stops_at_the_edge_of_the_node_that_holds_it() {
 }
 
 #[test]
+fn a_center_aligned_run_hit_lines_up_with_where_ratatui_paints_it() {
+    // ratatui halves the area and the run width independently before
+    // subtracting (Paragraph's get_line_offset), not `(area - width) / 2` —
+    // the two diverge whenever area and run width differ in parity, which
+    // used to shift the hitbox a column left of the glyph it names.
+    let lua = mlua::Lua::new();
+    let value: mlua::Value = lua
+        .load(r#"{ text = { { { text = "x", role = "action:go" } } }, align = "center" }"#)
+        .eval()
+        .expect("the table evaluates");
+    let node = thurbox::kernel::convert::to_node(&value, "plugins/90_test.lua")
+        .expect("the table converts");
+    let mut hits = Vec::new();
+    let mut terminal = Terminal::new(TestBackend::new(4, 1)).expect("terminal");
+    terminal
+        .draw(|frame| render_recording(frame, frame.area(), &node, &PlaceholderSurfaces, &mut hits))
+        .expect("draw");
+
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].rect, Rect::new(2, 0, 1, 1));
+    assert_eq!(
+        terminal.backend().buffer()[(hits[0].rect.x, 0)].symbol(),
+        "x",
+        "the hitbox must sit under the glyph ratatui actually painted"
+    );
+}
+
+#[test]
 fn an_overlay_run_is_a_target_on_the_border_it_paints_on() {
     // The chips the agent pane puts on its top border, and the scrollbar it
     // puts in the right border column: the column is ONE target, so a press

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -13,6 +13,14 @@ the whole rect, so a bar reaches the right edge without a padding span and a
 span that names its own colour survives it. `widgets.list` exposes the same
 thing as `selected_style` / `hover_style`.
 
+A second: a border is a **`frame`**, never hand-drawn cells. It takes styled
+title runs, `title_align`, `border_type` and an `overlay` that paints onto its
+own border cells (`top_left`/`top_right`/`bottom_left`/`bottom_right`/
+`right_column`) — a status strip, a scroll count or a scrollbar there costs no
+content cell. And a run inside a line carries its own `id`/`role`, so a chip is a
+click target without becoming a sized node; adjacent runs sharing an identity are
+one hitbox.
+
 ## "Install a plugin" means `thurbox-cli plugin install`
 
 A *plugin* here is a thurbox interface pane, not a package from a language

--- a/ui/README.md
+++ b/ui/README.md
@@ -12,7 +12,7 @@ works and one that fails at runtime with nothing on screen to say why.
 ```text
 layout.lua      the arrangement: which slots exist, and where
 lib/            shared helpers — widgets, theme roles, fuzzy match, text input,
-                border chrome, modal shells, scrolling, and the session-list
+                focus styling, modal shells, scrolling, and the session-list
                 and repo-picker models
 lib/thurbox.d.lua   the API as types: node props, ctx, the event payloads, every
                 published `thurbox.*` row, every command verb's options, and the
@@ -161,6 +161,22 @@ the base functions (`pairs`, `ipairs`, `type`, `tostring`, `tonumber`, `select`,
 | `run(key, cmd, opts)` | run a program and read its output — **only if trusted**, see below |
 | `files` | bounded reads the kernel performs for you |
 | `thurbox.platform` | `os` and `arch`, so a plugin shipping several builds can pick one |
+
+**Borders**: a node's `frame` is the whole border vocabulary — `title` (styled
+runs, not a bare string), `title_align`, `border_type` (`rounded` or `square`),
+`border_style`, `padding`, and `overlay`. The overlay paints runs onto the
+frame's *own* border cells after the block draws them —
+`top_left`/`top_right`/`bottom_left`/`bottom_right` along the horizontal borders
+and `right_column` one run per inner row down the right one — so a status strip,
+a scroll count or a scrollbar costs no content cell. Slots clip between the
+corners, which are never painted over.
+
+**Clickable spans**: a run inside a line takes `id`/`role` of its own and becomes
+a target over the columns it is laid out at, so a chip needs no node with a
+hand-computed `len`. Adjacent runs carrying the same identity coalesce into one
+hitbox — which is how ` ◀ F9 `, two runs because a run has one style, stays one
+button. It applies to overlay runs too: that is what makes the terminal pane's
+scrollbar one target the length of its column.
 
 **Dragging**: a node with `role = "drag"` takes hold of the pointer — the press
 arms no text selection and every move until release arrives as a further

--- a/ui/lib/chrome.lua
+++ b/ui/lib/chrome.lua
@@ -1,18 +1,15 @@
--- Hand-drawn border chrome.
+-- What the two full-height panes agree on about their borders.
 --
--- Two bundled panes draw their borders BY HAND rather than with a kernel
--- `frame`, because a frame's title is a plain, unstyled, left-aligned string
--- and cannot express what v1 puts on a border: the focused title *badge*
--- (inverted fg on an accent background), a right-aligned styled title, the
--- per-session status-dot strip, scroll counts overlaid on the border cells, or
--- a scrollbar in the border column. Composing the border out of `text` nodes
--- costs nothing — the border rows are the rows a frame would have occupied —
--- and stays inside the four-kind vocabulary.
---
--- This module is the half those panes must agree on: the span/cell primitives
--- border segments are layered with, the focus styling both map the same three
--- levels through, and the framed-pane builder the terminal pane composes its
--- chrome from. What stays in each pane is its own layout decisions.
+-- The borders themselves are ordinary kernel `frame`s. They were once drawn by
+-- hand, out of `text` nodes and a cell buffer, because a frame's title was a
+-- plain unstyled left-aligned string and there was no way to put anything else
+-- on a border cell. A frame now takes styled title runs, a `title_align`, a
+-- `border_type` and an `overlay` — the strip, the scroll counts and the
+-- scrollbar all paint onto the border cells the block drew — so the cell buffer
+-- and the framed-pane builder are gone and what is left here is the agreement:
+-- the three focus levels both panes map through, and the box-drawing set the
+-- agent pane's hint box still draws by hand because it is a box INSIDE a pane,
+-- not a frame around one.
 
 local theme = require("lib.theme")
 local widgets = require("lib.widgets")
@@ -28,68 +25,6 @@ function chrome.spans_len(spans)
     total = total + widgets.len(span.text or "")
   end
   return total
-end
-
--- ── Cell buffers ────────────────────────────────────────────────────────────
---
--- A border row is built as a cell buffer so segments can be *layered* the way
--- v1 layers them: the dot strip is a right-aligned title, and the scroll count
--- is painted over the same cells afterwards.
-
-function chrome.new_cells(width, char, style)
-  local cells = {}
-  for index = 1, width do
-    cells[index] = { ch = char, style = style }
-  end
-  return cells
-end
-
---- Paint `text` into the buffer starting at `at` (1-based). Out-of-range cells
---- are dropped, which is how an over-long title clips at either edge.
-function chrome.place_text(cells, at, text, style)
-  local index = at
-  for _, code in utf8.codes(text or "") do
-    if index >= 1 and index <= #cells then
-      cells[index] = { ch = utf8.char(code), style = style }
-    end
-    index = index + 1
-  end
-  return index
-end
-
-function chrome.place_spans(cells, at, spans)
-  local index = at
-  for _, span in ipairs(spans) do
-    index = chrome.place_text(cells, index, span.text, span.style)
-  end
-  return index
-end
-
---- Coalesce the buffer back into spans. Styles are compared by identity, which
---- is exact here because every segment is painted with one shared style table.
----
---- Each run's characters accumulate in a buffer and concatenate once at flush:
---- a border row is mostly one long run of `─`, and appending to a string per
---- cell was O(width²) byte copying — ~200 intermediate strings per border at
---- 200 columns, twice per render.
-function chrome.cells_to_spans(cells)
-  local spans, buffer, current_style = {}, nil, nil
-  local function flush()
-    if buffer then
-      spans[#spans + 1] = { text = table.concat(buffer), style = current_style }
-    end
-  end
-  for _, cell in ipairs(cells) do
-    if buffer and cell.style == current_style then
-      buffer[#buffer + 1] = cell.ch
-    else
-      flush()
-      buffer = { cell.ch }
-      current_style = cell.style
-    end
-  end
-  flush()
-  return spans
 end
 
 -- ── Focus styling ───────────────────────────────────────────────────────────
@@ -125,135 +60,8 @@ function chrome.title_style(level)
   return { fg = theme.border }
 end
 
--- ── The framed pane ─────────────────────────────────────────────────────────
-
-chrome.ROUNDED = { tl = "╭", tr = "╮", bl = "╰", br = "╯", h = "─", v = "│" }
+--- The square box-drawing set, for a box a pane draws INSIDE itself out of
+--- text — where there is no frame to ask for `border_type = "square"`.
 chrome.SQUARE = { tl = "┌", tr = "┐", bl = "└", br = "┘", h = "─", v = "│" }
-
---- The top border as a NODE, not a run list.
----
---- Identity is per node, so a chip painted as one span among many can never be
---- a click target however it is styled. When any run carries a `role`, the row
---- becomes a horizontal box of one text node per run, each with an exact `len`
---- so the geometry is bit-identical to the single-node form.
-local function top_row_node(runs)
-  local clickable = false
-  for _, run in ipairs(runs) do
-    if run.role then
-      clickable = true
-      break
-    end
-  end
-  if not clickable then
-    return { type = "text", len = 1, text = { runs } }
-  end
-
-  local children = {}
-  for _, run in ipairs(runs) do
-    local width = widgets.len(run.text)
-    if width > 0 then
-      children[#children + 1] = {
-        type = "text",
-        len = width,
-        role = run.role,
-        text = { { { text = run.text, style = run.style } } },
-      }
-    end
-  end
-  return { type = "box", axis = "horizontal", len = 1, children = children }
-end
-
---- A bordered pane whose title can be right-aligned and styled, and whose right
---- border column can be replaced row-by-row (that is where a scrollbar goes).
----
---- opts: width, height, title, title_style, title_align, border_style, square,
----       left (runs painted over the top border's left half),
----       right_column (runs, one per inner row),
----       right_column_role (identity for that column, so it can be clicked),
----       body (node)
-function chrome.frame(opts)
-  local width, height = opts.width or 0, opts.height or 0
-  if width < 2 or height < 2 then
-    return opts.body
-  end
-
-  local set = opts.square and chrome.SQUARE or chrome.ROUNDED
-  local border = opts.border_style
-  local inner_w, inner_h = width - 2, height - 2
-
-  local title = opts.title or ""
-  local top
-  if opts.title_align == "right" then
-    -- The strip is painted first and the title fills what it leaves, so the two
-    -- share one row without either being drawn over the other.
-    local left, left_w = opts.left or {}, 0
-    for _, run in ipairs(left) do
-      left_w = left_w + widgets.len(run.text)
-    end
-    title = widgets.keep_right(title, math.max(0, inner_w - left_w))
-    top = { { text = set.tl, style = border } }
-    for _, run in ipairs(left) do
-      top[#top + 1] = run
-    end
-    top[#top + 1] = {
-      text = string.rep(set.h, math.max(0, inner_w - left_w - widgets.len(title))),
-      style = border,
-    }
-    top[#top + 1] = { text = title, style = opts.title_style }
-    top[#top + 1] = { text = set.tr, style = border }
-  else
-    title = widgets.keep_left(title, inner_w)
-    top = {
-      { text = set.tl, style = border },
-      { text = title, style = opts.title_style },
-      { text = string.rep(set.h, inner_w - widgets.len(title)), style = border },
-      { text = set.tr, style = border },
-    }
-  end
-
-  local edge = { text = set.v, style = border }
-  --- One border column, `inner_h` rows tall.
-  ---
-  --- `role` is what makes it a click target: identity is per node, and this is
-  --- one node for the whole column, so a press arrives with `y` already being
-  --- the row of the bar it landed on and `h` the length of the bar. A column
-  --- with no role is inert chrome, which is what the left edge is.
-  local function column(rows, role)
-    local lines = {}
-    for row = 1, inner_h do
-      lines[row] = { (rows and rows[row]) or edge }
-    end
-    return { type = "text", len = 1, role = role, text = lines }
-  end
-
-  return {
-    type = "box",
-    axis = "vertical",
-    children = {
-      top_row_node(top),
-      {
-        type = "box",
-        axis = "horizontal",
-        fill = 1,
-        children = {
-          column(nil),
-          opts.body,
-          column(opts.right_column, opts.right_column and opts.right_column_role),
-        },
-      },
-      {
-        type = "text",
-        len = 1,
-        text = {
-          {
-            { text = set.bl, style = border },
-            { text = string.rep(set.h, inner_w), style = border },
-            { text = set.br, style = border },
-          },
-        },
-      },
-    },
-  }
-end
 
 return chrome

--- a/ui/lib/thurbox.d.lua
+++ b/ui/lib/thurbox.d.lua
@@ -41,9 +41,16 @@
 ---@alias thurbox.StyleSpec thurbox.Color|thurbox.Style
 
 --- One styled run within a line.
+---
+--- `id`/`role` make the run itself a click target over the columns it is laid
+--- out at, so a chip inside a line needs no node of its own. Adjacent runs
+--- carrying the SAME identity coalesce into one hitbox, which is how a
+--- two-colour button (` ◀ F9 `) stays one target.
 ---@class thurbox.Span
 ---@field text string|number|boolean
 ---@field style? thurbox.StyleSpec
+---@field id? string
+---@field role? string
 
 --- One line: a bare string, one span, or a list of spans.
 ---@alias thurbox.Line string|number|boolean|thurbox.Span|thurbox.Span[]
@@ -51,14 +58,28 @@
 --- What a `text` node or a frame title accepts: one line, or a list of them.
 ---@alias thurbox.Text thurbox.Line|thurbox.Line[]
 
---- A frame drawn around a node. `borders` is all-or-none and the border type is
---- fixed; there is no `title_align`.
+--- Runs painted onto a frame's own border cells, after the block is drawn.
+---
+--- Border cells cost no content row or column, which is why the status-dot
+--- strip, the `▲ N`/`▼ N` scroll counts and the terminal scrollbar live here.
+--- Each slot is clipped between the corners, which are never painted over.
+---@class thurbox.Overlay
+---@field top_left? thurbox.Text Rightward from the cell after the top-left corner.
+---@field top_right? thurbox.Text Leftward from the cell before the top-right corner.
+---@field bottom_left? thurbox.Text
+---@field bottom_right? thurbox.Text
+---@field right_column? thurbox.Text One run per inner row, down the right border column.
+
+--- A frame drawn around a node. `borders` is all-or-none.
 ---@class thurbox.Frame
 ---@field title? thurbox.Text
+---@field title_align? "left"|"center"|"centre"|"right"
 ---@field borders? "all"|"none"
+---@field border_type? "rounded"|"square"|"plain"
 ---@field border_style? thurbox.StyleSpec
 ---@field style? thurbox.StyleSpec
 ---@field padding? integer
+---@field overlay? thurbox.Overlay
 
 --- What every node may say about its space and its identity.
 ---

--- a/ui/plugins/10_sessions.lua
+++ b/ui/plugins/10_sessions.lua
@@ -11,14 +11,12 @@
 -- dot strip on the top border, and the `▲ N`/`▼ N` scroll indicators overlaid on
 -- the border rows.
 --
--- WHY THE BORDER IS DRAWN BY HAND. `Frame.title` is a plain, unstyled,
--- left-aligned string, so a frame cannot express any of the three things v1 puts
--- on its border: the focused title *badge* (inverted fg on an accent
--- background), the right-aligned per-session status dots, or the scroll counts
--- overlaid on the border cells. Drawing a header line inside the frame would
--- cost a content row and so would not be parity. Composing the border out of
--- `text` nodes costs nothing — the border rows are the rows the frame would have
--- occupied — and stays inside the four-kind vocabulary.
+-- The border is an ordinary kernel `frame`. It was drawn by hand, out of a cell
+-- buffer, for as long as a frame title was a plain unstyled left-aligned string
+-- — a frame could express none of the three things v1 puts on this border. It
+-- can now: the title is styled runs, so the focused badge is a title; the dot
+-- strip and the scroll counts are `frame.overlay`, painted onto the border cells
+-- after the block, which is what keeps them off the content rows.
 
 local chrome = require("lib.chrome")
 local fuzzy = require("lib.fuzzy")
@@ -31,11 +29,11 @@ local session_model = require("lib.session_model")
 local theme = require("lib.theme")
 local widgets = require("lib.widgets")
 
--- ── The model, the border chrome and the ordering algebra live in lib/ ──────
+-- ── The model, the focus styling and the ordering algebra live in lib/ ──────
 --
 -- `lib.session_model` builds the item list (one selectable unit per row, with
 -- the group header glued to its group's first session), `lib.chrome` holds the
--- cell primitives and focus styles the hand-drawn border is composed from, and
+-- focus levels this pane and the terminal pane map their borders through, and
 -- `lib.order` is the move/sort algebra over the rendered items. All three are
 -- pure over what this pane hands them; everything about how a row LOOKS stays
 -- here.
@@ -464,6 +462,31 @@ local function persist_order(items)
   end
 end
 
+--- `glyph N ` right-aligned over the tail of `strip`.
+---
+--- v1 LAYERS the two: the count is painted onto border cells the dot strip
+--- already occupies, so it covers the last dots rather than pushing them left.
+--- One right-aligned run list says the same thing, and the dots it would have
+--- covered are dropped here instead of overwritten there.
+local function with_count(strip, glyph, count)
+  if count <= 0 then
+    return strip
+  end
+  local text = glyph .. " " .. count .. " "
+  local keep = chrome.spans_len(strip) - widgets.len(text)
+  local runs, used = {}, 0
+  for _, run in ipairs(strip) do
+    local width = widgets.len(run.text)
+    if used + width > keep then
+      break
+    end
+    used = used + width
+    runs[#runs + 1] = run
+  end
+  runs[#runs + 1] = { text = text, style = { fg = theme.muted } }
+  return runs
+end
+
 return {
   name = "sessions",
   slot = "sessions",
@@ -682,35 +705,21 @@ return {
       end
     end
 
-    -- One edge node shared by every row this render: the `│` cells are
-    -- identical within a frame, and building two four-deep tables per row was
-    -- pure churn (the agent pane's `edge` upvalue is the same pattern).
-    local edge = { type = "text", len = 1, text = { { { text = "│", style = frame_style } } } }
     local function row(line)
       line = line or {}
       return {
-        type = "box",
-        axis = "horizontal",
+        type = "text",
         len = 1,
-        children = {
-          edge,
-          {
-            type = "text",
-            fill = 1,
-            text = { line.spans or {} },
-            -- The row's own style covers this rect and this rect only: the
-            -- edges are siblings, so a selection bar reaches the border and
-            -- never paints over it.
-            style = line.style,
-            id = line.id,
-            class = line.class,
-            -- Decoration (the search plugin) finds rows by this role, and only
-            -- the content is inside it — so a highlight can never repaint the
-            -- border cells.
-            role = line.id and "row" or nil,
-          },
-          edge,
-        },
+        text = { line.spans or {} },
+        -- The row's own style covers this rect and this rect only, and the rect
+        -- is the frame's inner width — so a selection bar reaches the border and
+        -- never paints over it.
+        style = line.style,
+        id = line.id,
+        class = line.class,
+        -- Decoration (the search plugin) finds rows by this role, and only the
+        -- content is inside it — so a highlight can never repaint the border.
+        role = line.id and "row" or nil,
       }
     end
 
@@ -783,37 +792,25 @@ return {
     end
 
     local children = {}
-
-    -- Top border: the title badge at the left, the dot strip right-aligned, and
-    -- the "items above" count painted over it — the same layering v1 gets from
-    -- a right-aligned title plus a paragraph drawn on the border cells.
-    local top = chrome.new_cells(width, "─", frame_style)
-    top[1] = { ch = "╭", style = frame_style }
-    top[width] = { ch = "╮", style = frame_style }
-    chrome.place_spans(top, 2, { { text = " Sessions ", style = chrome.title_style(level) } })
-    if #dots > 0 then
-      chrome.place_spans(top, width - chrome.spans_len(dots), dots)
-    end
-    if above > 0 then
-      local text = "▲ " .. above .. " "
-      chrome.place_text(top, width - widgets.len(text), text, { fg = theme.muted })
-    end
-    children[#children + 1] = { type = "text", len = 1, text = { chrome.cells_to_spans(top) } }
-
     for index = 1, inner_height do
       children[#children + 1] = row(lines[index])
     end
 
-    local bottom = chrome.new_cells(width, "─", frame_style)
-    bottom[1] = { ch = "╰", style = frame_style }
-    bottom[width] = { ch = "╯", style = frame_style }
-    if below > 0 then
-      local text = "▼ " .. below .. " "
-      chrome.place_text(bottom, width - widgets.len(text), text, { fg = theme.muted })
-    end
-    children[#children + 1] = { type = "text", len = 1, text = { chrome.cells_to_spans(bottom) } }
-
-    return { type = "box", children = children }
+    -- The title badge at the left, the dot strip right-aligned on the same row
+    -- with the "items above" count over its tail, and "items below" on the
+    -- bottom border — every one of them a border cell, so none costs a row.
+    return {
+      type = "box",
+      children = children,
+      frame = {
+        title = { { text = " Sessions ", style = chrome.title_style(level) } },
+        border_style = frame_style,
+        overlay = {
+          top_right = with_count(dots, "▲", above),
+          bottom_right = with_count({}, "▼", below),
+        },
+      },
+    }
   end,
 
   --- Go to a session you just made, when you asked to be taken there.

--- a/ui/plugins/20_agent.lua
+++ b/ui/plugins/20_agent.lua
@@ -18,13 +18,13 @@
 --
 -- Replace this file and you have replaced the central pane.
 --
--- The chrome here is drawn BY HAND rather than with `widgets.panel`, because
--- v1's terminal pane needs three things the kernel's `frame` cannot express:
+-- The chrome here is an ordinary kernel `frame`. It was drawn by hand for as
+-- long as a frame could not express the three things v1's terminal pane needs:
 -- a RIGHT-aligned border title, a STYLED one (the focused badge is
 -- inverted_fg-on-accent), and a scrollbar overlaid on the right border column
--- so it costs zero content columns. A framed node hands its whole inner rect to
--- one child, which forecloses all three. Composing the border out of `text`
--- nodes keeps every one of them and still uses only the four primitives.
+-- so it costs zero content columns. `title_align`, styled title runs and
+-- `frame.overlay` are each of those, so the border is one table again and the
+-- surface keeps the whole inner rect.
 
 local chrome = require("lib.chrome")
 local panels = require("lib.panels")
@@ -271,6 +271,14 @@ end
 
 -- --- the scrollbar ---------------------------------------------------------
 
+--- The role the scrollbar column carries.
+---
+--- The kernel's own spelling for "a press here takes hold of the pointer", so
+--- the moves that follow reach this pane instead of painting a text selection
+--- across the terminal the bar is about to scroll. This pane has one draggable,
+--- so the bare role identifies it; a pane with two would tell them apart by `id`.
+local DRAG = "drag"
+
 local SCROLLBAR = { begin_ = "▲", end_ = "▼", track = "║", thumb = "█" }
 
 --- Integer divide, rounding to nearest — ratatui's `rounding_divide`.
@@ -340,11 +348,13 @@ local function scrollbar_rows(height, content_len, viewport, position)
   local track_end = track_length - (thumb_start + thumb_length)
 
   -- The caps carry no style in v1 (ratatui leaves begin/end unstyled); the
-  -- track and thumb do.
-  local track_run = { text = SCROLLBAR.track, style = { fg = theme.muted } }
-  local thumb_run = { text = SCROLLBAR.thumb, style = { fg = theme.accent } }
+  -- track and thumb do. Every row carries `DRAG`, and adjacent runs sharing an
+  -- identity coalesce into ONE hitbox — which is what makes the bar a single
+  -- target the length of the column rather than one target per row.
+  local track_run = { text = SCROLLBAR.track, style = { fg = theme.muted }, role = DRAG }
+  local thumb_run = { text = SCROLLBAR.thumb, style = { fg = theme.accent }, role = DRAG }
 
-  local rows = { { text = SCROLLBAR.begin_ } }
+  local rows = { { text = SCROLLBAR.begin_, role = DRAG } }
   for _ = 1, thumb_start do
     rows[#rows + 1] = track_run
   end
@@ -354,7 +364,7 @@ local function scrollbar_rows(height, content_len, viewport, position)
   for _ = 1, track_end do
     rows[#rows + 1] = track_run
   end
-  rows[#rows + 1] = { text = SCROLLBAR.end_ }
+  rows[#rows + 1] = { text = SCROLLBAR.end_, role = DRAG }
   return rows
 end
 
@@ -368,19 +378,12 @@ local function bar_content_len(depth)
   return depth + 1
 end
 
---- The role the scrollbar column carries.
----
---- The kernel's own spelling for "a press here takes hold of the pointer", so
---- the moves that follow reach this pane instead of painting a text selection
---- across the terminal the bar is about to scroll. This pane has one draggable,
---- so the bare role identifies it; a pane with two would tell them apart by `id`.
-local DRAG = "drag"
-
 --- A press or a drag on the scrollbar, mapped back to a scroll offset.
 ---
---- The bar is one node for the whole column, so `hit.y` is already the row of
---- the bar under the pointer and `hit.h` its length — which is the only reason a
---- `pure` pane can answer this at all, since `render` may not stash geometry.
+--- Every row of the bar carries the same role, so the paint walk coalesces them
+--- into one hitbox: `hit.y` is already the row of the bar under the pointer and
+--- `hit.h` its length — which is the only reason a `pure` pane can answer this
+--- at all, since `render` may not stash geometry.
 local function scrollbar_grab(id, hit)
   local surface = surface_of(id, tab_of(id))
   local scroll, depth = scroll_of(surface)
@@ -623,10 +626,10 @@ end
 --- at 1, exactly where v1 puts the chevron rect (`terminal.x + 1`).
 local function border_strip(width, border_style, active)
   local runs, cursor = {}, 1
-  --- `role`, when given, is the kernel's click verb for this run. It only
-  --- reaches the hit registry if the run becomes a node of its own, which is
-  --- what `chrome` does with a tagged run -- identity is per NODE, so a chip
-  --- painted as one span among many is unclickable however it is styled.
+  --- `role`, when given, is the kernel's click verb for this run: a run carries
+  --- its own identity and the paint walk registers a hitbox over the columns it
+  --- laid the run out at. The `─` filler between chips is what puts each one at
+  --- the column it belongs at, since the overlay paints its runs consecutively.
   local function put(at, text, style, role)
     if at > cursor then
       runs[#runs + 1] = { text = string.rep("─", at - cursor), style = border_style }
@@ -640,11 +643,11 @@ local function border_strip(width, border_style, active)
     -- The chevron and its ` F9 ` hint are ONE affordance in two colours: the
     -- chevron reads accent, the hint muted.
     --
-    -- They are two runs — a run is one node and a node has one style — but both
-    -- carry the SAME role, so the kernel hit-tests them as one target. Without
-    -- that the hint was inert: not clickable, and not lit when the pointer was
-    -- over it, which made the button feel like it had a three-cell hitbox in the
-    -- middle of a six-cell label.
+    -- They are two runs — a run has one style — but both carry the SAME role,
+    -- and adjacent runs sharing an identity coalesce into one hitbox, so the
+    -- kernel hit-tests them as one target. Without that the hint was inert: not
+    -- clickable, and not lit when the pointer was over it, which made the button
+    -- feel like it had a three-cell hitbox in the middle of a six-cell label.
     local toggle = "action:sessions.toggle_panel"
     -- v1: "a button by action but a bare border glyph by look, so it takes the
     -- subtle band too" — a filled pill here would invent a chip on the border
@@ -691,11 +694,19 @@ local function border_strip(width, border_style, active)
   return runs, cursor
 end
 
--- --- hand-drawn chrome -----------------------------------------------------
---
--- The framed-pane builder itself is `chrome.frame` (`lib/chrome.lua`), shared
--- with the session list's border helpers. What stays here is what this pane
--- puts ON that frame: the strip above, the scrollbar, and the titles.
+--- This pane's border: a right-aligned styled title, the tab strip painted over
+--- the top border's left half, and the scrollbar down the right border column.
+---
+--- All three are border cells, which is the point — the surface underneath
+--- keeps the full inner rect, exactly as v1 insets the terminal vertically only.
+local function border_frame(title, level, border, strip, bar)
+  return {
+    title = { { text = title, style = chrome.title_style(level) } },
+    title_align = "right",
+    border_style = border,
+    overlay = { top_left = strip, right_column = bar },
+  }
+end
 
 -- --- the empty pane --------------------------------------------------------
 
@@ -858,15 +869,13 @@ return {
     -- No session: v1 switches to a different frame entirely — SQUARE borders,
     -- a muted left-aligned " No Session " title, and the hint box.
     if not session then
-      return chrome.frame({
-        width = width,
-        height = height,
-        square = true,
-        title = " No Session ",
-        title_align = "left",
+      local body = empty_body(math.max(0, width - 2), math.max(0, height - 2))
+      body.frame = {
+        title = { { text = " No Session " } },
+        border_type = "square",
         border_style = { fg = theme.muted },
-        body = empty_body(math.max(0, width - 2), math.max(0, height - 2)),
-      })
+      }
+      return body
     end
 
     -- v1 draws neither the chevron nor the tabs on the empty welcome screen, so
@@ -891,19 +900,12 @@ return {
     -- deliberate v2 addition — styled `danger`, the role for a thing that is
     -- broken, rather than the working-yellow it used to borrow.
     if session.attach_error then
-      return chrome.frame({
-        width = width,
-        height = height,
-        title = title,
-        title_align = "right",
-        title_style = chrome.title_style(level),
-        border_style = border,
-        left = strip,
-        body = centered({
-          { { text = "no live terminal", style = { fg = theme.bad, bold = true } } },
-          { { text = session.attach_error, style = { fg = theme.muted } } },
-        }),
+      local body = centered({
+        { { text = "no live terminal", style = { fg = theme.bad, bold = true } } },
+        { { text = session.attach_error, style = { fg = theme.muted } } },
       })
+      body.frame = border_frame(title, level, border, strip)
+      return body
     end
 
     -- The bar overlays the right border column, so the terminal grid keeps the
@@ -921,25 +923,15 @@ return {
       )
     end
 
-    return chrome.frame({
-      width = width,
-      height = height,
-      title = title,
-      title_align = "right",
-      title_style = chrome.title_style(level),
-      border_style = border,
-      left = strip,
-      right_column = rows,
-      right_column_role = DRAG,
-      -- The shell is a second surface over the same primitive, addressed as
-      -- `<id>#shell` — no new node kind, and the kernel resolves the suffix.
-      body = {
-        type = "surface",
-        session = surface,
-        scroll = scroll,
-        fill = 1,
-      },
-    })
+    -- The shell is a second surface over the same primitive, addressed as
+    -- `<id>#shell` — no new node kind, and the kernel resolves the suffix.
+    return {
+      type = "surface",
+      session = surface,
+      scroll = scroll,
+      fill = 1,
+      frame = border_frame(title, level, border, strip, rows),
+    }
   end,
 
   -- The palette's rows (Ctrl+P). None of these spends a chord: the tabs are


### PR DESCRIPTION
## Intent

Step 5 of the Lua-UI series (2026-09-04 review, §2 problems 3 and 5, §5 step 5): frame parity, so two bundled panes stop drawing their borders by hand.

The goal: a plugin author, human or LLM, can produce a clean consistent pane with little code. The rule kept throughout the series is that the four node kinds (text, box, input, surface) stay four — every improvement arrives as a prop on an existing kind, a global, or a Lua lib. Steps 1-3 (thurbox.d.lua types #1070, widgets.list overflow #1069, text.style #1071) are already in the base; step 4 (text width globals, ui/lib/widgets.lua length helpers + src/kernel/host/api.rs) was in flight on another branch and was deliberately left untouched here.

Three source comments claimed a frame title is 'plain, unstyled, left-aligned' (ui/lib/chrome.lua, 10_sessions.lua, 20_agent.lua headers). The 'unstyled' half was already false — titles take styled runs. What was genuinely missing, and is added here in src/kernel/{node,convert,paint}.rs:
- frame.title_align (left|center|right), a Block::title_alignment call.
- frame.border_type (rounded|square; 'plain' accepted as ratatui's own spelling for square) — the border type was hard-coded Rounded.
- frame.overlay = { top_left, top_right, bottom_left, bottom_right, right_column }: runs painted onto the frame's own border cells AFTER the block. The review names left/right/right_column; bottom_left/bottom_right were added because the session list's 'items below' count lives on the bottom border and the three named slots could not express it. Slots clip between the corners, which are never painted over.
- Run-level identity: a Run carries optional id/role and paint.rs registers a Hit per run from the column offsets it already computes. Adjacent runs sharing an identity coalesce into ONE hitbox — that is deliberate and is the point: the agent pane's ' <chevron> F9 ' collapse toggle is two runs because a run has one style, and it used to be two hitboxes with a documented complaint about a three-cell hitbox in a six-cell label. tests/mouse.rs's existing test asserting two targets was updated to assert one, matching its own name.

Everything new round-trips through convert::to_lua, including a title's RUNS — to_lua was flattening a title through title_text(), which would have stripped the session list's title badge the moment the search pane decorated it (search decorates both of these panes, and there is a recorded incident of exactly this class).

Then the Lua side: ui/lib/chrome.lua loses its cell buffer (new_cells/place_text/place_spans/cells_to_spans), top_row_node and chrome.frame — 259 lines down to 64, now only the focus levels the two panes agree on plus the SQUARE glyph set the agent pane's hint box still needs (that box is drawn inside a pane, not around one). 10_sessions.lua's 27 lines of border assembly become one frame table with an overlay; 20_agent.lua's three chrome.frame calls become three frame tables. The three stale comments are fixed.

Frames are byte-identical throughout — tests/frames.rs and tests/session_list.rs pin them cell for cell and pass unchanged. The one deliberate visible change: the agent pane's ' No Session ' title took the terminal's default foreground (chrome.frame was never passed a title_style there) and now takes the border's muted colour, which is what that pane's own comment already claimed and what build_block does for every unstyled title run.

Tests were written first and failed for the right reason before any implementation: four new frames.rs tests (title alignment, border type, overlay painting, corner clipping) and four new mouse.rs tests (a run-level target, coalescing, clipping at the node edge, overlay/scrollbar targets), plus the decoration.rs round-trip test extended to carry title_align, border_type, an overlay and a run identity.

Docs updated in the same PR per the repo rule: docs/PLUGINS.md (frame vocabulary + clickable runs), ui/README.md, ui/AGENTS.md, .claude/skills/thurbox-kernel/SKILL.md and ui/lib/thurbox.d.lua. thurbox.yml needed no change: it is selene's standard library and declares globals and thurbox.* fields, not node/frame table keys, and this adds no global.

Gated locally before pushing: just lint (fmt, clippy -D warnings, deny, rumdl, shellcheck, selene, stylua, lua-language-server, check-lua-types) and just test (2439 tests, all passing), plus the full 20-hook prek pre-commit run on a signed commit. PR/commit scope must be core or ui — never 'kernel'.

## What Changed

- Added `frame.title_align` (left/center/right), `frame.border_type` (rounded/square/plain), and `frame.overlay` (top_left/top_right/bottom_left/bottom_right/right_column) to the node/convert/paint pipeline in `src/kernel/node.rs`, `src/kernel/convert.rs`, and `src/kernel/paint.rs`, so a frame's border can be painted declaratively instead of by hand.
- Added run-level identity (`id`/`role`) so `paint.rs` registers one coalesced hitbox per identity across adjacent runs, and fixed `convert::to_lua` to round-trip a title's styled runs instead of flattening them through `title_text()`.
- Rewrote `ui/lib/chrome.lua` to drop its manual cell-buffer border drawing (`new_cells`/`place_text`/`place_spans`/`cells_to_spans`, `top_row_node`, `chrome.frame`), shrinking it from 259 to 64 lines, and converted `ui/plugins/10_sessions.lua` and `ui/plugins/20_agent.lua` to build frame tables with overlays instead of assembling borders manually.
- Extended `tests/frames.rs`, `tests/mouse.rs`, and `tests/decoration.rs` to cover title alignment, border type, overlay painting/clipping, and single-hitbox run coalescing; updated `docs/PLUGINS.md`, `ui/README.md`, `ui/AGENTS.md`, `ui/lib/thurbox.d.lua`, and the `thurbox-kernel` skill to document the new frame vocabulary.

## Risk Assessment

✅ Low: The round-1 finding (center-align hitbox off-by-one due to a formula mismatch with ratatui's get_line_offset) is fixed correctly — I verified the new formula `(area.width/2 - width/2).max(0)` is byte-for-byte what ratatui-widgets 0.3.2's Paragraph actually uses, and the added regression test asserts the hit rect against the real painted glyph. I re-reviewed the full diff (node.rs, convert.rs, paint.rs, chrome.lua, 10_sessions.lua, 20_agent.lua, and all test/doc files) for correctness: overlay clipping/corner-preservation math, run-identity coalescing (paint_row/paint_column/extend/push_hit), the Lua-side dots/count layering (with_count) and border_frame wiring, and the to_lua round-trip for title runs and overlay all check out against the stated intent, with no dangling references to the removed chrome.lua cell-buffer API and no thurbox.yml/architecture_rules drift needed. All new tests render real buffers or drive real hit-testing rather than grepping source, satisfying the test-quality rule.

## Testing

Ran the frame-parity feature's own new/updated test suite (frames.rs, mouse.rs, decoration.rs, session_list.rs — 56 tests) on top of the passing baseline `cargo nextest run --all`; all pass, including the center-align hitbox-parity regression test tied to the prior review finding. Found one gap: the intent's single deliberate visual change (the agent pane's empty-state title taking the border's muted colour instead of the terminal default) had no colour-asserting test since the pinned frame literals in frames.rs are text-only, so I added a small focused test that renders the real bundled pane and asserts the title's fg matches the border's fg rather than Color::Reset — verified it actually distinguishes old vs. new behavior by checking the base commit's chrome.lua never applied a title style on that path. That test passes; no other findings.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"da0a89ebe47e6b9fac826d580bf82725497e8e56","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `ui/lib/chrome.lua` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `src/kernel/paint.rs:719` - record_run_hits computes the center-align x-offset for a text node&#39;s run hitboxes as `(area.width - width).max(0) / 2`, but ratatui&#39;s own Paragraph rendering (get_line_offset in ratatui-widgets) computes `area.width/2 - width/2` (each halved independently, then subtracted). These two formulas diverge whenever area.width and the run-text width have different parity (verified exhaustively: e.g. area width=4, run text width=1 cell — real paint offset is 2, this code computes 1; area width=4, width=3 — real is 1, this computes 0). For a center-aligned, non-wrapped text node whose identified run(s) hit this parity case, the registered click Hit rect sits one column to the left of where the text is actually painted, so a click on the real rightmost cell of the text misses, and a click one cell left of the text (blank space) wrongly registers. No currently shipped bundled pane combines `align=&#34;center&#34;` with a run `role`/`id` (the only center-aligned text in 20_agent.lua&#39;s `centered()` helper carries no identity), so no existing frames/mouse test catches this, but the run-identity + text.align combination is a documented, general-purpose part of the public Lua node API this PR ships (ui/lib/thurbox.d.lua, docs/PLUGINS.md), so any plugin author combining them hits a silently wrong hitbox.

🔧 Fix: placeholder
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `cargo nextest run --all`
- `cargo nextest run -E 'test(a_frame_title_takes_the_alignment_it_asks_for) or test(a_frame_draws_the_border_type_it_asks_for) or test(a_frame_overlay_paints_onto_the_border_cells) or test(an_overlay_never_paints_over_a_corner) or test(a_run_that_names_a_role_is_a_target_over_its_own_columns) or test(adjacent_runs_sharing_an_identity_are_one_target) or test(a_run_hit_stops_at_the_edge_of_the_node_that_holds_it) or test(a_center_aligned_run_hit_lines_up_with_where_ratatui_paints_it) or test(an_overlay_run_is_a_target_on_the_border_it_paints_on) or test(the_collapse_toggle_is_one_target_covering_its_chevron_and_its_hint)'`
- `cargo nextest run -E 'binary(frames) or binary(mouse) or binary(decoration) or binary(session_list)' (56 tests, byte-for-byte pinned frames unchanged)`
- `Added and ran tests/frames.rs::the_no_session_title_takes_the_borders_muted_colour_not_the_terminals_default (new focused test verifying the agent pane's empty-state title fg equals the border's muted colour rather than Color::Reset)`
- `Manually diffed base vs target chrome.lua/20_agent.lua to confirm the new colour test distinguishes old (unstyled, terminal-default title) from new (patched to border_style) behavior`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
