### PR TITLE
feat(ui): add the ui.lua component layer and action/message command verbs

### DIFF
--- a/.claude/skills/thurbox-kernel/SKILL.md
+++ b/.claude/skills/thurbox-kernel/SKILL.md
@@ -185,6 +185,31 @@ examples to read and copy from, not a catalogue thurbox maintains for anyone —
 `check` fails on a pane that **loaded but which no arrangement places** — the only
 failure with no symptom — and prints the `layout.lua` line to add.
 
+**`ui/lib/ui.lua` is the component layer**, and the first thing a pane should
+reach for: `ui.panel` (one focus convention — a brighter border and a title
+badge, never a marker glyph), `ui.list` (variable row heights, a sticky window,
+the selection bar as the row's own `style`, overflow either as marker rows or as
+`▲ N`/`▼ N` on the frame), `ui.cursor` (`{index, offset, follow}` plus the
+steer/publish protocol, so another pane writing `store.selected` moves the list
+and the list's own echo is not mistaken for one), `ui.row` (a span builder that
+knows the row's width, so a trailing note is budgeted rather than re-measured),
+`ui.empty`, `ui.modal`, `ui.footer` (hints resolved from the key **registry**,
+so a rebind moves them), `ui.status`/`ui.dots`, `ui.rule`. `lib/widgets.lua` is
+the primitive kit underneath it. `10_sessions` and `80_restore` are the two
+worked consumers; `65_search`, `70_new_session` and `20_agent` still spell their
+own and are the follow-up.
+
+**Two commands reach outside a pane's own rect.** `command("message", { text,
+level })` puts a sentence in the message band — kernel chrome stays kernel-drawn
+and a plugin contributes to it, as it contributes a pill or a binding, instead of
+spending a row of its own on a message line. `command("action", { text =
+"help.open" })` runs a declared action through the very handler a click on an
+`action:` node runs, so a **key handler** can open help, settings, themes or the
+palette; the issuing plugin is the fallback owner, stamped by the kernel. Both
+are applied on the UI thread (the action registry, the modals and the band are
+the loop's), and both refuse rather than guess — a message with no `text`, or a
+`level` no band badges, is an error at parse time and not a silent no-op.
+
 **Measuring text is the kernel's job** (`host::api::install_text`). The `text`
 global gives a plugin `text.width(s)`, `text.truncate(s, cols, opts)` and
 `text.pad(s, cols, align)`, all in terminal COLUMNS and all backed by the same

--- a/docs/CONSTITUTION.md
+++ b/docs/CONSTITUTION.md
@@ -76,7 +76,8 @@ The interface is Lua on a Rust kernel (ADR-23). v1's TEA loop — a single
 with a mechanism rather than a review habit:
 
 1. **Four node kinds, forever** — `text`, `box`, `input`, `surface`.
-   Everything else composes in `ui/lib/widgets.lua`.
+   Everything else composes in Lua: `ui/lib/ui.lua` (the component
+   layer) over `ui/lib/widgets.lua` (the primitive kit).
    *Enforced by* `tests/kernel_mvp.rs`, which asserts the count.
 2. **Layout resolves before render** — rects are computed first, then
    each plugin is called with its own. Plugins declare size statically,

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -230,9 +230,10 @@ levers, in the order they pay:
    so `rawequal(published, cache.src)` is a sound one-comparison staleness
    test. Build once into an upvalue, rebuild on identity change. Never key a
    cache on anything time-based.
-3. **Window before you build.** Compute the visible slice
-   (`widgets.window`, or `lib/scroll` for variable-height rows) and build
-   spans only for it; a thousand-row list costs its ten visible rows.
+3. **Window before you build.** `ui.list` does this for you — it calls `row`
+   only for the rows it draws — and under it are `widgets.window` and
+   `lib/scroll` for variable-height rows. Either way a thousand-row list costs
+   its ten visible rows.
 4. **Hoist per-row work.** A `store` read crosses the VM boundary; a
    `theme.role` lookup walks tables; `fuzzy.compile(query)` splits the query
    once so per-row matching does not. Read once per render, pass down.
@@ -394,10 +395,37 @@ Those three examples are literally `tests/fixtures/lua_types/`, and
 to stay that way.
 
 Lists, gauges, panels, dividers and tables are **not** node kinds — they are
-`lib/widgets.lua`, composed from the four. When you need a new appearance, add
-it there. A prior version of this design froze its catalog at six kinds and
-watched it reach sixteen, because every new appearance had nowhere else to go
-and each one cost a release. A widget in Lua costs a file save.
+Lua, composed from the four. When you need a new appearance, add it there. A
+prior version of this design froze its catalog at six kinds and watched it reach
+sixteen, because every new appearance had nowhere else to go and each one cost a
+release. A widget in Lua costs a file save.
+
+The Lua side is two layers. `lib/ui.lua` is the **component layer** — the shapes
+a pane turns out to be, and the conventions that make several panes look like one
+program — and it is what a new pane should reach for first:
+
+```lua
+local ui = require("lib.ui")
+
+ui.panel({ title = "Notes", focused = ctx.focused, body = ui.list({ … }) })
+ui.list({ items = rows, cursor = ui.cursor("notes", rows), row = spans_of, … })
+ui.row({ width = w }):add(name, { fg = theme.text }):trailing(age):spans_list()
+ui.modal({ title = "Pick one", cols = 60, children = { body, ui.footer({ … }) } })
+```
+
+| | what it is |
+|---|---|
+| `ui.panel{title, focused, body, overlay_left, overlay_right, right_column, border, title_align}` | a framed pane in the one focus convention — a brighter border and a title badge, never a marker glyph |
+| `ui.list{items, cursor, width, height, row, header, empty, on_overflow, pad, len, fill}` | a scrolling list: variable row heights, the sticky window, the selection bar, hover, and overflow either as marker rows or as `▲ N`/`▼ N` on the frame |
+| `ui.cursor(key, items, opts)` | `{index, offset, follow}` with `move`/`select`/`select_by_id`/`follow`. `opts.steer` names the `store` key another pane moves this list with — and the protocol that tells a foreign write from this list's own echo |
+| `ui.row{width, tone}` | a span builder that knows the row's columns: `:add`, `:gap`, `:button`, `:match`, `:trailing`, `:spans_list` |
+| `ui.empty{title, width, hint, hint_action}` | the one empty state, its chord shown only while something is bound to it |
+| `ui.modal{title, cols, children}` / `ui.footer{actions, primary, cancel}` | a float sized from its children, and hints resolved from the key registry |
+| `ui.status` / `ui.dots` / `ui.rule` / `ui.chord` / `ui.describe` / `ui.follow` / `ui.reset` | a status glyph with its spinner, the border strip of them, a group heading, and the registry lookups |
+
+`lib/widgets.lua` is the **primitive kit** underneath it — measurement,
+windowing, `widgets.list`, `widgets.panel`, `widgets.gauge`. Reach past `ui` for
+what it does not cover:
 
 ```lua
 local widgets = require("lib.widgets")
@@ -866,6 +894,26 @@ end
 This is not a limitation to work around. A plugin that could wait would be a
 plugin that can freeze the interface on a slow git fetch or an unreachable SSH
 host.
+
+Two verbs reach outside your own rect:
+
+```lua
+command("message", { text = "nothing to undo" })              -- INFO in the band
+command("message", { text = "no such host", level = "error" })
+command("action",  { text = "help.open" })                    -- as its chord would
+```
+
+`message` puts a sentence in the message band. The band stays kernel-drawn —
+your pane contributes to it as it contributes a pill or a binding, rather than
+spending a row of its own on a message line. `level` is `info` (the default),
+`success` or `error`, and anything else is refused rather than read as `info`: a
+severity nobody badges renders as an ordinary message, which is a message nobody
+notices.
+
+`action` runs a declared action through the very handler a click on a `role =
+"action:…"` node runs, so a **key handler** can open help, settings, themes or
+the palette. Before it, those were reachable only by painting a node and waiting
+for a click — which is why three floats rebuilt a modal shell of their own.
 
 ## Floating panes and modals
 

--- a/docs/V2-KERNEL.md
+++ b/docs/V2-KERNEL.md
@@ -47,7 +47,8 @@ clone — `docs/PLUGINS.md` has the commands and what the two demonstrate.
    ─────────────────────────             ──────────────────────────
    node      four primitives             layout.lua    arrangement
    layout    rects before render         lib/theme     roles
-   convert   table <-> node              lib/widgets   list, gauge, panel…
+   convert   table <-> node              lib/ui        panel, list, cursor, row…
+                                         lib/widgets   measure, window, list…
    paint     node -> ratatui             lib/tree      decoration helper
    host      VM, reload, isolation       plugins/*     3 panes + 3 floats
    registry  keys, settings, commands
@@ -72,7 +73,8 @@ clone — `docs/PLUGINS.md` has the commands and what the two demonstrate.
 ## The five rules
 
 **1. Four node kinds, forever.** `text`, `box`, `input`, `surface`. Everything
-else composes in `ui/lib/widgets.lua`. A prior attempt froze its catalog at six
+else composes in Lua — `ui/lib/ui.lua`, the component layer, over
+`ui/lib/widgets.lua`, the primitive kit. A prior attempt froze its catalog at six
 and reached sixteen, because it never built the userland layer and each new
 appearance had nowhere else to live. `tests/kernel_mvp.rs` asserts the count.
 

--- a/src/coordinator/commands.rs
+++ b/src/coordinator/commands.rs
@@ -102,6 +102,21 @@ impl App {
                 event.payload.push(("source".to_string(), source.into()));
                 self.enqueue_event(event);
             }
+            // A declared action, run exactly as a click on an `action:` node
+            // runs one — the same handler, so a pane's key and its own button
+            // cannot come to mean different things. The issuing plugin is the
+            // fallback owner, which is what the click path passes too.
+            Command::Action { owner, action } => {
+                let asked = self
+                    .host
+                    .name_of_path(owner)
+                    .and_then(|name| self.host.index_of(name))
+                    .unwrap_or(self.focus);
+                self.run_clicked_action(action, asked);
+            }
+            // The message band is kernel chrome; this is a plugin contributing
+            // to it, like a pill or a binding.
+            Command::Message { text, level } => self.report(text.clone(), *level),
             _ => return false,
         }
         true

--- a/src/kernel/bands.rs
+++ b/src/kernel/bands.rs
@@ -34,6 +34,21 @@ pub enum Level {
 }
 
 impl Level {
+    /// The name a plugin writes in `command("message", { level = … })`.
+    ///
+    /// `None` for anything else, so a level nobody badges is refused at parse
+    /// time rather than quietly read as `Info` — a misspelt severity that
+    /// renders as an ordinary message is a message nobody notices, which is
+    /// the failure the three levels exist to prevent.
+    pub fn parse(name: &str) -> Option<Self> {
+        match name {
+            "info" => Some(Level::Info),
+            "success" => Some(Level::Success),
+            "error" => Some(Level::Error),
+            _ => None,
+        }
+    }
+
     /// The badge v1 prints in front of the text.
     fn badge(self) -> &'static str {
         match self {

--- a/src/kernel/bundled.rs
+++ b/src/kernel/bundled.rs
@@ -56,6 +56,7 @@ pub const BUNDLED: &[(&str, &str)] = &[
     ),
     ("lib/theme.lua", include_str!("../../ui/lib/theme.lua")),
     ("lib/widgets.lua", include_str!("../../ui/lib/widgets.lua")),
+    ("lib/ui.lua", include_str!("../../ui/lib/ui.lua")),
     ("lib/tree.lua", include_str!("../../ui/lib/tree.lua")),
     ("lib/panels.lua", include_str!("../../ui/lib/panels.lua")),
     ("lib/hover.lua", include_str!("../../ui/lib/hover.lua")),
@@ -1024,6 +1025,7 @@ mod tests {
             "layout.lua",
             "lib/theme.lua",
             "lib/widgets.lua",
+            "lib/ui.lua",
             "plugins/10_sessions.lua",
             "plugins/20_agent.lua",
         ] {

--- a/src/kernel/command/execute.rs
+++ b/src/kernel/command/execute.rs
@@ -180,6 +180,8 @@ pub(super) fn execute(
         | Command::Editor { .. }
         | Command::Focus { .. }
         | Command::Emit { .. }
+        | Command::Action { .. }
+        | Command::Message { .. }
         | Command::Plugin { .. } => unreachable!("applied on the UI thread"),
     }
 }

--- a/src/kernel/command/mod.rs
+++ b/src/kernel/command/mod.rs
@@ -285,6 +285,36 @@ pub enum Command {
         name: String,
         payload: Vec<(String, super::events::Field)>,
     },
+    /// Run a declared action, exactly as its chord or a click on it would.
+    ///
+    /// UI-thread applied, because the action registry and the kernel's own
+    /// modals are the loop's. Without this a pane could reach `help.open` only
+    /// by *painting* a node with `role = "action:…"` and waiting for a click —
+    /// so a key handler could not open help, settings, themes or the palette
+    /// at all, and three panes rebuilt a float shell rather than reuse the
+    /// modal furniture the kernel already has.
+    ///
+    /// `owner` is **stamped by the kernel** from the plugin executing, like
+    /// [`Command::Program`]'s. It is the fallback the click path already
+    /// carries: an action no binding declares is offered to the pane that
+    /// asked for it, which is how a pane reaches its own undeclared verbs.
+    Action {
+        owner: String,
+        action: String,
+    },
+    /// Say something in the message band.
+    ///
+    /// UI-thread applied: the band draws from state the loop holds, and its
+    /// text expires on a timer the loop owns.
+    ///
+    /// The band is kernel chrome and stays kernel-drawn — a plugin contributes
+    /// a sentence and a severity, exactly as it contributes a pill or a
+    /// binding. That is what lets a pane report a refusal it made itself
+    /// without spending a row of its own on a message line.
+    Message {
+        text: String,
+        level: super::bands::Level,
+    },
 }
 
 /// A further repository a new session spans.
@@ -352,6 +382,8 @@ impl Command {
             Command::Order { .. } => "order",
             Command::Setting { .. } => "set",
             Command::Emit { .. } => "emit",
+            Command::Action { .. } => "action",
+            Command::Message { .. } => "message",
         }
     }
 
@@ -389,6 +421,10 @@ impl Command {
             // that enumerates sessions.
             | Command::Program { .. }
             | Command::Emit { .. }
+            // Chrome, not a row: an action names a verb and a message a
+            // sentence.
+            | Command::Action { .. }
+            | Command::Message { .. }
             | Command::Focus { .. } => "",
         }
     }
@@ -417,6 +453,8 @@ impl Command {
                 | Command::Focus { .. }
                 | Command::Plugin { .. }
                 | Command::Emit { .. }
+                | Command::Action { .. }
+                | Command::Message { .. }
         )
     }
 
@@ -478,6 +516,7 @@ impl Command {
             owner,
             argv,
             payload,
+            level,
         } = args;
         // An event names nothing the kernel owns: the name is the subject, and
         // every other field travels as the payload. Refused for a kernel name so
@@ -492,6 +531,33 @@ impl Command {
                 name,
                 payload,
             });
+        }
+        // Chrome a pane contributes to. Neither names a session: one names a
+        // verb the registry already knows, the other a sentence.
+        if kind == "action" {
+            let Some(action) = text.filter(|t| !t.is_empty()) else {
+                // Names the field, because the field is what goes wrong:
+                // `{ action = … }` is what this verb invites, and an option no
+                // verb reads is collected and ignored — so it would enqueue a
+                // no-op with nothing to report.
+                return Err("command \"action\" needs an action id in text".to_string());
+            };
+            return Ok(Command::Action { owner, action });
+        }
+        if kind == "message" {
+            let Some(text) = text.filter(|t| !t.is_empty()) else {
+                return Err("command \"message\" needs text".to_string());
+            };
+            let level = match level.as_deref() {
+                None => super::bands::Level::Info,
+                Some(name) => super::bands::Level::parse(name).ok_or_else(|| {
+                    format!(
+                        "command \"message\" got level {name:?} — try \"info\", \
+                         \"success\" or \"error\""
+                    )
+                })?,
+            };
+            return Ok(Command::Message { text, level });
         }
         // The interface's own files name no session, and the verb is explicit:
         // removing a plugin is destructive, so it is never the default.
@@ -692,7 +758,8 @@ impl Command {
             "editor" => Ok(Command::Editor { session }),
             other => Err(format!(
                 "unknown command {other:?} — try create, fork, sync, copy, diff, \
-                 delete, restore, restart, send, reorder, theme, set or emit"
+                 delete, restore, restart, send, reorder, theme, set, emit, \
+                 action or message"
             )),
         }
     }
@@ -742,6 +809,8 @@ pub struct Args {
     /// Every other scalar field of the options table, for a command that
     /// forwards them whole — an event's payload.
     pub payload: Vec<(String, super::events::Field)>,
+    /// How severe a message is: `info`, `success` or `error`.
+    pub level: Option<String>,
 }
 
 #[cfg(test)]
@@ -836,6 +905,77 @@ mod tests {
                 delta: -1
             })
         );
+    }
+
+    /// A pane reaching the action registry from a key handler, which is the
+    /// only way it can open help, settings, themes or the palette without
+    /// painting a node and waiting for a click.
+    #[test]
+    fn an_action_command_carries_the_action_and_the_plugin_that_asked() {
+        assert_eq!(
+            Command::parse(
+                "action",
+                Args {
+                    text: Some("help.open".into()),
+                    owner: "plugins/10_sessions.lua".into(),
+                    ..Args::default()
+                }
+            ),
+            Ok(Command::Action {
+                owner: "plugins/10_sessions.lua".into(),
+                action: "help.open".into(),
+            })
+        );
+        // Names the field, because the field is what goes wrong: `{ action = … }`
+        // is what the verb invites, and it parses to no text at all.
+        let error = Command::parse("action", Args::default()).unwrap_err();
+        assert!(error.contains("text"), "{error}");
+    }
+
+    /// The message band is kernel chrome, so a plugin contributes to it rather
+    /// than drawing it — and it names a severity the band already badges.
+    #[test]
+    fn a_message_names_a_level_the_band_can_badge() {
+        assert_eq!(
+            Command::parse(
+                "message",
+                Args {
+                    text: Some("nothing to undo".into()),
+                    ..Args::default()
+                }
+            ),
+            Ok(Command::Message {
+                text: "nothing to undo".into(),
+                level: crate::kernel::bands::Level::Info,
+            })
+        );
+        assert_eq!(
+            Command::parse(
+                "message",
+                Args {
+                    text: Some("gone".into()),
+                    level: Some("error".into()),
+                    ..Args::default()
+                }
+            ),
+            Ok(Command::Message {
+                text: "gone".into(),
+                level: crate::kernel::bands::Level::Error,
+            })
+        );
+        // Refused rather than quietly read as info: a level nobody badges is a
+        // typo, and a typo that renders as a normal message is invisible.
+        let error = Command::parse(
+            "message",
+            Args {
+                text: Some("gone".into()),
+                level: Some("critical".into()),
+                ..Args::default()
+            },
+        )
+        .unwrap_err();
+        assert!(error.contains("critical"), "{error}");
+        assert!(error.contains("success"), "{error}");
     }
 
     #[test]

--- a/src/kernel/host/api.rs
+++ b/src/kernel/host/api.rs
@@ -252,6 +252,7 @@ fn install_command(lua: &Lua, queue: Queue, current_path: Rc<RefCell<String>>) -
             agent: get_string("agent"),
             host: get_string("host"),
             status: get_string("status"),
+            level: get_string("level"),
             file: get_string("file"),
             action: get_string("action"),
             // A Lua array of session ids. Read here rather than as text so a

--- a/tests/keymap.rs
+++ b/tests/keymap.rs
@@ -368,9 +368,13 @@ fn undo_restores_the_delete_that_was_just_made_and_nothing_else() {
     .expect("render the list");
     host.drain_commands();
 
-    // Nothing deleted yet: the key is inert rather than restoring a stranger.
+    // Nothing deleted yet: the key says so rather than restoring a stranger.
+    // Silence was indistinguishable from the chord never arriving — Ctrl+Z is
+    // global, so it fires with the column hidden and from a focused terminal.
     fire(&host, "ctrl+z");
-    assert!(host.drain_commands().is_empty());
+    let issued = host.drain_commands();
+    assert_eq!(issued.len(), 1, "{issued:?}");
+    assert_eq!(issued[0].kind(), "message");
 
     fire(&host, "ctrl+d");
     host.drain_commands();
@@ -380,9 +384,12 @@ fn undo_restores_the_delete_that_was_just_made_and_nothing_else() {
     assert_eq!(issued[0].kind(), "restore");
     assert_eq!(issued[0].session(), snapshot.sessions[0].id);
 
-    // One undo per delete: the second press has nothing left to undo.
+    // One undo per delete: the second press has nothing left to undo, and says
+    // that rather than restoring the row again.
     fire(&host, "ctrl+z");
-    assert!(host.drain_commands().is_empty());
+    let issued = host.drain_commands();
+    assert_eq!(issued.len(), 1, "{issued:?}");
+    assert_eq!(issued[0].kind(), "message");
 }
 
 /// Chords v1 hands to the agent that v2 does not yet.

--- a/tests/plugin_chrome.rs
+++ b/tests/plugin_chrome.rs
@@ -1,0 +1,141 @@
+//! What a pane may say, and what it may set off, outside its own rect.
+//!
+//! Two gaps this closes, both recorded in the panes themselves. The creation
+//! flow states one of them in a comment — "a plugin cannot write the message
+//! band (it is kernel chrome), so a refusal this flow makes itself is shown on
+//! its own footer row instead" — and pays a row of every modal for it. The
+//! other is quieter: the kernel's own modals are reachable from a `role =
+//! "action:…"` node and therefore only from the *mouse*, so a pane could not
+//! open help from a key handler at all.
+//!
+//! Both are commands rather than globals, for the reason every write is one: a
+//! plugin says what it wants and the loop does it on a later frame. The
+//! coordinator half — the band actually showing the text, the modal actually
+//! opening — is asserted on a real terminal in `tests/tui_e2e.rs`; what is
+//! pinned here is the vocabulary, and that a mistake in it is refused rather
+//! than swallowed.
+
+use thurbox::kernel::bands::Level;
+use thurbox::kernel::command::Command;
+use thurbox::kernel::host::{KeyPress, LuaHost, RenderContext};
+
+/// An interface of exactly the bundled `lib/` plus the panes given, so a test
+/// pane may `require` the component layer without the bundled panes' snapshot
+/// needs.
+fn interface(plugins: &[(&str, &str)]) -> (tempfile::TempDir, std::path::PathBuf) {
+    let home = tempfile::tempdir().expect("tempdir");
+    let ui = home.path().join("ui");
+    thurbox::kernel::bundled::materialize(&ui);
+    for (name, source) in plugins {
+        std::fs::write(ui.join("plugins").join(name), source).expect("write");
+    }
+    (home, ui)
+}
+
+/// A pane whose only job is to run `body` when `x` is pressed.
+fn presser(body: &str) -> String {
+    format!(
+        r#"return {{
+  name = "presser",
+  slot = "sessions",
+  render = function()
+    return {{ type = "text", text = "" }}
+  end,
+  on_key = function(key)
+    if key.key == "x" then
+      {body}
+      return true
+    end
+    return false
+  end,
+}}"#
+    )
+}
+
+fn press_x(host: &LuaHost) -> Result<Vec<Command>, String> {
+    let index = host.index_of("presser").expect("no presser");
+    host.render(
+        index,
+        RenderContext {
+            width: 40,
+            height: 10,
+            focused: true,
+            elapsed: 0.0,
+            frame: 0,
+        },
+    )
+    .expect("render");
+    let key = KeyPress {
+        name: "x".to_string(),
+        ch: Some('x'),
+        ..KeyPress::default()
+    };
+    match host.on_key(index, &key) {
+        Ok(_) => Ok(host.drain_commands()),
+        Err(e) => Err(e.message),
+    }
+}
+
+fn issued(body: &str) -> Result<Vec<Command>, String> {
+    let (_home, ui) = interface(&[("91_presser.lua", &presser(body))]);
+    let host = LuaHost::new(&ui);
+    assert!(host.error.is_none(), "{:?}", host.error);
+    press_x(&host)
+}
+
+#[test]
+fn a_pane_can_run_a_kernel_action_from_a_key_handler() {
+    let commands = issued(r#"command("action", { text = "help.open" })"#).expect("key");
+    assert_eq!(
+        commands,
+        vec![Command::Action {
+            // Stamped from the plugin executing, never read from the options
+            // table — the same rule `program` and `emit` follow. It is the
+            // fallback owner a click carries, so an action nothing declares
+            // still reaches the pane that asked for it.
+            owner: "plugins/91_presser.lua".to_string(),
+            action: "help.open".to_string(),
+        }]
+    );
+}
+
+#[test]
+fn a_pane_can_say_something_in_the_message_band() {
+    let commands = issued(r#"command("message", { text = "nothing to undo" })"#).expect("key");
+    assert_eq!(
+        commands,
+        vec![Command::Message {
+            text: "nothing to undo".to_string(),
+            level: Level::Info,
+        }]
+    );
+
+    let commands =
+        issued(r#"command("message", { text = "gone", level = "error" })"#).expect("key");
+    assert_eq!(
+        commands,
+        vec![Command::Message {
+            text: "gone".to_string(),
+            level: Level::Error,
+        }]
+    );
+}
+
+/// The trap the `command` option list already documents: a name no verb reads
+/// is collected and ignored, so a verb whose required field is misspelt has to
+/// refuse rather than enqueue a no-op.
+#[test]
+fn a_message_with_no_text_and_a_level_nobody_badges_are_both_refused() {
+    let error = issued(r#"command("message", { message = "oops" })"#).expect_err("refused");
+    assert!(error.contains("text"), "{error}");
+
+    let error = issued(r#"command("message", { text = "oops", level = "critical" })"#)
+        .expect_err("refused");
+    assert!(error.contains("critical"), "{error}");
+}
+
+#[test]
+fn an_action_with_no_action_is_refused() {
+    let error = issued(r#"command("action", { action = "help.open" })"#).expect_err("refused");
+    assert!(error.contains("text"), "{error}");
+}

--- a/tests/restore.rs
+++ b/tests/restore.rs
@@ -65,15 +65,27 @@ fn snapshot() -> Snapshot {
 }
 
 fn registry(host: &LuaHost) -> Registry {
+    registry_rebound(host, None)
+}
+
+/// The registry, optionally with one action moved to another chord — which is
+/// the whole point of the footer reading it rather than naming keys itself.
+fn registry_rebound(host: &LuaHost, rebind: Option<(&str, &str)>) -> Registry {
     let mut registry = Registry::default();
     let (bindings, settings) = host.declarations();
     registry.declare(bindings, settings);
+    if let Some((action, chord)) = rebind {
+        registry.rebind(action, Some(chord)).expect("rebind");
+    }
     registry
 }
 
 fn publish_in(host: &LuaHost, snapshot: &Snapshot) {
+    publish_with(host, snapshot, registry(host));
+}
+
+fn publish_with(host: &LuaHost, snapshot: &Snapshot, registry: Registry) {
     let themes = Themes::load(None);
-    let registry = registry(host);
     let diffs = thurbox::kernel::diff::DiffStore::new();
     let repos = thurbox::kernel::repos::RepoStore::with_hosts(Default::default());
     host.publish(&Published {
@@ -240,6 +252,43 @@ fn esc_closes_without_restoring_anything() {
     press(&host, "esc");
     assert!(host.drain_commands().is_empty());
     assert!(!rendered(&host, &snapshot(), PLUGIN).0);
+}
+
+/// The footer's hints come from the key REGISTRY, not from the letters this
+/// pane happens to have declared — so a rebind moves the hint with the key.
+///
+/// That is the whole reason `ui.footer` takes actions rather than strings. Four
+/// panes wrote their hints out as literals, and a rebound chord left every one
+/// of them advertising a key that no longer did anything.
+#[test]
+fn the_footer_names_the_chord_the_registry_resolves() {
+    let host = host();
+    press(&host, "ctrl+u");
+    let tree = tree(&host);
+    assert!(tree.contains("j/k"), "the declared chords: {tree}");
+
+    // Move "next session" to `n` and the hint follows it, with no edit here.
+    let index = host.index_of(PLUGIN).expect("no restore plugin");
+    publish_with(
+        &host,
+        &snapshot(),
+        registry_rebound(&host, Some(("restore.next", "n"))),
+    );
+    let out = host
+        .render(
+            index,
+            RenderContext {
+                width: 60,
+                height: 16,
+                focused: false,
+                elapsed: 0.0,
+                frame: 0,
+            },
+        )
+        .expect("render");
+    let tree = format!("{:?}", out.node);
+    assert!(tree.contains("n/k"), "the rebound chord: {tree}");
+    assert!(!tree.contains("j/k"), "the old chord is gone: {tree}");
 }
 
 #[test]

--- a/tests/tui_e2e.rs
+++ b/tests/tui_e2e.rs
@@ -747,6 +747,70 @@ fn a_pane_that_fails_to_load_is_reported_and_the_rest_of_the_interface_runs() {
     assert!(status.success(), "exit must still be clean: {status:?}");
 }
 
+/// A pane written for this test, dropped in beside the bundled ones.
+fn interface_plus(name: &str, body: &str) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let source = Path::new(env!("CARGO_MANIFEST_DIR")).join("ui");
+    copy_tree(&source, dir.path());
+    std::fs::write(dir.path().join("plugins").join(name), body).expect("add a pane");
+    dir
+}
+
+#[test]
+fn a_pane_can_speak_in_the_message_band_and_open_a_kernel_modal() {
+    // The coordinator half of `command("message")` and `command("action")`.
+    // Both are only reachable through the loop: one writes the status the
+    // message band reads, the other runs a declared action exactly as a click
+    // on it would — and neither can be seen from a `TestBackend`, because the
+    // bands and the modals are drawn by the binary's own `draw`.
+    //
+    // `ctrl+p` is the palette's chord and reaches the pane from anywhere, so
+    // the scenario needs no focus dance; `p` alone would be swallowed by
+    // whatever holds the keyboard.
+    let interface = interface_plus(
+        "91_speaker.lua",
+        r#"return {
+  name = "speaker",
+  slot = "sessions",
+  render = function()
+    return { type = "text", text = "" }
+  end,
+  keys = {
+    { key = "ctrl+g", action = "speaker.say", desc = "say something", scope = "global" },
+    { key = "ctrl+b", action = "speaker.help", desc = "open help", scope = "global" },
+  },
+  on_action = function(action)
+    if action == "speaker.say" then
+      command("message", { text = "the pane said so", level = "error" })
+      return true
+    elseif action == "speaker.help" then
+      command("action", { text = "help.open" })
+      return true
+    end
+    return false
+  end,
+}"#,
+    );
+    let profile = Profile::new();
+    let mut tui = Tui::spawn_with(&profile, 40, 120, |cmd| {
+        cmd.env("THURBOX_UI_DIR", interface.path());
+    });
+    tui.wait_for("No sessions yet");
+
+    tui.send(b"\x07");
+    // The band badges the level the pane asked for, which is what makes this a
+    // contribution to kernel chrome rather than a string the pane painted.
+    tui.wait_for("ERROR");
+    tui.wait_for("the pane said so");
+
+    tui.send(b"\x02");
+    tui.wait_for("Keybindings");
+    tui.send(ESC);
+    tui.wait_gone("Keybindings");
+
+    assert!(tui.quit().success());
+}
+
 // --- a live session ---------------------------------------------------------
 
 fn git(dir: &Path, args: &[&str]) {

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -7,13 +7,22 @@ file reloads it; there is no build step.
 `README.md` beside this file is the reference — the node kinds, the sizing rules,
 what you can read and write. This file is the part that is easy to get wrong.
 
-One habit it pays to have before you write a row: a highlight is a **node
-style**, not a loop over spans. `{ type = "text", style = { bg = … } }` covers
-the whole rect, so a bar reaches the right edge without a padding span and a
-span that names its own colour survives it. `widgets.list` exposes the same
-thing as `selected_style` / `hover_style`.
+The first habit: **start from `lib/ui.lua`**, the component layer, not from raw
+nodes. `ui.panel` is a framed pane in the one focus convention this interface
+has, `ui.list` is a scrolling list with the window arithmetic and the selection
+bar already in it, `ui.cursor` is the "where am I, and did somebody else steer
+me" state every pane with a list grows, `ui.row` is a span builder that knows
+how wide the row is, and `ui.empty`/`ui.footer` are the one empty state and the
+one footer — with hints resolved from the key registry, so a rebind moves them.
+`10_sessions.lua` and `80_restore.lua` are the worked examples. `lib/widgets.lua`
+is the primitive kit underneath; reach past `ui` for the piece it does not cover.
 
-A second: a border is a **`frame`**, never hand-drawn cells. It takes styled
+A second habit, for when you do: a highlight is a **node style**, not a loop over
+spans. `{ type = "text", style = { bg = … } }` covers the whole rect, so a bar
+reaches the right edge without a padding span and a span that names its own
+colour survives it. `ui.list` and `widgets.list` both do this for you.
+
+A third: a border is a **`frame`**, never hand-drawn cells. It takes styled
 title runs, `title_align`, `border_type` and an `overlay` that paints onto its
 own border cells (`top_left`/`top_right`/`bottom_left`/`bottom_right`/
 `right_column`) — a status strip, a scroll count or a scrollbar there costs no
@@ -58,10 +67,10 @@ Put generated files in `$XDG_CACHE_HOME/<plugin>/` (or `~/.cache/<plugin>/`).
 
 **There is no `npm`, `cargo`, `pip` or `go get` in this directory, and nothing to
 run one on.** No `package.json`, no lockfile of that kind, no `node_modules`. The
-only dependencies a pane has are the modules in `lib/` — widgets, theme, fuzzy,
-textinput, chrome, modal, scroll, order, settings, panels, hover, tree, and the
-session-list/path-picker/repo-picker models — which are already here and are reached with
-`require("lib.theme")`. If you find yourself about to run a
+only dependencies a pane has are the modules in `lib/` — ui, widgets, theme,
+fuzzy, textinput, chrome, modal, scroll, order, settings, panels, hover, tree, and
+the session-list/path-picker/repo-picker models — which are already here and are
+reached with `require("lib.ui")`. If you find yourself about to run a
 package manager, you have misread the request.
 
 `plugins.toml` records what this interface is composed of and `plugins.lock` what
@@ -156,7 +165,12 @@ of a fresh table (writing the same *value* is free; a new table never is).
   permission error. The VM enforces it, so `plugin check` is what catches it here —
   the static lint that also enforces it needs the thurbox checkout's own config.
 - **No blocking.** Reads come from a snapshot and return instantly; writes are
-  `command(...)` calls the kernel applies later. There is nothing to await.
+  `command(...)` calls the kernel applies later. There is nothing to await. Two of
+  those writes reach outside your own rect: `command("message", { text =, level = })`
+  says something in the kernel's message band, and `command("action", { text =
+  "help.open" })` runs a declared action — which is how a **key handler** opens
+  help, settings, themes or the palette, rather than painting a `role =
+  "action:…"` node and hoping for a click.
 - **No granting yourself a capability.** A pane that wants to run a program says so
   with `capabilities = { … }`, and the *user* grants it in settings
   (`Ctrl+,` → `]` → `t`). You cannot do that step for them, and you should not

--- a/ui/README.md
+++ b/ui/README.md
@@ -83,7 +83,7 @@ said out loud.
 
 ```lua
 local theme = require("lib.theme")
-local widgets = require("lib.widgets")
+local ui = require("lib.ui")
 
 return {
   name = "example",     -- what the focus ring and help call it
@@ -115,16 +115,25 @@ return {
 
   render = function(ctx)
     -- ctx carries the RESOLVED rect: ctx.width, ctx.height, ctx.focused.
-    local rows = {}
-    for _, session in ipairs(thurbox.sessions) do
-      rows[#rows + 1] = { spans = { { text = "  " .. session.name,
-        style = { fg = theme.text } } } }
-    end
-    return {
-      type = "box",
-      frame = widgets.panel("Example", ctx.focused),
-      children = { widgets.list({ rows = rows, height = ctx.height - 2 }) },
-    }
+    local items = thurbox.sessions
+    return ui.panel({
+      title = "Example",
+      focused = ctx.focused,
+      body = ui.list({
+        items = items,
+        cursor = ui.cursor("example", items),
+        width = ctx.width - 2,
+        height = ctx.height - 2,
+        on_overflow = "rows",
+        row = function(session)
+          return ui.row({ width = ctx.width - 2 })
+            :add(" " .. session.name, { fg = theme.text })
+            :trailing(session.branch, { fg = theme.muted })
+            :spans_list()
+        end,
+        empty = ui.empty({ title = "Nothing here yet", width = ctx.width - 2 }),
+      }),
+    })
   end,
 
   on_action = function(action)
@@ -139,6 +148,34 @@ return {
 
 Save it as `plugins/90_example.lua` and it is a pane. `thurbox-cli plugin new
 <name>` writes a starter that already loads.
+
+## The component layer (`lib/ui.lua`)
+
+`lib/widgets.lua` is the primitive kit — measurement, windowing, a row of text.
+`lib/ui.lua` is the layer above it: the shapes a pane turns out to be, with the
+conventions that make six panes look like one program. Reach for it first; drop
+to `widgets` for the piece it does not cover.
+
+| | what it is |
+|---|---|
+| `ui.panel{title, focused, body, overlay_left, overlay_right, right_column, border, title_align}` | a framed pane in the one focus convention. Focus is a brighter border and a title badge, never a marker glyph |
+| `ui.list{items, cursor, width, height, row, header, empty, on_overflow, pad, len, fill}` | a scrolling list. Variable row heights (`header` glues a group heading to its first row), the selection bar, hover, and the window arithmetic |
+| `ui.cursor(key, items, opts)` | `{index, offset, follow}` over a list, with `move`/`select`/`select_by_id`/`follow`. `opts.steer` is the `store` key another pane moves this list with; `opts.request` a one-shot "go to this row" |
+| `ui.row{width, tone}` | a span builder that knows the row's columns: `:add`, `:gap`, `:button`, `:match` (search hits), `:trailing` (a note budgeted against what is left), `:spans_list` |
+| `ui.empty{title, width, hint, hint_action}` | the one empty state — a blank line, the sentence centred, and the chord that fixes it, shown only while something is bound to it |
+| `ui.modal{title, cols, children, crumbs, border}` | a float sized from what is in it |
+| `ui.footer{actions, primary, cancel}` | key hints resolved **from the registry**, plus the confirm/dismiss pills |
+| `ui.status(name, elapsed)` / `ui.dots(items, elapsed, status_of)` | a status glyph, spinner included; and the strip of them a panel puts on its border |
+| `ui.rule(label, width)` | `── label ────`, the group heading |
+| `ui.chord(action)` / `ui.describe(action)` / `ui.follow(key, id)` / `ui.reset(key)` | the registry lookups, and a cursor addressed without holding one |
+
+Two things the layer decides so a pane does not: a **selected row is a
+full-width bar** (the row's own `style`, so a span that names a colour keeps it),
+and **hints come from the key registry**, so a rebind moves the hint and a
+removed action takes its hint with it.
+
+`10_sessions.lua` and `80_restore.lua` are the two worked examples — a
+full-height pane and a float.
 
 ## What you have to work with
 
@@ -155,6 +192,7 @@ the base functions (`pairs`, `ipairs`, `type`, `tostring`, `tonumber`, `select`,
 |---|---|
 | `thurbox` | the read side — the snapshot. `thurbox.sessions`, `.settings`, `.theme`, `.repos`, `.runs`, `.diffs`, `.metrics`, `.chrome`, `.ui_dir`, … |
 | `command(name, args)` | the write side. Accepted now, applied by the kernel later. |
+| `text` | display width in COLUMNS: `text.width`, `text.truncate`, `text.pad` |
 | `store` | scratch state that survives a frame, and how you *ask* for things (`store.want_branches`, `store.want_worktrees`, `store.want_content`, …) |
 | `state` | your plugin's own scratch state — survives a reload, **not** a restart |
 | `require` | `lib/` modules only |
@@ -191,6 +229,15 @@ plus `wheel.x`/`wheel.y` inside your rect — before the kernel turns it into an
 what a pane that already declares those keys wants. It exists for the pane that
 cannot declare them: one taking `input = "session"` hands every unclaimed key to
 the agent.
+
+**Speaking and acting outside your pane**: `command("message", { text = …,
+level = "info"|"success"|"error" })` puts a sentence in the message band, which
+stays kernel-drawn — a pane contributes to it as it contributes a pill or a
+binding, rather than spending a row of its own on a message line.
+`command("action", { text = "help.open" })` runs a declared action exactly as its
+chord or a click on it would, which is how a **key handler** reaches help,
+settings, themes or the palette. Before these two, both were reachable only by
+painting a node with `role = "action:…"` and waiting for a click.
 
 **Events**: declare `events = { "session.status", … }` and an `on_event(name,
 payload)` and the kernel calls you once per change, with the same environment a

--- a/ui/lib/chrome.lua
+++ b/ui/lib/chrome.lua
@@ -1,4 +1,4 @@
--- What the two full-height panes agree on about their borders.
+-- What the full-height panes agree on about their borders.
 --
 -- The borders themselves are ordinary kernel `frame`s. They were once drawn by
 -- hand, out of `text` nodes and a cell buffer, because a frame's title was a
@@ -7,9 +7,11 @@
 -- `border_type` and an `overlay` — the strip, the scroll counts and the
 -- scrollbar all paint onto the border cells the block drew — so the cell buffer
 -- and the framed-pane builder are gone and what is left here is the agreement:
--- the three focus levels both panes map through, and the box-drawing set the
--- agent pane's hint box still draws by hand because it is a box INSIDE a pane,
--- not a frame around one.
+-- the three focus levels a pane's border and title map through — reached through
+-- `lib/ui`'s `ui.panel` for a pane that uses the component layer, and directly by
+-- the agent pane, which still assembles its own frame — and the box-drawing set
+-- the agent pane's hint box draws by hand because it is a box INSIDE a pane, not
+-- a frame around one.
 
 local theme = require("lib.theme")
 local widgets = require("lib.widgets")

--- a/ui/lib/thurbox.d.lua
+++ b/ui/lib/thurbox.d.lua
@@ -809,11 +809,23 @@ function require(name) end
 ---@field session string
 ---@field text? string The new session's name.
 
+--- Run a declared action, exactly as its chord or a click on it would — which
+--- is how a pane opens help, settings, themes or the palette from a key
+--- handler. The plugin that asked is the fallback owner, stamped by the kernel.
+---@class (exact) thurbox.cmd.Action
+---@field text string The action id. `action` is not read.
+
+--- Say something in the message band. The band stays kernel-drawn; this is a
+--- sentence and a severity contributed to it, like a pill or a binding.
+---@class (exact) thurbox.cmd.Message
+---@field text string
+---@field level? "info"|"success"|"error" Defaults to `info`; anything else is refused.
+
 ---@alias thurbox.Verb
 ---| "emit" | "plugin" | "set" | "task" | "dispatch" | "automation"
 ---| "create" | "bookmark" | "focus" | "open" | "theme" | "order" | "program"
 ---| "delete" | "restore" | "restart" | "send" | "reorder" | "fork"
----| "sync" | "copy" | "diff" | "shell" | "editor"
+---| "sync" | "copy" | "diff" | "shell" | "editor" | "action" | "message"
 
 --- The only way a plugin changes anything. Enqueues and returns; it never runs
 --- the operation, which is why a plugin cannot stall the loop.
@@ -844,6 +856,8 @@ function require(name) end
 ---@overload fun(verb: "diff", opts: thurbox.cmd.Session)
 ---@overload fun(verb: "shell", opts: thurbox.cmd.Session)
 ---@overload fun(verb: "editor", opts: thurbox.cmd.Session)
+---@overload fun(verb: "action", opts: thurbox.cmd.Action)
+---@overload fun(verb: "message", opts: thurbox.cmd.Message)
 ---@param verb thurbox.Verb
 ---@param opts? table
 function command(verb, opts) end

--- a/ui/lib/ui.lua
+++ b/ui/lib/ui.lua
@@ -1,0 +1,862 @@
+-- The component layer: what a pane is made of, spelled once.
+--
+-- `lib/widgets.lua` is the primitive kit — measurement, windowing, a row of
+-- text. This is the layer above it: the handful of shapes every pane in this
+-- interface turns out to be, with the conventions that make them look like one
+-- program rather than six.
+--
+-- The conventions, and why they are here rather than in each pane:
+--
+--   * **One focus border.** A panel's border and title come from
+--     `lib/chrome`'s three levels. Three panes had grown three different
+--     answers to "what does focused look like", and a fourth pane copied
+--     whichever it was written next to.
+--   * **One selection idiom.** A selected row is a full-width bar
+--     (`selection_bg`/`selection_fg`), painted as the row's own `style`, never
+--     a marker glyph eating two columns of every row. Hover is the same band
+--     with the foreground left alone.
+--   * **One empty state.** A blank line, the sentence centred, and — when
+--     something is actually bound to it — the chord that fixes it, also
+--     centred.
+--   * **One footer.** Hints are resolved from the key registry, so a rebind
+--     moves the hint with the key and a removed action takes its hint with it.
+--
+-- Everything here composes the four kernel node kinds. Nothing here is a node
+-- kind, and nothing here is appearance the kernel decides: a pane still says
+-- which glyph, which role and when to drop a trailing status. What it no
+-- longer says is how a window is computed, where a selection bar comes from,
+-- or what a border looks like when the pane has focus.
+
+local chrome = require("lib.chrome")
+local fuzzy = require("lib.fuzzy")
+local hover = require("lib.hover")
+local modal = require("lib.modal")
+local scroll = require("lib.scroll")
+local theme = require("lib.theme")
+local widgets = require("lib.widgets")
+
+local ui = {}
+
+-- ── Status ──────────────────────────────────────────────────────────────────
+
+--- Glyph and colour for a session status, with `working` animated.
+---
+--- `theme.status` answers the static half; the spinner is the one status whose
+--- glyph depends on the frame, and every pane that draws a status was choosing
+--- between the two itself.
+---@param name thurbox.Status
+---@param elapsed number?
+---@return { glyph: string, color: thurbox.Color? }
+function ui.status(name, elapsed)
+  local spec = theme.status(name)
+  if name == "working" then
+    return { glyph = theme.spinner_frame(elapsed), color = spec.color }
+  end
+  return spec
+end
+
+--- One status glyph per item, in render order — a panel's border strip.
+---
+--- `status_of` returns the status to draw, or nil for an item the strip skips
+--- (work in flight has no status of its own yet).
+---@param items table[]
+---@param elapsed number?
+---@param status_of fun(item: table): string?
+---@return thurbox.Span[]
+function ui.dots(items, elapsed, status_of)
+  local runs = {}
+  for _, item in ipairs(items) do
+    local status = status_of(item)
+    if status then
+      local spec = ui.status(status, elapsed)
+      runs[#runs + 1] = { text = spec.glyph, style = { fg = spec.color } }
+    end
+  end
+  return runs
+end
+
+-- ── The key registry ────────────────────────────────────────────────────────
+
+-- Memoized on the published table's identity: `thurbox.registry` is a gated
+-- group, so seeing the same table object again means the same bindings — and a
+-- footer resolves several actions per render, each of which would otherwise
+-- walk every plugin's bindings.
+local chord_cache = { src = nil, by_action = {} }
+
+--- The chord bound to `action`, or nil when nothing is.
+---
+--- Read from the registry rather than written into a pane, because every chord
+--- is rebindable and every action is removable: a hint naming a key that
+--- resolves to nothing is worse than no hint at all.
+---@param action string
+---@return string?
+function ui.chord(action)
+  local registry = thurbox and thurbox.registry
+  if not rawequal(registry, chord_cache.src) then
+    chord_cache.src = registry
+    chord_cache.by_action = {}
+  end
+  local cached = chord_cache.by_action[action]
+  if cached ~= nil then
+    return cached or nil
+  end
+  local found
+  for _, binding in ipairs((registry and registry.keys) or {}) do
+    if binding.action == action and binding.key then
+      found = binding.key
+      break
+    end
+  end
+  -- `false` marks "looked, nothing bound", so a miss is remembered too.
+  chord_cache.by_action[action] = found or false
+  return found
+end
+
+--- What the registry says an action does, for a hint that writes no label.
+---@param action string
+---@return string?
+function ui.describe(action)
+  for _, binding in ipairs((thurbox and thurbox.registry and thurbox.registry.keys) or {}) do
+    if binding.action == action and binding.desc and binding.desc ~= "" then
+      return binding.desc
+    end
+  end
+  return nil
+end
+
+-- ── The cursor ──────────────────────────────────────────────────────────────
+
+--- Read an item's identity. A falsy one means the item selects nothing — a
+--- header, or a row for work that has no session yet.
+local function identity(item, id)
+  if item == nil then
+    return nil
+  end
+  if type(id) == "function" then
+    return id(item)
+  end
+  return item[id or "id"]
+end
+
+local Cursor = {}
+Cursor.__index = Cursor
+
+--- Clamp onto a selectable row, then publish where we landed.
+---
+--- Publishing is what lets another pane read the selection; remembering what
+--- was published is what lets this one tell an outside write from its own echo.
+function Cursor:_settle()
+  local count = #self.items
+  self.index = widgets.clamp(self.index, count)
+  if count > 0 and not identity(self.items[self.index], self.key_of) then
+    self.index = self:_step(self.index, 1)
+  end
+  state[self.prefix .. ".cursor"] = self.index
+  local target = self:id()
+  if self.steer then
+    store[self.steer] = target
+    state[self.prefix .. ".published"] = target
+  end
+end
+
+--- The next index in `step`'s direction that selects something.
+function Cursor:_step(from, step)
+  local count = #self.items
+  if count == 0 then
+    return 1
+  end
+  local at = from
+  for _ = 1, count do
+    at = (at - 1 + step) % count + 1
+    if identity(self.items[at], self.key_of) then
+      return at
+    end
+  end
+  return from
+end
+
+--- The selected item's identity, or nil when nothing is selected.
+function Cursor:id()
+  return identity(self.items[self.index], self.key_of) or nil
+end
+
+--- The selected item itself.
+function Cursor:item()
+  return self.items[self.index]
+end
+
+--- Move by `step` rows, skipping what selects nothing. Drops any follow: you
+--- moved the cursor yourself, so it is no longer chasing a row.
+function Cursor:move(step)
+  self.index = self:_step(self.index, step)
+  self:_stop_following()
+  self:_settle()
+  return self.index
+end
+
+--- Put the cursor at `index`.
+function Cursor:select(index)
+  self.index = index
+  self:_stop_following()
+  self:_settle()
+  return self.index
+end
+
+--- Put the cursor on the row carrying `id`, if it is in the list.
+function Cursor:select_by_id(id)
+  for index, item in ipairs(self.items) do
+    if identity(item, self.key_of) == id then
+      return self:select(index)
+    end
+  end
+  return nil
+end
+
+--- Chase `id` until a render lands on it.
+---
+--- Sticky rather than immediate because the row may not be here yet: a reorder
+--- and a spawn both land a frame or two after the keystroke, and by then the
+--- row that was under the cursor has moved or has only just appeared.
+function Cursor:follow(id)
+  ui.follow(self.prefix, id)
+end
+
+function Cursor:_stop_following()
+  state[self.prefix .. ".follow"] = nil
+end
+
+--- The first visible row, 0-based — what `ui.list` scrolled to last frame.
+function Cursor:offset()
+  return state[self.prefix .. ".offset"] or 0
+end
+
+function Cursor:set_offset(offset)
+  state[self.prefix .. ".offset"] = offset
+end
+
+--- Forget where the cursor was, for a list that opens fresh each time.
+function Cursor:reset()
+  ui.reset(self.prefix)
+end
+
+--- Forget where the cursor named `key` was — a list that opens fresh starts at
+--- the top rather than wherever it was left the last time it was up.
+---@param key string
+function ui.reset(key)
+  state[key .. ".cursor"] = nil
+  state[key .. ".offset"] = nil
+  state[key .. ".follow"] = nil
+end
+
+--- Ask the cursor named `key` to chase `id`, without holding one.
+---
+--- An event handler has no list to build a cursor over — the row it is being
+--- told about may not be in the snapshot yet, which is the whole reason a
+--- follow is sticky.
+---@param key string
+---@param id string?
+function ui.follow(key, id)
+  state[key .. ".follow"] = id
+end
+
+--- A list cursor that survives the list changing under it.
+---
+--- The state a pane with a list invariably grows — where the cursor is, where
+--- the window is, which row it is chasing, and what it last told everyone else
+--- — written once. Four panes had four spellings of it and none of them agreed
+--- on what happens when the list is reordered under the selection.
+---
+--- Built fresh on every call, from `state`, so a render, a key handler and a
+--- click handler all see the same cursor without passing one around.
+---
+--- opts:
+---   id      — the field carrying an item's identity, or a function returning
+---             it. An item with none selects nothing and is skipped.
+---   steer   — a `store` key this cursor publishes its selection to, and reads
+---             a *foreign* write of as a request to move. Another pane steering
+---             the list is the reason this is not simply a write: publishing
+---             every frame would otherwise undo the write a frame later, so a
+---             value this cursor did not publish is followed instead.
+---   request — a `store` key carrying a one-shot "go to this row" (a clicked OS
+---             notification, `thurbox-cli session focus`). Consumed here,
+---             because a plain `store` write would be overwritten by the next
+---             publish.
+---@param key string A name for this list's state, unique within the plugin.
+---@param items table[]
+---@param opts table?
+function ui.cursor(key, items, opts)
+  opts = opts or {}
+  local self = setmetatable({
+    prefix = key,
+    items = items,
+    key_of = opts.id,
+    steer = opts.steer,
+    index = state[key .. ".cursor"] or 1,
+  }, Cursor)
+
+  if opts.request and store[opts.request] then
+    state[key .. ".follow"] = store[opts.request]
+    store[opts.request] = nil
+  end
+  if self.steer then
+    local steered = store[self.steer]
+    if steered and steered ~= state[key .. ".published"] then
+      state[key .. ".follow"] = steered
+    end
+  end
+  local follow = state[key .. ".follow"]
+  if follow then
+    for index, item in ipairs(items) do
+      if identity(item, self.key_of) == follow then
+        self.index = index
+        break
+      end
+    end
+  end
+  self:_settle()
+  return self
+end
+
+-- ── The row builder ─────────────────────────────────────────────────────────
+
+local Row = {}
+Row.__index = Row
+
+--- The style a span actually wears, after the row has had its say.
+---
+--- A span that named no style is left alone: it is structure — a separator, an
+--- indent — and dimming or un-colouring it says nothing while making it
+--- different from the same cells drawn by a pane that did not ask.
+function Row:_tone(style)
+  if style == nil or self.tone == nil then
+    return style
+  end
+  return self.tone(style)
+end
+
+--- Append a run.
+function Row:add(run, style)
+  if run == nil or run == "" then
+    return self
+  end
+  self.spans[#self.spans + 1] = { text = run, style = self:_tone(style) }
+  self.used = self.used + widgets.len(run)
+  return self
+end
+
+--- Append `n` blank columns.
+function Row:gap(n)
+  return self:add(string.rep(" ", math.max(0, n or 1)))
+end
+
+--- Append a run that is its own click target. A run carries `id`/`role` of its
+--- own, so a chip inside a line needs no node with a hand-computed `len`.
+function Row:button(label, style, role, id)
+  if label == nil or label == "" then
+    return self
+  end
+  self.spans[#self.spans + 1] = { text = label, style = self:_tone(style), role = role, id = id }
+  self.used = self.used + widgets.len(label)
+  return self
+end
+
+--- Append text with its search hits marked, or plain when there are none.
+---
+--- `hits` is what `fuzzy.match` returned. A marked run names its own colour, so
+--- it survives a selection bar that supplies only what a span left unsaid —
+--- which matters because previewing a result moves the cursor onto the very row
+--- whose marks would otherwise disappear.
+function Row:match(subject, hits, style, hit_style)
+  if not hits then
+    return self:add(subject, style)
+  end
+  for _, span in ipairs(fuzzy.spans(subject, hits, self:_tone(style), hit_style)) do
+    self.spans[#self.spans + 1] = span
+  end
+  self.used = self.used + widgets.len(subject)
+  return self
+end
+
+--- The row's trailing note — a status, an age — appended after a separator and
+--- budgeted against what is left of the row.
+---
+--- Dropped rather than overflowed: a note that would arrive truncated to a
+--- column or two says nothing and costs the columns something else could have
+--- used. v1 drops it at the same threshold.
+local SEPARATOR = "  "
+local MIN_TRAILING = 4
+
+--- `note` rather than `text`: `text` is the kernel's measurement global, and a
+--- local of that name in a function that measures is a trap waiting for the next
+--- edit.
+function Row:trailing(note, style)
+  if not note or note == "" then
+    return self
+  end
+  -- A row with no width budgets nothing: it is being built for a rect nobody
+  -- has resolved, and truncating against a guess is worse than not truncating.
+  if not self.width then
+    return self:add(SEPARATOR):add(note, style)
+  end
+  local avail = math.max(0, self.width - self.used - widgets.len(SEPARATOR))
+  if avail < MIN_TRAILING then
+    return self
+  end
+  self:add(SEPARATOR)
+  return self:add(widgets.truncate_hard(note, avail), style)
+end
+
+--- The spans, ready for a `text` node.
+function Row:spans_list()
+  return self.spans
+end
+
+--- A span builder that knows how wide the row is.
+---
+--- The width is the whole point: every trailing note, every truncation and
+--- every right-hand budget in this interface was computed by re-measuring the
+--- spans built so far, in each pane, with its own idea of what the row's
+--- columns were.
+---
+--- opts:
+---   width — the row's columns (a list passes its own inner width). Omit it and
+---           `:trailing` budgets nothing, which is what a row built for a rect
+---           nobody has resolved wants
+---   tone  — a function every span's style passes through, which is how a row
+---           says "this whole row is dimmed" or "the bar underneath speaks for
+---           every colour" without each caller branching
+---@param opts table?
+function ui.row(opts)
+  opts = opts or {}
+  return setmetatable({
+    spans = {},
+    used = 0,
+    width = opts.width,
+    tone = opts.tone,
+  }, Row)
+end
+
+--- `── label ───────`, muted, full bleed — the rule that heads a group.
+---@param label string
+---@param width integer
+---@return thurbox.Span[]
+function ui.rule(label, width)
+  local line = "── " .. label .. " "
+  local used = widgets.len(line)
+  if width > used then
+    line = line .. string.rep("─", width - used)
+  end
+  return { { text = line, style = { fg = theme.muted } } }
+end
+
+-- ── The empty state ─────────────────────────────────────────────────────────
+
+local function centred(sentence, width)
+  local pad = math.max(0, math.floor((width - widgets.len(sentence)) / 2))
+  return { { text = string.rep(" ", pad) .. sentence, style = { fg = theme.muted } } }
+end
+
+--- The one empty state: a blank line, the sentence, and the way out.
+---
+--- Returns the LINES rather than a node, so a modal can size itself against
+--- them — a float is measured in cells and an empty state that grew a line
+--- would otherwise clip its own footer.
+---
+--- `hint_action` is looked up in the registry and the hint is dropped when
+--- nothing is bound: an empty state advertising a chord that does nothing is
+--- the failure this whole indirection exists to prevent.
+---
+--- opts: title, width, hint (a format string taking the chord), hint_action
+---@param opts table
+---@return thurbox.Span[][]
+function ui.empty(opts)
+  local width = opts.width or 0
+  local lines = { {}, centred(opts.title or "", width) }
+  local chord = opts.hint_action and ui.chord(opts.hint_action)
+  if chord and opts.hint then
+    lines[#lines + 1] = centred(string.format(opts.hint, chord), width)
+  end
+  return lines
+end
+
+-- ── The list ────────────────────────────────────────────────────────────────
+
+--- An overflow marker: a row of its own, never drawn over one.
+local function marker(label)
+  return { type = "text", len = 1, text = theme.dim(label), role = "overflow" }
+end
+
+--- The first visible item, and how many rows are hidden at each end.
+local function window_of(heights, offset, selected, height)
+  local first, visible = scroll.window_variable(heights, offset, selected, height)
+  return first, first - 1, #heights - (first - 1 + visible)
+end
+
+--- The window with room kept for however many overflow markers it needs.
+---
+--- A marker is a row, so it costs a line the rows would otherwise have had —
+--- and giving up that line can push a further row out of view, which calls for
+--- the second marker too. Hence the escalation rather than one subtraction.
+---
+--- A list with no line to spare shows rows and no markers: a strip made
+--- entirely of "N more" says nothing.
+local function marked_window(heights, offset, selected, height)
+  for markers = 0, 2 do
+    if height - markers < 1 then
+      break
+    end
+    local first, above, below = window_of(heights, offset, selected, height - markers)
+    if (above > 0 and 1 or 0) + (below > 0 and 1 or 0) <= markers then
+      return first, above, below
+    end
+  end
+  return (window_of(heights, offset, selected, height)), 0, 0
+end
+
+--- The selection bar and the hover band.
+---
+--- Built per row rather than hoisted, because a theme change must be picked up
+--- on the next frame and a role reads through the theme's own memo — and at
+--- most two rows on screen wear one.
+local function selected_style()
+  return {
+    bg = theme.role("selection_bg"),
+    fg = theme.role("selection_fg"),
+    bold = true,
+  }
+end
+
+--- Only the BACKGROUND is tinted, so a status dot and a branch colour survive
+--- being pointed at. A button gets the stronger accent fill instead; a row is
+--- not a button.
+local function hover_style()
+  return { bg = theme.role("selection_bg") }
+end
+
+--- A scrolling list of rows, with the selection bar and the window written
+--- once.
+---
+--- What a pane still decides: what a row says (`row`), what heads a group
+--- (`header`), and what "nothing here" reads as. What it no longer decides:
+--- where the window is, how the selection looks, whether a hidden row is
+--- announced, or how any of that is spelled.
+---
+--- The returned box carries `above` and `below` — the counts of rows hidden at
+--- each end. `ui.panel` reads them off the node, which is what puts a `▲ N` on
+--- the border instead of costing a content row. (An extra key on a node table
+--- is how a plugin carries its own bookkeeping; the kernel ignores it.)
+---
+--- opts:
+---   items       — the model rows, in render order
+---   cursor      — a `ui.cursor`, or a plain index
+---   width       — the row's columns, for the empty state's centring
+---   height      — the rows available
+---   row(item, selected) → spans
+---   header(item) → spans | spans[] | nil, drawn above the row and never
+---                  selected: a group heading glued to its group's first row,
+---                  so clicking the heading selects that row and the window
+---                  arithmetic counts the pair as one item
+---   id_of(item) → the row's identity, for hover, clicks and decoration
+---                 (defaults to the cursor's)
+---   class_of(item) → an extra class on the row
+---   empty       — the lines `ui.empty` returned, or a string to centre
+---   on_overflow — "rows" (markers take a line each) or "border" (the counts
+---                 ride the frame, and no line is spent on them)
+---   pad         — fill the remaining lines with blanks, so the box is exactly
+---                 `height` rows however few items there are
+---   len, fill   — the returned box's own size
+---@param opts table
+function ui.list(opts)
+  local items = opts.items or {}
+  local width = opts.width or 0
+  local cursor = opts.cursor
+  local tracked = type(cursor) == "table"
+  local selected = tracked and cursor.index or (cursor or 1)
+  local height = opts.height or #items
+  local children, above, below = {}, 0, 0
+
+  local function line(spans)
+    children[#children + 1] = { type = "text", len = 1, text = { spans } }
+  end
+
+  if #items == 0 then
+    local lines = opts.empty
+    if type(lines) == "string" then
+      lines = { centred(lines, width) }
+    end
+    for _, spans in ipairs(lines or {}) do
+      line(spans)
+    end
+  else
+    -- Headers are built in the pass that measures the list: they decide an
+    -- item's height, and building them again to draw them would be the second
+    -- source of truth this module exists to remove.
+    local heights, headers = {}, {}
+    for index, item in ipairs(items) do
+      local head = opts.header and opts.header(item) or nil
+      if head and #head == 0 then
+        head = nil
+      elseif head and head[1].text ~= nil then
+        -- One span list, not a list of them: a SPAN is what carries `text`.
+        head = { head }
+      end
+      headers[index] = head
+      heights[index] = 1 + (head and #head or 0)
+    end
+
+    local offset = tracked and cursor:offset() or 0
+    local first
+    if opts.on_overflow == "rows" then
+      first, above, below = marked_window(heights, offset, selected, height)
+    else
+      first, above, below = window_of(heights, offset, selected, height)
+    end
+    if tracked then
+      cursor:set_offset(first - 1)
+    end
+
+    local markers = ((opts.on_overflow == "rows" and above > 0) and 1 or 0)
+      + ((opts.on_overflow == "rows" and below > 0) and 1 or 0)
+    local budget = height - markers
+    if opts.on_overflow == "rows" and above > 0 then
+      children[#children + 1] = marker("  ↑ " .. above .. " more")
+    end
+
+    local drawn = 0
+    for index = first, #items do
+      if drawn >= budget then
+        break
+      end
+      -- A header may be the last thing that fits: it belongs to the row below
+      -- it, and drawing the pair or nothing would leave a blank line where the
+      -- reader can see there is more list.
+      for _, head in ipairs(headers[index] or {}) do
+        if drawn >= budget then
+          break
+        end
+        line(head)
+        drawn = drawn + 1
+      end
+      if drawn < budget then
+        local item = items[index]
+        local is_selected = index == selected
+        local id = (opts.id_of and opts.id_of(item))
+          or (tracked and identity(item, cursor.key_of))
+          or nil
+        local classes = { "row" }
+        local extra = opts.class_of and opts.class_of(item)
+        if extra then
+          classes[#classes + 1] = extra
+        end
+        if is_selected then
+          classes[#classes + 1] = "selected"
+        end
+        -- The bar is the row's own `style`: the kernel paints it across the
+        -- row's rect before the spans go on top, so it reaches the border with
+        -- no spacer span and no style merged into every span by hand. It is
+        -- the row's and not the list's, so it never bleeds onto a header glued
+        -- above a group's first row.
+        local style
+        if is_selected then
+          style = selected_style()
+        elseif id and hover.id(id) then
+          style = hover_style()
+        end
+        children[#children + 1] = {
+          type = "text",
+          len = 1,
+          text = { opts.row(item, is_selected) },
+          style = style,
+          id = id or nil,
+          class = table.concat(classes, " "),
+          -- Decoration finds rows by this role, and only the content is inside
+          -- it — so a highlight can never repaint the border.
+          role = id and "row" or nil,
+        }
+        drawn = drawn + 1
+      end
+    end
+
+    if opts.on_overflow == "rows" and below > 0 then
+      children[#children + 1] = marker("  ↓ " .. below .. " more")
+    end
+  end
+
+  if opts.pad then
+    while #children < height do
+      line({})
+    end
+  end
+
+  return {
+    type = "box",
+    len = opts.len,
+    fill = opts.fill,
+    children = children,
+    above = above,
+    below = below,
+  }
+end
+
+-- ── The panel ───────────────────────────────────────────────────────────────
+
+--- `glyph N ` laid over the tail of `strip`.
+---
+--- v1 LAYERS the two: the count is painted onto border cells the dot strip
+--- already occupies, so it covers the last dots rather than pushing them left.
+--- One right-aligned run list says the same thing, and the dots it would have
+--- covered are dropped here instead of overwritten there.
+local function with_count(strip, glyph, count)
+  if count <= 0 then
+    return strip
+  end
+  local text = glyph .. " " .. count .. " "
+  local keep = 0
+  for _, run in ipairs(strip) do
+    keep = keep + widgets.len(run.text)
+  end
+  keep = keep - widgets.len(text)
+  local runs, used = {}, 0
+  for _, run in ipairs(strip) do
+    local run_width = widgets.len(run.text)
+    if used + run_width > keep then
+      break
+    end
+    used = used + run_width
+    runs[#runs + 1] = run
+  end
+  runs[#runs + 1] = { text = text, style = { fg = theme.muted } }
+  return runs
+end
+
+--- A framed pane, in the one focus convention this interface has.
+---
+--- Focus is communicated by COLOUR — a brighter border and a title badge —
+--- never by a marker glyph, which is a rule the agent pane states and one
+--- panel builder used to contradict.
+---
+--- The overlays paint onto the border cells the block already drew, so a status
+--- strip, a scroll count or a scrollbar costs no content row and no content
+--- column.
+---
+--- A `body` built by `ui.list` with `on_overflow = "border"` carries its own
+--- hidden-row counts, and they are laid over the top-right and bottom-right
+--- overlays here rather than by the pane.
+---
+--- opts: title, focused, level, body, overlay_left, overlay_right,
+---       right_column, border, title_align
+---@param opts table
+---@return thurbox.BoxNode
+function ui.panel(opts)
+  local level = opts.level or (opts.focused and "focused" or "active")
+  local body = opts.body
+  local children = body
+  if body and body.type then
+    children = { body }
+  end
+
+  local top_right = opts.overlay_right
+  local bottom_right
+  if opts.body and type(opts.body.above) == "number" then
+    top_right = with_count(top_right or {}, "▲", opts.body.above)
+    bottom_right = with_count({}, "▼", opts.body.below)
+  end
+
+  return {
+    type = "box",
+    children = children,
+    frame = {
+      title = { { text = " " .. (opts.title or "") .. " ", style = chrome.title_style(level) } },
+      title_align = opts.title_align,
+      border_style = opts.border or chrome.border_style(level),
+      overlay = {
+        top_left = opts.overlay_left,
+        top_right = top_right,
+        bottom_right = bottom_right,
+        right_column = opts.right_column,
+      },
+    },
+  }
+end
+
+-- ── The float ───────────────────────────────────────────────────────────────
+
+--- A modal float, sized from what is in it.
+---
+--- Every float in this interface had hand-summed its own height, and each sum
+--- had to be revisited whenever a row was added to its body — which is how one
+--- of them came to clip its own footer. `rows` is still accepted for a float
+--- whose body is not a list of fixed-height children.
+---
+--- opts: title, cols, rows, children, crumbs, border
+---@param opts table
+---@return thurbox.BoxNode
+function ui.modal(opts)
+  local rows = opts.rows
+  if not rows then
+    -- The borders, plus every child that declared a height. A child that did
+    -- not is the caller's business to size, which is what `rows` is for.
+    rows = 2
+    for _, child in ipairs(opts.children or {}) do
+      rows = rows + (child.len or 0)
+    end
+  end
+  return modal.frame(opts.title, {
+    cols = opts.cols,
+    rows = rows,
+    crumbs = opts.crumbs,
+    border = opts.border,
+    children = opts.children,
+  })
+end
+
+--- The footer strip: key hints on the left, the confirm and dismiss pills on
+--- the right.
+---
+--- Hints are resolved from the key registry rather than written out, so a
+--- rebind moves the hint with the key and an action nobody bound shows no hint
+--- at all. An entry is one of:
+---
+---   "plugin.action"                  — the chord and the description the
+---                                      binding itself declares
+---   { "plugin.action", "label" }     — that chord, this label
+---   { { "a", "b" }, "label" }        — both chords, joined with `/`
+---   { key = "esc", label = "close" } — a chord the registry does not carry
+---                                      (`esc` and `enter` belong to every
+---                                      modal and are declared by none)
+---
+--- opts: actions, primary, cancel, key, style
+---@param opts table
+---@return thurbox.BoxNode
+function ui.footer(opts)
+  local hints = {}
+  for _, entry in ipairs(opts.actions or {}) do
+    local label, chord
+    if type(entry) == "string" then
+      chord, label = ui.chord(entry), ui.describe(entry)
+    elseif entry.key then
+      chord, label = entry.key, entry.label
+    else
+      label = entry[2]
+      local actions = type(entry[1]) == "table" and entry[1] or { entry[1] }
+      local chords = {}
+      for _, action in ipairs(actions) do
+        local found = ui.chord(action)
+        if found then
+          chords[#chords + 1] = found
+        end
+      end
+      chord = #chords > 0 and table.concat(chords, "/") or nil
+    end
+    if chord and label then
+      hints[#hints + 1] = { chord, label }
+    end
+  end
+  return modal.footer(hints, opts.primary, {
+    cancel = opts.cancel,
+    key = opts.key,
+    style = opts.style,
+  })
+end
+
+return ui

--- a/ui/lib/widgets.lua
+++ b/ui/lib/widgets.lua
@@ -10,8 +10,15 @@
 -- converter arm, a renderer arm, type definitions and a release. Everything
 -- below costs a file save.
 --
--- So: when you need a new appearance, add it HERE. Adding a node kind to the
+-- So: when you need a new appearance, add it in Lua. Adding a node kind to the
 -- kernel is a design decision, not a shortcut.
+--
+-- Which of the two Lua files, though: this one is the PRIMITIVE KIT — measuring,
+-- windowing, a row of text, a bar. `lib/ui.lua` is the component layer above it,
+-- and it is what a pane should reach for first: a panel, a list, a cursor, a row
+-- builder, an empty state, a footer, and with them the conventions that make
+-- several panes look like one program. A new appearance that a pane composes is
+-- this file's; a new SHAPE, with a convention attached, is `ui`'s.
 
 local hover = require("lib.hover")
 local theme = require("lib.theme")

--- a/ui/plugins/10_sessions.lua
+++ b/ui/plugins/10_sessions.lua
@@ -11,53 +11,39 @@
 -- dot strip on the top border, and the `▲ N`/`▼ N` scroll indicators overlaid on
 -- the border rows.
 --
--- The border is an ordinary kernel `frame`. It was drawn by hand, out of a cell
--- buffer, for as long as a frame title was a plain unstyled left-aligned string
--- — a frame could express none of the three things v1 puts on this border. It
--- can now: the title is styled runs, so the focused badge is a title; the dot
--- strip and the scroll counts are `frame.overlay`, painted onto the border cells
--- after the block, which is what keeps them off the content rows.
+-- The border is an ordinary kernel `frame`, and this file no longer spells it:
+-- `ui.panel` does. It was drawn by hand, out of a cell buffer, for as long as a
+-- frame title was a plain unstyled left-aligned string — a frame could express
+-- none of the three things v1 puts on this border. It can now: the title is
+-- styled runs, so the focused badge is a title; the dot strip and the scroll
+-- counts are `frame.overlay`, painted onto the border cells after the block,
+-- which is what keeps them off the content rows.
+--
+-- What is left here is the DECISIONS — which glyph, which colour role, when to
+-- drop a trailing status, what a repo header says — while the window
+-- arithmetic, the selection bar, the empty state and the focus border are
+-- `lib/ui`'s, shared with every other pane.
 
-local chrome = require("lib.chrome")
 local fuzzy = require("lib.fuzzy")
-local hover = require("lib.hover")
 local order = require("lib.order")
 local panels = require("lib.panels")
 local plugin_settings = require("lib.settings")
-local scroll = require("lib.scroll")
 local session_model = require("lib.session_model")
 local theme = require("lib.theme")
+local ui = require("lib.ui")
 local widgets = require("lib.widgets")
 
--- ── The model, the focus styling and the ordering algebra live in lib/ ──────
+-- ── The model, the components and the ordering algebra live in lib/ ─────────
 --
 -- `lib.session_model` builds the item list (one selectable unit per row, with
--- the group header glued to its group's first session), `lib.chrome` holds the
--- focus levels this pane and the terminal pane map their borders through, and
--- `lib.order` is the move/sort algebra over the rendered items. All three are
--- pure over what this pane hands them; everything about how a row LOOKS stays
--- here.
+-- the group header glued to its group's first session), `lib.ui` is the
+-- component layer — the panel, the list, the cursor and the row builder, and
+-- with them the window arithmetic, the selection bar and the focus border this
+-- pane used to spell itself — and `lib.order` is the move/sort algebra over the
+-- rendered items. All three are pure over what this pane hands them; everything
+-- about how a row LOOKS stays here.
 
 -- ── Turning a model item into lines ────────────────────────────────────────
-
---- `── label ────────`, muted, full bleed. The header never reflects selection:
---- highlighting belongs to the session rows alone.
-local function header_line(label, inner_width)
-  local text = "── " .. label .. " "
-  local used = widgets.len(text)
-  if inner_width > used then
-    text = text .. string.rep("─", inner_width - used)
-  end
-  return { { text = text, style = { fg = theme.muted } } }
-end
-
-local function status_glyph(status, elapsed)
-  local spec = theme.status(status)
-  if status == "working" then
-    return theme.spinner_frame(elapsed), spec.color
-  end
-  return spec.glyph, spec.color
-end
 
 --- The status text that follows the name. v1 shows the agent's notification (or
 --- the word "Blocked") for a blocked row, and the OSC activity title otherwise;
@@ -87,23 +73,6 @@ local function agent_status_text(session)
     end
   end
   return nil
-end
-
---- Append the trailing status, budgeted against the width actually available.
---- Dropped rather than overflowed, exactly as v1 drops it.
-local SEPARATOR = "  "
-local MIN_WIDTH = 4
-
-local function push_status(spans, text, style, inner_width)
-  if not text or text == "" then
-    return
-  end
-  local used = chrome.spans_len(spans) + widgets.len(SEPARATOR)
-  local avail = math.max(0, inner_width - used)
-  if avail >= MIN_WIDTH then
-    spans[#spans + 1] = { text = SEPARATOR }
-    spans[#spans + 1] = { text = widgets.truncate_hard(text, avail), style = style }
-  end
 end
 
 --- The live search query, or nil when nothing is being searched.
@@ -150,22 +119,22 @@ local function name_hits(session, search)
   return nil
 end
 
---- The spans of one session row, and the style the whole row wears.
+--- The spans of one session row.
 ---
---- The second return is the node's own `style`: the kernel paints it across the
---- row's whole rect before the spans go on top, which is what a selection bar
---- and a hover band are. Nothing here pads the spans to the right edge or merges
---- a style into each of them by hand.
-local function session_line(item, inner_width, elapsed, is_selected, work, search)
+--- The row's own `style` — the selection bar, the hover band — is `ui.list`'s,
+--- not this pane's: it is the one selection idiom the whole interface uses, and
+--- a pane that spelled its own would be the fourth spelling. What is still
+--- decided here is every colour a span asks for, and `tone` is where a row says
+--- the bar speaks for all of them.
+local function session_line(item, width, elapsed, is_selected, work, search)
   local session = item.session
-  local glyph, glyph_color
-  glyph, glyph_color = status_glyph(session.status, elapsed)
+  local spec = ui.status(session.status, elapsed)
+  local glyph, glyph_color = spec.glyph, spec.color
   -- A blocked row's text is an attention message, so it keeps the dot's colour;
   -- plain activity is muted, leaving the name the row's visual anchor. v1 draws
   -- the same split.
   local trailing = agent_status_text(session)
-  local trailing_color
-  trailing_color = glyph_color
+  local trailing_color = glyph_color
   if session.status ~= "blocked" then
     trailing_color = theme.muted
   end
@@ -186,85 +155,58 @@ local function session_line(item, inner_width, elapsed, is_selected, work, searc
 
   local hits = name_hits(session, search)
 
-  --- The colour a span wears, unless the ROW speaks for all of them.
-  ---
-  --- Selected: nothing names a foreground, so every cell takes the bar's —
-  --- a span that named one would poke a hole in it. Unmatched: v1 keeps a
-  --- non-matching row on screen and lets the contrast do the filtering, so the
-  --- list never jumps around under a cursor you are still moving.
-  local function tone(color)
-    if is_selected then
-      return nil
-    end
-    if search and hits == nil then
-      return { fg = theme.muted }
-    end
-    return { fg = color }
-  end
+  local row = ui.row({
+    width = width,
+    --- The colour a span wears, unless the ROW speaks for all of them.
+    ---
+    --- Selected: nothing names a foreground, so every cell takes the bar's —
+    --- a span that named one would poke a hole in it. Unmatched: v1 keeps a
+    --- non-matching row on screen and lets the contrast do the filtering, so
+    --- the list never jumps around under a cursor you are still moving.
+    tone = function(style)
+      if is_selected then
+        return nil
+      end
+      if search and hits == nil then
+        return { fg = theme.muted }
+      end
+      return style
+    end,
+  })
 
-  local spans = { { text = " " .. glyph .. " ", style = tone(glyph_color) } }
+  row:add(" " .. glyph .. " ", { fg = glyph_color })
 
   -- Nesting prefix: a tree mark for a child inside the group, a lone mark for
   -- one whose parent renders elsewhere in the list.
   if item.depth > 0 then
-    spans[#spans + 1] = {
-      text = string.rep("  ", item.depth - 1) .. "└ ",
-      style = tone(theme.muted),
-    }
+    row:add(string.rep("  ", item.depth - 1) .. "└ ", { fg = theme.muted })
   elseif item.cross_group then
-    spans[#spans + 1] = { text = "↳ ", style = tone(theme.muted) }
+    row:add("↳ ", { fg = theme.muted })
   end
 
   -- An agent running on another machine, then a session that owns a worktree.
   if session.host then
-    spans[#spans + 1] = { text = "⇅ ", style = tone(theme.accent) }
+    row:add("⇅ ", { fg = theme.accent })
   end
   if (session.worktrees or 0) > 0 then
-    spans[#spans + 1] = { text = "⑂ ", style = tone(theme.branch) }
+    row:add("⑂ ", { fg = theme.branch })
   end
 
   -- Never truncated: the name is the row's anchor, and overflow clips.
-  local name_style = tone(theme.text)
-  if hits then
-    -- A matched run is the one thing that keeps its colour on a selected row:
-    -- it names a foreground, and the bar underneath supplies only what a span
-    -- left unsaid. v1 layered the same two the same way round —
-    -- `highlight_style` was built ON TOP of the row's base style
-    -- (`src/ui/highlight.rs`) — and previewing a result moves this list's
-    -- cursor onto the row, so the selected row is exactly the one whose marks
-    -- would otherwise disappear.
-    local hit_style = { fg = theme.accent, bold = true, underline = true }
-    for _, span in ipairs(fuzzy.spans(session.name or "?", hits, name_style, hit_style)) do
-      spans[#spans + 1] = span
-    end
-  else
-    spans[#spans + 1] = { text = session.name or "?", style = name_style }
-  end
+  --
+  -- A matched run is the one thing that keeps its colour on a selected row: it
+  -- names a foreground, and the bar underneath supplies only what a span left
+  -- unsaid. v1 layered the same two the same way round — `highlight_style` was
+  -- built ON TOP of the row's base style (`src/ui/highlight.rs`) — and
+  -- previewing a result moves this list's cursor onto the row, so the selected
+  -- row is exactly the one whose marks would otherwise disappear.
+  row:match(session.name or "?", hits, { fg = theme.text }, {
+    fg = theme.accent,
+    bold = true,
+    underline = true,
+  })
 
-  push_status(spans, trailing, tone(trailing_color), inner_width)
-
-  -- The bar is the row's own style rather than a list-wide highlight, which
-  -- would bleed onto the group header glued above a group's first row.
-  if is_selected then
-    return spans,
-      {
-        bg = theme.role("selection_bg"),
-        fg = theme.role("selection_fg"),
-        bold = true,
-      }
-  end
-  if hover.id(session.id) then
-    -- v1's row hover: a subtle band marking what a click would hit. Only the
-    -- BACKGROUND is tinted — each cell keeps its own fg, so the status dot and
-    -- the branch colour survive being hovered. A button gets the stronger
-    -- accent fill instead (see the agent pane's chips); a row is not a button.
-    --
-    -- Skipped on the selected row because v1 tints it to the colour it already
-    -- has, which is no change at all.
-    return spans, { bg = theme.role("selection_bg") }
-  end
-
-  return spans
+  return row:trailing(trailing, { fg = trailing_color }):spans_list()
 end
 
 --- v1's phase vocabulary, which the placeholder row shows beside the label.
@@ -280,8 +222,8 @@ local PHASE_LABEL = {
   persisting = "spawning…",
 }
 
-local function pending_line(command, inner_width, elapsed)
-  local failed = command.phase == "failed"
+local function pending_line(work, width, elapsed)
+  local failed = work.phase == "failed"
   local glyph, glyph_style
   if failed then
     glyph, glyph_style = "✗", { fg = theme.role("status_error") }
@@ -290,40 +232,24 @@ local function pending_line(command, inner_width, elapsed)
     glyph, glyph_style = theme.spinner_frame(elapsed), { fg = theme.warn }
   end
 
-  local label = command.subject or "new session"
+  local label = work.subject or "new session"
   local phase
   if failed then
-    phase = command.error and ("failed: " .. command.error) or "failed"
+    phase = work.error and ("failed: " .. work.error) or "failed"
   else
-    phase = PHASE_LABEL[command.phase] or "creating…"
+    phase = PHASE_LABEL[work.phase] or "creating…"
   end
 
-  local spans = {
-    { text = " " .. glyph .. " ", style = glyph_style },
-    { text = label, style = { fg = theme.secondary } },
-  }
-  -- Drop the phase rather than overflow a narrow panel.
-  local used = 3 + widgets.len(label)
-  if inner_width > used + widgets.len(phase) + 2 then
-    spans[#spans + 1] = { text = "  " .. phase, style = { fg = theme.muted } }
+  local row = ui.row({ width = width })
+  row:add(" " .. glyph .. " ", glyph_style)
+  row:add(label, { fg = theme.secondary })
+  -- Drop the phase rather than overflow a narrow panel. Not `row:trailing`:
+  -- that keeps a note only when four columns are left for it, and a creation
+  -- phase is either shown whole or not at all.
+  if width > row.used + widgets.len(phase) + 2 then
+    row:add("  " .. phase, { fg = theme.muted })
   end
-  return spans
-end
-
---- Move the cursor by `step`, skipping items that select nothing.
-local function move(items, from, step)
-  local count = #items
-  if count == 0 then
-    return 1
-  end
-  local at = from
-  for _ = 1, count do
-    at = (at - 1 + step) % count + 1
-    if items[at].target then
-      return at
-    end
-  end
-  return from
+  return row:spans_list()
 end
 
 local function sessions()
@@ -434,22 +360,20 @@ local function delete_for_good(session, question)
   }
 end
 
---- The chord bound to opening the creation flow, if anything is.
----
---- Read from the registry rather than hardcoded, because it is rebindable and
---- because the flow is removable: the empty state must not name a key that
---- resolves to nothing.
-local function new_session_chord()
-  for _, binding in ipairs((thurbox and thurbox.registry and thurbox.registry.keys) or {}) do
-    if binding.action == "new_session.open" then
-      return binding.key
-    end
-  end
-  return nil
-end
-
 --- Persist a rendered order. Header ownership is a *rendering* property of the
 --- first row in a group, so it is left to the next build rather than carried.
+--- This list's cursor, in the one spelling every handler here reads it with.
+---
+--- `target` is a model item's identity — nil on a group header, `false` on work
+--- with no session yet — so a row that selects nothing is skipped by
+--- construction rather than by each caller checking. `steer` is the `store` key
+--- another pane writes to move this list; `request` is the one-shot
+--- `focus_session` a clicked notification or `thurbox-cli session focus` leaves,
+--- and it is read only by `render` because consuming it anywhere else would
+--- spend it on a frame that is not being drawn.
+local CURSOR_OPTS = { id = "target", steer = "selected" }
+local CURSOR_OPTS_WITH_REQUEST = { id = "target", steer = "selected", request = "focus_session" }
+
 local function persist_order(items)
   local ids = {}
   for _, item in ipairs(items) do
@@ -460,31 +384,6 @@ local function persist_order(items)
   if #ids > 0 then
     command("order", { list = ids })
   end
-end
-
---- `glyph N ` right-aligned over the tail of `strip`.
----
---- v1 LAYERS the two: the count is painted onto border cells the dot strip
---- already occupies, so it covers the last dots rather than pushing them left.
---- One right-aligned run list says the same thing, and the dots it would have
---- covered are dropped here instead of overwritten there.
-local function with_count(strip, glyph, count)
-  if count <= 0 then
-    return strip
-  end
-  local text = glyph .. " " .. count .. " "
-  local keep = chrome.spans_len(strip) - widgets.len(text)
-  local runs, used = {}, 0
-  for _, run in ipairs(strip) do
-    local width = widgets.len(run.text)
-    if used + width > keep then
-      break
-    end
-    used = used + width
-    runs[#runs + 1] = run
-  end
-  runs[#runs + 1] = { text = text, style = { fg = theme.muted } }
-  return runs
 end
 
 return {
@@ -636,16 +535,12 @@ return {
     -- ctx.width/height are THIS PANE's, not the screen's.
     local width = math.max(0, ctx.width or 0)
     local height = math.max(0, ctx.height or 0)
-    local level = ctx.focused and "focused" or "active"
-    local frame_style = chrome.border_style(level)
     if width < 2 or height < 2 then
       return { type = "text", text = "" }
     end
     local inner_width = width - 2
-    local inner_height = height - 2
 
-    local list = sessions()
-    local items = session_model.build(list)
+    local items = session_model.build(sessions())
     local busy = session_model.pending()
     -- The live query, read once per render and compiled once: `session_line`
     -- runs per visible row, and each used to re-read the store and re-split
@@ -653,164 +548,63 @@ return {
     local query = search_query()
     local search = query and { text = query, needle = fuzzy.compile(query) } or nil
 
-    -- Keep the cursor on the session it was on, not on a row number.
-    --
-    -- A reorder is a command: it lands a frame or two later, and the row that
-    -- was under the cursor has moved by then. Following the id instead means
-    -- holding J walks a session down the list, which is what you meant.
-    local cursor = state.cursor or 1
-    -- An outside request to select a session: a clicked OS notification, or
-    -- `thurbox-cli session focus`. Consumed here and cleared, because the cursor
-    -- is republished from this pane every frame — anything that merely wrote
-    -- `store.selected` would be overwritten a frame later.
-    if store.focus_session then
-      state.follow = store.focus_session
-      store.focus_session = nil
-    end
-    -- Another PANE may steer the selection by writing `store.selected` — the
-    -- search strip jumping to a result, a task opening the session it spawned.
-    -- Publishing the cursor every frame would undo that write a frame later, so a
-    -- value this pane did not publish is read as a request and followed. v1's
-    -- panes call `App::select_session` for the same reason.
-    local steered = store.selected
-    if steered and steered ~= state.published then
-      state.follow = steered
-    end
-    if state.follow then
-      for index, item in ipairs(items) do
-        if item.target == state.follow then
-          cursor = index
-          break
-        end
-      end
-    end
-    cursor = widgets.clamp(cursor, #items)
-    if #items > 0 and not items[cursor].target then
-      cursor = move(items, cursor, 1)
-    end
-    state.cursor = cursor
-    -- Publish the selection so the agent pane knows what to show, remembering
-    -- what was published so an outside write can be told from our own echo.
-    local target = items[cursor] and items[cursor].target or nil
-    store.selected = target
-    state.published = target
+    -- The cursor follows the SESSION it was on rather than a row number, is
+    -- steered by another pane writing `store.selected`, and answers a focus
+    -- request from outside the interface — all three written once in `ui.cursor`
+    -- and shared with the two handlers below.
+    local cursor = ui.cursor("sessions", items, CURSOR_OPTS_WITH_REQUEST)
 
-    -- One dot per session on the top border, in render order, each in its own
-    -- status colour. Suppressed entirely when there are no sessions.
-    local dots = {}
-    for _, item in ipairs(items) do
-      if item.kind == "session" then
-        local glyph, color = status_glyph(item.session.status, ctx.elapsed)
-        dots[#dots + 1] = { text = glyph, style = { fg = color } }
-      end
-    end
-
-    local function row(line)
-      line = line or {}
-      return {
-        type = "text",
-        len = 1,
-        text = { line.spans or {} },
-        -- The row's own style covers this rect and this rect only, and the rect
-        -- is the frame's inner width — so a selection bar reaches the border and
-        -- never paints over it.
-        style = line.style,
-        id = line.id,
-        class = line.class,
-        -- Decoration (the search plugin) finds rows by this role, and only the
-        -- content is inside it — so a highlight can never repaint the border.
-        role = line.id and "row" or nil,
-      }
-    end
-
-    local lines, above, below = {}, 0, 0
-
-    if #items == 0 then
-      -- v1's placeholder: a blank line, then two centred muted lines.
-      local function centred(text)
-        local pad = math.max(0, math.floor((inner_width - widgets.len(text)) / 2))
-        return { { text = string.rep(" ", pad) .. text, style = { fg = theme.muted } } }
-      end
-      -- `{ spans = … }`, like every other entry: the row builder below reads
-      -- `line.spans`, so a bare span list here renders as a blank row — which is
-      -- exactly what the placeholder did until a test looked at it.
-      lines[1] = { spans = {} }
-      lines[2] = { spans = centred("No sessions yet") }
-      -- v1's second line names the chord that creates one, and it is only shown
-      -- when something actually answers it: the chord is looked up in the
-      -- registry rather than written here, so a rebind — or the flow being
-      -- removed — cannot leave the empty state advertising a key that does
-      -- nothing.
-      local chord = new_session_chord()
-      if chord then
-        lines[3] = { spans = centred("Press " .. chord .. " to create one") }
-      end
-    else
-      local heights = {}
-      for index, item in ipairs(items) do
-        heights[index] = item.header and 2 or 1
-      end
-
-      local first, visible =
-        scroll.window_variable(heights, state.offset or 0, cursor, inner_height)
-      state.offset = first - 1
-      above = first - 1
-      below = #items - (first - 1 + visible)
-
-      for index = first, #items do
-        local item = items[index]
-        if #lines >= inner_height then
-          break
-        end
-        if item.header then
-          lines[#lines + 1] = { spans = header_line(item.header, inner_width) }
-        end
-        if #lines < inner_height then
+    return ui.panel({
+      title = "Sessions",
+      focused = ctx.focused,
+      -- One dot per session, in render order and in its own status colour,
+      -- painted onto the top border. The scroll counts are laid over its tail
+      -- by `ui.panel`, from the list's own hidden-row counts — every one of
+      -- them a border cell, so none costs a row.
+      overlay_right = ui.dots(items, ctx.elapsed, function(item)
+        return item.kind == "session" and item.session.status or nil
+      end),
+      body = ui.list({
+        items = items,
+        cursor = cursor,
+        width = inner_width,
+        height = height - 2,
+        on_overflow = "border",
+        -- The pane is a column of its own: it holds its rows apart from the
+        -- bottom border however few of them there are.
+        pad = true,
+        --- `── label ────────`, muted, full bleed. The header never reflects
+        --- selection: highlighting belongs to the session rows alone.
+        header = function(item)
+          return item.header and ui.rule(item.header, inner_width) or nil
+        end,
+        class_of = function(item)
+          return item.kind == "pending" and "pending-row" or "session-row"
+        end,
+        row = function(item, selected)
           if item.kind == "pending" then
-            lines[#lines + 1] = {
-              spans = pending_line(item.command, inner_width, ctx.elapsed),
-              class = "pending-row",
-            }
-          else
-            local spans, style = session_line(
-              item,
-              inner_width,
-              ctx.elapsed,
-              index == cursor,
-              busy[item.session.id],
-              search
-            )
-            lines[#lines + 1] = {
-              spans = spans,
-              style = style,
-              id = item.session.id,
-              class = "session-row",
-            }
+            return pending_line(item.command, inner_width, ctx.elapsed)
           end
-        end
-      end
-    end
-
-    local children = {}
-    for index = 1, inner_height do
-      children[#children + 1] = row(lines[index])
-    end
-
-    -- The title badge at the left, the dot strip right-aligned on the same row
-    -- with the "items above" count over its tail, and "items below" on the
-    -- bottom border — every one of them a border cell, so none costs a row.
-    return {
-      type = "box",
-      children = children,
-      frame = {
-        title = { { text = " Sessions ", style = chrome.title_style(level) } },
-        border_style = frame_style,
-        overlay = {
-          top_right = with_count(dots, "▲", above),
-          bottom_right = with_count({}, "▼", below),
-        },
-      },
-    }
+          return session_line(
+            item,
+            inner_width,
+            ctx.elapsed,
+            selected,
+            busy[item.session.id],
+            search
+          )
+        end,
+        -- v1's placeholder, and its second line names the chord that creates a
+        -- session — shown only while something actually answers it, so a rebind
+        -- or the flow being removed cannot leave this advertising a dead key.
+        empty = ui.empty({
+          title = "No sessions yet",
+          width = inner_width,
+          hint = "Press %s to create one",
+          hint_action = "new_session.open",
+        }),
+      }),
+    })
   end,
 
   --- Go to a session you just made, when you asked to be taken there.
@@ -835,7 +629,7 @@ return {
     -- the one that shows a session, takes the keyboard. `store.selected` is
     -- written here as well as followed, because a pane that draws before this
     -- one otherwise shows the previous session for a frame.
-    state.follow = id
+    ui.follow("sessions", id)
     store.selected = id
     command("focus", { text = "agent" })
   end,
@@ -855,15 +649,7 @@ return {
       return false
     end
     local items = session_model.build(sessions())
-    local index = widgets.index_of(items, hit.id, "target")
-    if not index then
-      return false
-    end
-    state.follow = nil
-    state.cursor = index
-    store.selected = hit.id
-    state.published = hit.id
-    return true
+    return ui.cursor("sessions", items, CURSOR_OPTS):select_by_id(hit.id) ~= nil
   end,
 
   on_action = function(action)
@@ -877,31 +663,29 @@ return {
       -- restores its own `pending_delete` — rather than reaching for the most
       -- recently deleted row, which may belong to another instance.
       if not state.deleted then
-        return false
+        -- Said out loud rather than swallowed. Ctrl+Z is global: it fires
+        -- from a focused terminal, and with the column hidden (F9) there is
+        -- nothing on screen to tell "there was nothing to undo" from a chord
+        -- that never arrived.
+        command("message", { text = "nothing to undo" })
+        return true
       end
       command("restore", { session = state.deleted })
       state.deleted = nil
       return true
     end
 
-    local list = sessions()
-    local items = session_model.build(list)
+    local items = session_model.build(sessions())
     if #items == 0 then
       return false
     end
-    local at = widgets.clamp(state.cursor or 1, #items)
-    local id = items[at].target or nil
-
-    -- Moving the cursor republishes the selection here as well as in render,
-    -- because Ctrl+J/K are global: with the column hidden (F9) or a terminal
-    -- focused, this pane may not render again before the agent pane does.
-    local function select_row(index)
-      state.follow = nil
-      state.cursor = index
-      local target = items[index] and items[index].target or store.selected
-      store.selected = target
-      state.published = target
-    end
+    -- The same cursor `render` builds, from the same state: moving it here
+    -- republishes the selection as well, because Ctrl+J/K are global — with the
+    -- column hidden (F9) or a terminal focused, this pane may not render again
+    -- before the agent pane does.
+    local cursor = ui.cursor("sessions", items, CURSOR_OPTS)
+    local at = cursor.index
+    local id = cursor:id()
 
     -- Actions, not chords. The kernel already resolved which key was pressed,
     -- so the capital-vs-shift encoding trap is its problem now, not ours.
@@ -912,11 +696,11 @@ return {
         command("focus", { text = "agent" })
       end
     elseif action == "sessions.next" then
-      select_row(move(items, at, 1))
+      cursor:move(1)
     elseif action == "sessions.previous" then
-      select_row(move(items, at, -1))
+      cursor:move(-1)
     elseif action == "sessions.first" then
-      select_row(move(items, 0, 1))
+      cursor:select(1)
 
     -- Every state change below is a COMMAND: accepted instantly, its effect
     -- appearing in a later snapshot. Nothing here waits for anything.
@@ -962,23 +746,23 @@ return {
     elseif action == "sessions.editor" and id then
       command("editor", { session = id })
     -- A move is computed over the RENDERED items and sent whole, so a root row
-    -- drags its subtree and a group edge moves the group. `state.follow` keeps
-    -- the cursor on the session rather than the row index, since the order it
-    -- was pressed at lands a frame or two later.
+    -- drags its subtree and a group edge moves the group. The cursor FOLLOWS the
+    -- session rather than the row index, since the order it was pressed at lands
+    -- a frame or two later.
     elseif action == "sessions.move_down" and id then
       local moved = order.move_block(items, at, true)
       if moved then
-        state.follow = id
+        cursor:follow(id)
         persist_order(moved)
       end
     elseif action == "sessions.move_up" and id then
       local moved = order.move_block(items, at, false)
       if moved then
-        state.follow = id
+        cursor:follow(id)
         persist_order(moved)
       end
     elseif action == "sessions.sort" then
-      state.follow = id
+      cursor:follow(id)
       persist_order(order.sorted_within_groups(items))
     else
       return false

--- a/ui/plugins/80_restore.lua
+++ b/ui/plugins/80_restore.lua
@@ -11,8 +11,8 @@
 -- through `store.confirm` — the same confirmation the session list uses for a
 -- delete, which is why there is no bespoke `ConfirmRestore` here.
 
-local modal = require("lib.modal")
 local theme = require("lib.theme")
+local ui = require("lib.ui")
 local widgets = require("lib.widgets")
 
 --- The float's width, asked for in CELLS rather than as a share of the screen.
@@ -25,18 +25,22 @@ local widgets = require("lib.widgets")
 local MODAL_COLS = 60
 
 --- The columns a row inside the float actually gets: the frame's own border on
---- each side, then the selection marker `widgets.list` draws.
+--- each side, then the column the row is indented by so its text does not sit
+--- against the frame.
 local function row_cols(cols)
-  return math.max(1, cols - 4)
+  return math.max(1, cols - 3)
 end
 
---- Rows shown at once. More than this and the list windows, which
---- `widgets.list` does with the overflow markers already.
+--- Rows shown at once. More than this and the list windows, which `ui.list`
+--- does with the overflow markers already.
 local LIST_MAX = 10
 
 local function deleted()
   return (thurbox and thurbox.deleted) or {}
 end
+
+--- The name this float's cursor keeps its state under.
+local CURSOR = "restore"
 
 local function is_open()
   return state.open == true
@@ -44,14 +48,10 @@ end
 
 local function close()
   state.open = nil
-  state.cursor = nil
-end
-
---- The selection, always resolved against the list it indexes: rows leave
---- `thurbox.deleted` as they are restored, so a stored cursor outlives the row
---- it pointed at.
-local function cursor_in(list)
-  return widgets.clamp(state.cursor or 1, #list)
+  -- The list opens at the top rather than wherever it was left: rows leave
+  -- `thurbox.deleted` as they are restored, so a remembered cursor outlives the
+  -- row it pointed at.
+  ui.reset(CURSOR)
 end
 
 --- One row, in v1's spelling: `name (agent) 3m ago [wt]`.
@@ -72,23 +72,37 @@ local function row_spans(entry, cols)
   -- Truncated against the columns a row really has, so the tag is never what
   -- gets clipped: it is the part of the row that changes what Enter means.
   text = widgets.truncate(text, math.max(1, row_cols(cols) - widgets.len(tag)))
-  local spans = { { text = text, style = { fg = base } } }
+  local row = ui.row({ width = cols - 2 })
+  -- One column of lead-in, so the text clears the frame. The selected row wears
+  -- the interface's full-width bar rather than a marker glyph, so there is
+  -- nothing else to make room for.
+  row:add(" ")
+  row:add(text, { fg = base })
   if entry.partial then
-    spans[#spans + 1] = { text = tag, style = { fg = theme.bad } }
+    row:add(tag, { fg = theme.bad })
   end
-  return spans
+  return row:spans_list()
 end
 
---- v1's `key_hint_line` plus its `[ Restore ]` / `[ Close ]` pills — the
---- shared `modal.footer`, with the Restore pill offered only while there is a
---- row for Enter to act on.
+--- v1's `key_hint_line` plus its `[ Restore ]` / `[ Close ]` pills — the shared
+--- `ui.footer`, with the Restore pill offered only while there is a row for
+--- Enter to act on.
+---
+--- The navigation hint names the chords the REGISTRY resolves rather than the
+--- letters this file happens to have declared, so a rebind moves the hint with
+--- the key. `esc` is written out because no binding carries it: dismissing is
+--- what a modal owns without declaring.
 local function footer(list)
-  local hints = {}
+  local actions = {}
   if #list > 0 then
-    hints[#hints + 1] = { "j/k", "navigate" }
+    actions[#actions + 1] = { { "restore.next", "restore.previous" }, "navigate" }
   end
-  hints[#hints + 1] = { "esc", "close" }
-  return modal.footer(hints, #list > 0 and "Restore" or nil, { cancel = "Close" })
+  actions[#actions + 1] = { key = "esc", label = "close" }
+  return ui.footer({
+    actions = actions,
+    primary = #list > 0 and "Restore" or nil,
+    cancel = "Close",
+  })
 end
 
 --- Ask before a restore the kernel would otherwise refuse, through the
@@ -127,9 +141,9 @@ return {
   -- This render reads `thurbox.deleted`, `state` and the theme and writes
   -- nothing, so the kernel may reuse the tree — and floats render every frame
   -- even while closed, so without this the closed state costs a Lua call per
-  -- frame forever. `state.open`/`state.cursor` writes bump the state version,
-  -- which is part of the cache key, and `thurbox.deleted` rides the snapshot
-  -- version, so opening and refreshing stay on the very next frame.
+  -- frame forever. `state.open` and the cursor's own writes bump the state
+  -- version, which is part of the cache key, and `thurbox.deleted` rides the
+  -- snapshot version, so opening and refreshing stay on the very next frame.
   pure = true,
   -- Never a tab stop: it is up only while it is open, and it takes every key
   -- while it is.
@@ -164,34 +178,33 @@ return {
     -- the clamp the kernel will apply to the float is applied to the rows too.
     local cols = math.min(MODAL_COLS, math.max(4, ctx.width or MODAL_COLS))
     local list = deleted()
-    local cursor = cursor_in(list)
-    -- Spans only for the visible window — the list's own window is a sub-range
-    -- of this one (it shrinks to make room for the overflow markers), so every
-    -- row it reads has spans; off-window entries are placeholders whose spans
-    -- the list never reads. The deleted list can be long after an unpurged
-    -- week, and it shows ten rows.
-    local height = math.max(1, math.min(#list, LIST_MAX))
-    local first, last = widgets.window(#list, height, cursor)
-    local rows = {}
-    for index, entry in ipairs(list) do
-      if index >= first and index <= last then
-        rows[index] = { spans = row_spans(entry, cols), id = entry.id }
-      else
-        rows[index] = { spans = {}, id = entry.id }
-      end
-    end
-    local body = widgets.list({
-      rows = rows,
-      selected = cursor,
-      height = height,
-      len = height,
-      empty = "  No deleted sessions",
-    })
+    local cursor = ui.cursor(CURSOR, list)
+    -- The empty state is measured rather than assumed a row high: this float is
+    -- sized in cells, and one that guessed would clip its own footer.
+    local empty = ui.empty({ title = "No deleted sessions", width = cols - 2 })
+    -- The deleted list can be long after an unpurged week, and it shows ten
+    -- rows. `ui.list` builds spans only for the rows it draws, so a long list
+    -- costs the ten it shows.
+    local height = #list > 0 and math.min(#list, LIST_MAX) or #empty
 
-    return modal.frame("Restore Deleted Sessions", {
+    return ui.modal({
+      title = "Restore Deleted Sessions",
       cols = cols,
-      rows = height + 3,
-      children = { body, footer(list) },
+      children = {
+        ui.list({
+          items = list,
+          cursor = cursor,
+          width = cols - 2,
+          height = height,
+          len = height,
+          on_overflow = "rows",
+          row = function(entry)
+            return row_spans(entry, cols)
+          end,
+          empty = empty,
+        }),
+        footer(list),
+      },
     })
   end,
 
@@ -203,19 +216,19 @@ return {
         close()
       else
         state.open = true
-        state.cursor = 1
+        ui.reset(CURSOR)
       end
       return true
     end
     if not is_open() then
       return false
     end
-    local list = deleted()
+    local cursor = ui.cursor(CURSOR, deleted())
     if action == "restore.next" then
-      state.cursor = widgets.clamp(cursor_in(list) + 1, #list)
+      cursor:move(1)
       return true
     elseif action == "restore.previous" then
-      state.cursor = widgets.clamp(cursor_in(list) - 1, #list)
+      cursor:move(-1)
       return true
     end
     return false
@@ -232,8 +245,7 @@ return {
       return true
     end
     if key.key == "enter" then
-      local list = deleted()
-      local entry = list[cursor_in(list)]
+      local entry = ui.cursor(CURSOR, deleted()):item()
       if not entry then
         -- An empty list still swallows the key: a modal that acted on nothing
         -- would be indistinguishable from one that failed.
@@ -262,10 +274,7 @@ return {
       return false
     end
     if hit.id then
-      local index = widgets.index_of(deleted(), hit.id)
-      if index then
-        state.cursor = index
-      end
+      ui.cursor(CURSOR, deleted()):select_by_id(hit.id)
     end
     -- Claimed either way, so a miss inside the float does not fall through to
     -- the pane beneath it.


### PR DESCRIPTION
## Intent

Step 6 of a six-step series that acts on a read-only review of thurbox's Lua interface layer (~/.cache/thurbox-review/2026-09-04-lua-ui-review.md). Steps 1-5 are merged (PRs #1069-#1073: the thurbox.d.lua type definitions, the widgets.list overflow fix, text.style on text nodes, text.width/truncate/pad globals, and frame title_align/border_type/overlay). This step lands the component layer the review proposes in its section 3.2 and the two kernel command verbs from section 3.1, so that a plugin author - human or LLM - can produce a clean, consistent pane with little code.

Concretely, as asked: add ui/lib/ui.lua with ui.panel, ui.list, ui.cursor, ui.row, ui.empty, ui.modal, ui.footer, ui.status/ui.dots, ui.rule and the registry lookups (ui.chord/ui.describe/ui.follow/ui.reset); add command("action", {text=id}) and command("message", {text, level}) to src/kernel/command/mod.rs; and convert ui/plugins/10_sessions.lua and ui/plugins/80_restore.lua onto the layer.

Deliberate decisions the user made or approved, which a reviewer reading only the diff would not know:

1. SCOPE WAS DELIBERATELY LIMITED. The user asked to "keep the PR reviewable: land ui/lib/ui.lua, the two command verbs, and the sessions + restore conversions; leave search and new_session for a follow-up if the diff grows, and say so." So 65_search.lua, 70_new_session.lua and 20_agent.lua are NOT converted and still spell their own panel, list, footer and cursor. That is intentional, not an oversight, and it is stated in the commit message. widgets.list, widgets.panel and lib/modal.lua therefore stay in place - 65_search still uses them - even though the review wants them retired eventually.

2. ui.chips AND ui.field ARE DELIBERATELY ABSENT even though the review section 3.2 lists them. Their only consumers would be 20_agent (chips) and the creation flow (field), neither of which is in scope. The review itself records that this bundle already carries four widgets no plugin calls ("Dead on arrival in the bundle: widgets.hints, widgets.gauge, widgets.divider, widgets.pad"), so shipping a component with no consumer would repeat exactly the mistake the review names. Both come with the follow-up conversions. This is stated in the commit message.

3. TWO FRAME CHANGES ARE INTENTIONAL, and are the section 4 inconsistencies the conversion unifies (the step brief explicitly permits frame changes "only where the review 4 inconsistencies are being unified, and each such change is called out"):
- the restore float loses its per-row "▸ " selection marker in favour of the full-width selection bar the session list uses (review 4, "selection": one idiom, not three), which also gives each row one more column of text (row_cols goes from cols-4 to cols-3);
- the restore float centres its empty state instead of left-aligning " No deleted sessions" (review 4, "empty state": "four spellings, two alignments"), which makes the float one row taller.
The session list frames are byte-identical - tests/frames.rs passes unchanged, which is the proof that the conversion is a refactor.

4. Ctrl+Z WITH NOTHING TO UNDO NOW POSTS A MESSAGE instead of returning false silently, and tests/keymap.rs was updated accordingly (it previously asserted no command at all). This is a deliberate behaviour change and the first real consumer of command("message"): Ctrl+Z is a global chord that fires from a focused agent terminal and with the session column hidden by F9, so silence was indistinguishable from the keystroke never arriving. The keymap test still proves the important thing - that it does not restore a stranger row.

5. command("action") ships with kernel tests, an e2e test and type definitions but NO Lua consumer in this PR. That is expected: its consumers are the modal-shell simplifications in 70_new_session/60_confirm/80_restore that the review section 2.8 describes, which belong to the follow-up. It is a public plugin API verb, not an internal helper.

6. ui.cursor writes its state under prefixed top-level keys (state["sessions.cursor"] etc) rather than a nested table, because the kernel's state proxy returns a fresh table per read so in-place mutation of a nested table is lost (review section 2.4). Idempotent writes do not bump the state version, so both converted panes stay pure = true and the render cache still works.

7. ui.row:trailing is NOT right-aligned even though the review sketch spells it :right(). The session list's actual behaviour is a budgeted trailing append after a two-space separator, dropped below four columns - making it truly right-aligned would change the frames for no reason the review asks for. The method is named for what it does and the doc comment says why.

Tests written first, all failing for the right reason before the implementation: unit tests in src/kernel/command/mod.rs for both verbs and their refusals; tests/plugin_chrome.rs (new) for the Lua-to-Command path including the misspelt-option trap; a tui_e2e scenario driving a real pty that asserts the message band badges ERROR and that command("action") opens the help modal - the coordinator half is only reachable through the binary's own draw; and a new tests/restore.rs test proving the footer hint follows a rebind through the key registry rather than naming keys itself.

Docs updated in the same PR per the repo rule: ui/README.md (new component-layer section, the whole-plugin example rewritten onto the layer, the two verbs), ui/AGENTS.md, docs/PLUGINS.md, docs/CONSTITUTION.md, docs/V2-KERNEL.md and .claude/skills/thurbox-kernel/SKILL.md. Stale comments in ui/lib/chrome.lua, ui/lib/widgets.lua and the session list header were refreshed where the layer took work off them.

Local gate before running this: just lint (fmt, clippy, deny, rumdl, shellcheck, selene, stylua, lua-language-server, check-lua-types) and just test (2459 tests) both pass; all 20 pre-commit hooks passed; the commit is SSH-signed as LeTuR.

PR title must be a conventional commit whose scope is one of api/cli/ui/git/core/docs/deps/config/mcp - never "kernel" - because main is squash-merge and cog reads the PR title.

## What Changed

- Added `ui/lib/ui.lua`, a new Lua component layer (`ui.panel`, `ui.list`, `ui.cursor`, `ui.row`, `ui.empty`, `ui.modal`, `ui.footer`, `ui.status`/`ui.dots`, `ui.rule`, plus registry lookups `ui.chord`/`ui.describe`/`ui.follow`/`ui.reset`) so plugin panes can be built with less boilerplate; `ui/lib/thurbox.d.lua` type definitions were extended to cover it.
- Added two kernel command verbs, `command("action", {text=id})` and `command("message", {text, level})`, in `src/kernel/command/mod.rs`, wired through `src/coordinator/commands.rs`, `src/kernel/command/execute.rs`, `src/kernel/host/api.rs`, and `src/kernel/bands.rs`/`src/kernel/bundled.rs`; a Ctrl+Z with nothing to undo now posts a message via this path instead of silently doing nothing (`tests/keymap.rs` updated accordingly).
- Converted `ui/plugins/10_sessions.lua` and `ui/plugins/80_restore.lua` onto the new component layer, unifying the restore float's selection marker into the full-width selection bar and centering its empty state to match the session list; `ui/lib/chrome.lua` and `ui/lib/widgets.lua` were refreshed alongside.
- Added `tests/plugin_chrome.rs`, extended `tests/tui_e2e.rs` and `tests/restore.rs`, and updated `ui/README.md`, `ui/AGENTS.md`, `docs/PLUGINS.md`, `docs/CONSTITUTION.md`, `docs/V2-KERNEL.md`, and `.claude/skills/thurbox-kernel/SKILL.md` to document the new layer and command verbs.

## Risk Assessment

✅ Low: The change is a faithful, mechanical refactor of two panes onto a new shared Lua component layer plus two well-tested kernel command verbs; every deliberate deviation (frame changes, Ctrl+Z messaging, missing chips/field, action with no consumer, unusual cursor state keys) is explicitly called out in the intent and verified present in the diff, all new Rust code follows established patterns (UI-thread gating, exhaustive match arms, idempotent state-write versioning), and the new tests exercise real interfaces (rendered trees, a real pty, parsed commands) rather than source-text greps.

## Testing

Targeted nextest selectors for every test file this change touches or adds (plugin_chrome.rs, frames.rs, keymap.rs, restore.rs, tui_e2e.rs, and the new kernel::command::tests) all pass, including the real-pty tui_e2e scenario that is the only way to exercise the coordinator half of command(\"message\")/command(\"action\"). Beyond the test suite, I drove the actual thurbox dev binary end-to-end in an isolated sandbox and captured three screenshots that visually confirm the two deliberate section-4 frame/behavior unifications called out in the intent: the restore float's empty state is centered (not left-aligned) after the 80_restore.lua conversion, and Ctrl+Z with nothing to undo now visibly posts an INFO message to the band instead of doing nothing silently. A spot-check confirmed the stated out-of-scope plugins (65_search.lua, 20_agent.lua) were deliberately left on the old widgets.lua API. No product or setup issues found; no cleanup needed beyond removing the temporary /tmp sandbox and tmux socket used for screenshotting, which never touched the worktree.

- Evidence: Sessions panel rendered via converted 10_sessions.lua on the new ui.lib component layer (local file: <code>01-sessions-panel-ui-lib.png</code>)
- Evidence: Restore float&#39;s unified centered empty state (&#39;No deleted sessions&#39;) after the 80_restore.lua conversion (review section 4 &#39;empty state&#39; unification) (local file: <code>02-restore-float-empty-state.png</code>)
- Evidence: Ctrl+Z with nothing to undo now posts &#39;nothing to undo&#39; to the message band via command(&#34;message&#34;) instead of doing nothing silently (local file: <code>03-ctrl-z-nothing-to-undo-message-band.png</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"59c0d18ecee21ecb4fe89f763b0e1afa40ee788d","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `cargo nextest run --all`
- `cargo nextest run --all (baseline, already green before this phase)`
- `cargo nextest run -E 'binary(plugin_chrome) or binary(frames)' — 24/24 passed (new Lua-to-Command kernel tests; frames.rs byte-identical proof for the session list conversion)`
- `cargo nextest run -E "test(kernel::command::tests) or test(a_pane_can_speak_in_the_message_band_and_open_a_kernel_modal)" — 26/26 passed (command("action")/command("message") unit tests plus the tui_e2e real-pty scenario asserting the ERROR badge, message text, and command("action") opening the help modal)`
- `cargo nextest run -E 'binary(keymap) or binary(restore) or binary(tui_e2e)' broad pass covering undo-posts-a-message (tests/keymap.rs) and the footer-follows-a-rebind test (tests/restore.rs)`
- `Manual end-to-end verification: built target/debug/thurbox (dev profile), launched it in an isolated VHS-driven sandbox (fresh HOME/XDG via scripts/dev/lib/sandbox-env.sh) seeded with a stub agent + one session, and screenshotted (1) the sessions panel rendered by the converted ui/plugins/10_sessions.lua on ui.lib, (2) the restore float's centered 'No deleted sessions' empty state (ui/plugins/80_restore.lua conversion), (3) Ctrl+Z with nothing to undo posting 'nothing to undo' to the message band`
- `grep spot-check: ui/plugins/65_search.lua and ui/plugins/20_agent.lua still require lib.widgets/lib.panels directly (not converted onto ui.lib), matching the PR's stated deliberate scope limit`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
