### PR TITLE
fix(core): stop reporting unknown agent status as idle

### DIFF
--- a/.agents/skills/thurbox-cli/SKILL.md
+++ b/.agents/skills/thurbox-cli/SKILL.md
@@ -266,7 +266,7 @@ Each line carries:
 | `event` | `present` (baseline) / `created` / `changed` / `gone` |
 | `reason` | `spawned`, `registered`, `restored` · `state`, `stopped`, `started`, `updated` · `soft_deleted`, `force_deleted` |
 | `from_state`, `to_state` | the transition itself, for a `changed`/`state` event |
-| `state`, `hook_state`, `state_source`, `hook_coverage`, `hook_blocked_is_heuristic`, `hook_state_contradicted` | the same gating fields `session get` publishes, so reacting to a `blocked` needs no follow-up call |
+| `state`, `hook_state`, `state_source`, `hook_coverage`, `hook_blocked_is_heuristic`, `hook_state_contradicted`, `detected_agent` | the same gating fields `session get` publishes, so reacting to a `blocked` needs no follow-up call |
 
 `reason` is what a bare event name could not say: a `gone` used to mean both
 deletes, and only one of them is restorable. `hook_state_contradicted` is
@@ -426,6 +426,21 @@ still replays the recorded command. It is refused for an agent thurbox ships no
 hooks for, since the whole point is the coverage it unlocks and a typo would
 unlock nothing silently. `get`/`list`/`doctor` publish it as `reports_as` (null
 when the row reports as itself).
+
+**`detected_agent` is the third name and a different fact.** `get`/`doctor`
+(and `list --verify`) also publish which registered agent was found *in the
+pane*, under its registry name — `antigravity`, not the `agy` its argv spells —
+whenever that is not the agent the row was created with. `agent` is what the
+row was created as, `reports_as` what a driver declared, `detected_agent` what
+is observably running; null on an unprobed listing means **not checked**, the
+same as every other pane field. It is deliberately never written back as
+`reports_as`: a declaration is durable and an observation is not.
+
+The match is in **command position only** — argv0, a shell's `-c` operand or
+its script, and past `exec`/`env`/`VAR=value` prefixes. It used to match a bare
+token anywhere in the command line, so a driver's multi-kilobyte prose brief in
+argv could name an agent that was not there (`perl -e 'sleep 300' claude` read
+as claude). A missed identity is a blank; a wrong one is on screen.
 
 `session doctor` follows the same fact from the other end: a `--command` session
 that has declared nothing is **`ok`, "no hooks expected"** rather than `fail` —

--- a/.agents/skills/thurbox-cli/SKILL.md
+++ b/.agents/skills/thurbox-cli/SKILL.md
@@ -430,7 +430,12 @@ when the row reports as itself).
 **`detected_agent` is the third name and a different fact.** `get`/`doctor`
 (and `list --verify`) also publish which registered agent was found *in the
 pane*, under its registry name — `antigravity`, not the `agy` its argv spells —
-whenever that is not the agent the row was created with. `agent` is what the
+whenever that is not the agent the row was created with **and the observation
+determines which profile it is**. An executable that several registered
+profiles share (the shipped `agents.toml` builds exactly that when it shows you
+how to pin a model) publishes `detected_agent: null` beside
+`hook_corroboration: "foreign-agent"` and `state: "running"`: an agent is
+demonstrably there, and `ps` cannot say which profile. `agent` is what the
 row was created as, `reports_as` what a driver declared, `detected_agent` what
 is observably running; null on an unprobed listing means **not checked**, the
 same as every other pane field. It is deliberately never written back as

--- a/.agents/skills/thurbox-session-status/SKILL.md
+++ b/.agents/skills/thurbox-session-status/SKILL.md
@@ -24,18 +24,28 @@ module exists to prevent:
 | `done` | blue | `●` (filled) | a turn just finished; shown until you switch away (hook) |
 | `idle` | green | `○` (hollow) | acknowledged (you moved off a Done), never active, or at rest |
 | `unreachable` | muted grey | `⊘` | remote host down/offline; the ordinary row, derived from a live attach failure, awaiting reconnect |
+| `running` | `status_running` (accent) | `◍` | an agent holds the pane and nothing has signalled — an observation, never a claim about what it is doing |
+| `uncovered` | `status_unknown` (muted) | `◌` | this agent is wired to report nothing, so its silence means nothing |
+| `unreported` | `status_unknown` (muted) | `◌` | the agent *can* report and has not yet |
 | `stopped` | — | — | parked by `session stop`: no process at all, which is why it outranks whatever the hook columns still hold |
-| `running` | — | — | an agent holds the pane and nothing has signalled — an observation, never a claim about what it is doing |
-| `uncovered` | — | — | this agent is wired to report nothing, so its silence means nothing |
-| `unreported` | — | — | the agent *can* report and has not yet |
 
-The last four carry no dot: the interface can always observe quiescence and
-reachability and knows the park mark from the row, so its rows resolve to the
-first five. The others are what a headless surface answers when a fact the
-interface has is one it cannot observe. The `Error` state v1 reserved for a
-crashed agent is gone with `SessionStatus`: it was never derived (process exit
-carries no failure signal), and a word no surface can produce is one more thing
-for a driver to handle for nothing.
+**Only `stopped` carries no dot**, because a parked session is at rest by
+definition and `idle` describes it without lying. The three above it each have
+one, and that is a correction: the interface used to derive its status from the
+hook columns alone (`derive_state`), so `hook_state = NULL` answered `Idle` and
+`theme.lua`'s `or STATUS_GLYPHS.idle` drew the green hollow circle — for a
+session a harness had launched an agent into, mid-turn, with nothing wired to
+report it. `idle` means *the agent said it is at rest*; none of these three
+does, and spelling them apart is the whole reason the vocabulary has nine words
+instead of five.
+
+The interface now derives through the same `Assessment` the CLI does
+(`kernel::snapshot::assess`), which is what makes `running` reachable there —
+and `running` needs the pane, so see **Reading the pane from the interface**
+below. The `Error` state v1 reserved for a crashed agent is gone with
+`SessionStatus`: it was never derived (process exit carries no failure signal),
+and a word no surface can produce is one more thing for a driver to handle for
+nothing.
 
 **Unreachable sessions.** A persisted **remote** session whose host cannot be
 reached **always appears in the list**, tagged `Unreachable`, rather than
@@ -74,8 +84,9 @@ the kernel's shared **animation tick** (`kernel::host::ANIMATION_HZ` = 8), which
 the loop advances **only while something is actually animating** — a free-running
 one invalidated every `pure` pane on every idle frame (ADR-P16). The filled `●`
 (Done) vs hollow `○` (Idle) pair reads done-vs-seen at a glance; the glyphs
-themselves live in `ui/lib/theme.lua`, so a state with no row in the table above
-simply draws the way `idle` does.
+themselves live in `ui/lib/theme.lua`, whose `or STATUS_GLYPHS.idle` fallback
+now catches only `stopped` — every other word in the table has a row of its
+own, which is the point.
 
 - **Reading it headlessly.** `session get`/`list --json` report the raw
   `hook_state` **plus what it takes to judge it**: `hook_state_at` /
@@ -112,9 +123,33 @@ simply draws the way `idle` does.
   `thurbox-cli session signal --state <s>` with **no arguments** (documented as
   a stable contract in `docs/CONFIG.md`); and failing that, a pane whose
   foreground is an agent the registry knows reports `state: "running"` /
-  `state_source: "process"` / `hook_corroboration: "foreign-agent"` —
-  deliberately coarse, since process inspection cannot say what an agent is
-  *doing*.
+  `state_source: "process"` / `hook_corroboration: "foreign-agent"` /
+  `detected_agent: "<name>"` — deliberately coarse, since process inspection
+  cannot say what an agent is *doing*.
+  **Three names, three fields.** `agent` is what the row was created as,
+  `reports_as` what a driver *declared* (`session reports-as`), and
+  `detected_agent` what is observably in the pane — the registry **name**, so
+  `antigravity` rather than the `agy` its argv spells. Detection is never
+  written back as `reports_as`: a declaration is durable and an observation is
+  not, and deriving one from the other would make a passing process permanent.
+  The interface publishes all three onto its session rows, and shows the third
+  as `zsh → claude` in the terminal pane's title and `claude · no status
+  reported` beside the row.
+  **Matching is in command position only** (`runs_program`): argv0, a shell's
+  `-c` operand or its script, and past `exec`/`env`/`VAR=value` prefixes. It
+  used to match a bare token *anywhere* in the command line, and the shape a
+  harness produces — a multi-kilobyte prose brief in argv, printed back by `ps`
+  as one long line — made `perl -e 'sleep 300' claude` a claude agent holding
+  the pane. A missed identity is a blank; a wrong one is on screen.
+- **Reading the pane from the interface.** The probe costs one
+  `display-message` plus one `ps`, which the render loop may not pay, so
+  `kernel::snapshot::PaneProbe` runs it on a worker thread and the verdict is
+  folded in when it lands (`Assessment::with_corroboration`). It is asked
+  **only** about rows whose `hook_state` is null, is cached for
+  `PANE_PROBE_TTL` (2 s), and a moved verdict forces the snapshot rebuild —
+  `PRAGMA data_version` cannot see a worker's answer. A session whose hooks
+  work costs nothing at all. See `docs/PERFORMANCE.md` → *Freshness is a
+  property of a cached answer*.
 - **The callback.** Agents report transitions with
   `thurbox-cli session signal --state <working|blocked|done|idle>`
   (`cli::sessions::Action::Signal`). Identity is the injected
@@ -131,7 +166,8 @@ simply draws the way `idle` does.
   `mark_session_seen` / `load_hook_states` (`storage/sessions.rs`).
   `upsert_session` deliberately **never** lists the hook columns, so the
   TUI's full-row write-back can't clobber a state a headless hook set. A
-  fresh spawn seeds **nothing** — a never-reported session is `Idle`, and the
+  fresh spawn seeds **nothing** — a never-reported session reads `unreported`
+  (or `running`, once the pane probe finds its agent), never `idle`, and the
   agent's hooks drive it from there (so an idle, just-booted agent doesn't look
   stuck working).
 - **A parked session takes no state.** `set_hook_state` returns `false` for a
@@ -157,6 +193,7 @@ simply draws the way `idle` does.
   | fold | input | who can supply it |
   |---|---|---|
   | `derive_state` (incl. the `done → idle` acknowledgment) | `hook_state`, `hook_state_at`, `seen_at` — all stored | everyone |
+  | `classify_foreground` → `Assessment::with_corroboration` | the pane's foreground process group | anyone who can run `ps` |
   | `with_output_quiescence` | terminal output age | the interface only |
   | `with_reachability` | a live attach error | the interface only |
 
@@ -198,7 +235,8 @@ simply draws the way `idle` does.
   group dot would restate what every member row shows. Status only recolors — it
   **never** reorders rows (the order is status-independent).
 - **Colours** are tunable theme fields: `status_working` / `status_blocked`
-  / `status_done` / `status_idle` / `status_unreachable`
+  / `status_done` / `status_idle` / `status_unreachable` / `status_running` /
+  `status_unknown`
   (`session::theme_config`, all 36 presets + custom-theme overrides), published
   to Lua as theme roles and read by the pane. `status_error` is a separate
   role (a failed *command*, e.g. `bands.rs`'s `Level::Error` — not a session

--- a/.agents/skills/thurbox-session-status/SKILL.md
+++ b/.agents/skills/thurbox-session-status/SKILL.md
@@ -148,8 +148,12 @@ own, which is the point.
   **only** about rows whose `hook_state` is null, is cached for
   `PANE_PROBE_TTL` (2 s), and a moved verdict forces the snapshot rebuild —
   `PRAGMA data_version` cannot see a worker's answer. A session whose hooks
-  work costs nothing at all. See `docs/PERFORMANCE.md` → *Freshness is a
-  property of a cached answer*.
+  work costs nothing at all. Once one starts reporting, the cached verdict
+  and the row's published `detected_agent` are both dropped at that same
+  moment — the former by `poll_pane_probes` retaining only the still-probed
+  ids, the latter by `apply_hook_states` clearing it in place, since that
+  write is on our own connection and no refresh follows it to do so instead.
+  See `docs/PERFORMANCE.md` → *Freshness is a property of a cached answer*.
 - **The callback.** Agents report transitions with
   `thurbox-cli session signal --state <working|blocked|done|idle>`
   (`cli::sessions::Action::Signal`). Identity is the injected

--- a/.agents/skills/thurbox-session-status/SKILL.md
+++ b/.agents/skills/thurbox-session-status/SKILL.md
@@ -129,7 +129,19 @@ own, which is the point.
   **Three names, three fields.** `agent` is what the row was created as,
   `reports_as` what a driver *declared* (`session reports-as`), and
   `detected_agent` what is observably in the pane — the registry **name**, so
-  `antigravity` rather than the `agy` its argv spells. Detection is never
+  `antigravity` rather than the `agy` its argv spells.
+  **Only when the observation determines one.** `ps` reports the executable,
+  not the profile, so an executable that more than one registered profile
+  claims yields no name at all — `hook_corroboration` still reads
+  `foreign-agent` and the state still reads `running`, because the *presence*
+  is observed, but `detected_agent` is null. This is a live shape, not a
+  theoretical one: the shipped `agents.toml` walks the user through building it
+  ("Pin a model" adds `claude-opus` on the same `command` as `claude`). Taking
+  the first matching entry published whichever the file happened to list first
+  — a confident name nothing had determined, and worse on screen than the bare
+  `shell` label this vocabulary exists to improve on, because a specific name
+  invites trust. Deliberately not resolved by a tie-break on argv either: the
+  worth of the field is that it is never wrong. Detection is never
   written back as `reports_as`: a declaration is durable and an observation is
   not, and deriving one from the other would make a passing process permanent.
   The interface publishes all three onto its session rows, and shows the third

--- a/.agents/skills/thurbox-session-status/SKILL.md
+++ b/.agents/skills/thurbox-session-status/SKILL.md
@@ -148,11 +148,14 @@ own, which is the point.
   **only** about rows whose `hook_state` is null, is cached for
   `PANE_PROBE_TTL` (2 s), and a moved verdict forces the snapshot rebuild —
   `PRAGMA data_version` cannot see a worker's answer. A session whose hooks
-  work costs nothing at all. Once one starts reporting, the cached verdict
-  and the row's published `detected_agent` are both dropped at that same
-  moment — the former by `poll_pane_probes` retaining only the still-probed
-  ids, the latter by `apply_hook_states` clearing it in place, since that
-  write is on our own connection and no refresh follows it to do so instead.
+  work costs nothing at all. **A pane verdict is published only for a row
+  nothing has reported for**: `kernel::snapshot::assess` folds one in only
+  when `hook.state` is `None`, so a verdict cached before the hook onset
+  cannot reach the screen even if it races a rebuild and outlives the poll
+  that would otherwise have evicted it. `poll_pane_probes` retaining just the
+  still-probed ids and `apply_hook_states` clearing `detected_agent` in place
+  are the supporting hygiene, not the guarantee — the latter is load-bearing
+  only because that path corrects its row directly and never reaches `assess`.
   See `docs/PERFORMANCE.md` → *Freshness is a property of a cached answer*.
 - **The callback.** Agents report transitions with
   `thurbox-cli session signal --state <working|blocked|done|idle>`

--- a/README.md
+++ b/README.md
@@ -625,6 +625,7 @@ takes to judge it:
 | `hook_coverage` / `hook_states_reportable` | what this agent can report at all (`aider` can only ever say `blocked`) |
 | `hook_blocked_is_heuristic` | whether its `blocked` is a text match on a notification body |
 | `hook_corroboration` / `hook_state_contradicted` | what actually holds the pane, and whether it agrees |
+| `detected_agent` | which registered agent was found in the pane, when it is not the one the row was created with |
 | `state` / `state_source` | the best answer available, and whether it came from a hook or from the pane |
 | `stopped` | whether the session is parked (`session stop`) — no process at all |
 

--- a/benches/frame_cost.rs
+++ b/benches/frame_cost.rs
@@ -118,6 +118,8 @@ fn snapshot(sessions: usize) -> Snapshot {
                 worktree_count: 1,
                 git: None,
                 hook_state: Some("idle".into()),
+                reports_as: None,
+                detected_agent: None,
                 shell_backend_id: None,
                 member_dirs: vec![format!("{repo}/worktrees/w{nth}").into()],
             }

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -557,9 +557,13 @@ no id. A finished turn shows `Done` (blue) — for the session you're watching t
 The hooks are wired up automatically by the built-in **hooks** extension
 (auto-activated on first run). Opt out with `thurbox-cli extension deactivate
 hooks`. The status colours are tunable theme keys (`status_working` /
-`status_blocked` / `status_done` / `status_idle` / `status_unreachable` — see
-`themes.toml`). `status_error` is a separate role, for a failed *command* in
-the list, not a session state.
+`status_blocked` / `status_done` / `status_idle` / `status_unreachable` /
+`status_running` / `status_unknown` — see `themes.toml`). `status_running` is
+an agent seen holding a pane that has reported nothing, and `status_unknown`
+the two silences behind it (`uncovered`, `unreported`); both are spelled apart
+from `status_idle`, which is the agent's own report that it is at rest.
+`status_error` is a separate role, for a failed *command* in the list, not a
+session state.
 
 The wiring is applied **only to agents thurbox launches** — it never edits your
 own global agent config (e.g. your personal `~/.claude/settings.json`). thurbox's

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -82,14 +82,24 @@ persisted columns onto a `SessionState` once per tick:
 | `done` | blue | `●` | a turn just finished; shown until you switch away |
 | `idle` | green | `○` | acknowledged, never active, or at rest |
 | `unreachable` | muted grey | `⊘` | remote host is down/offline; placeholder row awaiting reconnect |
+| `running` | accent | `◍` | an agent holds the pane and nothing has signalled — observed, never a claim about the turn |
+| `uncovered` | muted grey | `◌` | this agent is wired to report nothing, so its silence means nothing |
+| `unreported` | muted grey | `◌` | the agent *can* report and has not yet |
 
-`SessionState` carries four more words — `stopped`, `running`, `uncovered`,
-`unreported` — that the interface never has to draw, because it can always
-observe the park mark, the pane and the terminal. They are the answers a
-headless surface gives when one of those facts is out of its reach, and they
-are spelled apart from `idle` so "we cannot know" is never read as "the agent
-says it is at rest". One enum, so `session get`, `session list`,
-`thurbox-cli watch` and the session list cannot disagree about a row.
+Those last three are drawn apart from `idle` on purpose, and it took a bug to
+prove why: the interface derived its dot from the hook columns alone, so a
+session a harness had launched an agent into — nothing wired, nothing signalled
+— drew the green hollow circle while the agent worked. `idle` says *the agent
+reported that it is at rest*; none of the three does. `stopped` (parked by
+`session stop`) is the one word with no dot of its own, because a parked
+session is at rest by definition.
+
+One enum, so `session get`, `session list`, `thurbox-cli watch` and the session
+list cannot disagree about a row — and since the interface has to answer
+`running`, it probes what holds each unreported session's pane. That probe
+shells out, so it runs on a worker thread and only for rows whose agent has
+reported nothing (`kernel::snapshot::PaneProbe`); a session whose hooks work
+costs nothing.
 
 A `Done` session becomes `Idle` once you move focus off it (you've
 acknowledged it); a `working` session that goes quiet for 10 s is

--- a/docs/ORCHESTRATION.md
+++ b/docs/ORCHESTRATION.md
@@ -238,6 +238,7 @@ gone — and each one comes with what it takes to judge it:
 | `hook_coverage`, `hook_states_reportable` | what this agent can report at all |
 | `hook_blocked_is_heuristic` | whether its `blocked` is a text match on a notification body |
 | `hook_corroboration`, `hook_state_contradicted` | what actually holds the pane, and whether it agrees |
+| `detected_agent` | which registered agent is in the pane, when it is not the row's own |
 | `state`, `state_source` | the best answer available, and where it came from |
 | `stopped` | whether the session is parked — `session stop`, no pane |
 | `reports_as` | the agent the hook fields were read against, when a driver declared one |
@@ -251,7 +252,16 @@ to report nothing), `stopped` (the session is parked) or `running` (an
 agent holds the pane and has not signalled — `session get`'s probe only).
 None of those four is a state an agent can signal, and `state_source` is
 null for the first three. The piped (TOON) `session list` shows this
-column.
+column, and so does the interface — its session list derives through the
+same `Assessment`, so a driver reconciling the screen with a `session
+get` never has to reconcile two vocabularies.
+
+`agent`, `reports_as` and `detected_agent` are three different facts and
+no two of them substitute for each other: what the row was created as,
+what a driver *declared* it runs, and what is observably in the pane
+right now. Detection is deliberately never written back as `reports_as`
+— a declaration is durable, an observation is not, and deriving one from
+the other would make a passing process permanent.
 
 A finished turn reads `done` until somebody looks at it and `idle`
 after: the interface stamps `seen_at` when focus moves off, and every

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -796,6 +796,16 @@ fetch stuck for the process lifetime. Each is now a TTL, an in-flight marker, or
 generation counter. **If you add a cache to the loop, give it an age**; the review
 that found these is in the history, and they were one field each.
 
+`PaneProbe::known` — what holds each session's pane, which is what lets the
+interface say `running` instead of `idle` for an agent a harness launched — is a
+`PANE_PROBE_TTL` (2 s) cache under the same rule. It is also the case for
+**asking narrowly**: the answer costs one `display-message` plus one `ps`, so it
+is asked only about rows whose `hook_state` is null. A session whose agent
+reports for itself already has a better answer than a process listing can give,
+and probing it would put a subprocess per session on every refresh — which is
+the cost the interface declined by skipping the check altogether, at the price
+of the dot it then drew.
+
 An age can be a **generation key** rather than a clock, and then *which* key you
 pick is the whole of the correctness. `GitStats::known` caches `merged` — is this
 branch's work already on origin's default? — keyed on the **commit** it was

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -806,6 +806,15 @@ and probing it would put a subprocess per session on every refresh — which is
 the cost the interface declined by skipping the check altogether, at the price
 of the dot it then drew.
 
+Its eviction is a generation key on top of that TTL: `retain` is handed the
+exact id set `poll_pane_probes` is about to ask about, not "every session in
+the snapshot", so a row whose `hook_state` turns `Some` drops its cached
+verdict the moment it leaves that set rather than carrying it forward. The
+published `detected_agent` gets the same treatment at the source: a hook write
+lands through this process's own connection, so `PRAGMA data_version` will not
+move to trigger a refresh — `apply_hook_states` clears `detected_agent` on the
+row it just patched rather than waiting on one.
+
 An age can be a **generation key** rather than a clock, and then *which* key you
 pick is the whole of the correctness. `GitStats::known` caches `merged` — is this
 branch's work already on origin's default? — keyed on the **commit** it was

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -806,14 +806,25 @@ and probing it would put a subprocess per session on every refresh — which is
 the cost the interface declined by skipping the check altogether, at the price
 of the dot it then drew.
 
-Its eviction is a generation key on top of that TTL: `retain` is handed the
-exact id set `poll_pane_probes` is about to ask about, not "every session in
-the snapshot", so a row whose `hook_state` turns `Some` drops its cached
-verdict the moment it leaves that set rather than carrying it forward. The
-published `detected_agent` gets the same treatment at the source: a hook write
-lands through this process's own connection, so `PRAGMA data_version` will not
-move to trigger a refresh — `apply_hook_states` clears `detected_agent` on the
-row it just patched rather than waiting on one.
+A cached verdict cannot be trusted to publish, though, because eviction and a
+rebuild race: a hook state read fresh off the database can reach `assess`
+*before* the poll that would have evicted the now-stale entry catches up (the
+cache is invalidated by the row set `poll_pane_probes` last computed, one tick
+behind the read that just changed `hook.state`). So the actual invariant lives
+in `assess` itself: a pane verdict is folded in only when `hook.state` is
+`None`, never unconditionally. `best_state` already answers from the hook
+columns whenever they hold anything, so this changes nothing about the derived
+status — it only stops a verdict cached before the hook onset from being
+attached to a row that now speaks for itself.
+
+`retain` and the in-place `apply_hook_states` clear stay, but as the weaker
+guarantees they actually are: `retain` is hygiene (a cache that outlives the
+question it answers wastes a subprocess re-asking it, `assess`'s gate is what
+keeps a stale answer off the screen), and `apply_hook_states` clears
+`detected_agent` because that path corrects its row directly and never reaches
+`assess` at all — a hook write landing through this process's own connection
+never moves `PRAGMA data_version`, so no refresh, and no `assess` call, ever
+follows it.
 
 An age can be a **generation key** rather than a clock, and then *which* key you
 pick is the whole of the correctness. `GitStats::known` caches `merged` — is this

--- a/src/agent/themes_config.rs
+++ b/src/agent/themes_config.rs
@@ -32,6 +32,7 @@ pub const SEED_THEMES_TOML: &str = r##"# Thurbox custom themes  —  ~/.config/t
 #
 # Overridable colour keys: accent, accent_bright, status_working,
 # status_blocked, status_done, status_idle, status_error, status_unreachable,
+# status_running, status_unknown,
 # text_primary, text_secondary, text_muted,
 # border_focused, border_unfocused, role_name, branch_name, search_bar,
 # keybind_hint, tool_allowed, tool_disallowed, danger, selection_bg,
@@ -193,6 +194,8 @@ mod tests {
             "status_idle",
             "status_error",
             "status_unreachable",
+            "status_running",
+            "status_unknown",
             "text_primary",
             "text_secondary",
             "text_muted",

--- a/src/cli/session_doctor.rs
+++ b/src/cli/session_doctor.rs
@@ -152,7 +152,8 @@ impl Report {
             "hook_reported": self.hook.reported,
             "hook_coverage": self.hook.coverage.as_str(),
             "hook_states_reportable": self.hook.states_reportable(),
-            "hook_corroboration": self.hook.corroboration.map(|c| c.as_str()),
+            "hook_corroboration": self.hook.corroboration.as_ref().map(|c| c.as_str()),
+            "detected_agent": self.hook.detected_agent(),
             "hook_state_contradicted": self.hook.contradicted,
             "checks": self.findings.iter().map(|f| json!({
                 "check": f.key,
@@ -358,7 +359,7 @@ fn diagnose(
                       puts one back"
                 .into(),
         });
-    } else if let Some(corroboration) = hook.corroboration {
+    } else if let Some(corroboration) = hook.corroboration.as_ref() {
         let process = hook.foreground_process.as_deref().unwrap_or("nothing");
         findings.push(if hook.contradicted == Some(true) {
             Finding {
@@ -620,10 +621,15 @@ mod tests {
 
     #[test]
     fn a_pane_that_disagrees_is_called_out() {
-        let known = vec!["claude".to_string()];
         let hook =
             Assessment::from_hooks(&registry(), "claude", Some("working"), Some(0), None, 1_000)
-                .with_pane("claude", &known, Some("bash"), Some("bash"), Some(false));
+                .with_pane(
+                    "claude",
+                    &registry(),
+                    Some("bash"),
+                    Some("bash"),
+                    Some(false),
+                );
         let report = diagnose_agent(&row("s", "claude", "local-tmux"), &hook, true, Some("/x"));
         assert_eq!(level_of(&report, "pane"), Level::Warn);
         let detail = &report

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -34,7 +34,8 @@ pub enum Action {
     ///
     /// **Unprobed fields are null, and null means "not checked".** Without
     /// `--verify` the pane is never looked at, so `hook_corroboration`,
-    /// `hook_state_contradicted` and `foreground_process`/`foreground_command`
+    /// `detected_agent`, `hook_state_contradicted` and
+    /// `foreground_process`/`foreground_command`
     /// are all `null` — *unchecked*, which is a different answer from
     /// `false`/"nothing found" (a remote session, which has no pane to look at
     /// from here, says `hook_corroboration: "unavailable"` instead). For the
@@ -70,6 +71,13 @@ pub enum Action {
     /// coverage of its agent's hooks, and — for a local session — what the
     /// pane's foreground process says about it (`hook_corroboration`,
     /// `hook_state_contradicted`). Pass `--no-verify` to skip the pane probe.
+    ///
+    /// `detected_agent` names the registered agent found holding the pane when
+    /// it is not the one the row was created with — the shape a harness that
+    /// owns the agent launch produces. Three names, three fields: `agent` is
+    /// what the row was created as, `reports_as` what a driver declared, and
+    /// this what is observably running. It is a live reading and is never
+    /// written back as `reports_as`.
     ///
     /// A session parked by `session stop` reports `stopped: true` and
     /// `state: "stopped"`, and its pane is not probed — there is none.
@@ -1356,7 +1364,7 @@ fn render_session_detail(s: &SharedSession, hook: &crate::session::Assessment) -
             output::dash(s.parent_session_id.map(|id| id.to_string()).as_deref()),
         ),
     ];
-    if let Some(corroboration) = hook.corroboration {
+    if let Some(corroboration) = hook.corroboration.as_ref() {
         pairs.push((
             "pane",
             match hook.foreground_process.as_deref() {
@@ -1364,6 +1372,11 @@ fn render_session_detail(s: &SharedSession, hook: &crate::session::Assessment) -
                 None => corroboration.as_str().to_string(),
             },
         ));
+    }
+    // Named, never implied: an agent seen in the pane says which agent is
+    // there, and nothing at all about whether it is mid-turn.
+    if let Some(detected) = hook.detected_agent() {
+        pairs.push(("detected_agent", detected.to_string()));
     }
     let mut block = output::kv(&pairs);
     for w in &s.worktrees {
@@ -2000,11 +2013,10 @@ impl SessionFacts {
             .get(agent)
             .map(|d| d.command.clone())
             .unwrap_or_else(|| agent.to_string());
-        let known: Vec<String> = registry.agents.iter().map(|a| a.command.clone()).collect();
         let pane = crate::agent::tmux::pane_state(&s.id.to_string(), &s.name);
         hook.with_pane(
             &command,
-            &known,
+            registry,
             pane.foreground_process.as_deref(),
             pane.foreground_command.as_deref(),
             pane.dead,

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -79,6 +79,13 @@ pub enum Action {
     /// this what is observably running. It is a live reading and is never
     /// written back as `reports_as`.
     ///
+    /// It is `null` whenever the observation does not determine one profile:
+    /// `ps` reports the executable, so an executable that several registered
+    /// agents share (pinning a model puts `claude-opus` on `claude`'s command)
+    /// answers `hook_corroboration: "foreign-agent"` and `state: "running"`
+    /// with no name — an agent is there, and which one is not knowable from
+    /// the process listing.
+    ///
     /// A session parked by `session stop` reports `stopped: true` and
     /// `state: "stopped"`, and its pane is not probed — there is none.
     /// `backend_id` still names the window it had: it is what the row records,

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -526,119 +526,13 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, CommandError>
             deleted: true,
             parent: _,
             verify: _,
-        } => {
-            let rows = db
-                .list_deleted_sessions()
-                .map_err(|e| format!("list_deleted_sessions: {e}"))?;
-            let json = Value::Array(rows.iter().map(deleted_session_to_json).collect());
-            let human = if rows.is_empty() {
-                "No deleted sessions.".to_string()
-            } else {
-                output::table(
-                    &["NAME", "AGENT", "BACKEND", "RECOVERABLE", "ID"],
-                    &rows
-                        .iter()
-                        .map(|r| {
-                            vec![
-                                r.name.clone(),
-                                r.agent.clone(),
-                                r.backend_type.clone(),
-                                if r.force_deleted { "in part" } else { "fully" }.to_string(),
-                                r.id.to_string(),
-                            ]
-                        })
-                        .collect::<Vec<_>>(),
-                )
-            };
-            Ok(CommandOutput::new(json, human)
-                .list(
-                    "deleted_sessions",
-                    &["name", "agent", "force_deleted", "id"],
-                )
-                .empty("0 deleted sessions to restore")
-                .help([
-                    "thurbox-cli session restore <name|id>   bring one back",
-                    "thurbox-cli session restore <name|id> --best-effort   for a force-deleted row",
-                ]))
-        }
+        } => run_list_deleted(db),
         Action::List {
             parent,
             deleted: false,
             verify,
-        } => {
-            let parent_id = parent
-                .as_deref()
-                .map(|reference| resolve(db, reference).map(|s| s.id))
-                .transpose()?;
-            let sessions: Vec<SharedSession> = db
-                .list_active_sessions()
-                .map_err(|e| format!("list_active_sessions: {e}"))?
-                .into_iter()
-                .filter(|s| parent_id.is_none() || s.parent_session_id == parent_id)
-                .collect();
-            let facts = SessionFacts::load(db);
-            let bases = db.load_base_branches().unwrap_or_default();
-            let updated = db.load_updated_at().unwrap_or_default();
-            let registry = crate::agent::agent_config::load_or_seed();
-            let assessments: Vec<crate::session::Assessment> = sessions
-                .iter()
-                .map(|s| facts.assess(&registry, s, verify))
-                .collect();
-            let json = Value::Array(
-                sessions
-                    .iter()
-                    .zip(&assessments)
-                    .map(|(s, hook)| {
-                        crate::session_ops::mirror::session_to_json_assessed(
-                            s,
-                            hook,
-                            bases.get(&s.id).map(String::as_str),
-                            updated.get(&s.id).copied(),
-                        )
-                    })
-                    .collect(),
-            );
-            Ok(
-                CommandOutput::new(json, render_session_list(&sessions, &assessments))
-                    // `state`, not `hook_state`: the raw latched word is null for a
-                    // session that never reported and carries no age or coverage to
-                    // judge it by, so an agent reading the default answer would get
-                    // less than the human table on the same call. `--json` still
-                    // carries `hook_state` verbatim for a consumer that reads it.
-                    //
-                    // The id is not decoration: every follow-up command resolves a
-                    // session by UUID, so omitting it would only buy a second call.
-                    .list("sessions", &["name", "agent", "state", "id"])
-                    .empty(match parent_id {
-                        Some(id) => format!("0 sessions with parent {id}"),
-                        None => "0 active sessions on this machine".to_string(),
-                    })
-                    .help([
-                        "thurbox-cli session get <id>   the full record, worktrees included",
-                        "thurbox-cli session capture <id> --lines 50   what its pane is showing",
-                        "thurbox-cli session list --json   every field, for a script",
-                    ]),
-            )
-        }
-        Action::Get { uuid, no_verify } => {
-            let session = resolve(db, &uuid)?;
-            let facts = SessionFacts::load(db);
-            let bases = db.load_base_branches().unwrap_or_default();
-            let registry = crate::agent::agent_config::load_or_seed();
-            let hook = facts.assess(&registry, &session, !no_verify);
-            Ok(CommandOutput::new(
-                crate::session_ops::mirror::session_to_json_assessed(
-                    &session,
-                    &hook,
-                    bases.get(&session.id).map(String::as_str),
-                    db.load_updated_at()
-                        .unwrap_or_default()
-                        .get(&session.id)
-                        .copied(),
-                ),
-                render_session_detail(&session, &hook),
-            ))
-        }
+        } => run_list_active(db, parent, verify),
+        Action::Get { uuid, no_verify } => run_get(db, uuid, no_verify),
         Action::Create {
             name,
             repo_path,
@@ -655,340 +549,46 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, CommandError>
             resume,
             on_existing,
             reports_as,
-        } => {
-            let parent_session_id = parent
-                .as_deref()
-                .map(|reference| resolve(db, reference).map(|s| s.id))
-                .transpose()?;
-            let extra_repos = super::parse_extra_repos(&add_repo, &add_dir);
-            let env = parse_env(&env)?;
-            let registry = crate::agent::agent_config::load_or_seed();
-            // Checked before anything is spawned: a typo here is silent
-            // otherwise, and the session it would have described is already
-            // running by the time the caller could notice.
-            if let Some(declared) = &reports_as {
-                check_reports_as(&registry, declared)?;
-            }
-            // Names are not unique, so "already exists" is a decision the
-            // caller makes rather than something thurbox assumes — and it is a
-            // decision about *this* backend, since a mirrored host's rows share
-            // the namespace.
-            let backend = crate::session_ops::spawn::backend_type_for(host.as_deref())?;
-            let existing =
-                resolve_existing(db, &name, on_existing, &backend, reports_as.as_deref())?;
-            if let Existing::Answered(output) = existing {
-                return Ok(*output);
-            }
-            let req = crate::session_ops::SpawnRequest {
+        } => run_create(
+            db,
+            CreateArgs {
                 name,
                 repo_path,
+                agent,
                 worktree_branch,
                 base_branch,
-                agent,
                 host,
-                parent_session_id,
-                extra_repos,
+                parent,
+                add_repo,
+                add_dir,
                 command,
-                args: arg,
+                arg,
                 env,
-                resume_session_id: resume,
-                ..Default::default()
-            };
-            let res = match crate::session_ops::spawn_session_headless(db, req) {
-                Ok(res) => res,
-                // `replace` tore the old session down first, so a spawn that
-                // fails here would otherwise leave the caller with neither
-                // session. Put back what can be put back before reporting.
-                Err(e) => return Err(rollback_replace(db, &existing, e).into()),
-            };
-            if let Some(declared) = &reports_as {
-                if let Err(e) = db.set_reports_as(res.session_id, Some(declared)) {
-                    return Err(format!(
-                        "session '{}' ({}) was created, but declaring it as '{declared}' \
-                         failed: set_reports_as: {e}. Retry with `thurbox-cli session \
-                         reports-as {} {declared}`",
-                        res.name, res.session_id, res.session_id
-                    )
-                    .into());
-                }
-            }
-            // Nothing has signalled yet, so this is `uncovered` or `unreported`
-            // — read against whatever will actually report.
-            let state = crate::session::Assessment::from_hooks(
-                &registry,
-                reports_as.as_deref().unwrap_or(&res.agent),
-                None,
-                None,
-                None,
-                0,
-            )
-            .state_word();
-            // A host driven from afar has no interface of its own to arm the
-            // heartbeat: this creation is the moment its sessions start needing
-            // the tick (status polls, extension self-heal, reaping).
-            super::automations::arm_heartbeat();
-            let mut human = format!(
-                "Created session '{}' ({}) — {}\ncwd: {}",
-                res.name,
-                res.agent,
-                res.session_id,
-                res.cwd.display()
-            );
-            if let Some(note) = &res.sharing {
-                human.push_str(&format!("\n  {note}"));
-            }
-            push_hook_failures(&mut human, &res.hook_failures);
-            Ok(CommandOutput::new(
-                json!({
-                    "id": res.session_id.to_string(),
-                    "name": res.name,
-                    "agent": res.agent,
-                    "agent_session_id": res.agent_session_id,
-                    // The pane, the checkouts and the server: everything the
-                    // caller would otherwise have to come back for with a
-                    // second `session get`, and poll for until it appeared.
-                    "backend_id": res.backend_id,
-                    "worktrees": res.worktrees.iter().map(worktree_json).collect::<Vec<_>>(),
-                    "tmux_socket": crate::agent::tmux::local_socket_name(),
-                    "cwd": res.cwd.display().to_string(),
-                    "parent_session_id": res.parent_session_id.map(|id| id.to_string()),
-                    "hook_failures": res.hook_failures,
-                    "sharing": res.sharing,
-                    "reports_as": reports_as,
-                    // Present here only so `--on-existing adopt` can answer in
-                    // the same shape: a session that was just spawned is
-                    // running by construction and has said nothing yet, while
-                    // one that was already there may be parked.
-                    "stopped": false,
-                    "state": state,
-                    "created": true,
-                }),
-                human,
-            ))
-        }
+                resume,
+                on_existing,
+                reports_as,
+            },
+        ),
         Action::Delete { uuid, force } => delete_session(db, &uuid, force),
         Action::Restore {
             session,
             best_effort,
         } => restore_deleted(db, &session, best_effort),
-        Action::Reap { session } => {
-            let row = super::session_ref::resolve_deleted(db, &session)?;
-            let reaped = crate::session_ops::reap_soft_deleted(db, row.id)?;
-            let human = if reaped {
-                format!("Reaped session '{}' ({})", row.name, row.id)
-            } else {
-                format!(
-                    "Nothing to reap for '{}' ({}): it came back, or was force-deleted",
-                    row.name, row.id
-                )
-            };
-            Ok(CommandOutput::new(
-                json!({
-                    "reaped": reaped,
-                    "id": row.id.to_string(),
-                    "name": row.name,
-                }),
-                human,
-            ))
-        }
-        Action::Restart { uuid, if_missing } => {
-            let session = resolve(db, &uuid)?;
-            let report = crate::session_ops::restart::restart_session_headless_with(
-                db, session.id, if_missing,
-            )?;
-            let mut human = format!("Restarted session '{}' ({})", session.name, session.id);
-            push_hook_failures(&mut human, &report.hook_failures);
-            Ok(CommandOutput::new(
-                json!({
-                    "restarted": true,
-                    "session_id": session.id.to_string(),
-                    "session_name": session.name,
-                    "hook_failures": report.hook_failures,
-                }),
-                human,
-            ))
-        }
+        Action::Reap { session } => run_reap(db, session),
+        Action::Restart { uuid, if_missing } => run_restart(db, uuid, if_missing),
         Action::Send {
             uuid,
             text,
             no_enter,
-        } => {
-            let session = resolve(db, &uuid)?;
-            if text.trim().is_empty() {
-                return Err("text must not be empty".into());
-            }
-            refuse_if_parked(db, &session)?;
-            let id = session.id.to_string();
-            let mut args = vec!["session", "send", &id, &text];
-            if no_enter {
-                args.push("--no-enter");
-            }
-            if let Some(remote) = delegate_to_host(&session, &args)? {
-                return Ok(remote);
-            }
-            let submit = !no_enter;
-            crate::agent::tmux::send_text_now(
-                &session.id.to_string(),
-                &session.name,
-                &text,
-                submit,
-            )
-            .map_err(|e| format!("send_text_now: {e}"))?;
-            let human = if submit {
-                format!("Sent to '{}'.", session.name)
-            } else {
-                format!("Typed into '{}' (not submitted).", session.name)
-            };
-            Ok(CommandOutput::new(
-                json!({
-                    "sent": true,
-                    "submitted": submit,
-                    "session_id": session.id.to_string(),
-                    "session_name": session.name,
-                }),
-                human,
-            ))
-        }
-        Action::Key { uuid, key } => {
-            let session = resolve(db, &uuid)?;
-            let resolved =
-                crate::agent::tmux::resolve_key(&key).ok_or_else(|| unknown_key(&key))?;
-            refuse_if_parked(db, &session)?;
-            let id = session.id.to_string();
-            if let Some(remote) =
-                delegate_to_host(&session, &["session", "key", &id, &resolved.name])?
-            {
-                return Ok(remote);
-            }
-            crate::agent::tmux::send_key_now(
-                &session.id.to_string(),
-                &session.name,
-                &resolved.tmux,
-            )
-            .map_err(|e| format!("send_key_now: {e}"))?;
-            Ok(CommandOutput::new(
-                json!({
-                    "sent": true,
-                    "key": resolved.name,
-                    "tmux_key": resolved.tmux,
-                    "session_id": session.id.to_string(),
-                    "session_name": session.name,
-                }),
-                format!("Sent {} to '{}'.", resolved.name, session.name),
-            ))
-        }
+        } => run_send(db, uuid, text, no_enter),
+        Action::Key { uuid, key } => run_key(db, uuid, key),
         Action::Capture { uuid, lines, ansi } => capture_pane(db, &uuid, lines, ansi),
-        Action::Focus { uuid } => {
-            let session = resolve(db, &uuid)?;
-            db.set_pending_focus_session_id(session.id)
-                .map_err(|e| format!("set_pending_focus_session_id: {e}"))?;
-            Ok(CommandOutput::new(
-                json!({
-                    "focused": true,
-                    "session_id": session.id.to_string(),
-                    "session_name": session.name,
-                }),
-                format!("Focus requested for '{}'.", session.name),
-            ))
-        }
-        Action::Sync { host, adopt } => {
-            let reports = crate::session_ops::mirror::sync(db, host.as_deref(), adopt)?;
-            let json = Value::Array(reports.iter().map(|r| r.to_json()).collect());
-            let human = if reports.is_empty() {
-                "No shareable hosts configured.".to_string()
-            } else {
-                reports
-                    .iter()
-                    .map(render_mirror_report)
-                    .collect::<Vec<_>>()
-                    .join("\n")
-            };
-            Ok(CommandOutput::new(json, human))
-        }
-        Action::Register { json_row } => {
-            let value: Value =
-                serde_json::from_str(&json_row).map_err(|e| format!("--json-row: {e}"))?;
-            let row = crate::session_ops::mirror::session_from_json(
-                &value,
-                crate::session_ops::spawn::LOCAL_TMUX_BACKEND_TYPE,
-            )?;
-            register_running_session(db, row)
-        }
-        Action::Stop { session } => {
-            let target = resolve(db, &session)?;
-            let killed = crate::session_ops::restart::stop_session_headless(db, target.id)?;
-            Ok(CommandOutput::new(
-                json!({
-                    "id": target.id.to_string(),
-                    "name": target.name,
-                    "stopped": true,
-                    "killed_window": killed,
-                }),
-                format!(
-                    "Stopped '{}' ({}). Its worktree and conversation are untouched.",
-                    target.name, target.id
-                ),
-            )
-            .help([
-                "thurbox-cli session start <ref>   put its pane back",
-                "thurbox-cli session delete <ref>   let it go for good",
-            ]))
-        }
-        Action::Start { session } => {
-            let target = resolve(db, &session)?;
-            let report = crate::session_ops::restart::start_session_headless(db, target.id)?;
-            let mut human = format!("Started '{}' ({})", target.name, target.id);
-            push_hook_failures(&mut human, &report.hook_failures);
-            Ok(CommandOutput::new(
-                json!({
-                    "id": target.id.to_string(),
-                    "name": target.name,
-                    "stopped": false,
-                    "hook_failures": report.hook_failures,
-                }),
-                human,
-            ))
-        }
-        Action::Fork { session, name } => {
-            let source = resolve(db, &session)?;
-            let res = crate::session_ops::fork_session_headless(
-                db,
-                source.id,
-                name.as_deref().unwrap_or_default(),
-            )?;
-            // Whether the conversation actually came along is the agent's
-            // answer, not thurbox's: an agent with no `fork_args` gets a fresh
-            // one, and saying so beats letting the caller assume continuity.
-            let registry = crate::agent::agent_config::load_or_seed();
-            let continues = registry
-                .get(&res.agent)
-                .map(|def| !def.fork_args.is_empty())
-                .unwrap_or(false);
-            let human = format!(
-                "Forked '{}' → '{}' ({})\n{}",
-                source.name,
-                res.name,
-                res.session_id,
-                if continues {
-                    "  continuing its conversation"
-                } else {
-                    "  starting a fresh conversation (this agent declares no fork_args)"
-                }
-            );
-            Ok(CommandOutput::new(
-                json!({
-                    "id": res.session_id.to_string(),
-                    "name": res.name,
-                    "agent": res.agent,
-                    "parent_session_id": source.id.to_string(),
-                    "backend_id": res.backend_id,
-                    "worktrees": res.worktrees.iter().map(worktree_json).collect::<Vec<_>>(),
-                    "cwd": res.cwd.display().to_string(),
-                    "continues_conversation": continues,
-                }),
-                human,
-            ))
-        }
+        Action::Focus { uuid } => run_focus(db, uuid),
+        Action::Sync { host, adopt } => run_sync(db, host, adopt),
+        Action::Register { json_row } => run_register(db, json_row),
+        Action::Stop { session } => run_stop(db, session),
+        Action::Start { session } => run_start(db, session),
+        Action::Fork { session, name } => run_fork(db, session, name),
         Action::Exec {
             session,
             exit_passthrough,
@@ -1001,35 +601,532 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, CommandError>
         } => set_reports_as(db, &session, agent.as_deref(), clear),
         Action::Meta { action } => run_meta(action, db),
         Action::Doctor { uuid } => super::session_doctor::run(db, uuid.as_deref()),
-        Action::Signal { state, session } => {
-            let target = resolve_signal_target(db, session.as_deref())?;
-            if !db
-                .set_hook_state(target.id, &state)
-                .map_err(|e| format!("set_hook_state: {e}"))?
-            {
-                return Err(format!(
-                    "'{}' is parked, so it has no turn to report; \
-                     thurbox-cli session start {} first",
-                    target.name, target.id
+        Action::Signal { state, session } => run_signal(db, state, session),
+    }
+}
+
+fn run_list_deleted(db: &Database) -> Result<CommandOutput, CommandError> {
+    let rows = db
+        .list_deleted_sessions()
+        .map_err(|e| format!("list_deleted_sessions: {e}"))?;
+    let json = Value::Array(rows.iter().map(deleted_session_to_json).collect());
+    let human = if rows.is_empty() {
+        "No deleted sessions.".to_string()
+    } else {
+        output::table(
+            &["NAME", "AGENT", "BACKEND", "RECOVERABLE", "ID"],
+            &rows
+                .iter()
+                .map(|r| {
+                    vec![
+                        r.name.clone(),
+                        r.agent.clone(),
+                        r.backend_type.clone(),
+                        if r.force_deleted { "in part" } else { "fully" }.to_string(),
+                        r.id.to_string(),
+                    ]
+                })
+                .collect::<Vec<_>>(),
+        )
+    };
+    Ok(CommandOutput::new(json, human)
+        .list(
+            "deleted_sessions",
+            &["name", "agent", "force_deleted", "id"],
+        )
+        .empty("0 deleted sessions to restore")
+        .help([
+            "thurbox-cli session restore <name|id>   bring one back",
+            "thurbox-cli session restore <name|id> --best-effort   for a force-deleted row",
+        ]))
+}
+
+fn run_list_active(
+    db: &Database,
+    parent: Option<String>,
+    verify: bool,
+) -> Result<CommandOutput, CommandError> {
+    let parent_id = parent
+        .as_deref()
+        .map(|reference| resolve(db, reference).map(|s| s.id))
+        .transpose()?;
+    let sessions: Vec<SharedSession> = db
+        .list_active_sessions()
+        .map_err(|e| format!("list_active_sessions: {e}"))?
+        .into_iter()
+        .filter(|s| parent_id.is_none() || s.parent_session_id == parent_id)
+        .collect();
+    let facts = SessionFacts::load(db);
+    let bases = db.load_base_branches().unwrap_or_default();
+    let updated = db.load_updated_at().unwrap_or_default();
+    let registry = crate::agent::agent_config::load_or_seed();
+    let assessments: Vec<crate::session::Assessment> = sessions
+        .iter()
+        .map(|s| facts.assess(&registry, s, verify))
+        .collect();
+    let json = Value::Array(
+        sessions
+            .iter()
+            .zip(&assessments)
+            .map(|(s, hook)| {
+                crate::session_ops::mirror::session_to_json_assessed(
+                    s,
+                    hook,
+                    bases.get(&s.id).map(String::as_str),
+                    updated.get(&s.id).copied(),
                 )
-                .into());
-            }
-            // The same state on the pane, for a peer's live subscription:
-            // best-effort, and nothing at all outside tmux.
-            if let Err(e) = crate::agent::tmux::set_own_pane_state(&state) {
-                tracing::debug!("could not set the pane state option: {e:#}");
-            }
-            Ok(CommandOutput::new(
-                json!({
-                    "signaled": true,
-                    "session_id": target.id.to_string(),
-                    "session_name": target.name,
-                    "state": state,
-                }),
-                format!("Signaled {state} for '{}'.", target.name),
-            ))
+            })
+            .collect(),
+    );
+    Ok(
+        CommandOutput::new(json, render_session_list(&sessions, &assessments))
+            // `state`, not `hook_state`: the raw latched word is null for a
+            // session that never reported and carries no age or coverage to
+            // judge it by, so an agent reading the default answer would get
+            // less than the human table on the same call. `--json` still
+            // carries `hook_state` verbatim for a consumer that reads it.
+            //
+            // The id is not decoration: every follow-up command resolves a
+            // session by UUID, so omitting it would only buy a second call.
+            .list("sessions", &["name", "agent", "state", "id"])
+            .empty(match parent_id {
+                Some(id) => format!("0 sessions with parent {id}"),
+                None => "0 active sessions on this machine".to_string(),
+            })
+            .help([
+                "thurbox-cli session get <id>   the full record, worktrees included",
+                "thurbox-cli session capture <id> --lines 50   what its pane is showing",
+                "thurbox-cli session list --json   every field, for a script",
+            ]),
+    )
+}
+
+fn run_get(db: &Database, uuid: String, no_verify: bool) -> Result<CommandOutput, CommandError> {
+    let session = resolve(db, &uuid)?;
+    let facts = SessionFacts::load(db);
+    let bases = db.load_base_branches().unwrap_or_default();
+    let registry = crate::agent::agent_config::load_or_seed();
+    let hook = facts.assess(&registry, &session, !no_verify);
+    Ok(CommandOutput::new(
+        crate::session_ops::mirror::session_to_json_assessed(
+            &session,
+            &hook,
+            bases.get(&session.id).map(String::as_str),
+            db.load_updated_at()
+                .unwrap_or_default()
+                .get(&session.id)
+                .copied(),
+        ),
+        render_session_detail(&session, &hook),
+    ))
+}
+
+/// Every option `session create` takes — carried as one struct so the
+/// dispatcher's match arm stays under clippy's argument-count lint instead of
+/// forwarding fifteen positional parameters.
+struct CreateArgs {
+    name: String,
+    repo_path: PathBuf,
+    agent: Option<String>,
+    worktree_branch: Option<String>,
+    base_branch: Option<String>,
+    host: Option<String>,
+    parent: Option<String>,
+    add_repo: Vec<String>,
+    add_dir: Vec<String>,
+    command: Option<String>,
+    arg: Vec<String>,
+    env: Vec<String>,
+    resume: Option<String>,
+    on_existing: OnExisting,
+    reports_as: Option<String>,
+}
+
+fn run_create(db: &Database, args: CreateArgs) -> Result<CommandOutput, CommandError> {
+    let CreateArgs {
+        name,
+        repo_path,
+        agent,
+        worktree_branch,
+        base_branch,
+        host,
+        parent,
+        add_repo,
+        add_dir,
+        command,
+        arg,
+        env,
+        resume,
+        on_existing,
+        reports_as,
+    } = args;
+    let parent_session_id = parent
+        .as_deref()
+        .map(|reference| resolve(db, reference).map(|s| s.id))
+        .transpose()?;
+    let extra_repos = super::parse_extra_repos(&add_repo, &add_dir);
+    let env = parse_env(&env)?;
+    let registry = crate::agent::agent_config::load_or_seed();
+    // Checked before anything is spawned: a typo here is silent
+    // otherwise, and the session it would have described is already
+    // running by the time the caller could notice.
+    if let Some(declared) = &reports_as {
+        check_reports_as(&registry, declared)?;
+    }
+    // Names are not unique, so "already exists" is a decision the
+    // caller makes rather than something thurbox assumes — and it is a
+    // decision about *this* backend, since a mirrored host's rows share
+    // the namespace.
+    let backend = crate::session_ops::spawn::backend_type_for(host.as_deref())?;
+    let existing = resolve_existing(db, &name, on_existing, &backend, reports_as.as_deref())?;
+    if let Existing::Answered(output) = existing {
+        return Ok(*output);
+    }
+    let req = crate::session_ops::SpawnRequest {
+        name,
+        repo_path,
+        worktree_branch,
+        base_branch,
+        agent,
+        host,
+        parent_session_id,
+        extra_repos,
+        command,
+        args: arg,
+        env,
+        resume_session_id: resume,
+        ..Default::default()
+    };
+    let res = match crate::session_ops::spawn_session_headless(db, req) {
+        Ok(res) => res,
+        // `replace` tore the old session down first, so a spawn that
+        // fails here would otherwise leave the caller with neither
+        // session. Put back what can be put back before reporting.
+        Err(e) => return Err(rollback_replace(db, &existing, e).into()),
+    };
+    if let Some(declared) = &reports_as {
+        if let Err(e) = db.set_reports_as(res.session_id, Some(declared)) {
+            return Err(format!(
+                "session '{}' ({}) was created, but declaring it as '{declared}' \
+                 failed: set_reports_as: {e}. Retry with `thurbox-cli session \
+                 reports-as {} {declared}`",
+                res.name, res.session_id, res.session_id
+            )
+            .into());
         }
     }
+    // Nothing has signalled yet, so this is `uncovered` or `unreported`
+    // — read against whatever will actually report.
+    let state = crate::session::Assessment::from_hooks(
+        &registry,
+        reports_as.as_deref().unwrap_or(&res.agent),
+        None,
+        None,
+        None,
+        0,
+    )
+    .state_word();
+    // A host driven from afar has no interface of its own to arm the
+    // heartbeat: this creation is the moment its sessions start needing
+    // the tick (status polls, extension self-heal, reaping).
+    super::automations::arm_heartbeat();
+    let mut human = format!(
+        "Created session '{}' ({}) — {}\ncwd: {}",
+        res.name,
+        res.agent,
+        res.session_id,
+        res.cwd.display()
+    );
+    if let Some(note) = &res.sharing {
+        human.push_str(&format!("\n  {note}"));
+    }
+    push_hook_failures(&mut human, &res.hook_failures);
+    Ok(CommandOutput::new(
+        json!({
+            "id": res.session_id.to_string(),
+            "name": res.name,
+            "agent": res.agent,
+            "agent_session_id": res.agent_session_id,
+            // The pane, the checkouts and the server: everything the
+            // caller would otherwise have to come back for with a
+            // second `session get`, and poll for until it appeared.
+            "backend_id": res.backend_id,
+            "worktrees": res.worktrees.iter().map(worktree_json).collect::<Vec<_>>(),
+            "tmux_socket": crate::agent::tmux::local_socket_name(),
+            "cwd": res.cwd.display().to_string(),
+            "parent_session_id": res.parent_session_id.map(|id| id.to_string()),
+            "hook_failures": res.hook_failures,
+            "sharing": res.sharing,
+            "reports_as": reports_as,
+            // Present here only so `--on-existing adopt` can answer in
+            // the same shape: a session that was just spawned is
+            // running by construction and has said nothing yet, while
+            // one that was already there may be parked.
+            "stopped": false,
+            "state": state,
+            "created": true,
+        }),
+        human,
+    ))
+}
+
+fn run_reap(db: &Database, session: String) -> Result<CommandOutput, CommandError> {
+    let row = super::session_ref::resolve_deleted(db, &session)?;
+    let reaped = crate::session_ops::reap_soft_deleted(db, row.id)?;
+    let human = if reaped {
+        format!("Reaped session '{}' ({})", row.name, row.id)
+    } else {
+        format!(
+            "Nothing to reap for '{}' ({}): it came back, or was force-deleted",
+            row.name, row.id
+        )
+    };
+    Ok(CommandOutput::new(
+        json!({
+            "reaped": reaped,
+            "id": row.id.to_string(),
+            "name": row.name,
+        }),
+        human,
+    ))
+}
+
+fn run_restart(
+    db: &Database,
+    uuid: String,
+    if_missing: bool,
+) -> Result<CommandOutput, CommandError> {
+    let session = resolve(db, &uuid)?;
+    let report =
+        crate::session_ops::restart::restart_session_headless_with(db, session.id, if_missing)?;
+    let mut human = format!("Restarted session '{}' ({})", session.name, session.id);
+    push_hook_failures(&mut human, &report.hook_failures);
+    Ok(CommandOutput::new(
+        json!({
+            "restarted": true,
+            "session_id": session.id.to_string(),
+            "session_name": session.name,
+            "hook_failures": report.hook_failures,
+        }),
+        human,
+    ))
+}
+
+fn run_send(
+    db: &Database,
+    uuid: String,
+    text: String,
+    no_enter: bool,
+) -> Result<CommandOutput, CommandError> {
+    let session = resolve(db, &uuid)?;
+    if text.trim().is_empty() {
+        return Err("text must not be empty".into());
+    }
+    refuse_if_parked(db, &session)?;
+    let id = session.id.to_string();
+    let mut args = vec!["session", "send", &id, &text];
+    if no_enter {
+        args.push("--no-enter");
+    }
+    if let Some(remote) = delegate_to_host(&session, &args)? {
+        return Ok(remote);
+    }
+    let submit = !no_enter;
+    crate::agent::tmux::send_text_now(&session.id.to_string(), &session.name, &text, submit)
+        .map_err(|e| format!("send_text_now: {e}"))?;
+    let human = if submit {
+        format!("Sent to '{}'.", session.name)
+    } else {
+        format!("Typed into '{}' (not submitted).", session.name)
+    };
+    Ok(CommandOutput::new(
+        json!({
+            "sent": true,
+            "submitted": submit,
+            "session_id": session.id.to_string(),
+            "session_name": session.name,
+        }),
+        human,
+    ))
+}
+
+fn run_key(db: &Database, uuid: String, key: String) -> Result<CommandOutput, CommandError> {
+    let session = resolve(db, &uuid)?;
+    let resolved = crate::agent::tmux::resolve_key(&key).ok_or_else(|| unknown_key(&key))?;
+    refuse_if_parked(db, &session)?;
+    let id = session.id.to_string();
+    if let Some(remote) = delegate_to_host(&session, &["session", "key", &id, &resolved.name])? {
+        return Ok(remote);
+    }
+    crate::agent::tmux::send_key_now(&session.id.to_string(), &session.name, &resolved.tmux)
+        .map_err(|e| format!("send_key_now: {e}"))?;
+    Ok(CommandOutput::new(
+        json!({
+            "sent": true,
+            "key": resolved.name,
+            "tmux_key": resolved.tmux,
+            "session_id": session.id.to_string(),
+            "session_name": session.name,
+        }),
+        format!("Sent {} to '{}'.", resolved.name, session.name),
+    ))
+}
+
+fn run_focus(db: &Database, uuid: String) -> Result<CommandOutput, CommandError> {
+    let session = resolve(db, &uuid)?;
+    db.set_pending_focus_session_id(session.id)
+        .map_err(|e| format!("set_pending_focus_session_id: {e}"))?;
+    Ok(CommandOutput::new(
+        json!({
+            "focused": true,
+            "session_id": session.id.to_string(),
+            "session_name": session.name,
+        }),
+        format!("Focus requested for '{}'.", session.name),
+    ))
+}
+
+fn run_sync(
+    db: &Database,
+    host: Option<String>,
+    adopt: bool,
+) -> Result<CommandOutput, CommandError> {
+    let reports = crate::session_ops::mirror::sync(db, host.as_deref(), adopt)?;
+    let json = Value::Array(reports.iter().map(|r| r.to_json()).collect());
+    let human = if reports.is_empty() {
+        "No shareable hosts configured.".to_string()
+    } else {
+        reports
+            .iter()
+            .map(render_mirror_report)
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+    Ok(CommandOutput::new(json, human))
+}
+
+fn run_register(db: &Database, json_row: String) -> Result<CommandOutput, CommandError> {
+    let value: Value = serde_json::from_str(&json_row).map_err(|e| format!("--json-row: {e}"))?;
+    let row = crate::session_ops::mirror::session_from_json(
+        &value,
+        crate::session_ops::spawn::LOCAL_TMUX_BACKEND_TYPE,
+    )?;
+    register_running_session(db, row)
+}
+
+fn run_stop(db: &Database, session: String) -> Result<CommandOutput, CommandError> {
+    let target = resolve(db, &session)?;
+    let killed = crate::session_ops::restart::stop_session_headless(db, target.id)?;
+    Ok(CommandOutput::new(
+        json!({
+            "id": target.id.to_string(),
+            "name": target.name,
+            "stopped": true,
+            "killed_window": killed,
+        }),
+        format!(
+            "Stopped '{}' ({}). Its worktree and conversation are untouched.",
+            target.name, target.id
+        ),
+    )
+    .help([
+        "thurbox-cli session start <ref>   put its pane back",
+        "thurbox-cli session delete <ref>   let it go for good",
+    ]))
+}
+
+fn run_start(db: &Database, session: String) -> Result<CommandOutput, CommandError> {
+    let target = resolve(db, &session)?;
+    let report = crate::session_ops::restart::start_session_headless(db, target.id)?;
+    let mut human = format!("Started '{}' ({})", target.name, target.id);
+    push_hook_failures(&mut human, &report.hook_failures);
+    Ok(CommandOutput::new(
+        json!({
+            "id": target.id.to_string(),
+            "name": target.name,
+            "stopped": false,
+            "hook_failures": report.hook_failures,
+        }),
+        human,
+    ))
+}
+
+fn run_fork(
+    db: &Database,
+    session: String,
+    name: Option<String>,
+) -> Result<CommandOutput, CommandError> {
+    let source = resolve(db, &session)?;
+    let res = crate::session_ops::fork_session_headless(
+        db,
+        source.id,
+        name.as_deref().unwrap_or_default(),
+    )?;
+    // Whether the conversation actually came along is the agent's
+    // answer, not thurbox's: an agent with no `fork_args` gets a fresh
+    // one, and saying so beats letting the caller assume continuity.
+    let registry = crate::agent::agent_config::load_or_seed();
+    let continues = registry
+        .get(&res.agent)
+        .map(|def| !def.fork_args.is_empty())
+        .unwrap_or(false);
+    let human = format!(
+        "Forked '{}' → '{}' ({})\n{}",
+        source.name,
+        res.name,
+        res.session_id,
+        if continues {
+            "  continuing its conversation"
+        } else {
+            "  starting a fresh conversation (this agent declares no fork_args)"
+        }
+    );
+    Ok(CommandOutput::new(
+        json!({
+            "id": res.session_id.to_string(),
+            "name": res.name,
+            "agent": res.agent,
+            "parent_session_id": source.id.to_string(),
+            "backend_id": res.backend_id,
+            "worktrees": res.worktrees.iter().map(worktree_json).collect::<Vec<_>>(),
+            "cwd": res.cwd.display().to_string(),
+            "continues_conversation": continues,
+        }),
+        human,
+    ))
+}
+
+fn run_signal(
+    db: &Database,
+    state: String,
+    session: Option<String>,
+) -> Result<CommandOutput, CommandError> {
+    let target = resolve_signal_target(db, session.as_deref())?;
+    if !db
+        .set_hook_state(target.id, &state)
+        .map_err(|e| format!("set_hook_state: {e}"))?
+    {
+        return Err(format!(
+            "'{}' is parked, so it has no turn to report; \
+             thurbox-cli session start {} first",
+            target.name, target.id
+        )
+        .into());
+    }
+    // The same state on the pane, for a peer's live subscription:
+    // best-effort, and nothing at all outside tmux.
+    if let Err(e) = crate::agent::tmux::set_own_pane_state(&state) {
+        tracing::debug!("could not set the pane state option: {e:#}");
+    }
+    Ok(CommandOutput::new(
+        json!({
+            "signaled": true,
+            "session_id": target.id.to_string(),
+            "session_name": target.name,
+            "state": state,
+        }),
+        format!("Signaled {state} for '{}'.", target.name),
+    ))
 }
 
 /// Read a session's pane: its rendered text, and the live state around it.

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -68,7 +68,7 @@ pub struct WatchArgs {
     #[arg(long, value_name = "SEQ")]
     pub since: Option<i64>,
     /// Also check each event's session against its pane, filling
-    /// `hook_state_contradicted`.
+    /// `hook_state_contradicted` and `detected_agent`.
     ///
     /// Off by default for the same reason `session list --verify` is: it costs
     /// a multiplexer query and a `ps` per event.
@@ -342,6 +342,9 @@ fn base(id: SessionId, facts: &SessionFacts, hook: &Assessment) -> Value {
         "hook_coverage": hook.coverage.as_str(),
         "hook_blocked_is_heuristic": hook.blocked_is_heuristic(),
         "hook_state_contradicted": hook.contradicted,
+        // Which agent is in the pane, when it is not the one the row was
+        // created with — `--verify` only, like every other pane field.
+        "detected_agent": hook.detected_agent(),
     })
 }
 
@@ -381,11 +384,10 @@ fn assess(
         .get(&facts.agent)
         .map(|d| d.command.clone())
         .unwrap_or_else(|| facts.agent.clone());
-    let known: Vec<String> = registry.agents.iter().map(|a| a.command.clone()).collect();
     let pane = crate::agent::tmux::pane_state(&facts.name, &facts.backend_id);
     hook.with_pane(
         &command,
-        &known,
+        registry,
         pane.foreground_process.as_deref(),
         pane.foreground_command.as_deref(),
         pane.dead,

--- a/src/kernel/events.rs
+++ b/src/kernel/events.rs
@@ -406,6 +406,8 @@ mod tests {
             git: None,
             stopped: false,
             hook_state: None,
+            reports_as: None,
+            detected_agent: None,
             shell_backend_id: None,
             member_dirs: Vec::new(),
         }

--- a/src/kernel/host/publish.rs
+++ b/src/kernel/host/publish.rs
@@ -632,15 +632,31 @@ fn build_sessions(
 ) -> Result<Value, String> {
     let sessions = lua.create_table().map_err(|e| e.to_string())?;
     for (index, row) in snapshot.sessions.iter().enumerate() {
-        // Pre-sized: this row takes ~28 named fields, and a table grown one
+        // Pre-sized: this row takes ~30 named fields, and a table grown one
         // field at a time rehashes itself on the way there — per session,
         // per frame.
         let entry = lua
-            .create_table_with_capacity(0, 30)
+            .create_table_with_capacity(0, 32)
             .map_err(|e| e.to_string())?;
         set(&entry, "id", to_lua_string(lua, &row.id)?)?;
         set(&entry, "name", to_lua_string(lua, &row.name)?)?;
         set(&entry, "agent", to_lua_string(lua, &row.agent)?)?;
+        // Three names, three fields, because they are three different facts and
+        // no two of them can stand in for each other: what the row was created
+        // as, what a driver declared it runs (`session reports-as`), and what is
+        // observably in the pane right now. A row created as `zsh` with claude
+        // running in it is otherwise a session the interface can only call
+        // `zsh`.
+        set(
+            &entry,
+            "reports_as",
+            opt_lua_string(lua, row.reports_as.as_deref())?,
+        )?;
+        set(
+            &entry,
+            "detected_agent",
+            opt_lua_string(lua, row.detected_agent.as_deref())?,
+        )?;
         let attach_error = attach_errors.get(&row.id).map(String::as_str);
         set(
             &entry,

--- a/src/kernel/notify.rs
+++ b/src/kernel/notify.rs
@@ -187,6 +187,8 @@ mod tests {
             git: None,
             stopped: false,
             hook_state: None,
+            reports_as: None,
+            detected_agent: None,
             shell_backend_id: None,
             member_dirs: Vec::new(),
         }

--- a/src/kernel/snapshot.rs
+++ b/src/kernel/snapshot.rs
@@ -129,7 +129,9 @@ pub struct SessionRow {
     /// A live reading with a short life (see `PANE_PROBE_TTL`) and no claim
     /// about what the agent is *doing* — that is `status`, which stays
     /// [`SessionState::Running`] precisely because no process inspection can
-    /// tell a turn in flight from a prompt waiting for input.
+    /// tell a turn in flight from a prompt waiting for input. Dropped the
+    /// moment the row starts reporting its own hook state, since the agent is
+    /// then speaking for itself and an inspected pane has nothing left to add.
     pub detected_agent: Option<String>,
 }
 
@@ -908,6 +910,7 @@ impl SnapshotStore {
             // refresh would re-derive from the row we just wrote.
             row.status = derive_state(Some(&event.state), Some(now_ms()), None);
             row.hook_state = Some(event.state);
+            row.detected_agent = None;
             applied += 1;
         }
         if applied > 0 {
@@ -1551,8 +1554,10 @@ mod tests {
         );
     }
 
-    #[test]
-    fn a_hook_report_evicts_a_stale_pane_probe() {
+    /// Seed an in-memory store with one session whose pane probe already found
+    /// a foreign agent, so `detected_agent` is published for it — the
+    /// "firstmate" scenario: a bare shell with a real agent running in it.
+    fn store_with_a_detected_agent() -> (SnapshotStore, crate::sync::SharedSession) {
         let database = Database::open_in_memory().expect("in-memory database opens");
         let row = crate::sync::SharedSession {
             id: SessionId::default(),
@@ -1572,9 +1577,6 @@ mod tests {
         };
         database.upsert_session(&row).expect("upsert");
         let mut store = SnapshotStore::with_database(database);
-
-        // A firstmate-style pane probe found a foreign agent holding what was
-        // launched as a bare shell.
         store.panes.known.insert(
             row.id.to_string(),
             Probe {
@@ -1591,8 +1593,15 @@ mod tests {
             .expect("row published");
         assert_eq!(published.detected_agent.as_deref(), Some("claude"));
         assert!(published.hook_state.is_none());
+        (store, row)
+    }
 
-        // The same pane starts delivering real hook events.
+    #[test]
+    fn a_hook_report_clears_its_row_detected_agent_at_once() {
+        let (mut store, row) = store_with_a_detected_agent();
+
+        // The same pane starts delivering real hook events — through the exact
+        // entry point production code uses, with nothing else run in between.
         store.apply_hook_states(
             vec![(
                 "local-tmux".to_string(),
@@ -1601,8 +1610,6 @@ mod tests {
             )],
             Instant::now(),
         );
-        store.poll_pane_probes();
-        store.refresh();
 
         let published = store
             .current()
@@ -1613,7 +1620,28 @@ mod tests {
         assert_eq!(published.hook_state.as_deref(), Some("working"));
         assert_eq!(
             published.detected_agent, None,
-            "a pane verdict cached before the hook onset must not survive it"
+            "a pane verdict published before the hook onset must not survive it"
+        );
+    }
+
+    #[test]
+    fn a_hook_report_evicts_a_stale_pane_probe() {
+        let (mut store, row) = store_with_a_detected_agent();
+
+        store.apply_hook_states(
+            vec![(
+                "local-tmux".to_string(),
+                "%7".to_string(),
+                "working".to_string(),
+            )],
+            Instant::now(),
+        );
+        store.poll_pane_probes();
+
+        assert_eq!(
+            store.panes.get(&row.id.to_string()),
+            None,
+            "a row that now reports its own hook state must leave the probed cache"
         );
     }
 }

--- a/src/kernel/snapshot.rs
+++ b/src/kernel/snapshot.rs
@@ -133,6 +133,12 @@ pub struct SessionRow {
     /// for a row nothing has reported for (`assess`'s gate on `hook.state`),
     /// so it is never attached to a row that is already speaking for itself,
     /// regardless of what a stale probe answer still says.
+    ///
+    /// `None` also when an agent is demonstrably in the pane but *which* one
+    /// is not determined — several registered profiles sharing one executable,
+    /// which the shipped `agents.toml` teaches the user to create. The status
+    /// still reads [`SessionState::Running`], because presence is observed;
+    /// only the name is withheld. See [`crate::session::Corroboration`].
     pub detected_agent: Option<String>,
 }
 
@@ -1597,7 +1603,7 @@ mod tests {
         store.panes.known.insert(
             row.id.to_string(),
             Probe {
-                corroboration: Corroboration::ForeignAgent("claude".into()),
+                corroboration: Corroboration::ForeignAgent(Some("claude".into())),
                 at: Instant::now(),
             },
         );
@@ -1696,7 +1702,7 @@ mod tests {
         store.panes.known.insert(
             row.id.to_string(),
             Probe {
-                corroboration: Corroboration::ForeignAgent("claude".into()),
+                corroboration: Corroboration::ForeignAgent(Some("claude".into())),
                 at: Instant::now(),
             },
         );

--- a/src/kernel/snapshot.rs
+++ b/src/kernel/snapshot.rs
@@ -507,10 +507,11 @@ impl PaneProbe {
         self.known.get(session).map(|probe| &probe.corroboration)
     }
 
-    /// Forget sessions that are no longer in the snapshot, so the cache tracks
-    /// what exists rather than everything that ever did.
-    fn retain(&mut self, present: &std::collections::HashSet<&str>) {
-        self.known.retain(|id, _| present.contains(id.as_str()));
+    /// Forget every session this poll is not currently asking about, so a
+    /// verdict can only be published for a row thurbox is still actively
+    /// observing.
+    fn retain(&mut self, probed: &std::collections::HashSet<&str>) {
+        self.known.retain(|id, _| probed.contains(id.as_str()));
     }
 }
 
@@ -718,13 +719,6 @@ impl SnapshotStore {
     /// else already has a better answer than a process listing can give.
     fn poll_pane_probes(&mut self) -> bool {
         let moved = self.panes.drain();
-        let present: std::collections::HashSet<&str> = self
-            .current
-            .sessions
-            .iter()
-            .map(|row| row.id.as_str())
-            .collect();
-        self.panes.retain(&present);
 
         let wanted: Vec<(String, String, String)> = self
             .current
@@ -748,6 +742,11 @@ impl SnapshotStore {
                 (row.id.clone(), row.name.clone(), command)
             })
             .collect();
+
+        let probed: std::collections::HashSet<&str> =
+            wanted.iter().map(|(id, _, _)| id.as_str()).collect();
+        self.panes.retain(&probed);
+
         for (id, name, command) in wanted {
             self.panes.request(&id, &name, command, &self.registry);
         }
@@ -1549,6 +1548,72 @@ mod tests {
                 PathBuf::from("/worktrees/b"),
                 PathBuf::from("/reference"),
             ]
+        );
+    }
+
+    #[test]
+    fn a_hook_report_evicts_a_stale_pane_probe() {
+        let database = Database::open_in_memory().expect("in-memory database opens");
+        let row = crate::sync::SharedSession {
+            id: SessionId::default(),
+            name: "shell".into(),
+            agent: "zsh".into(),
+            backend_id: "%7".into(),
+            backend_type: "local-tmux".into(),
+            agent_session_id: None,
+            cwd: None,
+            additional_dirs: Vec::new(),
+            worktrees: Vec::new(),
+            shell_backend_id: None,
+            parent_session_id: None,
+            display_order: None,
+            tombstone: false,
+            tombstone_at: None,
+        };
+        database.upsert_session(&row).expect("upsert");
+        let mut store = SnapshotStore::with_database(database);
+
+        // A firstmate-style pane probe found a foreign agent holding what was
+        // launched as a bare shell.
+        store.panes.known.insert(
+            row.id.to_string(),
+            Probe {
+                corroboration: Corroboration::ForeignAgent("claude".into()),
+                at: Instant::now(),
+            },
+        );
+        store.refresh();
+        let published = store
+            .current()
+            .sessions
+            .iter()
+            .find(|s| s.id == row.id.to_string())
+            .expect("row published");
+        assert_eq!(published.detected_agent.as_deref(), Some("claude"));
+        assert!(published.hook_state.is_none());
+
+        // The same pane starts delivering real hook events.
+        store.apply_hook_states(
+            vec![(
+                "local-tmux".to_string(),
+                "%7".to_string(),
+                "working".to_string(),
+            )],
+            Instant::now(),
+        );
+        store.poll_pane_probes();
+        store.refresh();
+
+        let published = store
+            .current()
+            .sessions
+            .iter()
+            .find(|s| s.id == row.id.to_string())
+            .expect("row published");
+        assert_eq!(published.hook_state.as_deref(), Some("working"));
+        assert_eq!(
+            published.detected_agent, None,
+            "a pane verdict cached before the hook onset must not survive it"
         );
     }
 }

--- a/src/kernel/snapshot.rs
+++ b/src/kernel/snapshot.rs
@@ -129,9 +129,10 @@ pub struct SessionRow {
     /// A live reading with a short life (see `PANE_PROBE_TTL`) and no claim
     /// about what the agent is *doing* — that is `status`, which stays
     /// [`SessionState::Running`] precisely because no process inspection can
-    /// tell a turn in flight from a prompt waiting for input. Dropped the
-    /// moment the row starts reporting its own hook state, since the agent is
-    /// then speaking for itself and an inspected pane has nothing left to add.
+    /// tell a turn in flight from a prompt waiting for input. Published only
+    /// for a row nothing has reported for (`assess`'s gate on `hook.state`),
+    /// so it is never attached to a row that is already speaking for itself,
+    /// regardless of what a stale probe answer still says.
     pub detected_agent: Option<String>,
 }
 
@@ -509,9 +510,14 @@ impl PaneProbe {
         self.known.get(session).map(|probe| &probe.corroboration)
     }
 
-    /// Forget every session this poll is not currently asking about, so a
-    /// verdict can only be published for a row thurbox is still actively
-    /// observing.
+    /// Forget every session this poll is not currently asking about.
+    ///
+    /// Hygiene rather than the correctness guard: this cache tracking a set it
+    /// has stopped asking about would keep answering a question nobody put to
+    /// it, and re-requesting one that never left would waste a subprocess.
+    /// What stops a stale verdict from *publishing* is `assess`'s own gate on
+    /// `hook.state`, which does not depend on this eviction's timing relative
+    /// to a refresh.
     fn retain(&mut self, probed: &std::collections::HashSet<&str>) {
         self.known.retain(|id, _| probed.contains(id.as_str()));
     }
@@ -907,7 +913,10 @@ impl SnapshotStore {
             }
             // Corrected in place for the same reason `acknowledge` does it: this
             // is our own connection, so `PRAGMA data_version` will not move and a
-            // refresh would re-derive from the row we just wrote.
+            // refresh would re-derive from the row we just wrote. `detected_agent`
+            // is cleared here rather than left to that (absent) refresh, because
+            // this path never reaches `assess` at all — it writes the row
+            // directly, which is the one case its hook.state gate cannot cover.
             row.status = derive_state(Some(&event.state), Some(now_ms()), None);
             row.hook_state = Some(event.state);
             row.detected_agent = None;
@@ -1325,9 +1334,17 @@ fn assess(
     if crate::session::is_remote_backend(backend) {
         return assessment.pane_unavailable();
     }
+    // An observation is published only for a row nothing has reported for.
+    // `best_state` already answers from the hook columns whenever they hold
+    // anything, so this changes nothing about the derived status — it only
+    // stops a pane verdict, cached before the hook onset and not yet evicted
+    // by that onset's own poll, from being attached to a row that now speaks
+    // for itself.
     match pane {
-        Some(corroboration) => assessment.with_corroboration(corroboration.clone()),
-        None => assessment,
+        Some(corroboration) if !assessment.reported => {
+            assessment.with_corroboration(corroboration.clone())
+        }
+        _ => assessment,
     }
 }
 
@@ -1642,6 +1659,89 @@ mod tests {
             store.panes.get(&row.id.to_string()),
             None,
             "a row that now reports its own hook state must leave the probed cache"
+        );
+    }
+
+    /// The local path: an agent's own `thurbox-cli session signal` writes the
+    /// hook state through a second connection, never through
+    /// `apply_hook_states`, so only `refresh_if_due`'s normal DB-read cadence
+    /// ever sees it. Driven exactly as the coordinator drives it — no
+    /// hand-rolled `poll_pane_probes`/`refresh` call — because the ordering
+    /// between that cadence and the pane-probe cache is the thing under test.
+    #[test]
+    fn a_local_hook_report_does_not_resurrect_a_stale_detected_agent() {
+        let temp = tempfile::NamedTempFile::new().expect("temp file");
+        let path = temp.path();
+
+        let database = Database::open(path).expect("open store connection");
+        let row = crate::sync::SharedSession {
+            id: SessionId::default(),
+            name: "shell".into(),
+            agent: "zsh".into(),
+            backend_id: "%7".into(),
+            backend_type: "local-tmux".into(),
+            agent_session_id: None,
+            cwd: None,
+            additional_dirs: Vec::new(),
+            worktrees: Vec::new(),
+            shell_backend_id: None,
+            parent_session_id: None,
+            display_order: None,
+            tombstone: false,
+            tombstone_at: None,
+        };
+        database.upsert_session(&row).expect("upsert");
+        let mut store = SnapshotStore::with_database(database);
+
+        store.panes.known.insert(
+            row.id.to_string(),
+            Probe {
+                corroboration: Corroboration::ForeignAgent("claude".into()),
+                at: Instant::now(),
+            },
+        );
+        store.refresh();
+        let published = store
+            .current()
+            .sessions
+            .iter()
+            .find(|s| s.id == row.id.to_string())
+            .expect("row published");
+        assert_eq!(published.detected_agent.as_deref(), Some("claude"));
+
+        let driver = Database::open(path).expect("open a second connection");
+        driver
+            .set_hook_state(row.id, "working")
+            .expect("write the hook state through the other connection");
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            store.refresh_if_due();
+            let seen = store
+                .current()
+                .sessions
+                .iter()
+                .find(|s| s.id == row.id.to_string())
+                .expect("row published")
+                .hook_state
+                .clone();
+            if seen.as_deref() == Some("working") || Instant::now() >= deadline {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+
+        let published = store
+            .current()
+            .sessions
+            .iter()
+            .find(|s| s.id == row.id.to_string())
+            .expect("row published");
+        assert_eq!(published.hook_state.as_deref(), Some("working"));
+        assert_eq!(
+            published.detected_agent, None,
+            "a pane verdict cached before a hook onset seen through another \
+             connection must not publish once the row reports for itself"
         );
     }
 }

--- a/src/kernel/snapshot.rs
+++ b/src/kernel/snapshot.rs
@@ -14,7 +14,10 @@
 use std::path::PathBuf;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use crate::session::{derive_state, with_output_quiescence, SessionId, SessionState};
+use crate::session::{
+    derive_state, with_output_quiescence, AgentRegistry, Assessment, Corroboration, SessionId,
+    SessionState,
+};
 use crate::storage::Database;
 
 /// How often the snapshot is rebuilt. A read never waits on this; it only
@@ -111,6 +114,23 @@ pub struct SessionRow {
     /// or an acknowledged `done` (derived `idle`) would be written back and
     /// resurrected on every reconnect.
     pub hook_state: Option<String>,
+    /// The agent a driver **declared** this session runs (`session reports-as`),
+    /// when it declared one. A durable statement about the row.
+    pub reports_as: Option<String>,
+    /// The agent **observed** holding this session's pane, when it is not the
+    /// one the row was created with.
+    ///
+    /// The third of three names, and the reason all three are published: `agent`
+    /// is what the row was created as, `reports_as` is what a driver declared,
+    /// and this is what is running right now. A driver that asks for a bare
+    /// shell and starts an agent in it is otherwise a row labelled `zsh` with
+    /// nothing to say about the claude in front of the user.
+    ///
+    /// A live reading with a short life (see `PANE_PROBE_TTL`) and no claim
+    /// about what the agent is *doing* — that is `status`, which stays
+    /// [`SessionState::Running`] precisely because no process inspection can
+    /// tell a turn in flight from a prompt waiting for input.
+    pub detected_agent: Option<String>,
 }
 
 /// A session that was deleted but not purged.
@@ -366,6 +386,134 @@ impl GitStats {
     }
 }
 
+/// How long a pane verdict stands before it is asked for again.
+///
+/// The probe shells out — one `display-message` plus one `ps` — so it can no
+/// more run on the render path than a git stat can, and this bound is what
+/// stops a session that never reports from paying for one per refresh. Two
+/// seconds is also about the resolution the answer has: it says an agent is
+/// *there*, not what it is doing, and that fact changes when a process starts
+/// or exits.
+const PANE_PROBE_TTL: Duration = Duration::from_secs(2);
+
+/// One worker's answer: the session it probed, and what holds its pane.
+type ProbeResult = (String, Corroboration);
+
+/// One pane's verdict and when it was reached.
+struct Probe {
+    corroboration: Corroboration,
+    at: Instant,
+}
+
+/// What holds each session's pane, computed off the render path.
+///
+/// Another instance of the worker pattern (see [`GitStats`] beside it, and
+/// `kernel::updates`): touch the world on a thread, publish the result.
+///
+/// The interface used to skip this check altogether and derive its dot from
+/// the hook columns alone, which is why a driver-launched agent — nothing
+/// wired, nothing signalled — drew the green hollow `idle` circle while it
+/// worked.
+///
+/// Asked **only** about rows whose `hook_state` is null. An agent that reports
+/// for itself needs no observation ([`crate::session::best_state`] would
+/// discard it anyway), and probing every session every refresh is the cost the
+/// interface declined to pay in the first place.
+#[derive(Default)]
+struct PaneProbe {
+    known: std::collections::HashMap<String, Probe>,
+    inflight: std::collections::HashSet<String>,
+    channel: Option<(
+        std::sync::mpsc::Sender<ProbeResult>,
+        std::sync::mpsc::Receiver<ProbeResult>,
+    )>,
+}
+
+impl PaneProbe {
+    fn ensure_channel(&mut self) -> std::sync::mpsc::Sender<ProbeResult> {
+        if self.channel.is_none() {
+            self.channel = Some(std::sync::mpsc::channel());
+        }
+        self.channel.as_ref().expect("just created").0.clone()
+    }
+
+    /// Ask what holds a session's pane, unless a probe is in flight or the last
+    /// answer is still fresh.
+    fn request(
+        &mut self,
+        session: &str,
+        name: &str,
+        agent_command: String,
+        registry: &std::sync::Arc<AgentRegistry>,
+    ) {
+        if self.inflight.contains(session) {
+            return;
+        }
+        if self
+            .known
+            .get(session)
+            .is_some_and(|probe| probe.at.elapsed() < PANE_PROBE_TTL)
+        {
+            return;
+        }
+        self.inflight.insert(session.to_string());
+        let tx = self.ensure_channel();
+        let (session, name) = (session.to_string(), name.to_string());
+        let registry = std::sync::Arc::clone(registry);
+        std::thread::spawn(move || {
+            let pane = crate::agent::tmux::pane_state(&session, &name);
+            // Classified on the worker rather than at the fold, so the argv the
+            // verdict was read from — a driver's brief runs to kilobytes — never
+            // crosses the channel or lands in the snapshot.
+            let corroboration = crate::session::classify_foreground(
+                &agent_command,
+                &registry,
+                pane.foreground_process.as_deref(),
+                pane.foreground_command.as_deref(),
+                pane.dead,
+            );
+            let _ = tx.send((session, corroboration));
+        });
+    }
+
+    /// Take whatever the workers have answered, reporting whether any verdict
+    /// actually moved — which is what makes the derived rows stale.
+    fn drain(&mut self) -> bool {
+        let Some((_, rx)) = &self.channel else {
+            return false;
+        };
+        let mut moved = false;
+        while let Ok((session, corroboration)) = rx.try_recv() {
+            self.inflight.remove(&session);
+            // `Option::is_none_or` would read better but is stable only from
+            // 1.82; this crate's MSRV is 1.75.
+            let changed = self
+                .known
+                .get(&session)
+                .map_or(true, |probe| probe.corroboration != corroboration);
+            self.known.insert(
+                session,
+                Probe {
+                    corroboration,
+                    at: Instant::now(),
+                },
+            );
+            moved |= changed;
+        }
+        moved
+    }
+
+    fn get(&self, session: &str) -> Option<&Corroboration> {
+        self.known.get(session).map(|probe| &probe.corroboration)
+    }
+
+    /// Forget sessions that are no longer in the snapshot, so the cache tracks
+    /// what exists rather than everything that ever did.
+    fn retain(&mut self, present: &std::collections::HashSet<&str>) {
+        self.known.retain(|id, _| present.contains(id.as_str()));
+    }
+}
+
 /// Owns the snapshot and decides when to rebuild it.
 ///
 /// Refresh happens on the kernel's schedule, never inside a plugin call — so a
@@ -373,6 +521,12 @@ impl GitStats {
 pub struct SnapshotStore {
     database: Option<Database>,
     git: GitStats,
+    /// What holds each unreported session's pane — see [`PaneProbe`].
+    panes: PaneProbe,
+    /// The agent registry every state answer is judged against: coverage comes
+    /// from it, and so does the name a detected agent is reported under. Read
+    /// once, like `agents` below, so a refresh never touches the filesystem.
+    registry: std::sync::Arc<AgentRegistry>,
     /// Read once at startup: these change only when their config files do, and
     /// re-reading them every 400ms would be a filesystem hit for nothing.
     agents: Vec<AgentRow>,
@@ -426,11 +580,14 @@ impl SnapshotStore {
                 Some("could not resolve the database path".to_string()),
             ),
         };
+        let registry = read_registry();
         let mut store = Self {
             database,
             git: GitStats::default(),
-            agents: read_agents(),
-            agent_default: read_agent_default(),
+            panes: PaneProbe::default(),
+            agents: read_agents(&registry),
+            agent_default: registry.default_name().to_string(),
+            registry,
             hosts: read_hosts(),
             current: Snapshot {
                 error,
@@ -449,11 +606,14 @@ impl SnapshotStore {
     /// Build a store over an already-open database (tests, and any caller that
     /// owns its own connection).
     pub fn with_database(database: Database) -> Self {
+        let registry = read_registry();
         let mut store = Self {
             database: Some(database),
             git: GitStats::default(),
-            agents: read_agents(),
-            agent_default: read_agent_default(),
+            panes: PaneProbe::default(),
+            agents: read_agents(&registry),
+            agent_default: registry.default_name().to_string(),
+            registry,
             hosts: read_hosts(),
             current: Snapshot::default(),
             last_refresh: None,
@@ -503,7 +663,12 @@ impl SnapshotStore {
         if !due {
             return false;
         }
-        if self.rows_are_current() {
+        // Asked either way, like the git stats below and for the same reason:
+        // the answers come from worker threads, so `data_version` says nothing
+        // about them — and without asking on this path a verdict would be
+        // requested once and never refreshed.
+        let panes_moved = self.poll_pane_probes();
+        if !panes_moved && self.rows_are_current() {
             self.last_refresh = Some(Instant::now());
             let stamp = taken_at_stamp();
             let restamped = self.current.taken_at_ms != stamp;
@@ -538,6 +703,55 @@ impl SnapshotStore {
             Ok(current) => current == seen,
             Err(_) => false,
         }
+    }
+
+    /// Take the pane verdicts the workers have answered and ask for the ones
+    /// that are missing or stale, returning whether any verdict moved.
+    ///
+    /// A moved verdict makes the derived rows stale in a way `PRAGMA
+    /// data_version` cannot see, so it forces the rebuild rather than being
+    /// patched into the rows: the status it feeds is decided by `assess`, and a
+    /// second place that decided it would be the second answer this module was
+    /// written to prevent.
+    ///
+    /// Only rows whose agent has reported nothing are asked about — everything
+    /// else already has a better answer than a process listing can give.
+    fn poll_pane_probes(&mut self) -> bool {
+        let moved = self.panes.drain();
+        let present: std::collections::HashSet<&str> = self
+            .current
+            .sessions
+            .iter()
+            .map(|row| row.id.as_str())
+            .collect();
+        self.panes.retain(&present);
+
+        let wanted: Vec<(String, String, String)> = self
+            .current
+            .sessions
+            .iter()
+            .filter(|row| {
+                row.hook_state.is_none()
+                    && !row.stopped
+                    && !crate::session::is_remote_backend(&row.backend)
+            })
+            .map(|row| {
+                // The agent *binary*, not the agent name: `antigravity` runs
+                // `agy`, and a pane's foreground process is spelled the way it
+                // was invoked.
+                let agent = row.reports_as.as_deref().unwrap_or(&row.agent);
+                let command = self
+                    .registry
+                    .get(agent)
+                    .map(|def| def.command.clone())
+                    .unwrap_or_else(|| agent.to_string());
+                (row.id.clone(), row.name.clone(), command)
+            })
+            .collect();
+        for (id, name, command) in wanted {
+            self.panes.request(&id, &name, command, &self.registry);
+        }
+        moved
     }
 
     /// Attach whatever git stats are known and ask for anything stale.
@@ -684,7 +898,10 @@ impl SnapshotStore {
             let Some(id) = parse_id(&row.id) else {
                 continue;
             };
-            if database.set_hook_state(id, &event.state).is_err() {
+            // `Ok(false)` is a parked session refusing a state it has no
+            // process to be in — not a write that failed, and not one that
+            // happened, so the row must not be corrected as though it were.
+            if !matches!(database.set_hook_state(id, &event.state), Ok(true)) {
                 continue;
             }
             // Corrected in place for the same reason `acknowledge` does it: this
@@ -880,6 +1097,11 @@ impl SnapshotStore {
         let hooks = database.load_hook_states().unwrap_or_default();
         let bases = database.load_base_branches().unwrap_or_default();
         let stopped = database.load_stopped_sessions().unwrap_or_default();
+        // What a driver declared this row runs. Read here for the same reason
+        // `session get` reads it: the coverage a state is judged against belongs
+        // to the declared agent, not to the shell the row was created with.
+        let reports_as = database.load_reports_as().unwrap_or_default();
+        let now = crate::sync::current_time_millis() as i64;
 
         self.git.drain();
 
@@ -887,12 +1109,26 @@ impl SnapshotStore {
             .into_iter()
             .map(|session| {
                 let hook = hooks.get(&session.id);
-                let status = derive_state(
-                    hook.and_then(|h| h.state.as_deref()),
-                    hook.and_then(|h| h.state_at),
-                    hook.and_then(|h| h.seen_at),
-                );
                 let hook_state = hook.and_then(|h| h.state.clone());
+                let declared = reports_as.get(&session.id).cloned();
+                // The whole assessment, not `derive_state` alone. Deriving from
+                // the hook columns by themselves answers `idle` for a session
+                // that never reported — laundering "we cannot know" into "the
+                // agent says it is at rest", which is the one conflation
+                // `session::hook_status` exists to prevent. The CLI has always
+                // answered `running`/`uncovered`/`unreported` here; the screen
+                // now answers the same words.
+                let assessment = assess(
+                    &self.registry,
+                    declared.as_deref().unwrap_or(&session.agent),
+                    hook,
+                    now,
+                    stopped.contains(&session.id),
+                    &session.backend_type,
+                    self.panes.get(&session.id.to_string()),
+                );
+                let status = assessment.state();
+                let detected_agent = assessment.detected_agent().map(str::to_string);
                 let worktree = session.worktrees.first();
                 let members = session_members(
                     session.cwd.as_deref(),
@@ -925,6 +1161,8 @@ impl SnapshotStore {
                     shell_backend_id: session.shell_backend_id.clone(),
                     stopped: stopped.contains(&session.id),
                     hook_state,
+                    reports_as: declared,
+                    detected_agent,
                     member_dirs,
                 }
             })
@@ -1052,10 +1290,58 @@ impl SnapshotStore {
     }
 }
 
+/// One row's whole state assessment, from the columns plus whatever the pane
+/// probe has answered so far.
+///
+/// The same [`Assessment`] the CLI builds (`cli::sessions::SessionFacts::
+/// assess`), with the pane verdict handed in rather than probed for: the render
+/// loop may not shell out, so [`PaneProbe`] does it on a worker and the answer
+/// arrives here later. `None` means *not looked at yet*, which resolves to
+/// `uncovered`/`unreported` — both honest, and neither of them `idle`.
+fn assess(
+    registry: &AgentRegistry,
+    agent: &str,
+    hook: Option<&crate::storage::HookRow>,
+    now: i64,
+    parked: bool,
+    backend: &str,
+    pane: Option<&Corroboration>,
+) -> Assessment {
+    let assessment = Assessment::from_hooks(
+        registry,
+        agent,
+        hook.and_then(|h| h.state.as_deref()),
+        hook.and_then(|h| h.state_at),
+        hook.and_then(|h| h.seen_at),
+        now,
+    );
+    if parked {
+        return assessment.parked();
+    }
+    // A remote pane lives on its own host's multiplexer, which is not a thing
+    // this process can ask `ps` about — `unavailable`, never `unknown`.
+    if crate::session::is_remote_backend(backend) {
+        return assessment.pane_unavailable();
+    }
+    match pane {
+        Some(corroboration) => assessment.with_corroboration(corroboration.clone()),
+        None => assessment,
+    }
+}
+
+/// The registry the launcher itself uses, read once.
+///
+/// One read rather than three: the picker's rows, the agent a bare launch
+/// preselects and the coverage every state answer is judged against are all
+/// this one file, and `load_or_seed` seeds it when it is missing.
+fn read_registry() -> std::sync::Arc<AgentRegistry> {
+    std::sync::Arc::new(crate::agent::agent_config::load_or_seed())
+}
+
 /// Agents from the registry the launcher itself uses — so the flow can never
 /// offer one that would fail to launch.
-fn read_agents() -> Vec<AgentRow> {
-    crate::agent::agent_config::load_or_seed()
+fn read_agents(registry: &AgentRegistry) -> Vec<AgentRow> {
+    registry
         .agents
         .iter()
         .map(|agent| AgentRow {
@@ -1063,13 +1349,6 @@ fn read_agents() -> Vec<AgentRow> {
             command: agent.command.clone(),
         })
         .collect()
-}
-
-/// The agent a bare launch would use, so the flow preselects the same one.
-fn read_agent_default() -> String {
-    crate::agent::agent_config::load_or_seed()
-        .default_name()
-        .to_string()
 }
 
 /// Configured and discovered hosts. Empty means local only, and the flow skips

--- a/src/kernel/terminal/mod.rs
+++ b/src/kernel/terminal/mod.rs
@@ -1700,6 +1700,8 @@ mod tests {
             git: None,
             stopped: false,
             hook_state: None,
+            reports_as: None,
+            detected_agent: None,
             shell_backend_id: None,
             member_dirs: Vec::new(),
         }

--- a/src/kernel/theme.rs
+++ b/src/kernel/theme.rs
@@ -239,6 +239,8 @@ pub fn palette_roles(p: &ThemePalette) -> BTreeMap<&'static str, String> {
         status_idle,
         status_error,
         status_unreachable,
+        status_running,
+        status_unknown,
         text_primary,
         text_secondary,
         text_muted,
@@ -275,6 +277,8 @@ pub fn palette_roles(p: &ThemePalette) -> BTreeMap<&'static str, String> {
         ("status_idle", status_idle),
         ("status_error", status_error),
         ("status_unreachable", status_unreachable),
+        ("status_running", status_running),
+        ("status_unknown", status_unknown),
         ("text_primary", text_primary),
         ("text_secondary", text_secondary),
         ("text_muted", text_muted),
@@ -391,12 +395,12 @@ mod tests {
 
     #[test]
     fn the_role_table_covers_every_palette_field() {
-        // 31 colours; nerd_font_enabled is a flag, not a role.
+        // 33 colours; nerd_font_enabled is a flag, not a role.
         let palette = ThemePreset::Default.palette();
         let roles = palette_roles(&palette);
         assert_eq!(
             roles.len(),
-            31,
+            33,
             "got {:?}",
             roles.keys().collect::<Vec<_>>()
         );

--- a/src/session/hook_status.rs
+++ b/src/session/hook_status.rs
@@ -278,7 +278,16 @@ pub enum Corroboration {
     /// answer used to be computed and thrown away, leaving every surface to
     /// say "some agent" about a pane thurbox could name. Not `Copy` for it,
     /// which is the price of the payload and is paid once here.
-    ForeignAgent(String),
+    ///
+    /// `None` when the executable is one **several** registered profiles
+    /// share, which is a shape the shipped `agents.toml` walks the user
+    /// through: pinning a model means a second entry on the same `command`
+    /// (`claude-opus` beside `claude`). A process listing sees the executable,
+    /// not the profile, so there is no answer to publish — and the variant
+    /// still says an agent is *present*, which is observed, while leaving the
+    /// identity blank, which is not. A plausible-but-arbitrary name is worse
+    /// than none: it invites exactly the trust it has not earned.
+    ForeignAgent(Option<String>),
     /// A bare interactive shell holds the pane. For a session whose agent was
     /// launched into that pane, this means the agent is gone.
     Shell,
@@ -318,7 +327,7 @@ impl Corroboration {
     /// pane permanent.
     pub fn detected_agent(&self) -> Option<&str> {
         match self {
-            Corroboration::ForeignAgent(name) => Some(name.as_str()),
+            Corroboration::ForeignAgent(name) => name.as_deref(),
             _ => None,
         }
     }
@@ -544,7 +553,13 @@ pub fn classify_foreground(
     if own_is_agent && (name == own || runs_program(line, own)) {
         return Corroboration::Agent;
     }
-    let foreign = registry
+    // Every registry profile whose executable this pane could be running —
+    // walked rather than `find`-ed, because the *first* match is not an answer.
+    // Several profiles may share one executable, and the shipped `agents.toml`
+    // walks the user through creating exactly that: pinning a model means a
+    // second entry on the same `command` (`claude-opus` beside `claude`).
+    // Taking the first would publish whichever the file happens to list first.
+    let mut found = registry
         .agents
         .iter()
         .map(|def| (def, executable_name(&def.command)))
@@ -552,9 +567,18 @@ pub fn classify_foreground(
         // A registry entry that *is* a shell (the bare-shell agent an external
         // driver asks for) must not make every shell look like an agent.
         .filter(|(_, c)| !SHELLS.contains(c))
-        .find(|(_, c)| name == *c || runs_program(line, c));
-    if let Some((def, _)) = foreign {
-        return Corroboration::ForeignAgent(def.name.clone());
+        .filter(|(_, c)| name == *c || runs_program(line, c))
+        .map(|(def, _)| def.name.as_str());
+    if let Some(first) = found.next() {
+        // Presence is observed; identity may not be. `ps` reports the
+        // executable, and two profiles that share one are indistinguishable
+        // through it — so the presence is reported and the name is left blank
+        // rather than guessed. Deliberately not broken by a tie-break on argv:
+        // a heuristic that is usually right is the failure this whole change
+        // set out to remove, and a confident wrong name is worse on screen
+        // than the bare `shell` label it replaced.
+        let names_one_agent = found.all(|other| other == first);
+        return Corroboration::ForeignAgent(names_one_agent.then(|| first.to_string()));
     }
     if SHELLS.contains(&name) {
         return Corroboration::Shell;
@@ -1374,7 +1398,7 @@ mod tests {
             Some("claude --permission-mode acceptEdits"),
             Some(false),
         );
-        assert_eq!(seen, Corroboration::ForeignAgent("claude".into()));
+        assert_eq!(seen, Corroboration::ForeignAgent(Some("claude".into())));
         assert_eq!(seen.detected_agent(), Some("claude"));
         assert_eq!(seen.agent_present(), Some(true));
         assert_eq!(
@@ -1462,10 +1486,76 @@ mod tests {
             let seen = classify_foreground("zsh", &known, Some("sh"), Some(line), Some(false));
             assert_eq!(
                 seen,
-                Corroboration::ForeignAgent("claude".into()),
+                Corroboration::ForeignAgent(Some("claude".into())),
                 "should have found claude in {line}"
             );
         }
+    }
+
+    /// One executable, several registered profiles: an agent is demonstrably
+    /// there, and *which* one is not something a process listing can say.
+    ///
+    /// This is not a theoretical registry. The shipped `agents.toml` walks the
+    /// user through building it: pinning a model means a second entry on the
+    /// same `command`, `claude-opus` beside `claude`. Taking the first match
+    /// published whichever profile the file happened to list first — a
+    /// confident name the observation never determined, which is worse on
+    /// screen than the bare `shell` label this vocabulary set out to improve
+    /// on, because a specific name invites trust.
+    #[test]
+    fn an_executable_several_profiles_share_names_no_agent() {
+        // Exactly the shape the shipped config's "Pin a model" section builds.
+        let shared = registry(vec![
+            agent("shell", "zsh", None),
+            agent("claude", "claude", Some("claude")),
+            agent("claude-opus", "claude", Some("claude")),
+        ]);
+        let seen = classify_foreground(
+            "zsh",
+            &shared,
+            Some("claude"),
+            Some("claude --model opus"),
+            Some(false),
+        );
+
+        // An agent IS running here — that much is observed, and the status
+        // must not lose it.
+        assert_eq!(seen, Corroboration::ForeignAgent(None));
+        assert_eq!(seen.agent_present(), Some(true));
+        assert_eq!(
+            best_state(None, None, None, Some(&seen)),
+            Some((SessionState::Running, StateSource::Process))
+        );
+        // But nothing may be published about WHICH, in either order — the
+        // answer must not depend on how the file happens to be sorted.
+        assert_eq!(seen.detected_agent(), None);
+        let reversed = registry(vec![
+            agent("shell", "zsh", None),
+            agent("claude-opus", "claude", Some("claude")),
+            agent("claude", "claude", Some("claude")),
+        ]);
+        assert_eq!(
+            classify_foreground("zsh", &reversed, Some("claude"), None, Some(false)),
+            Corroboration::ForeignAgent(None)
+        );
+
+        // And the blank reaches the assessment as a blank, beside a status
+        // that still says something is running.
+        let assessment = Assessment::from_hooks(&shared, "shell", None, None, None, NOW)
+            .with_corroboration(seen);
+        assert_eq!(assessment.detected_agent(), None);
+        assert_eq!(assessment.state(), SessionState::Running);
+
+        // The single-profile case is untouched: one profile owning the
+        // executable is still named, or the guard would have cost the feature.
+        let sole = registry(vec![
+            agent("shell", "zsh", None),
+            agent("claude", "claude", Some("claude")),
+        ]);
+        assert_eq!(
+            classify_foreground("zsh", &sole, Some("claude"), None, Some(false)).detected_agent(),
+            Some("claude")
+        );
     }
 
     /// R3. The detector resolved *which* agent holds the pane and then dropped
@@ -1480,7 +1570,10 @@ mod tests {
             agent("antigravity", "agy", Some("antigravity")),
         ]);
         let seen = classify_foreground("zsh", &known, Some("agy"), Some("agy"), Some(false));
-        assert_eq!(seen, Corroboration::ForeignAgent("antigravity".into()));
+        assert_eq!(
+            seen,
+            Corroboration::ForeignAgent(Some("antigravity".into()))
+        );
         assert_eq!(seen.detected_agent(), Some("antigravity"));
 
         // And it reaches the assessment, beside — never instead of — the agent

--- a/src/session/hook_status.rs
+++ b/src/session/hook_status.rs
@@ -406,45 +406,90 @@ fn runs_program(command_line: &str, program: &str) -> bool {
             continue;
         }
         if expect_command {
-            if COMMAND_PREFIXES.contains(&token) || is_assignment(token) {
-                continue;
+            match command_position_token(token, program) {
+                CommandPositionToken::Prefix => {}
+                CommandPositionToken::Match => return true,
+                CommandPositionToken::Other { is_shell } => {
+                    expect_command = false;
+                    scanning_shell_options = is_shell;
+                }
             }
-            let name = executable_name(token);
-            if name == program {
-                return true;
-            }
-            expect_command = false;
-            scanning_shell_options = SHELLS.contains(&name);
             continue;
         }
         if !scanning_shell_options {
             continue;
         }
-        match token.strip_prefix('-') {
-            // `--` ends the option list; the next token is the operand.
-            Some("-") => {
+        match shell_option_token(token, program) {
+            ShellOptionToken::Match => return true,
+            ShellOptionToken::EndsOptions { next_is_command } => {
                 scanning_shell_options = false;
-                expect_command = true;
+                expect_command = next_is_command;
             }
-            // A cluster like `-lc`, whose operand is a whole command line.
-            Some(flags) if !flags.starts_with('-') => {
-                if flags.contains('c') {
-                    scanning_shell_options = false;
-                    expect_command = true;
-                }
-            }
-            // Any other long option: no shell takes one that runs a command.
-            Some(_) => {}
-            // The first operand — the script the shell runs, and so a command.
-            None => {
-                scanning_shell_options = false;
-                if executable_name(token) == program {
-                    return true;
-                }
-            }
+            ShellOptionToken::StillScanning => {}
         }
     }
     false
+}
+
+/// What a token means while `runs_program` still expects the command itself.
+enum CommandPositionToken {
+    /// A prefix (`exec`, `env`, `FOO=1`, …): the command is still ahead.
+    Prefix,
+    /// Resolves to `program` in command position.
+    Match,
+    /// Some other command; `is_shell` says whether its own options follow.
+    Other { is_shell: bool },
+}
+
+fn command_position_token(token: &str, program: &str) -> CommandPositionToken {
+    if COMMAND_PREFIXES.contains(&token) || is_assignment(token) {
+        return CommandPositionToken::Prefix;
+    }
+    let name = executable_name(token);
+    if name == program {
+        return CommandPositionToken::Match;
+    }
+    CommandPositionToken::Other {
+        is_shell: SHELLS.contains(&name),
+    }
+}
+
+/// What a token means while `runs_program` is walking a shell's own options.
+enum ShellOptionToken {
+    /// The shell's first operand resolves to `program`.
+    Match,
+    /// The option list ended here; `next_is_command` says whether the token
+    /// right after this one is a command (a script operand already consumed
+    /// its own answer, so it never is).
+    EndsOptions { next_is_command: bool },
+    /// Still an option; the shell's own options continue past it.
+    StillScanning,
+}
+
+fn shell_option_token(token: &str, program: &str) -> ShellOptionToken {
+    match token.strip_prefix('-') {
+        // `--` ends the option list; the next token is the operand.
+        Some("-") => ShellOptionToken::EndsOptions {
+            next_is_command: true,
+        },
+        // A cluster like `-lc`, whose operand is a whole command line.
+        Some(flags) if !flags.starts_with('-') => {
+            if flags.contains('c') {
+                ShellOptionToken::EndsOptions {
+                    next_is_command: true,
+                }
+            } else {
+                ShellOptionToken::StillScanning
+            }
+        }
+        // Any other long option: no shell takes one that runs a command.
+        Some(_) => ShellOptionToken::StillScanning,
+        // The first operand — the script the shell runs, and so a command.
+        None if executable_name(token) == program => ShellOptionToken::Match,
+        None => ShellOptionToken::EndsOptions {
+            next_is_command: false,
+        },
+    }
 }
 
 /// Commands that run another command: whatever follows one is still a command.
@@ -606,7 +651,7 @@ pub enum SessionState {
 impl SessionState {
     /// Every word, in the order a reader scans them — so a surface that counts
     /// or documents the vocabulary enumerates it rather than restating it.
-    pub const ALL: &'static [SessionState] = &[
+    pub const ALL: &[SessionState] = &[
         SessionState::Working,
         SessionState::Blocked,
         SessionState::Done,

--- a/src/session/hook_status.rs
+++ b/src/session/hook_status.rs
@@ -264,7 +264,7 @@ pub fn age_secs(state_at: Option<i64>, now: i64) -> Option<u64> {
 /// The decisive check the hook state cannot make for itself: `hook_state` is
 /// self-reported and latched, while this is observed. It is deliberately
 /// coarse — the question is "is an agent there", not "what is it doing".
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Corroboration {
     /// The foreground process is the session's own agent.
     Agent,
@@ -272,7 +272,13 @@ pub enum Corroboration {
     /// was created with — an agent some driver started inside a pane thurbox
     /// opened for something else (typically a bare shell). The session is
     /// running an agent whether or not it ever signalled.
-    ForeignAgent,
+    ///
+    /// Carries the registry **name** of the agent that was found, which is the
+    /// whole reason a driver-launched session can be labelled at all: the
+    /// answer used to be computed and thrown away, leaving every surface to
+    /// say "some agent" about a pane thurbox could name. Not `Copy` for it,
+    /// which is the price of the payload and is paid once here.
+    ForeignAgent(String),
     /// A bare interactive shell holds the pane. For a session whose agent was
     /// launched into that pane, this means the agent is gone.
     Shell,
@@ -291,10 +297,10 @@ pub enum Corroboration {
 }
 
 impl Corroboration {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &'static str {
         match self {
             Corroboration::Agent => "agent",
-            Corroboration::ForeignAgent => "foreign-agent",
+            Corroboration::ForeignAgent(_) => "foreign-agent",
             Corroboration::Shell => "shell",
             Corroboration::Other => "other",
             Corroboration::Dead => "dead",
@@ -303,10 +309,24 @@ impl Corroboration {
         }
     }
 
-    /// Whether an agent process is demonstrably running in the pane.
-    pub fn agent_present(self) -> Option<bool> {
+    /// The registered agent found holding the pane, when it is not the one the
+    /// session was created with.
+    ///
+    /// A live observation and nothing more — deliberately **not** written back
+    /// onto the row as `reports_as`, which is a durable declaration a driver
+    /// makes. Deriving one from the other would make a passing `claude` in the
+    /// pane permanent.
+    pub fn detected_agent(&self) -> Option<&str> {
         match self {
-            Corroboration::Agent | Corroboration::ForeignAgent => Some(true),
+            Corroboration::ForeignAgent(name) => Some(name.as_str()),
+            _ => None,
+        }
+    }
+
+    /// Whether an agent process is demonstrably running in the pane.
+    pub fn agent_present(&self) -> Option<bool> {
+        match self {
+            Corroboration::Agent | Corroboration::ForeignAgent(_) => Some(true),
             Corroboration::Shell | Corroboration::Dead => Some(false),
             // `Other` is a command the agent (or the user) is running; it says
             // nothing about whether the agent is still behind it.
@@ -347,34 +367,117 @@ fn executable_name(argv0: &str) -> &str {
     base.strip_suffix(".exe").unwrap_or(base)
 }
 
-/// Whether `command_line` runs `program` as a command rather than merely
-/// mentioning it — a whole whitespace-separated token whose executable name
-/// matches.
+/// Whether `command_line` runs `program` **in command position** rather than
+/// merely mentioning it somewhere in its argv.
 ///
 /// This is what keeps a wrapper honest: a remote session's window command is
 /// `/bin/sh -lc 'exec claude --resume …'`, whose argv0 is `sh`. Reading argv0
 /// alone would call that pane a shell and declare the agent lost.
+///
+/// The position matters as much as the token, because a driver-launched agent
+/// is handed a multi-kilobyte prose brief as one argv element and `ps` prints
+/// argv joined by spaces: matching a bare token *anywhere* reported
+/// `perl -e 'sleep 300' claude` as a claude agent holding the pane. Only four
+/// places start a command, and all four are checked here:
+///
+/// - argv0;
+/// - after `exec`, `env`, `command` or `nohup`, and past leading `VAR=value`
+///   assignments, all of which are prefixes to the command they run;
+/// - after a shell's `-c`/`-lc`/`-ic` option, whose operand is a whole new
+///   command line — the wrapper case above;
+/// - the shell's first operand, which is the script it runs: an agent shipped
+///   as a `#!/bin/sh` script is executed as `/bin/sh …/bin/codex`, and codex is
+///   what is running there;
+///
+/// and nowhere else. Everything a shell takes is honoured only while its *own*
+/// options are still being scanned, so a `-c` that turns up inside prose argv
+/// opens nothing. Anything else is a false negative rather than a false
+/// positive: no identity is more honest than a confidently wrong one.
 fn runs_program(command_line: &str, program: &str) -> bool {
-    command_line
-        .split_whitespace()
-        .any(|token| executable_name(token.trim_matches(['\'', '"'])) == program)
+    // `true` at the start of a line and after every prefix above: the next
+    // token that is not itself a prefix is the command being run.
+    let mut expect_command = true;
+    // Whether the command already resolved is a shell whose own options we are
+    // still walking — the only state in which what follows is a command again.
+    let mut scanning_shell_options = false;
+    for raw in command_line.split_whitespace() {
+        let token = raw.trim_matches(['\'', '"']);
+        if token.is_empty() {
+            continue;
+        }
+        if expect_command {
+            if COMMAND_PREFIXES.contains(&token) || is_assignment(token) {
+                continue;
+            }
+            let name = executable_name(token);
+            if name == program {
+                return true;
+            }
+            expect_command = false;
+            scanning_shell_options = SHELLS.contains(&name);
+            continue;
+        }
+        if !scanning_shell_options {
+            continue;
+        }
+        match token.strip_prefix('-') {
+            // `--` ends the option list; the next token is the operand.
+            Some("-") => {
+                scanning_shell_options = false;
+                expect_command = true;
+            }
+            // A cluster like `-lc`, whose operand is a whole command line.
+            Some(flags) if !flags.starts_with('-') => {
+                if flags.contains('c') {
+                    scanning_shell_options = false;
+                    expect_command = true;
+                }
+            }
+            // Any other long option: no shell takes one that runs a command.
+            Some(_) => {}
+            // The first operand — the script the shell runs, and so a command.
+            None => {
+                scanning_shell_options = false;
+                if executable_name(token) == program {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+/// Commands that run another command: whatever follows one is still a command.
+const COMMAND_PREFIXES: &[&str] = &["exec", "env", "command", "nohup"];
+
+/// Whether a token is a `VAR=value` assignment, which precedes the command it
+/// applies to (`FOO=1 claude …`, `env FOO=1 claude …`) rather than being one.
+fn is_assignment(token: &str) -> bool {
+    match token.split_once('=') {
+        Some((name, _)) => {
+            !name.is_empty() && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+        }
+        None => false,
+    }
 }
 
 /// Judge what holds a pane against the session's agent and every agent the user
 /// has defined.
 ///
 /// `agent_command` is the session's own agent binary (`AgentDef::command`, not
-/// the agent *name* — `antigravity` runs `agy`). `known_agents` is every
-/// command in the registry, which is what makes an externally-launched agent
-/// visible: thurbox wires no hooks for a session whose agent is `bash`, but if
-/// `claude` is in the registry and `claude` holds the pane, an agent is running.
+/// the agent *name* — `antigravity` runs `agy`). `registry` is every agent the
+/// user has defined, which is what makes an externally-launched agent visible:
+/// thurbox wires no hooks for a session whose agent is `bash`, but if `claude`
+/// is in the registry and `claude` holds the pane, an agent is running. The
+/// whole registry rather than a list of commands, so the answer can be
+/// reported under the *name* a person configured (`antigravity`, not `agy`).
 ///
 /// `dead` is tmux's `#{pane_dead}`; it is checked first because a dead pane
 /// still answers `#{pane_current_command}` with whatever last ran there, which
 /// is a plausible wrong answer rather than an honest absence.
 pub fn classify_foreground(
     agent_command: &str,
-    known_agents: &[String],
+    registry: &AgentRegistry,
     process: Option<&str>,
     command_line: Option<&str>,
     dead: Option<bool>,
@@ -396,16 +499,17 @@ pub fn classify_foreground(
     if own_is_agent && (name == own || runs_program(line, own)) {
         return Corroboration::Agent;
     }
-    let foreign = known_agents
+    let foreign = registry
+        .agents
         .iter()
-        .map(|c| executable_name(c))
-        .filter(|c| !c.is_empty() && *c != own)
+        .map(|def| (def, executable_name(&def.command)))
+        .filter(|(_, c)| !c.is_empty() && *c != own)
         // A registry entry that *is* a shell (the bare-shell agent an external
         // driver asks for) must not make every shell look like an agent.
-        .filter(|c| !SHELLS.contains(c))
-        .any(|c| name == c || runs_program(line, c));
-    if foreign {
-        return Corroboration::ForeignAgent;
+        .filter(|(_, c)| !SHELLS.contains(c))
+        .find(|(_, c)| name == *c || runs_program(line, c));
+    if let Some((def, _)) = foreign {
+        return Corroboration::ForeignAgent(def.name.clone());
     }
     if SHELLS.contains(&name) {
         return Corroboration::Shell;
@@ -423,7 +527,7 @@ pub fn classify_foreground(
 /// A contradiction is **reported, never applied**: the stored `hook_state` is
 /// left exactly as the agent wrote it, because overwriting an agent's own
 /// report with an inference is how a state becomes unfalsifiable.
-pub fn contradicts(state: Option<&str>, corroboration: Corroboration) -> bool {
+pub fn contradicts(state: Option<&str>, corroboration: &Corroboration) -> bool {
     matches!(state, Some("working" | "blocked"))
         && matches!(corroboration, Corroboration::Shell | Corroboration::Dead)
 }
@@ -649,7 +753,7 @@ pub fn best_state(
     hook_state: Option<&str>,
     state_at: Option<i64>,
     seen_at: Option<i64>,
-    corroboration: Option<Corroboration>,
+    corroboration: Option<&Corroboration>,
 ) -> Option<(SessionState, StateSource)> {
     if hook_state.is_some() {
         return Some((
@@ -658,7 +762,7 @@ pub fn best_state(
         ));
     }
     match corroboration {
-        Some(Corroboration::Agent | Corroboration::ForeignAgent) => {
+        Some(Corroboration::Agent | Corroboration::ForeignAgent(_)) => {
             Some((SessionState::Running, StateSource::Process))
         }
         _ => None,
@@ -805,6 +909,19 @@ impl Assessment {
         }
     }
 
+    /// The agent found holding the pane, when it is not the one the session was
+    /// created with — `None` when the pane was not looked at, holds a shell, or
+    /// holds this session's own agent.
+    ///
+    /// The third of three names for one row, and none of them substitutes for
+    /// another: [`Self::agent`] is what the row reports *as*, `reports_as` is
+    /// what a driver declared, and this is what is observably there right now.
+    pub fn detected_agent(&self) -> Option<&str> {
+        self.corroboration
+            .as_ref()
+            .and_then(Corroboration::detected_agent)
+    }
+
     /// Fold in what the pane's foreground process says.
     ///
     /// The stored state is left exactly as it was; the observation only adds
@@ -813,26 +930,40 @@ impl Assessment {
     pub fn with_pane(
         mut self,
         agent_command: &str,
-        known_agents: &[String],
+        registry: &AgentRegistry,
         process: Option<&str>,
         command_line: Option<&str>,
         dead: Option<bool>,
     ) -> Self {
-        let corroboration =
-            classify_foreground(agent_command, known_agents, process, command_line, dead);
-        self.contradicted = Some(contradicts(self.hook_state.as_deref(), corroboration));
         self.foreground_process = process.filter(|p| !p.is_empty()).map(str::to_string);
         self.foreground_command = command_line.filter(|c| !c.is_empty()).map(str::to_string);
-        self.corroboration = Some(corroboration);
+        self.with_corroboration(classify_foreground(
+            agent_command,
+            registry,
+            process,
+            command_line,
+            dead,
+        ))
+    }
+
+    /// Fold in an already-computed pane verdict.
+    ///
+    /// Split out of [`Self::with_pane`] for the caller that cannot classify
+    /// where it folds: the interface probes panes on a worker thread (the
+    /// render loop may not shell out), so the verdict arrives on its own and
+    /// the argv it was read from is not carried back.
+    pub fn with_corroboration(mut self, corroboration: Corroboration) -> Self {
+        self.contradicted = Some(contradicts(self.hook_state.as_deref(), &corroboration));
         if let Some((state, source)) = best_state(
             self.hook_state.as_deref(),
             self.state_at,
             self.seen_at,
-            Some(corroboration),
+            Some(&corroboration),
         ) {
             self.state = Some(state);
             self.state_source = Some(source);
         }
+        self.corroboration = Some(corroboration);
         self
     }
 
@@ -1119,7 +1250,10 @@ mod tests {
 
     #[test]
     fn the_session_agent_in_the_foreground_corroborates() {
-        let known = vec!["claude".to_string(), "codex".to_string()];
+        let known = registry(vec![
+            agent("claude", "claude", Some("claude")),
+            agent("codex", "codex", Some("codex")),
+        ]);
         assert_eq!(
             classify_foreground("claude", &known, Some("claude"), None, Some(false)),
             Corroboration::Agent
@@ -1141,7 +1275,7 @@ mod tests {
     fn a_login_wrapper_is_not_mistaken_for_a_bare_shell() {
         // The remote window command is `/bin/sh -lc 'exec claude …'`. Judging
         // argv0 alone would report a shell and declare the agent lost.
-        let known = vec!["claude".to_string()];
+        let known = registry(vec![agent("claude", "claude", Some("claude"))]);
         assert_eq!(
             classify_foreground(
                 "claude",
@@ -1156,27 +1290,27 @@ mod tests {
 
     #[test]
     fn a_bare_shell_contradicts_an_active_state() {
-        let known = vec!["claude".to_string()];
+        let known = registry(vec![agent("claude", "claude", Some("claude"))]);
         let shell =
             classify_foreground("claude", &known, Some("-bash"), Some("-bash"), Some(false));
         assert_eq!(shell, Corroboration::Shell);
         assert_eq!(shell.agent_present(), Some(false));
-        assert!(contradicts(Some("working"), shell));
-        assert!(contradicts(Some("blocked"), shell));
+        assert!(contradicts(Some("working"), &shell));
+        assert!(contradicts(Some("blocked"), &shell));
         // A finished turn asserts nothing about a live process.
-        assert!(!contradicts(Some("done"), shell));
-        assert!(!contradicts(Some("idle"), shell));
-        assert!(!contradicts(None, shell));
+        assert!(!contradicts(Some("done"), &shell));
+        assert!(!contradicts(Some("idle"), &shell));
+        assert!(!contradicts(None, &shell));
     }
 
     #[test]
     fn a_dead_pane_beats_the_command_name_it_still_answers_with() {
         // `remain-on-exit` keeps the frame, and tmux keeps naming the command
         // that died there — a plausible wrong answer, so deadness wins.
-        let known = vec!["claude".to_string()];
+        let known = registry(vec![agent("claude", "claude", Some("claude"))]);
         let dead = classify_foreground("claude", &known, Some("claude"), None, Some(true));
         assert_eq!(dead, Corroboration::Dead);
-        assert!(contradicts(Some("working"), dead));
+        assert!(contradicts(Some("working"), &dead));
     }
 
     #[test]
@@ -1184,7 +1318,10 @@ mod tests {
         // The externally-driven shape: the session's agent is a bare shell (so
         // thurbox wired no hooks and nothing ever signalled), and a driver
         // started a real agent inside the pane.
-        let known = vec!["bash".to_string(), "claude".to_string()];
+        let known = registry(vec![
+            agent("shell", "bash", None),
+            agent("claude", "claude", Some("claude")),
+        ]);
         let seen = classify_foreground(
             "bash",
             &known,
@@ -1192,10 +1329,11 @@ mod tests {
             Some("claude --permission-mode acceptEdits"),
             Some(false),
         );
-        assert_eq!(seen, Corroboration::ForeignAgent);
+        assert_eq!(seen, Corroboration::ForeignAgent("claude".into()));
+        assert_eq!(seen.detected_agent(), Some("claude"));
         assert_eq!(seen.agent_present(), Some(true));
         assert_eq!(
-            best_state(None, None, None, Some(seen)),
+            best_state(None, None, None, Some(&seen)),
             Some((SessionState::Running, StateSource::Process))
         );
 
@@ -1204,7 +1342,110 @@ mod tests {
         // as an agent running is the failure this branch exists to avoid.
         let idle = classify_foreground("bash", &known, Some("bash"), Some("bash -i"), Some(false));
         assert_eq!(idle, Corroboration::Shell);
-        assert_eq!(best_state(None, None, None, Some(idle)), None);
+        assert_eq!(best_state(None, None, None, Some(&idle)), None);
+    }
+
+    /// F6. `runs_program` matched a bare token anywhere in the command line, so
+    /// the *shape a foreign driver produces* — a multi-kilobyte prose brief in
+    /// argv, printed back by `ps` as one long space-separated line — classified
+    /// a pane holding no agent at all as a foreign agent.
+    #[test]
+    fn a_registry_name_mentioned_in_argv_is_not_an_agent_in_the_pane() {
+        let known = registry(vec![
+            agent("shell", "zsh", None),
+            agent("claude", "claude", Some("claude")),
+        ]);
+        // The reproduction, verbatim: `perl -e 'sleep 300' claude`.
+        let inert = classify_foreground(
+            "zsh",
+            &known,
+            Some("perl"),
+            Some("perl -e sleep 300 claude"),
+            Some(false),
+        );
+        assert_eq!(inert, Corroboration::Other);
+        assert_eq!(inert.detected_agent(), None);
+        assert_eq!(best_state(None, None, None, Some(&inert)), None);
+
+        // The same word inside prose, which is what a driver's brief is.
+        let brief = classify_foreground(
+            "zsh",
+            &known,
+            Some("zsh"),
+            Some("zsh -i -- read the report and tell claude to fix it"),
+            Some(false),
+        );
+        assert_eq!(brief, Corroboration::Shell);
+        // Even a `-c` that turns up mid-prose opens nothing: a shell's own
+        // options stop being scanned at its first operand.
+        let flag = classify_foreground(
+            "zsh",
+            &known,
+            Some("zsh"),
+            Some("zsh -i -- run it with -c claude afterwards"),
+            Some(false),
+        );
+        assert_eq!(flag, Corroboration::Shell);
+    }
+
+    /// The other half of F6: constraining the match must not lose the wrapper
+    /// shapes `runs_program` exists for.
+    #[test]
+    fn a_command_position_is_still_matched_through_every_wrapper() {
+        let known = registry(vec![
+            agent("shell", "zsh", None),
+            agent("claude", "claude", Some("claude")),
+        ]);
+        for line in [
+            // argv0, absolute or bare.
+            "claude --resume x",
+            "/usr/local/bin/claude --resume x",
+            // The remote window command: a shell whose `-c` operand is a whole
+            // new command line, with `exec` in front of it.
+            "/bin/sh -lc 'exec claude --resume x'",
+            "bash -c claude",
+            // An agent shipped as a `#!/bin/sh` script: the shell's first
+            // operand is the program that is running.
+            "/bin/sh /opt/agents/bin/claude",
+            // Prefixes to the command they run.
+            "env CLAUDE_CODE=1 claude --resume x",
+            "exec claude",
+            "nohup claude --resume x",
+            // A leading assignment, with no `env` at all.
+            "FOO=1 claude",
+        ] {
+            let seen = classify_foreground("zsh", &known, Some("sh"), Some(line), Some(false));
+            assert_eq!(
+                seen,
+                Corroboration::ForeignAgent("claude".into()),
+                "should have found claude in {line}"
+            );
+        }
+    }
+
+    /// R3. The detector resolved *which* agent holds the pane and then dropped
+    /// the answer on the floor, leaving every surface able to say only that
+    /// "some agent" was there.
+    #[test]
+    fn a_detected_agent_is_named_under_its_registry_name() {
+        // `antigravity` runs `agy`: the pane spells the binary, a person spells
+        // the agent, and the name is the half worth showing.
+        let known = registry(vec![
+            agent("shell", "zsh", None),
+            agent("antigravity", "agy", Some("antigravity")),
+        ]);
+        let seen = classify_foreground("zsh", &known, Some("agy"), Some("agy"), Some(false));
+        assert_eq!(seen, Corroboration::ForeignAgent("antigravity".into()));
+        assert_eq!(seen.detected_agent(), Some("antigravity"));
+
+        // And it reaches the assessment, beside — never instead of — the agent
+        // the row was created as.
+        let assessment =
+            Assessment::from_hooks(&known, "shell", None, None, None, NOW).with_corroboration(seen);
+        assert_eq!(assessment.detected_agent(), Some("antigravity"));
+        assert_eq!(assessment.agent, "shell");
+        // Named, and still not a claim about the turn: `running`, not `working`.
+        assert_eq!(assessment.state(), SessionState::Running);
     }
 
     #[test]
@@ -1212,35 +1453,35 @@ mod tests {
         // The agent's own report is richer than anything observable, so the
         // pane never overwrites it — it only ever adds the contradiction flag.
         assert_eq!(
-            best_state(Some("blocked"), None, None, Some(Corroboration::Shell)),
+            best_state(Some("blocked"), None, None, Some(&Corroboration::Shell)),
             Some((SessionState::Blocked, StateSource::Hook))
         );
         assert_eq!(
-            best_state(Some("idle"), None, None, Some(Corroboration::Agent)),
+            best_state(Some("idle"), None, None, Some(&Corroboration::Agent)),
             Some((SessionState::Idle, StateSource::Hook))
         );
     }
 
     #[test]
     fn an_unresolvable_pane_is_unknown_rather_than_guessed() {
-        let known = vec!["claude".to_string()];
+        let known = registry(vec![agent("claude", "claude", Some("claude"))]);
         for state in [
             classify_foreground("claude", &known, None, None, None),
             classify_foreground("claude", &known, Some(""), None, Some(false)),
         ] {
             assert_eq!(state, Corroboration::Unknown);
             assert_eq!(state.agent_present(), None);
-            assert!(!contradicts(Some("working"), state));
-            assert_eq!(best_state(None, None, None, Some(state)), None);
+            assert!(!contradicts(Some("working"), &state));
+            assert_eq!(best_state(None, None, None, Some(&state)), None);
         }
         // A remote pane is not unknown but unreadable, and says so.
         assert_eq!(Corroboration::Unavailable.agent_present(), None);
-        assert!(!contradicts(Some("working"), Corroboration::Unavailable));
+        assert!(!contradicts(Some("working"), &Corroboration::Unavailable));
     }
 
     #[test]
     fn a_command_the_agent_ran_is_neither_agent_nor_shell() {
-        let known = vec!["claude".to_string()];
+        let known = registry(vec![agent("claude", "claude", Some("claude"))]);
         let other = classify_foreground(
             "claude",
             &known,
@@ -1252,6 +1493,6 @@ mod tests {
         assert_eq!(other.agent_present(), None);
         // The agent is probably still there behind it, so this never
         // contradicts an active state.
-        assert!(!contradicts(Some("working"), other));
+        assert!(!contradicts(Some("working"), &other));
     }
 }

--- a/src/session/theme_config/mod.rs
+++ b/src/session/theme_config/mod.rs
@@ -29,6 +29,15 @@ pub struct ThemePalette {
     /// offline). Muted grey by default so a placeholder row reads as inert, not
     /// urgent.
     pub status_unreachable: Color,
+    /// Colour of the "running" status glyph: an agent demonstrably holds the
+    /// pane and has reported nothing. Deliberately **not** `status_working` —
+    /// the observation says an agent is there, never that a turn is in flight,
+    /// and wearing the working colour would make it a claim.
+    pub status_running: Color,
+    /// Colour of the "no signal" status glyph, shared by `uncovered` (this
+    /// agent is wired to report nothing) and `unreported` (it can report and
+    /// has not yet). Muted, because the honest content of both is an absence.
+    pub status_unknown: Color,
 
     pub text_primary: Color,
     pub text_secondary: Color,
@@ -450,6 +459,10 @@ pub struct CustomThemeDef {
     #[serde(default)]
     pub status_unreachable: Option<String>,
     #[serde(default)]
+    pub status_running: Option<String>,
+    #[serde(default)]
+    pub status_unknown: Option<String>,
+    #[serde(default)]
     pub text_primary: Option<String>,
     #[serde(default)]
     pub text_secondary: Option<String>,
@@ -531,7 +544,7 @@ impl CustomThemeDef {
     /// (`override_array_covers_every_color_field`) asserts it matches the
     /// struct's colour-field count, so a forgotten row can't silently make a
     /// colour un-overridable.
-    const COLOR_OVERRIDE_COUNT: usize = 31;
+    const COLOR_OVERRIDE_COUNT: usize = 33;
 
     /// Materialise the theme: base preset palette + overrides. Unparsable
     /// colours and an unknown base degrade to warnings, never to a hard
@@ -581,6 +594,16 @@ impl CustomThemeDef {
                 "status_unreachable",
                 &self.status_unreachable,
                 &mut palette.status_unreachable,
+            ),
+            (
+                "status_running",
+                &self.status_running,
+                &mut palette.status_running,
+            ),
+            (
+                "status_unknown",
+                &self.status_unknown,
+                &mut palette.status_unknown,
             ),
             (
                 "text_primary",
@@ -690,6 +713,8 @@ fn default_palette() -> ThemePalette {
         status_idle: Color::Green,
         status_error: Color::Red,
         status_unreachable: Color::DarkGray,
+        status_running: Color::Cyan,
+        status_unknown: Color::DarkGray,
 
         text_primary: Color::White,
         text_secondary: Color::Gray,
@@ -771,6 +796,11 @@ impl PaletteSlots {
             status_error: self.red,
             // Muted grey: an unreachable placeholder is inert, not urgent.
             status_unreachable: self.text_muted,
+            // The accent: an agent IS there, which is worth seeing — but not
+            // the working colour, which would claim a turn is running.
+            status_running: self.accent,
+            // Dimmest of all: "nothing reported" has no content to look at.
+            status_unknown: self.text_muted,
             text_primary: self.text_primary,
             text_secondary: self.text_secondary,
             text_muted: self.text_muted,

--- a/src/session_ops/mirror.rs
+++ b/src/session_ops/mirror.rs
@@ -167,8 +167,12 @@ pub fn session_to_json_assessed(
     );
     put(
         "hook_corroboration",
-        json!(hook.corroboration.map(|c| c.as_str())),
+        json!(hook.corroboration.as_ref().map(|c| c.as_str())),
     );
+    // Which agent the pane was found to be running, when it is not the one the
+    // row was created with. A live observation, distinct from `agent` and from
+    // `reports_as` — see `Assessment::detected_agent`.
+    put("detected_agent", json!(hook.detected_agent()));
     put("hook_state_contradicted", json!(hook.contradicted));
     put("foreground_process", json!(hook.foreground_process));
     put("foreground_command", json!(hook.foreground_command));

--- a/tests/attach_by_name.rs
+++ b/tests/attach_by_name.rs
@@ -65,6 +65,8 @@ fn row(name: &str) -> SessionRow {
         git: None,
         stopped: false,
         hook_state: None,
+        reports_as: None,
+        detected_agent: None,
         shell_backend_id: None,
         member_dirs: Vec::new(),
     }

--- a/tests/chrome.rs
+++ b/tests/chrome.rs
@@ -48,6 +48,8 @@ fn session(name: &str, branch: &str) -> SessionRow {
         git: None,
         stopped: false,
         hook_state: None,
+        reports_as: None,
+        detected_agent: None,
         shell_backend_id: None,
         member_dirs: Vec::new(),
     }

--- a/tests/cli_session_hook_state.rs
+++ b/tests/cli_session_hook_state.rs
@@ -503,6 +503,11 @@ fn an_agent_thurbox_did_not_launch_is_still_reported_as_running() {
     // empty one, and the coarser provenance says how far to trust it.
     assert_eq!(out["state"], Value::String("running".into()));
     assert_eq!(out["state_source"], Value::String("process".into()));
+    // And it says WHICH agent, under the name the registry spells it with —
+    // beside `agent`, never instead of it. Naming it is the difference between
+    // "some agent is here" and a row a person can act on.
+    assert_eq!(out["agent"], Value::String("shell".into()));
+    assert_eq!(out["detected_agent"], Value::String("codex".into()));
     assert_eq!(out["hook_state_contradicted"], Value::Bool(false));
     assert!(out["foreground_command"]
         .as_str()

--- a/tests/core_settings.rs
+++ b/tests/core_settings.rs
@@ -292,6 +292,8 @@ fn session_row() -> thurbox::kernel::snapshot::SessionRow {
         }),
         stopped: false,
         hook_state: None,
+        reports_as: None,
+        detected_agent: None,
         shell_backend_id: None,
         member_dirs: Vec::new(),
     }

--- a/tests/events.rs
+++ b/tests/events.rs
@@ -56,6 +56,8 @@ fn row(name: &str, status: &str) -> SessionRow {
         git: None,
         stopped: false,
         hook_state: None,
+        reports_as: None,
+        detected_agent: None,
         shell_backend_id: None,
         member_dirs: Vec::new(),
     }

--- a/tests/frames.rs
+++ b/tests/frames.rs
@@ -143,6 +143,8 @@ fn row(name: &str, repo: &str, status: &str) -> SessionRow {
         git: None,
         stopped: false,
         hook_state: None,
+        reports_as: None,
+        detected_agent: None,
         shell_backend_id: None,
         member_dirs: Vec::new(),
     }

--- a/tests/hover.rs
+++ b/tests/hover.rs
@@ -152,6 +152,8 @@ fn one_session() -> Snapshot {
             git: None,
             stopped: false,
             hook_state: None,
+            reports_as: None,
+            detected_agent: None,
             shell_backend_id: None,
             member_dirs: Vec::new(),
         }],

--- a/tests/kernel_frame_cost.rs
+++ b/tests/kernel_frame_cost.rs
@@ -178,6 +178,8 @@ fn row(id: &str, name: &str) -> SessionRow {
         git: None,
         stopped: false,
         hook_state: None,
+        reports_as: None,
+        detected_agent: None,
         shell_backend_id: None,
         member_dirs: Vec::new(),
     }

--- a/tests/kernel_mvp.rs
+++ b/tests/kernel_mvp.rs
@@ -117,6 +117,8 @@ fn row(name: &str, repo: &str, status: &str) -> SessionRow {
         git: None,
         stopped: false,
         hook_state: None,
+        reports_as: None,
+        detected_agent: None,
         shell_backend_id: None,
         member_dirs: Vec::new(),
     }
@@ -310,6 +312,47 @@ fn the_session_list_renders_real_snapshot_rows() {
     // the RIGHT side of the top border — it never spells out a count.
     assert!(screen.contains("Sessions"), "{screen}");
     assert!(!screen.contains("sessions · 4"), "{screen}");
+}
+
+/// R1 + R3, at the surface that had the bug. A session a driver launched an
+/// agent into reports nothing at all, and the interface drew the green hollow
+/// `idle` circle for it — "the agent says it is at rest" for an agent that was
+/// mid-turn. The three silences now each have their own glyph, and the agent
+/// found in the pane is named beside the one the row was created as.
+#[test]
+fn a_session_with_no_reported_status_never_draws_the_idle_dot() {
+    let host = host();
+    // What a foreign driver leaves behind: a row created as a bare shell, an
+    // agent running in its pane, and nothing wired to report a turn.
+    let mut driven = row("fm-worker", "thurbox", "idle");
+    driven.agent = "zsh".to_string();
+    driven.status = SessionState::Running;
+    driven.detected_agent = Some("claude".to_string());
+    // Wired to report nothing, and it has said nothing.
+    let mut uncovered = row("bare-shell", "thurbox", "idle");
+    uncovered.agent = "zsh".to_string();
+    uncovered.status = SessionState::Uncovered;
+    // Can report, and has not yet.
+    let mut unreported = row("just-spawned", "thurbox", "idle");
+    unreported.status = SessionState::Unreported;
+
+    publish(&host, &snapshot(vec![driven, uncovered, unreported]));
+    let screen = paint(&host, index_of(&host, "sessions"), 48, 12).join("\n");
+
+    // Not one row claims the agent said it is at rest.
+    assert!(!screen.contains('○'), "an idle dot survived:\n{screen}");
+    // An agent IS there (◍), and the two silences read as absences (◌).
+    assert!(screen.contains('◍'), "no running glyph in:\n{screen}");
+    assert!(screen.contains('◌'), "no silence glyph in:\n{screen}");
+    // And the row says which agent, without saying what it is doing.
+    assert!(screen.contains("claude"), "{screen}");
+    assert!(screen.contains("no status reported"), "{screen}");
+    assert!(!screen.contains("working"), "{screen}");
+
+    // The centre pane's title carries both names and the honest word.
+    let title = paint(&host, index_of(&host, "agent"), 90, 8).join("\n");
+    assert!(title.contains("zsh → claude"), "{title}");
+    assert!(title.contains("Running"), "{title}");
 }
 
 #[test]

--- a/tests/kernel_mvp.rs
+++ b/tests/kernel_mvp.rs
@@ -355,6 +355,30 @@ fn a_session_with_no_reported_status_never_draws_the_idle_dot() {
     assert!(title.contains("Running"), "{title}");
 }
 
+/// The follow-up: an agent IS in the pane (status `running`), but two
+/// registered profiles share its executable, so `classify_foreground`
+/// publishes `detected_agent: None` rather than an arbitrary first match. The
+/// row must still say an agent is running — never fall silent the way an
+/// `unreported` row does — while naming no one.
+#[test]
+fn a_running_session_with_no_determined_agent_says_so_without_a_name() {
+    let host = host();
+    let mut ambiguous = row("fm-worker", "thurbox", "idle");
+    ambiguous.agent = "zsh".to_string();
+    ambiguous.status = SessionState::Running;
+    ambiguous.detected_agent = None;
+
+    publish(&host, &snapshot(vec![ambiguous]));
+    let screen = paint(&host, index_of(&host, "sessions"), 64, 12).join("\n");
+
+    assert!(!screen.contains('○'), "an idle dot survived:\n{screen}");
+    assert!(screen.contains('◍'), "no running glyph in:\n{screen}");
+    assert!(
+        screen.contains("agent running · no status reported"),
+        "{screen}"
+    );
+}
+
 #[test]
 fn each_status_paints_its_own_glyph() {
     let host = host();

--- a/tests/keymap.rs
+++ b/tests/keymap.rs
@@ -70,6 +70,8 @@ fn row(name: &str) -> SessionRow {
         git: None,
         stopped: false,
         hook_state: None,
+        reports_as: None,
+        detected_agent: None,
         shell_backend_id: None,
         member_dirs: Vec::new(),
     }

--- a/tests/modals.rs
+++ b/tests/modals.rs
@@ -65,6 +65,8 @@ fn row(name: &str) -> SessionRow {
         git: None,
         stopped: false,
         hook_state: None,
+        reports_as: None,
+        detected_agent: None,
         shell_backend_id: None,
         member_dirs: Vec::new(),
     }

--- a/tests/mouse.rs
+++ b/tests/mouse.rs
@@ -50,6 +50,8 @@ fn row(name: &str, repo: &str) -> SessionRow {
         git: None,
         stopped: false,
         hook_state: None,
+        reports_as: None,
+        detected_agent: None,
         shell_backend_id: None,
         member_dirs: Vec::new(),
     }

--- a/tests/plugin_settings.rs
+++ b/tests/plugin_settings.rs
@@ -42,6 +42,8 @@ fn row(name: &str, repo: &str) -> SessionRow {
         git: None,
         stopped: false,
         hook_state: None,
+        reports_as: None,
+        detected_agent: None,
         shell_backend_id: None,
         member_dirs: Vec::new(),
     }

--- a/tests/remote_status.rs
+++ b/tests/remote_status.rs
@@ -70,7 +70,9 @@ fn status_of(store: &SnapshotStore, id: SessionId) -> String {
 #[test]
 fn a_remote_agents_report_reaches_its_session() {
     let (_home, mut store, id) = store_with_remote_session();
-    assert_eq!(status_of(&store, id), "idle");
+    // Not `idle`: nothing has reported for this row, and claude is wired to
+    // report — so the honest word before the first hook is `unreported`.
+    assert_eq!(status_of(&store, id), "unreported");
 
     let applied = store.apply_hook_states(
         vec![(
@@ -99,7 +101,7 @@ fn an_event_from_another_host_is_not_applied_here() {
         Instant::now(),
     );
     assert_eq!(applied, 0);
-    assert_eq!(status_of(&store, id), "idle");
+    assert_eq!(status_of(&store, id), "unreported");
 }
 
 #[test]
@@ -115,7 +117,7 @@ fn a_state_nobody_defines_is_ignored() {
         Instant::now(),
     );
     assert_eq!(applied, 0);
-    assert_eq!(status_of(&store, id), "idle");
+    assert_eq!(status_of(&store, id), "unreported");
 }
 
 #[test]
@@ -196,5 +198,5 @@ fn a_parked_event_is_eventually_given_up_on() {
     store.refresh();
     let applied = store.apply_hook_states(Vec::new(), early + Duration::from_secs(601));
     assert_eq!(applied, 0);
-    assert_eq!(status_of(&store, row.id), "idle");
+    assert_eq!(status_of(&store, row.id), "unreported");
 }

--- a/tests/render_props.rs
+++ b/tests/render_props.rs
@@ -56,6 +56,8 @@ fn row(name: &str, status: &str) -> SessionRow {
         git: None,
         stopped: false,
         hook_state: None,
+        reports_as: None,
+        detected_agent: None,
         shell_backend_id: None,
         member_dirs: Vec::new(),
     }

--- a/tests/search.rs
+++ b/tests/search.rs
@@ -49,6 +49,8 @@ fn row(id: &str, name: &str, agent: &str, branch: &str) -> SessionRow {
         git: None,
         stopped: false,
         hook_state: None,
+        reports_as: None,
+        detected_agent: None,
         shell_backend_id: None,
         member_dirs: Vec::new(),
     }

--- a/tests/session_lifetime.rs
+++ b/tests/session_lifetime.rs
@@ -38,6 +38,8 @@ fn row(id: &str, name: &str, backend: &str, pane: Option<&str>) -> SessionRow {
         git: None,
         stopped: false,
         hook_state: None,
+        reports_as: None,
+        detected_agent: None,
         shell_backend_id: None,
         member_dirs: Vec::new(),
     }

--- a/tests/session_list.rs
+++ b/tests/session_list.rs
@@ -44,6 +44,8 @@ fn row(id: &str, name: &str) -> SessionRow {
         git: None,
         stopped: false,
         hook_state: None,
+        reports_as: None,
+        detected_agent: None,
         shell_backend_id: None,
         member_dirs: Vec::new(),
     }

--- a/tests/session_state_agreement.rs
+++ b/tests/session_state_agreement.rs
@@ -84,10 +84,14 @@ impl Env {
 }
 
 fn seed(db: &Database, name: &str) -> SessionId {
+    seed_as(db, name, "claude")
+}
+
+fn seed_as(db: &Database, name: &str, agent: &str) -> SessionId {
     let row = SharedSession {
         id: SessionId::default(),
         name: name.into(),
-        agent: "claude".into(),
+        agent: agent.into(),
         backend_id: "%7".into(),
         backend_type: "local-tmux".into(),
         agent_session_id: Some("sid".into()),
@@ -183,6 +187,42 @@ fn an_unacknowledged_done_is_done_on_every_surface() {
     assert_eq!(
         states,
         ["done", "done", "done", "done"],
+        "get, list, watch, tui"
+    );
+}
+
+/// The regression the captain saw. A session that has reported **nothing** was
+/// `unreported` on all three CLI surfaces and `idle` on the interface, which
+/// draws the green hollow "the agent says it is at rest" dot — for a worker
+/// that was mid-turn. The interface derived from the hook columns alone; it now
+/// takes the same `Assessment` path the CLI does.
+#[test]
+fn a_session_that_never_reported_is_not_idle_on_any_surface() {
+    let env = Env::new();
+    let db = env.db();
+    let id = seed(&db, "silent");
+
+    let states = states(&env, id);
+    assert_eq!(
+        states,
+        ["unreported", "unreported", "unreported", "unreported"],
+        "get, list, watch, tui"
+    );
+}
+
+/// The other silence, and the one a foreign driver actually produces: a row
+/// created as a bare shell, which thurbox wires no hooks for. Its silence means
+/// nothing at all, and saying `idle` would launder that into a report.
+#[test]
+fn a_session_wired_to_report_nothing_is_uncovered_on_every_surface() {
+    let env = Env::new();
+    let db = env.db();
+    let id = seed_as(&db, "driver-owned", "zsh");
+
+    let states = states(&env, id);
+    assert_eq!(
+        states,
+        ["uncovered", "uncovered", "uncovered", "uncovered"],
         "get, list, watch, tui"
     );
 }

--- a/tests/session_status.rs
+++ b/tests/session_status.rs
@@ -202,7 +202,7 @@ fn fake_agent(bin: &std::path::Path, name: &str) -> std::path::PathBuf {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o700)).expect("chmod");
     }
     path
 }

--- a/tests/session_status.rs
+++ b/tests/session_status.rs
@@ -134,3 +134,212 @@ fn a_blocked_session_is_never_time_gated() {
     assert_eq!(store.apply_output_quiescence(silent), 0);
     assert_eq!(status_of(&store, &id), "blocked");
 }
+
+// --- what actually holds the pane ------------------------------------------
+
+/// A socket of this test's own, so it can never see — or kill — a real session.
+const PROBE_SOCKET: &str = "thurbox-probe-test";
+
+/// The tmux session name the local backend groups its windows under. Mirrors
+/// `agent::tmux::TMUX_SESSION`, which is private — and is `thurbox-dev` here,
+/// because a test build carries the same `dev_build` marker a dev binary does.
+const TMUX_SESSION: &str = "thurbox-dev";
+
+/// The externally-driven registry: the session's own "agent" is a bare shell,
+/// because the driver owns the real agent launch and starts it in the pane.
+const AGENTS_TOML: &str = r#"
+config_version = 1
+default = "claude"
+
+[[agents]]
+name = "claude"
+command = "claude"
+
+[[agents]]
+name = "shell"
+command = "bash"
+args = ["-i"]
+"#;
+
+fn have_tmux() -> bool {
+    std::process::Command::new("tmux")
+        .arg("-V")
+        .output()
+        .map(|out| out.status.success())
+        .unwrap_or(false)
+}
+
+/// Whether this machine's `ps` speaks the accounting the foreground resolution
+/// asks it for. A cut-down `ps` (busybox) knows none of these keywords.
+fn have_ps() -> bool {
+    std::process::Command::new("ps")
+        .args([
+            "-o",
+            "pid=,pgid=,tpgid=,args=",
+            "-p",
+            &std::process::id().to_string(),
+        ])
+        .output()
+        .map(|out| out.status.success() && !out.stdout.is_empty())
+        .unwrap_or(false)
+}
+
+fn tmux(args: &[&str]) -> std::process::Output {
+    std::process::Command::new("tmux")
+        .arg("-L")
+        .arg(PROBE_SOCKET)
+        .args(args)
+        .output()
+        .expect("run tmux")
+}
+
+/// An executable named after an agent, so the pane's process tree is what the
+/// probe would really see.
+fn fake_agent(bin: &std::path::Path, name: &str) -> std::path::PathBuf {
+    std::fs::create_dir_all(bin).expect("mkdir");
+    let path = bin.join(name);
+    std::fs::write(&path, "#!/bin/sh\nwhile :; do sleep 1; done\n").expect("write");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+    }
+    path
+}
+
+/// Turn the loop until the probe's answer has landed, or give up.
+///
+/// The verdict is computed on a worker thread and arrives through
+/// `refresh_if_due`, which is also rate-limited — so this is the loop's own
+/// cadence, not a poll of the pane.
+fn settle(store: &mut SnapshotStore, id: &str, want: &str) -> String {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+    loop {
+        store.refresh_if_due();
+        let state = status_of(store, id);
+        if state == want || std::time::Instant::now() >= deadline {
+            return state;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+}
+
+/// R1 + R3, end to end and through a real process tree: the interface's own
+/// derivation, the pane probe that feeds it, and the name it publishes.
+///
+/// The captain's symptom lives exactly here — a driver asks thurbox for a bare
+/// shell, starts an agent in the pane itself, and nothing is wired to report a
+/// turn. The interface used to draw the green hollow `idle` dot for that, which
+/// says the agent reported it is at rest. It now says an agent is running,
+/// names it, and still claims nothing about the turn.
+#[test]
+fn an_agent_a_driver_started_is_seen_and_named_by_the_interface() {
+    if !have_tmux() || !have_ps() {
+        eprintln!("skipping: needs tmux and a ps that knows tpgid");
+        return;
+    }
+    let home = tempfile::tempdir().expect("tempdir");
+    std::env::set_var("TMUX_TMPDIR", home.path());
+    std::env::set_var(thurbox::agent::tmux::SOCKET_OVERRIDE_ENV, PROBE_SOCKET);
+    let guard = thurbox::paths::TestPathGuard::new(home.path());
+    let agents = thurbox::agent::agent_config::agents_config_path().expect("agents path");
+    std::fs::create_dir_all(agents.parent().expect("config dir")).expect("mkdir");
+    std::fs::write(&agents, AGENTS_TOML).expect("write agents.toml");
+
+    let row = SharedSession {
+        id: SessionId::default(),
+        name: "driver-owned".into(),
+        // What the driver asked thurbox for. thurbox wires no hooks for it.
+        agent: "shell".into(),
+        // Empty, so the pane is resolved by window name.
+        backend_id: String::new(),
+        backend_type: "local-tmux".into(),
+        agent_session_id: None,
+        cwd: None,
+        additional_dirs: Vec::new(),
+        worktrees: Vec::new(),
+        shell_backend_id: None,
+        parent_session_id: None,
+        display_order: None,
+        tombstone: false,
+        tombstone_at: None,
+    };
+    let path = home.path().join("thurbox.db");
+    Database::open(&path)
+        .expect("db")
+        .upsert_session(&row)
+        .expect("persist");
+
+    // The driver's shape: thurbox opened a pane, the driver started an agent in
+    // it, and nothing was ever wired to report a turn.
+    let claude = fake_agent(&home.path().join("bin"), "claude");
+    tmux(&["new-session", "-d", "-s", TMUX_SESSION, "-n", "bash", "sh"]);
+    tmux(&[
+        "new-window",
+        "-t",
+        TMUX_SESSION,
+        "-n",
+        "tb-driver-owned",
+        &claude.to_string_lossy(),
+    ]);
+
+    let mut store = SnapshotStore::with_database(Database::open(&path).expect("db"));
+    let id = row.id.to_string();
+
+    // Something is running here — and that is the whole claim. `working` would
+    // be one the observation cannot support, and `idle` is the one this fix
+    // exists to stop: it says the agent reported that it is at rest.
+    assert_eq!(settle(&mut store, &id, "running"), "running");
+    assert_eq!(detected_of(&store, &id), Some("claude".to_string()));
+    // Beside the name the row was created with, never instead of it.
+    assert_eq!(agent_of(&store, &id), "shell");
+
+    // Now the same pane holding nothing but a process whose argv *mentions* an
+    // agent — the shape a driver's multi-kilobyte brief produces, and the false
+    // positive that made a bare pane report an agent (F6). Reaching it from
+    // `running` is what proves a fresh verdict was taken rather than a stale
+    // one left standing.
+    tmux(&[
+        "kill-window",
+        "-t",
+        &format!("{TMUX_SESSION}:tb-driver-owned"),
+    ]);
+    tmux(&[
+        "new-window",
+        "-t",
+        TMUX_SESSION,
+        "-n",
+        "tb-driver-owned",
+        "perl",
+        "-e",
+        "sleep 300",
+        "claude",
+    ]);
+
+    let inert = settle(&mut store, &id, "uncovered");
+    tmux(&["kill-server"]);
+    drop(guard);
+
+    assert_eq!(
+        inert, "uncovered",
+        "a pane merely mentioning an agent must not report one"
+    );
+    assert_eq!(detected_of(&store, &id), None);
+}
+
+fn row_of<'a>(store: &'a SnapshotStore, id: &str) -> &'a thurbox::kernel::snapshot::SessionRow {
+    store
+        .current()
+        .sessions
+        .iter()
+        .find(|row| row.id == id)
+        .expect("the session is in the snapshot")
+}
+
+fn detected_of(store: &SnapshotStore, id: &str) -> Option<String> {
+    row_of(store, id).detected_agent.clone()
+}
+
+fn agent_of(store: &SnapshotStore, id: &str) -> String {
+    row_of(store, id).agent.clone()
+}

--- a/tests/terminal_pane.rs
+++ b/tests/terminal_pane.rs
@@ -52,6 +52,8 @@ fn row(name: &str) -> SessionRow {
         git: None,
         stopped: false,
         hook_state: None,
+        reports_as: None,
+        detected_agent: None,
         shell_backend_id: None,
         member_dirs: Vec::new(),
     }

--- a/ui/lib/theme.lua
+++ b/ui/lib/theme.lua
@@ -96,6 +96,16 @@ local STATUS_GLYPHS = {
   idle = "○",
   error = "✗",
   unreachable = "⊘",
+  -- An agent holds the pane and has reported nothing. Filled, because
+  -- something IS there; not the working spinner, because no process listing
+  -- can tell a turn in flight from a prompt waiting for input.
+  running = "◍",
+  -- The two silences. Dotted, because the content of both is an absence: no
+  -- hooks are wired (`uncovered`), or none have fired yet (`unreported`).
+  -- Kept visibly apart from `idle`'s green hollow circle, which is a claim
+  -- that the agent said it is at rest.
+  uncovered = "◌",
+  unreported = "◌",
 }
 local STATUS_ROLES = {
   working = "status_working",
@@ -104,12 +114,21 @@ local STATUS_ROLES = {
   idle = "status_idle",
   error = "status_error",
   unreachable = "status_unreachable",
+  running = "status_running",
+  uncovered = "status_unknown",
+  unreported = "status_unknown",
 }
 
 --- Glyph and colour for a session status.
 ---
 --- Colour comes from the theme's own status roles, so a theme that recolours
 --- "blocked" recolours it here without this file changing.
+---
+--- The `idle` fallback is for a word this table has no row for — `stopped`,
+--- which is at rest by definition. It is deliberately NOT how the three
+--- silences are drawn: `running`, `uncovered` and `unreported` each have a row
+--- above, because falling through to `idle` is what made a working
+--- driver-launched agent draw the green "the agent says it is at rest" dot.
 ---@param name thurbox.Status
 ---@return { glyph: string, color: thurbox.Color? }
 function theme.status(name)

--- a/ui/lib/thurbox.d.lua
+++ b/ui/lib/thurbox.d.lua
@@ -284,6 +284,8 @@
 ---| "status_idle"
 ---| "status_error"
 ---| "status_unreachable"
+---| "status_running"
+---| "status_unknown"
 ---| "text_primary"
 ---| "text_secondary"
 ---| "text_muted"
@@ -310,8 +312,12 @@
 
 --- A session's derived status, as `SessionState::as_str` spells it.
 --- `lib/theme.lua` has a glyph and a role for `working`, `blocked`, `done`,
---- `idle` and `unreachable`, and falls back to `idle` for the rest — which is
---- why `theme.status` accepts the whole vocabulary.
+--- `idle`, `unreachable`, `running`, `uncovered` and `unreported`, and falls
+--- back to `idle` only for `stopped` — which is at rest by definition. The
+--- three silences are drawn apart from `idle` on purpose: `running` is "an
+--- agent holds the pane and said nothing", `uncovered` is "wired to report
+--- nothing" and `unreported` is "can report, has not yet". None of them is
+--- the agent saying it is at rest.
 ---@alias thurbox.Status
 ---| "working"
 ---| "blocked"
@@ -338,7 +344,9 @@
 ---@class (exact) thurbox.Session
 ---@field id string
 ---@field name string
----@field agent string
+---@field agent string What the row was created as.
+---@field reports_as? string What a driver declared this session runs (`session reports-as`).
+---@field detected_agent? string The registered agent observed in the pane, when it is not `agent`.
 ---@field status thurbox.Status
 ---@field backend string
 ---@field repo? string

--- a/ui/plugins/10_sessions.lua
+++ b/ui/plugins/10_sessions.lua
@@ -98,6 +98,13 @@ local function agent_status_text(session)
   if session.status == "unreported" then
     return "no status reported"
   end
+  -- An agent is demonstrably in the pane and could not be named: several
+  -- registered profiles share its executable, so `ps` sees the command and not
+  -- the profile. The row says what is actually known rather than falling
+  -- silent, and it never guesses which profile.
+  if session.status == "running" then
+    return "agent running · no status reported"
+  end
   return nil
 end
 

--- a/ui/plugins/10_sessions.lua
+++ b/ui/plugins/10_sessions.lua
@@ -53,6 +53,12 @@ local widgets = require("lib.widgets")
 --- Both come off the agent's own terminal — the activity line is its OSC window
 --- title, the notification its OSC 9/777 message — so they are published from
 --- the live pane rather than the database.
+---
+--- v2 adds the row nothing has reported for. Its dot says only that no status
+--- arrived, which is honest but not diagnosable, so the text names what thurbox
+--- does know: the agent found in the pane, or why the silence means nothing.
+--- Naming the agent never displaces what it said — an activity line is the
+--- agent talking, and it wins the rest of the line.
 local function agent_status_text(session)
   -- Nothing the agent said can be current on a host we cannot reach, so the
   -- row says why instead of showing a last message as if it were live.
@@ -68,9 +74,29 @@ local function agent_status_text(session)
   local activity = session.activity
   if activity then
     activity = activity:match("^%s*(.-)%s*$")
-    if activity ~= "" then
-      return activity
+    if activity == "" then
+      activity = nil
     end
+  end
+  -- An agent thurbox did not launch: the row is labelled with whatever the
+  -- driver asked for (`zsh`), and the agent actually in front of the user is
+  -- named here. It says WHICH agent, never what it is doing — the dot already
+  -- says that nothing has reported.
+  local detected = session.detected_agent
+  if detected then
+    if activity then
+      return detected .. " · " .. activity
+    end
+    return detected .. " · no status reported"
+  end
+  if activity then
+    return activity
+  end
+  if session.status == "uncovered" then
+    return "no status hooks"
+  end
+  if session.status == "unreported" then
+    return "no status reported"
   end
   return nil
 end

--- a/ui/plugins/20_agent.lua
+++ b/ui/plugins/20_agent.lua
@@ -228,6 +228,21 @@ end
 --- trailing space. The branch bracket is absent rather than empty when the
 --- session has no worktree, and the leading/trailing spaces keep the title off
 --- the rounded corners.
+--- What the pane is running, for the title's `(…)` bracket.
+---
+--- The row's own agent, plus the one observed in the pane when a driver started
+--- something else there — `(zsh → claude)`. Two names rather than one because
+--- neither is the whole truth: the row says what thurbox launched, the arrow
+--- says what answered.
+local function agent_word(session)
+  local agent = session.agent or ""
+  local detected = session.detected_agent
+  if detected and detected ~= agent then
+    return agent .. " → " .. detected
+  end
+  return agent
+end
+
 local function terminal_title(session, opts)
   opts = opts or {}
   local name = session.name or ""
@@ -238,7 +253,7 @@ local function terminal_title(session, opts)
     base = " "
       .. name
       .. " ("
-      .. (session.agent or "")
+      .. agent_word(session)
       .. ") ["
       .. session.branch
       .. "] ["
@@ -248,7 +263,7 @@ local function terminal_title(session, opts)
     base = " "
       .. name
       .. " ("
-      .. (session.agent or "")
+      .. agent_word(session)
       .. ") ["
       .. status_word(session.status)
       .. "] "


### PR DESCRIPTION
## Intent

The way shell/zsh-kind sessions are handled must be improved by thurbox. A firstmate-managed session that is genuinely working does not show a correct in-progress status - it shows the idle dot. thurbox knows the honest words for this case (running / uncovered / unreported) on its CLI surfaces, but the interface renders them all as idle, which claims the agent reported it is at rest when in truth nothing reported at all. That claim must stop.

The captain's own design steer: 'thurbox should somehow auto-detect the agent if possible', on a best-effort basis. He considers that the best direction. Where a driver opened a bare shell and started an agent in that pane, thurbox should work out which registered agent is actually running and show it - without inventing a turn status it cannot observe, since knowing an agent is there says nothing about whether it is mid-turn.

Follow-up round, from the captain after review of PR 1081: a detected identity must never be an arbitrary first match. When one executable maps to more than one registered agent profile, publish no detected agent at all rather than whichever profile is ordered first, and let the display fall back to the honest 'no status reported' rendering. The captain prefers the honest blank over a heuristic tie-break: the value of this feature is that it is never wrong, and a plausible-but-arbitrary name destroys exactly that. A confidently wrong name on screen is worse than the 'shell' label this change set out to improve on, because a wrong specific name invites trust.

He has authorized this fix and requires it to go through the no-mistakes pipeline. He approves every merge himself - do not merge.

## What Changed

- `session::hook_status`: `classify_foreground` now walks the whole agent registry instead of a command list, and `runs_program` matches only argv in actual command position (argv0, after `exec`/`env`/`command`/`nohup`/assignments, or after a shell's `-c`-style option) instead of matching any whitespace token anywhere in the command line. `Corroboration::ForeignAgent` now carries `Option<String>` — the detected agent's registered name when exactly one registry profile matches the running executable, or `None` when several profiles share that executable (no arbitrary first-match is published).
- `kernel::snapshot`: adds a `PaneProbe` worker that classifies each unreported session's foreground pane off the render path (2s TTL, remote/stopped/already-reporting sessions skipped) and folds the result through a shared `assess()` helper (also used by the CLI) so `SessionRow` now carries `reports_as` (declared agent) and `detected_agent` (observed agent) fields; a session with no hook state renders `running`/`uncovered`/`unreported` instead of falling back to `idle`. `apply_hook_states` clears `detected_agent` on a fresh hook write to avoid stale identity.
- `cli::sessions` and related CLI/tests: reworks session-state assessment to share the same `Assessment`/`Corroboration` logic and honest status vocabulary (`running`/`uncovered`/`unreported`) as the interface.
- `ui/lib/theme.lua`, `ui/lib/thurbox.d.lua`, `ui/plugins/10_sessions.lua`, `ui/plugins/20_agent.lua`: add glyphs/roles and status text for `running`/`uncovered`/`unreported` (no longer falling back to the idle dot), show the detected agent name in the session status line and pane title (`agent → detected`) when a driver-launched agent differs from the session's own agent.
- Updates `docs/CONFIG.md`, `docs/FEATURES.md`, `docs/ORCHESTRATION.md`, `docs/PERFORMANCE.md`, `.agents/skills/thurbox-cli/SKILL.md`, `.agents/skills/thurbox-session-status/SKILL.md`, and `README.md` to describe the new status vocabulary and pane-probe behavior; adds/updates tests across `tests/session_status.rs`, `tests/session_state_agreement.rs`, `tests/kernel_mvp.rs`, `tests/cli_session_hook_state.rs`, `tests/remote_status.rs`.

## Risk Assessment

✅ Low: The final commit (d2fc6cc) is a small, well-tested, behavior-correct fix for the captain's round-4 requirement (no arbitrary tie-break on shared-executable profiles), and it correctly threads Option<String> through every call site (CLI, kernel snapshot, Lua UI) with exhaustive matches already gated on the variant rather than the payload; the three earlier review-round fixes (stale detected_agent cache eviction, hot-patch on local hook write, and assess()'s reported-gate) were independently re-verified against their exact failure sequences and hold, including a real-tmux end-to-end test and a two-connection race test; a large mechanical refactor of src/cli/sessions.rs was independently verified behavior-preserving.

## Testing

Baseline `cargo nextest run --all` already passed; I additionally ran the targeted suite touching this commit's code (hook_status, snapshot, kernel_mvp, session_status, session_state_agreement, remote_status, cli_session_hook_state — 158 tests, all green) and closed a coverage gap by adding a kernel_mvp.rs test that renders the real bundled Lua UI for the ambiguous-detected-agent case and asserts the on-screen "agent running · no status reported" text, verifying it fails without the fix and passes with it. No findings — the change behaves as the intent requires.

<details>
<summary>Evidence: New regression test proving it fails before the fix and passes after</summary>

```text
Before (Lua branch reverted): panicked at tests/kernel_mvp.rs:376 — row rendered with no trailing status text at all ('◍ ⑂ fm-worker' with nothing after it).
After (fix restored): test passes — row renders '◍ ⑂ fm-worker agent running · no status reported'.
```
</details>
<details>
<summary>Evidence: Targeted test run summary</summary>

```text
Nextest run: 158 tests run: 158 passed, 2313 skipped (hook_status, snapshot, kernel_mvp, session_status incl. real-tmux e2e, session_state_agreement, remote_status, cli_session_hook_state)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"cc8dce73bfa4bb829bcc702676adc22df8ee700c","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `docs/ORCHESTRATION.md:241` - docs/ORCHESTRATION.md&#39;s field table still describes `detected_agent` only as &#34;which registered agent is in the pane, when it is not the row&#39;s own&#34; — it doesn&#39;t mention the round-4 behavior (added in d2fc6cc) that this is null when the pane&#39;s executable matches more than one registered profile, even though `agent_present`/`state: running`/`hook_corroboration: foreign-agent` still hold. The SKILL.md files, the Rust doc comments, and docs/FEATURES.md&#39;s ambient description were all updated for this case in the same commit, but this one table entry wasn&#39;t.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `cargo nextest run --all`
- `cargo nextest run -E 'test(a_running_session_with_no_determined_agent_says_so_without_a_name)' (new test, added this run) — fails without the ui/plugins/10_sessions.lua fix (verified by temporary revert), passes with it`
- `cargo nextest run -E 'test(an_executable_several_profiles_share_names_no_agent)' — src/session/hook_status.rs unit test proving classify_foreground returns ForeignAgent(None) for shared-executable profiles regardless of registry order, and ForeignAgent(Some(name)) is unaffected for the single-profile case`
- `cargo nextest run -E 'test(an_agent_a_driver_started_is_seen_and_named_by_the_interface)' — real-tmux e2e in tests/session_status.rs covering the single-profile detection path end to end`
- `cargo nextest run binary(kernel_mvp) binary(session_status) binary(session_state_agreement) binary(remote_status) binary(cli_session_hook_state) plus hook_status/snapshot unit tests — 158 tests, all passed`
- `git status --porcelain before/after to confirm only the added test remains in the working tree`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>


---

## Shared executables: in practice, not just in principle

Review asked whether more than one registered agent profile can share an
executable, or whether that is only theoretically possible. It happens in
practice, and thurbox's own seeded config is what produces it.

`src/agent/agent_config.rs` writes an `agents.toml` whose **"Pin a model"**
section is the documented way to fix an agent to a model, and it works by adding
a second profile on the same `command`:

```toml
[[agents]]
name = "claude-opus"
command = "claude"
args = ["--model", "opus"]    # always-on flag
```

The comment above it says the entry is "kept alongside the default `claude`
entry", so following the instructions thurbox ships leaves two profiles on one
executable. `CLAUDE.md` gives the same advice ("bake a model or other flags into
the agent's `args`").

The nine built-in profiles themselves all have distinct commands, so a stock
install is unaffected — the collision comes from the configuration thurbox hands
the user, not from its defaults.

That is why this publishes no name rather than tie-breaking. A `ps` listing sees
the executable; the field publishes the profile. When one executable maps to
several profiles the observation simply does not determine the answer, so
`detected_agent` is null while `hook_corroboration: "foreign-agent"` and
`state: "running"` still stand — presence is observed, identity is not. The row
falls back to `agent running · no status reported`.
