### PR TITLE
feat(core): report status hooks for grok and kimi

### DIFF
--- a/.agents/skills/thurbox-agents/SKILL.md
+++ b/.agents/skills/thurbox-agents/SKILL.md
@@ -115,9 +115,10 @@ uninstall reverse) fans each `[[agent_patches]]` out to the built-in named
 claude.json` claude gets — and, because the remote rewrite
 (`session_ops::spawn::adapt_agent_args_for_remote`) keys off the `--settings`
 arg rather than the agent name, remote/WSL wiring follows for free. Only the
-per-arg-patch families (claude, aider) need it; codex/opencode/antigravity/vibe/
-copilot wire through their own config dir, so a rebrand sharing that dir already
-reports. thurbox bakes in no agent knowledge — the *user* asserts the family.
+per-arg-patch families (claude, aider) need it; the config-dir agents
+(codex/opencode/antigravity/vibe/copilot/pi/omp/grok/kimi) wire through their own
+config dir, so a rebrand sharing that dir already reports. thurbox bakes in no
+agent knowledge — the *user* asserts the family.
 
 ### Multi-repo sessions (symlink workspace)
 

--- a/.agents/skills/thurbox-extensions/SKILL.md
+++ b/.agents/skills/thurbox-extensions/SKILL.md
@@ -139,9 +139,12 @@ ensure/self-heal). The `{home}` token expands to the resolved home dir.
 Three of those reach **outside** the extension home, all reversible:
 `[[external_files]]` drops a managed file into an agent's own config dir (guarded
 by `requires_dir`), `[[agent_patches]]` appends args to an existing agent in
-agents.toml, and `[[config_merges]]` deep-merges shipped JSON into an agent's
-*shared* config file (`agent::json_merge`; uninstall prunes by the
-`thurbox-cli session signal` marker, so removal survives payload schema changes).
+agents.toml, and `[[config_merges]]` deep-merges a shipped document into an
+agent's *shared* config file (`agent::json_merge`, or `agent::toml_merge` when
+the entry sets `format = "toml"` for a TOML config such as kimi's
+`~/.kimi-code/config.toml` — `toml_edit`, so the user's comments and key order
+survive; uninstall prunes by the `thurbox-cli session signal` marker either way,
+so removal survives payload schema changes).
 
 **Built-in extensions** (`session_ops::builtin`) — two of them, `hooks`
 (`extensions/hooks/`) and `ui-skill` (`extensions/ui-skill/`), which unlike user

--- a/.agents/skills/thurbox-extensions/SKILL.md
+++ b/.agents/skills/thurbox-extensions/SKILL.md
@@ -143,8 +143,10 @@ agents.toml, and `[[config_merges]]` deep-merges a shipped document into an
 agent's *shared* config file (`agent::json_merge`, or `agent::toml_merge` when
 the entry sets `format = "toml"` for a TOML config such as kimi's
 `~/.kimi-code/config.toml` — `toml_edit`, so the user's comments and key order
-survive; uninstall prunes by the `thurbox-cli session signal` marker either way,
-so removal survives payload schema changes).
+survive; JSON prunes by the `thurbox-cli session signal` marker in an entry's
+content, TOML by an ownership comment on the entry itself — which is why the TOML
+payload stamps every entry with one, and why a user hook that calls `session
+signal` survives uninstall there but would not in JSON).
 
 **Built-in extensions** (`session_ops::builtin`) — two of them, `hooks`
 (`extensions/hooks/`) and `ui-skill` (`extensions/ui-skill/`), which unlike user

--- a/.agents/skills/thurbox-remote-hosts/SKILL.md
+++ b/.agents/skills/thurbox-remote-hosts/SKILL.md
@@ -176,11 +176,13 @@ session), never on the loop, ADR-P12).
   pane id, or identity inside a pane (the psmux form bakes in
   `-L <socket>`). Delivery per agent: claude's hooks file travels via its
   `--settings` arg; agents wired through their **own config dir** (codex,
-  antigravity, opencode, vibe, copilot) are provisioned at spawn time by
+  antigravity, opencode, vibe, copilot, grok, kimi) are provisioned at spawn time by
   `session_ops::remote_hooks::provision_agent_hooks_on_host` — the rewritten
   payload shipped into the host's agent config dir with the local installer's
-  safety rules (`requires_dir` probe over ssh, prune-then-merge for shared JSON,
-  managed-marker guard for standalone files, compare-before-write; cached per
+  safety rules (`requires_dir` probe over ssh, prune-then-merge for a shared
+  config — JSON on a content marker, TOML (kimi) on the same ownership comment
+  used locally, see `thurbox-extensions`), managed-marker guard for standalone
+  files, compare-before-write; cached per
   `(backend, agent)`, best-effort, never fails the spawn; remote **cleanup** is a
   documented leave-behind). The local TUI's persistent control-mode connection
   subscribes once per connection (`refresh-client -B

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -124,7 +124,12 @@ CLIs support forking a conversation to a thurbox-pinned target.
 ### Status hook mechanisms
 
 Every built-in reports status via the **hooks** extension, but *how* the hook is
-delivered differs by what each CLI supports. All are declared in
+delivered differs by what each CLI supports. Two entries below (`grok`, `kimi`)
+are **not** built-in agents: their hooks are installed into their own config dirs
+all the same, so a session running one — started from a `--command` shell, a
+custom `agents.toml` entry, or an outside driver — reports state whoever launched
+it. Naming the agent on the row (`session create --reports-as grok`) is what
+resolves the coverage. All are declared in
 [`extensions/hooks/extension.toml`](../extensions/hooks/extension.toml); the
 embedded hook assets live in
 [`extensions/hooks/`](../extensions/hooks/) and are `include_str!`'d by
@@ -137,10 +142,27 @@ embedded hook assets live in
   - `aider`: `--notifications-command "thurbox-cli session signal --state
     blocked"`. aider has only a "waiting for input" callback, so **blocked is the
     only state it can report**.
-- **`config_merges` (reversible JSON deep-merge into a shared config file)** —
-  for agents whose hooks live in a file thurbox must not overwrite.
+- **`config_merges` (reversible deep-merge into a shared config file)** — for
+  agents whose hooks live in a file thurbox must not overwrite. JSON by default;
+  `format = "toml"` selects the TOML merge for an agent whose shared config is
+  TOML (kimi). Either way the semantics match: objects/tables recurse, arrays
+  union, a type conflict with the user's value is left alone, and uninstall
+  prunes exactly our entries by the `session signal` marker.
   - `codex`: merged into `~/.codex/hooks.json` (SessionStart→idle,
     UserPromptSubmit/PreToolUse→working, Stop→done; **no blocked**). *Experimental.*
+  - `kimi` (Kimi Code CLI): merged into `~/.kimi-code/config.toml` — TOML, so
+    the merge is `agent::toml_merge` (`format = "toml"` on the `[[config_merges]]`
+    entry) rather than the JSON one; `toml_edit` keeps the user's comments and key
+    order. Kimi reads hooks from a `[[hooks]]` array in that one shared file and
+    has no drop-in hooks dir, so a managed file would clobber the user's whole
+    configuration. SessionStart→idle, UserPromptSubmit/PreToolUse/PostToolUse→
+    working, PermissionRequest→blocked, PermissionResult→working, Stop→done. The
+    only agent here whose block edge is a **structured permission event on both
+    sides** — a real request event and a real result event — so `blocked` neither
+    false-fires nor latches. Kimi accepts exactly four keys per hook entry
+    (event/command/matcher/timeout) and refuses to load the whole config file on a
+    fifth, so `kimi-hooks.toml` must never grow one (a test pins this).
+    *Experimental.*
   - `antigravity` (`agy`): merged into the shared `~/.gemini/settings.json` (agy
     adopted claude's hook schema — PreToolUse/PostToolUse→working,
     Notification→blocked, Stop→done; no UserPromptSubmit, so working fires at the
@@ -166,6 +188,20 @@ embedded hook assets live in
     (session_start→idle, agent_start/tool_execution_start/tool_execution_end→
     working, agent_end→done; **blocked inferred only** from an
     `ask_user_question` tool call, cleared when that tool ends). *Experimental.*
+  - `grok` (xAI's Grok Build CLI): `~/.grok/hooks/thurbox-status.json` — grok
+    loads every `*.json` in that dir on its own, so a standalone drop never
+    touches a hook file the user wrote. It is the **global** dir deliberately:
+    global hooks are always trusted and load on first launch, while
+    `<project>/.grok/hooks` additionally needs the folder granted trust in grok's
+    own `~/.grok/trusted_folders.toml` (or a `--trust` launch flag, which would
+    only cover sessions thurbox itself launches). grok is Claude-Code-compatible,
+    so the mapping mirrors claude: SessionStart→idle,
+    UserPromptSubmit/PreToolUse/PostToolUse→working, Notification (payload
+    matched to permission/approval)→blocked, Stop→done. Every command is
+    deliberately `$`-free: a `$VAR` reference without an inline `:-default` makes
+    grok silently refuse to load the whole hook file, so the blocked edge pipes
+    stdin through `grep` instead of reusing claude's `case "$(cat)"` (a test pins
+    it). *Experimental.*
   - `omp`: a TypeScript extension at `~/.omp/agent/extensions/thurbox-status.ts`,
     mirroring pi's but mapping OMP's structured user-question tool — named `ask`
     — to blocked (it recognizes both `ask` and pi's `ask_user_question`), cleared
@@ -174,6 +210,32 @@ embedded hook assets live in
 Each `requires_dir` guard makes the drop a no-op when that agent isn't installed,
 so a fresh install with only claude present doesn't scatter files for agents you
 don't have.
+
+**Deliberately uninstrumented.** Two agents have a hook surface thurbox cannot
+reach with any of the three mechanisms, and are left out of the table so they
+keep reporting `uncovered` honestly rather than claiming a payload that never
+fires:
+
+- **cursor** (`cursor-agent`). The only scope its CLI is known to load hooks
+  from is per-project `<repo>/.cursor/hooks.json`, and only when the agent is
+  launched with `--trust` — which is a `[[agent_patches]]` flag, so it would
+  cover nothing an outside driver launches, and a per-repo file is not a config
+  dir any mechanism here writes to. User-scope `~/.cursor/hooks.json` is
+  documented for the IDE; in the CLI it is reported to run only the
+  shell/MCP/file-edit hooks, none of which can say `done`. Wiring it there would
+  latch a session at `working` forever. It becomes a plain `config_merges` entry
+  into `~/.cursor/hooks.json` the moment `stop`/`sessionStart` are confirmed to
+  fire from user scope in the CLI.
+- **muse** (Muse Code). Its hooks exist only as capabilities of a native plugin:
+  installing one means running `muse plugins install` and `muse plugins approve`
+  (the management CLI itself gated behind `MUSE_EXPERIMENTAL_PLUGINS`), and a
+  dropped-in config file is silently ignored. An extension manifest writes files;
+  it does not run an agent's install-and-approve commands, so there is nothing to
+  ship. Muse does keep a durable per-session event log
+  (`${XDG_DATA_HOME:-~/.local/share}/muse/sessions/YYYY/MM/DD/<uuid>/session.jsonl`)
+  whose `run` `started`/`terminal` events bracket every turn — reading it would be
+  a **fourth** delivery mechanism (a poller, not a hook) and is a separate
+  decision, not a variation on these three.
 
 **This list has a machine-readable twin.** `session::hook_status::
 AGENT_HOOK_COVERAGE` carries the same per-agent facts — the states each payload
@@ -220,7 +282,7 @@ name. It exists for a **user's** custom agent that runs a built-in under a
 different name (e.g. a rebranded-claude CLI called `fleet`): set `hook_schema =
 "claude"` and it inherits claude's `--settings` hook wiring under its own name.
 Only the per-arg-patch families (`claude`, `aider`) need it; the config-dir
-agents (codex/opencode/antigravity/vibe/copilot/pi) wire through their own config
+agents (codex/opencode/antigravity/vibe/copilot/pi/omp/grok/kimi) wire through their own config
 dir, so a rebrand sharing that dir already reports without it. See
 [CONFIG.md](CONFIG.md#agentstoml) and the `AgentDef.hook_schema` doc comment.
 
@@ -249,9 +311,17 @@ automatically. Work the checklist top to bottom:
    [`src/session_ops/builtin_hooks.rs`](../src/session_ops/builtin_hooks.rs), and
    add its row to `AGENT_HOOK_COVERAGE` in
    [`src/session/hook_status.rs`](../src/session/hook_status.rs) (the drift test
-   fails until it matches the payload). Bump the hooks extension `version`.
-   Skipping this step means the new agent launches fine but **never shows
-   working/blocked/done**.
+   fails until it matches the payload), and — for a `config_merges` /
+   `external_files` wiring — the matching entry in `remote_asset_for`
+   ([`src/session_ops/remote_hooks.rs`](../src/session_ops/remote_hooks.rs)), so
+   remote sessions get the same payload (a test fails until local and remote
+   agree). Bump the hooks extension `version`. Skipping this step means the new
+   agent launches fine but **never shows working/blocked/done**.
+
+   This step also stands **alone**: an agent thurbox ships no `[[agents]]` entry
+   for still gets its hooks installed into its own config dir, which is what
+   makes `grok`/`kimi` report for a driver that launches them itself. Steps 1,
+   3 and 4 are about launching an agent, not instrumenting one.
 
 3. **Docs — update every list of built-ins** (these are prose, not generated, so
    they drift):

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -147,7 +147,11 @@ embedded hook assets live in
   `format = "toml"` selects the TOML merge for an agent whose shared config is
   TOML (kimi). Either way the semantics match: objects/tables recurse, arrays
   union, a type conflict with the user's value is left alone, and uninstall
-  prunes exactly our entries by the `session signal` marker.
+  prunes exactly our entries. How "ours" is decided differs by format: JSON
+  matches the `session signal` marker in an entry's content, while TOML reads an
+  ownership comment stamped on each shipped entry — so a user hook that calls
+  `session signal` itself survives a TOML uninstall, and a payload that renames
+  an event replaces its old entry instead of stacking a second one beside it.
   - `codex`: merged into `~/.codex/hooks.json` (SessionStart→idle,
     UserPromptSubmit/PreToolUse→working, Stop→done; **no blocked**). *Experimental.*
   - `kimi` (Kimi Code CLI): merged into `~/.kimi-code/config.toml` — TOML, so

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1017,9 +1017,15 @@ selects `agent::toml_merge` (`toml_edit`, preserving the user's comments and
 key order) for an agent whose shared config is TOML (kimi's
 `~/.kimi-code/config.toml`). Either way the merge recurses objects/tables,
 unions arrays by deep-equality, and leaves a user's conflicting value
-untouched; uninstall **prunes by marker** (every shipped hook command
-contains `thurbox-cli session signal`), so removal stays correct even after
-the payload's schema changes across an update — no orphans. Writes are
+untouched; uninstall **prunes by marker**, but the two formats mark
+differently. JSON matches a marker in the entry's *content* (every shipped
+hook command contains `thurbox-cli session signal`) — the only handle a
+format without comments offers. TOML marks *ownership* with a comment on the
+entry (`agent::toml_merge`), which a content match cannot do: it tells our
+entry from a user hook that calls `session signal` itself, and still
+recognises ours after its event or command changes. So the TOML install
+prunes-then-merges, replacing our previous entries rather than accumulating
+beside them — no orphans either way, and no collateral. Writes are
 skipped when unchanged (it re-runs every startup + heartbeat tick). All
 three are honoured by `session_ops::install_extension` /
 `session_ops::uninstall_extension`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1009,16 +1009,20 @@ guarded by `requires_dir` so it's skipped when that agent isn't installed);
 `[[agent_patches]]` appends args to an **existing** agent in
 agents.toml (`apply_agent_patches` via `toml_edit`, reversible — uninstall
 removes exactly the injected subsequence); and `[[config_merges]]`
-**reversibly deep-merges** shipped JSON into an agent's own *shared* config
-file (`{path, source, requires_dir}`) — for agents whose hooks live in a
-file that would be clobbered by `[[external_files]]` (antigravity's
-`settings.json`). The merge (`agent::json_merge`) recurses objects, unions
-arrays by deep-equality, and leaves a user's conflicting value untouched;
-uninstall **prunes by marker** (every shipped hook command contains
-`thurbox-cli session signal`), so removal stays correct even after the
-payload's schema changes across an update — no orphans. Writes are skipped
-when unchanged (it re-runs every startup + heartbeat tick). All three are
-honoured by `session_ops::install_extension` / `session_ops::uninstall_extension`.
+**reversibly deep-merges** a shipped document into an agent's own *shared*
+config file (`{path, source, requires_dir}`) — for agents whose hooks live in
+a file that would be clobbered by `[[external_files]]` (antigravity's
+`settings.json`). JSON by default (`agent::json_merge`); `format = "toml"`
+selects `agent::toml_merge` (`toml_edit`, preserving the user's comments and
+key order) for an agent whose shared config is TOML (kimi's
+`~/.kimi-code/config.toml`). Either way the merge recurses objects/tables,
+unions arrays by deep-equality, and leaves a user's conflicting value
+untouched; uninstall **prunes by marker** (every shipped hook command
+contains `thurbox-cli session signal`), so removal stays correct even after
+the payload's schema changes across an update — no orphans. Writes are
+skipped when unchanged (it re-runs every startup + heartbeat tick). All
+three are honoured by `session_ops::install_extension` /
+`session_ops::uninstall_extension`.
 
 `thurbox-cli extension install <name|url|dir> [--home <dir>] [--force]`
 (`session_ops::install_extension`) is the one-command installer: it

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -160,10 +160,9 @@ the `thurbox-agents` skill for the `resume_latest` semantics.
 by name. Set `hook_schema = "claude"` on a **rebranded** agent (one whose
 `command` runs `claude` under a different `name`) and it inherits claude's hook
 wiring — the `--settings` patch locally, and the same rewrite on a remote/WSL
-host. It names the *family* to imitate, not a boolean; today the useful value is
-`"claude"` (the only family wired via a per-agent arg patch — codex/opencode/
-antigravity/vibe/copilot are wired through their own config dir, so a rebrand
-sharing that dir already reports status).
+host. It names the *family* to imitate, not a boolean; see
+[AGENTS.md](AGENTS.md#hook_schema-custom-rebrands-only) for which family is
+actually useful today and why.
 
 The seeded file also ships two commented, copy-pasteable templates
 below the built-ins — **Add your own agent** (every field annotated)

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -699,11 +699,13 @@ requires_dir = "~/.config/opencode"  # skip when that agent isn't installed
 name = "claude"
 append_args = ["--settings", "{home}/claude.json"]
 
-[[config_merges]]               # reversibly deep-merge JSON into an agent's own
+[[config_merges]]               # reversibly deep-merge into an agent's own
 path = "~/.gemini/settings.json"  #   SHARED config file (never clobbered)
 source = "antigravity-hooks.json"  # objects recurse, arrays union; uninstall prunes
 requires_dir = "~/.gemini"      #   exactly our entries (by marker). no-op write
                                 #   when unchanged; malformed target soft-skipped
+# format = "toml"                # OPTIONAL; JSON by default. Set for a TOML
+                                #   shared config (agent::toml_merge via toml_edit)
 
 # runtime spec (ensured on activate, self-healed if deleted) -----------------
 [[sessions]]

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -705,7 +705,9 @@ source = "antigravity-hooks.json"  # objects recurse, arrays union; uninstall pr
 requires_dir = "~/.gemini"      #   exactly our entries (by marker). no-op write
                                 #   when unchanged; malformed target soft-skipped
 # format = "toml"                # OPTIONAL; JSON by default. Set for a TOML
-                                #   shared config (agent::toml_merge via toml_edit)
+                                #   shared config (agent::toml_merge via toml_edit).
+                                #   TOML owns its entries by a comment on each, so
+                                #   the payload must stamp every one of them
 
 # runtime spec (ensured on activate, self-healed if deleted) -----------------
 [[sessions]]

--- a/extensions/hooks/README.md
+++ b/extensions/hooks/README.md
@@ -332,9 +332,11 @@ control-mode connection. Delivery per agent, at spawn time:
   is provisioned into the host's agent config dir
   (`session_ops::remote_hooks`), with the same safety rules as the local
   install: skipped when the agent isn't installed there (`requires_dir` probed
-  over ssh), deep-merge-not-clobber for a shared config (prune-then-merge on both
-  the `session signal` and `@thurbox_state` markers, so upgrades replace
-  rather than accumulate), managed-marker guard for standalone files, and
+  over ssh), deep-merge-not-clobber for a shared config (prune-then-merge so
+  upgrades replace rather than accumulate — JSON on either the `session
+  signal` or `@thurbox_state` marker in an entry's content, TOML on the same
+  ownership comment used locally, which recognises a stale entry under either
+  command form), managed-marker guard for standalone files, and
   compare-before-write.
 
 The local TUI receives the state over its persistent control-mode connection;

--- a/extensions/hooks/README.md
+++ b/extensions/hooks/README.md
@@ -89,6 +89,35 @@ passed by hand) and is suffixed `|| true` so it can never break the agent.
   Both `bash` and `powershell` commands are shipped, so status works on Windows
   too. **Caveat:** if a future `copilot` changes the hook schema, edit
   `copilot-hooks.json` (no code change).
+- **grok** *(experimental)* — xAI's Grok Build CLI loads every `*.json` in
+  `~/.grok/hooks/` on its own, so we drop a managed standalone file in (an
+  `[[external_files]]`, guarded by `requires_dir`, only when grok is installed)
+  and never touch a hook file you wrote. It is the **global** dir on purpose:
+  those hooks are always trusted and load on first launch, while
+  `<project>/.grok/hooks` additionally needs the folder granted trust in grok's
+  own `~/.grok/trusted_folders.toml`. grok is Claude-Code-compatible, so the
+  mapping mirrors claude: `SessionStart` → idle,
+  `UserPromptSubmit`/`PreToolUse`/`PostToolUse` → working, `Notification` →
+  blocked **only for permission/approval prompts** (the payload is matched, so
+  an idle nudge doesn't flip the dot red), `Stop` → done. Every command here is
+  `$`-free: grok silently refuses to load a whole hook file whose command
+  references `$VAR` without an inline `:-default`, so the blocked edge pipes
+  stdin through `grep` rather than reusing claude's `case "$(cat)"`. **Caveat:**
+  if a future grok renames its events, edit `grok-hooks.json` (no code change).
+- **kimi** *(experimental)* — Kimi Code CLI reads hooks from a `[[hooks]]` array
+  in `~/.kimi-code/config.toml`. That one file is your whole kimi configuration
+  and there is no drop-in hooks dir, so a managed file would clobber it — we
+  **merge** our entries in instead (a `[[config_merges]]` with `format = "toml"`,
+  guarded by `requires_dir`); `toml_edit` keeps your comments and key order, and
+  uninstall prunes exactly ours back out. Events: `SessionStart` → idle,
+  `UserPromptSubmit`/`PreToolUse`/`PostToolUse` → working, `PermissionRequest` →
+  blocked, `PermissionResult` → working, `Stop` → done. This is the one agent
+  here whose block edge is structured on **both** sides — a real permission
+  request and a real permission result — so `blocked` neither false-fires on an
+  idle notification nor latches until the next tool call. **Caveat:** kimi
+  accepts exactly four keys per hook entry (`event`/`command`/`matcher`/
+  `timeout`) and refuses to load the entire config file if it sees a fifth, so
+  `kimi-hooks.toml` must never grow one.
 - **antigravity** — antigravity (the `agy` CLI, the Gemini CLI successor) loads
   hooks only from its shared `~/.gemini/settings.json`, so we **JSON-merge** our
   entries in (a `[[config_merges]]`, guarded by `requires_dir`) without clobbering
@@ -133,6 +162,24 @@ passed by hand) and is suffixed `|| true` so it can never break the agent.
   Verified against OMP 17.0.6; if a future `omp` renames its events, edit
   `omp-status.ts` (no code change).
 
+## Agents this extension does not wire
+
+Two agents have a hook surface none of the three mechanisms can reach, so they
+are left out rather than given a payload that never fires — `session get` keeps
+saying `hook_coverage: "none"`, which is the truth:
+
+- **cursor** (`cursor-agent`) — the only scope its CLI is known to load
+  `stop`/`sessionStart` from is per-project `<repo>/.cursor/hooks.json`, and only
+  when launched with `--trust`. That is a per-repo file plus a launch flag, so it
+  would cover nothing an outside driver starts. User-scope `~/.cursor/hooks.json`
+  is documented for the IDE; in the CLI it is reported to run only the
+  shell/MCP/file-edit hooks — none of which can say `done`, so wiring it there
+  would latch a session at `working` forever.
+- **muse** (Muse Code) — its hooks exist only as capabilities of a native plugin
+  that must be installed *and approved* with `muse plugins install` / `muse
+  plugins approve`; a dropped-in config file is silently ignored. An extension
+  manifest writes files, it does not run an agent's commands.
+
 ## Custom agents (`hook_schema`)
 
 The wiring above is keyed to the built-in agent **names**, so a **custom** agent
@@ -152,9 +199,21 @@ thurbox then applies the `claude` `[[agent_patches]]` to `fleet` as well, so it
 reports working/blocked/done exactly like `claude` (locally and on a remote/WSL
 host). `hook_schema` names the *family* to imitate; today `"claude"` is the
 useful value — it's the family wired via a per-agent arg patch. The
-config-dir-wired families (codex/opencode/antigravity/vibe/copilot) don't need
-it: a rebrand that runs the same CLI reads the same `~/.<agent>/…` hook file and
-already reports.
+config-dir-wired families (codex/opencode/antigravity/vibe/copilot/grok/kimi)
+don't need it: a rebrand that runs the same CLI reads the same `~/.<agent>/…`
+hook file and already reports.
+
+**grok and kimi are wired without being built-in agents.** thurbox ships no
+`agents.toml` entry for either, but their payloads land in their own config dirs
+all the same — so a grok or kimi started from a `--command` shell, from your own
+`agents.toml` entry, or by an outside driver reports state like any built-in.
+Tell thurbox which agent the pane is really running so the row resolves that
+coverage:
+
+```bash
+thurbox-cli session create --name x --repo-path … --agent shell --reports-as grok
+thurbox-cli session reports-as <ref> kimi     # or --clear to take it back
+```
 
 ## Where the config lives
 
@@ -176,6 +235,8 @@ other agents are wired by a reversible merge into — or a managed file dropped 
 | copilot | `~/.copilot/hooks/thurbox-status.json` | managed standalone file (`requires_dir`) |
 | antigravity | `~/.gemini/settings.json` | reversible JSON-merge of our entries |
 | pi | `~/.pi/agent/extensions/thurbox-status.ts` | managed extension file (`requires_dir`) |
+| grok | `~/.grok/hooks/thurbox-status.json` | managed standalone file (`requires_dir`) |
+| kimi | `~/.kimi-code/config.toml` | reversible TOML-merge of our entries |
 | omp | `~/.omp/agent/extensions/thurbox-status.ts` | managed extension file (`requires_dir`) |
 
 The home dir is `~/.config/thurbox/hooks` for a release build and
@@ -238,13 +299,16 @@ This extension exercises two extension-manifest capabilities (see
   (reversible; uninstall removes exactly the injected subsequence).
 - `[[external_files]]` — place a file into an agent's **own** config dir
   (outside the extension home), guarded by `requires_dir`.
-- `[[config_merges]]` — **reversibly deep-merge** shipped JSON into an agent's
-  own *shared* config file (antigravity's `~/.gemini/settings.json`) without clobbering the
-  user's other settings: objects recurse, arrays union, and uninstall prunes
+- `[[config_merges]]` — **reversibly deep-merge** a shipped document into an
+  agent's own *shared* config file (antigravity's `~/.gemini/settings.json`,
+  kimi's `~/.kimi-code/config.toml`) without clobbering the
+  user's other settings: objects/tables recurse, arrays union, and uninstall prunes
   exactly the entries we shipped (matched by the `session signal` marker, so it
   stays correct across payload changes). Guarded by `requires_dir`; no-op when
-  the merge is already present. A merge whose target is malformed JSON is
-  soft-skipped (logged, never aborts the rest of the install).
+  the merge is already present. A merge whose target is malformed is
+  soft-skipped (logged, never aborts the rest of the install). JSON by default;
+  `format = "toml"` picks the TOML merge (`agent::toml_merge`, on `toml_edit`,
+  so the user's comments and key order survive).
 
   Note: on the **first** merge, thurbox rewrites `settings.json` with normalized
   formatting (alphabetized keys, 2-space indent). This is one-time and lossless —
@@ -260,11 +324,11 @@ control-mode connection. Delivery per agent, at spawn time:
 - **claude** — the `--settings` hooks file is copied to the host (rewritten)
   and the arg substituted.
 - **aider** — its literal `--notifications-command` arg is rewritten in place.
-- **codex / antigravity / opencode / vibe / copilot** — the rewritten payload
+- **codex / antigravity / opencode / vibe / copilot / grok / kimi** — the rewritten payload
   is provisioned into the host's agent config dir
   (`session_ops::remote_hooks`), with the same safety rules as the local
   install: skipped when the agent isn't installed there (`requires_dir` probed
-  over ssh), deep-merge-not-clobber for shared JSON (prune-then-merge on both
+  over ssh), deep-merge-not-clobber for a shared config (prune-then-merge on both
   the `session signal` and `@thurbox_state` markers, so upgrades replace
   rather than accumulate), managed-marker guard for standalone files, and
   compare-before-write.

--- a/extensions/hooks/README.md
+++ b/extensions/hooks/README.md
@@ -303,8 +303,12 @@ This extension exercises two extension-manifest capabilities (see
   agent's own *shared* config file (antigravity's `~/.gemini/settings.json`,
   kimi's `~/.kimi-code/config.toml`) without clobbering the
   user's other settings: objects/tables recurse, arrays union, and uninstall prunes
-  exactly the entries we shipped (matched by the `session signal` marker, so it
-  stays correct across payload changes). Guarded by `requires_dir`; no-op when
+  exactly the entries we shipped. JSON recognises them by the `session signal`
+  marker in their content; TOML by an ownership comment stamped on each entry,
+  which is stricter in both directions — a hook *you* wrote that calls `session
+  signal` is not ours and survives uninstall, and an entry of ours whose event or
+  command changed in a later payload is still ours and gets replaced rather than
+  duplicated. Guarded by `requires_dir`; no-op when
   the merge is already present. A merge whose target is malformed is
   soft-skipped (logged, never aborts the rest of the install). JSON by default;
   `format = "toml"` picks the TOML merge (`agent::toml_merge`, on `toml_edit`,

--- a/extensions/hooks/extension.toml
+++ b/extensions/hooks/extension.toml
@@ -14,7 +14,7 @@
 name = "hooks"
 description = "Report each agent's lifecycle state (working/blocked/done) to thurbox via agent hooks."
 config_version = 1
-version = "1.7.0"  # v1.7: omp (Oh My Pi) status extension (ask/ask_user_question → blocked); v1.6: vibe hooks rewritten to vibe 2.21.0's real schema (pre_tool/post_agent); v1.5: pi (pi.dev) status extension
+version = "1.8.0"  # v1.8: grok (global ~/.grok/hooks drop) + kimi (TOML merge into ~/.kimi-code/config.toml) status hooks; v1.7: omp (Oh My Pi) status extension (ask/ask_user_question → blocked); v1.6: vibe hooks rewritten to vibe 2.21.0's real schema (pre_tool/post_agent); v1.5: pi (pi.dev) status extension
 # Default home; the auto-activation path overrides this with *this build's*
 # resolved config dir (`~/.config/thurbox` or `~/.config/thurbox-dev`) so dev and
 # release installs stay isolated. See `session_ops::builtin_hooks::hooks_home`.
@@ -162,3 +162,50 @@ requires_dir = "~/.copilot"
 path = "~/.gemini/settings.json"
 source = "antigravity-hooks.json"
 requires_dir = "~/.gemini"
+
+# grok (xAI's Grok Build CLI) loads hooks from ~/.grok/hooks/*.json, each file
+# read on its own, so we drop a managed standalone file in rather than touching
+# any file the user owns. Guarded by requires_dir so it's a no-op when grok isn't
+# installed. Global hooks are ALWAYS trusted and load on first launch, which is
+# why this is the global dir and not <project>/.grok/hooks — the project scope
+# additionally needs the folder granted trust in grok's own
+# ~/.grok/trusted_folders.toml (or a `--trust` launch flag, which would only
+# cover sessions thurbox itself launches).
+#
+# Grok is Claude-Code-compatible, so the mapping mirrors claude.json:
+# SessionStart → idle, UserPromptSubmit/PreToolUse/PostToolUse → working,
+# Notification (payload matched to permission/approval) → blocked, Stop → done.
+# The blocked command deliberately contains no `$` — a `$VAR` reference in a
+# grok hook command must carry an inline `:-default` or grok silently refuses to
+# load the whole hook file — so it pipes stdin through `grep` instead of
+# claude's `case "$(cat)"`.
+#
+# EXPERIMENTAL: the event names are grok's documented set; if a future grok
+# renames them, edit grok-hooks.json (no code change).
+[[external_files]]
+path = "~/.grok/hooks/thurbox-status.json"
+source = "grok-hooks.json"
+requires_dir = "~/.grok"
+
+# kimi (Kimi Code CLI) reads hooks from a `[[hooks]]` array in ONE shared file,
+# ~/.kimi-code/config.toml — there is no drop-in hooks dir, and that file holds
+# the user's whole configuration, so a managed external_file would clobber it.
+# It is merged instead, exactly like codex/antigravity, with `format = "toml"`
+# selecting `agent::toml_merge` (toml_edit, so the user's comments and key order
+# survive); uninstall prunes exactly our entries by the `session signal` marker.
+#
+# Events: SessionStart → idle, UserPromptSubmit/PreToolUse/PostToolUse →
+# working, PermissionRequest → blocked, PermissionResult → working, Stop → done.
+# Unlike claude/antigravity the block edge is STRUCTURED (a real
+# permission-request event, not a text match on a notification body) and has a
+# real clearing event, so it neither false-fires nor latches.
+#
+# EXPERIMENTAL: kimi accepts exactly four keys per hook entry
+# (event/command/matcher/timeout) and refuses to load the whole config file on a
+# fifth, so kimi-hooks.toml must never grow one. If a future kimi renames the
+# events, edit kimi-hooks.toml (no code change).
+[[config_merges]]
+path = "~/.kimi-code/config.toml"
+source = "kimi-hooks.toml"
+requires_dir = "~/.kimi-code"
+format = "toml"

--- a/extensions/hooks/grok-hooks.json
+++ b/extensions/hooks/grok-hooks.json
@@ -1,0 +1,72 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "thurbox-cli session signal --state idle || true  # managed by thurbox `extension install` — do not edit",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "thurbox-cli session signal --state working || true",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "thurbox-cli session signal --state working || true",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "thurbox-cli session signal --state working || true",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if cat | grep -qiE 'permission|approval|approve'; then thurbox-cli session signal --state blocked ; fi; true",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "thurbox-cli session signal --state done || true",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/extensions/hooks/kimi-hooks.toml
+++ b/extensions/hooks/kimi-hooks.toml
@@ -1,0 +1,38 @@
+# Managed by thurbox `extension install`: these entries report Kimi Code's
+# lifecycle to the thurbox session they run in. Deactivating the hooks extension
+# prunes exactly them and leaves the rest of this file alone.
+
+[[hooks]]
+event = "SessionStart"
+command = "thurbox-cli session signal --state idle || true"
+timeout = 10
+
+[[hooks]]
+event = "UserPromptSubmit"
+command = "thurbox-cli session signal --state working || true"
+timeout = 10
+
+[[hooks]]
+event = "PreToolUse"
+command = "thurbox-cli session signal --state working || true"
+timeout = 10
+
+[[hooks]]
+event = "PostToolUse"
+command = "thurbox-cli session signal --state working || true"
+timeout = 10
+
+[[hooks]]
+event = "PermissionRequest"
+command = "thurbox-cli session signal --state blocked || true"
+timeout = 10
+
+[[hooks]]
+event = "PermissionResult"
+command = "thurbox-cli session signal --state working || true"
+timeout = 10
+
+[[hooks]]
+event = "Stop"
+command = "thurbox-cli session signal --state done || true"
+timeout = 10

--- a/extensions/hooks/kimi-hooks.toml
+++ b/extensions/hooks/kimi-hooks.toml
@@ -1,37 +1,52 @@
-# Managed by thurbox `extension install`: these entries report Kimi Code's
-# lifecycle to the thurbox session they run in. Deactivating the hooks extension
-# prunes exactly them and leaves the rest of this file alone.
+# Kimi Code CLI status hooks, merged into the user's own ~/.kimi-code/config.toml.
+#
+# The comment above each entry is its ownership record, not decoration: it is how
+# uninstall tells these entries from a hook the user wrote themselves (which may
+# legitimately call `thurbox-cli session signal` too), and how an update
+# recognises an entry of ours whose event or command has since changed. Every
+# entry must carry it — see `agent::toml_merge`.
+#
+# Kimi accepts exactly four keys per entry (event/command/matcher/timeout) and
+# refuses to load the whole config file when it sees a fifth, which is why
+# ownership lives in a comment rather than in a field.
 
+# managed by thurbox `extension install` — do not edit
 [[hooks]]
 event = "SessionStart"
 command = "thurbox-cli session signal --state idle || true"
 timeout = 10
 
+# managed by thurbox `extension install` — do not edit
 [[hooks]]
 event = "UserPromptSubmit"
 command = "thurbox-cli session signal --state working || true"
 timeout = 10
 
+# managed by thurbox `extension install` — do not edit
 [[hooks]]
 event = "PreToolUse"
 command = "thurbox-cli session signal --state working || true"
 timeout = 10
 
+# managed by thurbox `extension install` — do not edit
 [[hooks]]
 event = "PostToolUse"
 command = "thurbox-cli session signal --state working || true"
 timeout = 10
 
+# managed by thurbox `extension install` — do not edit
 [[hooks]]
 event = "PermissionRequest"
 command = "thurbox-cli session signal --state blocked || true"
 timeout = 10
 
+# managed by thurbox `extension install` — do not edit
 [[hooks]]
 event = "PermissionResult"
 command = "thurbox-cli session signal --state working || true"
 timeout = 10
 
+# managed by thurbox `extension install` — do not edit
 [[hooks]]
 event = "Stop"
 command = "thurbox-cli session signal --state done || true"

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -14,6 +14,7 @@ pub mod self_update;
 pub mod settings_config;
 pub mod themes_config;
 pub mod tmux;
+pub mod toml_merge;
 pub mod transport;
 pub mod version_check;
 

--- a/src/agent/toml_merge.rs
+++ b/src/agent/toml_merge.rs
@@ -4,25 +4,57 @@
 //! It exists because kimi (Kimi Code CLI) reads its hooks from one shared file,
 //! `~/.kimi-code/config.toml`, and offers no drop-in hooks directory: dropping a
 //! managed file there would clobber the user's whole configuration, and the JSON
-//! merge cannot read it. The semantics are deliberately the same as the JSON
-//! one, so a manifest author reasons about one mechanism:
+//! merge cannot read it.
 //!
 //! - [`merge`]: tables merge recursively; arrays (both `[[array of tables]]` and
 //!   inline arrays) union by rendered equality — an entry the target already has
 //!   is not appended twice. Idempotent, and a **type conflict with the user's
 //!   value is left alone** (never overwritten).
-//! - [`prune_marked`]: remove our entries on uninstall by the **marker** every
-//!   shipped hook command carries, so it stays correct across payload changes.
+//! - [`prune_owned`]: remove our entries — and only ours — by an **ownership
+//!   marker carried in each entry's own comment**.
 //!
-//! The one behaviour JSON does not need: the target is parsed with `toml_edit`
-//! rather than `toml`, so the user's comments, key order and spacing survive a
-//! merge into a file they wrote by hand. The consequence for a manifest author
-//! is that the *shape* has to match — a target spelling kimi's hooks as an
-//! inline `hooks = [{…}]` array where the payload ships `[[hooks]]` tables is a
-//! type conflict, so it is left untouched and the agent goes unreported rather
-//! than having its config rewritten into the other shape.
+//! # Why ownership is a comment and not a content match
+//!
+//! [`crate::agent::json_merge::prune_marked`] identifies our entries by finding
+//! a marker *in the entry's content* (every shipped hook command contains
+//! `thurbox-cli session signal`). That is the only thing JSON offers — it has no
+//! comments, and an ownership *key* inside the entry is not available either:
+//! kimi accepts exactly four keys per hook and refuses to load the entire config
+//! file when it sees a fifth. But a content match cannot answer either half of
+//! the question it is asked:
+//!
+//! - It cannot tell **our** entry from the user's. `extensions/hooks/README.md`
+//!   tells a user with an uninstrumented agent to call `thurbox-cli session
+//!   signal` from their own hook; a content match then deletes that hook on
+//!   uninstall — destroying configuration we never wrote.
+//! - It cannot recognise **our own previous entry** once its content changes. A
+//!   payload that renames an event or edits a command leaves the old entry
+//!   behind, so updates accumulate duplicates.
+//!
+//! TOML has one thing JSON does not: comment decor that `toml_edit` binds to the
+//! entry and carries through a render/re-parse round trip. So an entry is ours
+//! **iff its own comment says so**, which answers both halves — a user hook that
+//! merely mentions the signal command is not ours, and an entry of ours whose
+//! content has since changed still is. Callers pair [`prune_owned`] with
+//! [`merge`] (prune, then merge) so an update replaces our entries rather than
+//! stacking a second copy beside them.
+//!
+//! The marker's one failure mode is a third-party tool that strips comments
+//! while rewriting the file: our entries stop being recognised, so the next
+//! install appends a second copy instead of replacing. That degrades to a
+//! duplicate signal — the same state written twice, which is idempotent — and is
+//! deliberately preferred to a content rule that deletes the user's own hooks.
+//!
+//! The target is parsed with `toml_edit` rather than `toml`, so the user's
+//! comments, key order and spacing survive a merge into a file they wrote by
+//! hand. The consequence for a manifest author is that the *shape* has to match
+//! — a target spelling kimi's hooks as an inline `hooks = [{…}]` array where the
+//! payload ships `[[hooks]]` tables is a type conflict, so it is left untouched
+//! and the agent goes unreported rather than having its config rewritten into
+//! the other shape. An inline array also has no comment to own, which is the
+//! second reason the payload ships `[[hooks]]` tables.
 
-use toml_edit::{DocumentMut, Item, Value};
+use toml_edit::{DocumentMut, Item, Table, Value};
 
 /// Deep-merge `source` into `target` in place (see module docs).
 pub fn merge(target: &mut DocumentMut, source: &DocumentMut) {
@@ -63,12 +95,32 @@ fn merge_item(target: &mut Item, source: &Item) {
     }
 }
 
-/// Remove every array entry whose rendered TOML contains `marker`, anywhere in
-/// `doc`, then drop keys whose array *we* emptied. Reverses a [`merge`] of hook
-/// entries on uninstall: every entry we ship carries the marker in its command,
-/// so this removes exactly (and only) ours.
-pub fn prune_marked(doc: &mut DocumentMut, marker: &str) {
+/// Remove every `[[array of tables]]` entry **thurbox owns** — one whose own
+/// comment carries `marker` — anywhere in `doc`, then drop a key whose array
+/// *we* emptied.
+///
+/// Ownership is the entry's comment, never its content: a user hook that calls
+/// `thurbox-cli session signal` itself is not ours and survives, and an entry of
+/// ours whose event or command changed in a later payload is still ours and is
+/// replaced. See the module docs for why the JSON sibling cannot do this.
+///
+/// Reverses a [`merge`] on uninstall, and pairs with it on install
+/// (prune, then merge) so an update replaces rather than accumulates.
+pub fn prune_owned(doc: &mut DocumentMut, marker: &str) {
     prune_item(doc.as_item_mut(), marker);
+}
+
+/// Whether `table` is an entry thurbox wrote: its own comment carries `marker`.
+///
+/// The comment is the table's *prefix decor*, which `toml_edit` preserves across
+/// a render and re-parse. Deliberately not `Table::to_string`, which renders the
+/// body without any decor at all.
+fn is_owned(table: &Table, marker: &str) -> bool {
+    table
+        .decor()
+        .prefix()
+        .and_then(|d| d.as_str())
+        .is_some_and(|prefix| prefix.contains(marker))
 }
 
 fn prune_item(item: &mut Item, marker: &str) {
@@ -89,11 +141,10 @@ fn prune_item(item: &mut Item, marker: &str) {
             }
         }
         Item::ArrayOfTables(entries) => {
-            entries.retain(|e| !e.to_string().contains(marker));
+            entries.retain(|t| !is_owned(t, marker));
         }
-        Item::Value(Value::Array(entries)) => {
-            entries.retain(|e| !e.to_string().contains(marker));
-        }
+        // An inline array carries no comment, so nothing in one can be proven
+        // ours. Left alone rather than guessed at from its content.
         _ => {}
     }
 }
@@ -110,22 +161,33 @@ fn is_empty_array(item: &Item) -> bool {
 mod tests {
     use super::*;
 
-    const M: &str = "thurbox-cli session signal";
+    /// The signal command every shipped hook carries — and, deliberately, the
+    /// thing a user may put in a hook of their own.
+    const SIGNAL: &str = "thurbox-cli session signal";
+    /// The ownership marker the payload stamps on each entry it ships.
+    const OWNED: &str = "thurbox `extension install`";
 
     fn doc(text: &str) -> DocumentMut {
         text.parse().expect("valid TOML")
     }
 
-    fn ours() -> DocumentMut {
+    /// A payload entry shaped like the shipped one: an ownership comment above
+    /// an otherwise ordinary `[[hooks]]` table.
+    fn ours(event: &str, state: &str, timeout: u32) -> DocumentMut {
         doc(&format!(
-            "[[hooks]]\nevent = \"Stop\"\ncommand = \"{M} --state done || true\"\n"
+            "# managed by {OWNED}\n[[hooks]]\nevent = \"{event}\"\n\
+             command = \"{SIGNAL} --state {state} || true\"\ntimeout = {timeout}\n"
         ))
+    }
+
+    fn hooks_len(text: &str) -> usize {
+        doc(text)["hooks"].as_array_of_tables().unwrap().len()
     }
 
     #[test]
     fn merge_into_empty_takes_source() {
         let mut target = doc("");
-        merge(&mut target, &ours());
+        merge(&mut target, &ours("Stop", "done", 10));
         assert!(target.to_string().contains("--state done"));
     }
 
@@ -133,21 +195,21 @@ mod tests {
     fn merge_preserves_user_entries_comments_and_unrelated_keys() {
         let mut target = doc("# my config\nmodel = \"kimi-for-coding\"\n\n\
              [[hooks]]\nevent = \"Stop\"\ncommand = \"notify-send done\"\n");
-        merge(&mut target, &ours());
+        merge(&mut target, &ours("Stop", "done", 10));
         let out = target.to_string();
         assert!(out.contains("# my config"), "comment survived: {out}");
         assert!(out.contains("model = \"kimi-for-coding\""));
         assert!(out.contains("notify-send done"), "user hook survived");
         assert!(out.contains("--state done"), "ours appended");
-        assert_eq!(doc(&out)["hooks"].as_array_of_tables().unwrap().len(), 2);
+        assert_eq!(hooks_len(&out), 2);
     }
 
     #[test]
     fn merge_is_idempotent() {
         let mut target = doc("");
-        merge(&mut target, &ours());
+        merge(&mut target, &ours("Stop", "done", 10));
         let once = target.to_string();
-        merge(&mut target, &ours());
+        merge(&mut target, &ours("Stop", "done", 10));
         assert_eq!(target.to_string(), once);
     }
 
@@ -157,40 +219,83 @@ mod tests {
         // `[[hooks]]`. Rewriting their file into the other shape is not ours to
         // do, so nothing is merged.
         let mut target = doc("hooks = [{ event = \"Stop\", command = \"mine\" }]\n");
-        merge(&mut target, &ours());
+        merge(&mut target, &ours("Stop", "done", 10));
         assert!(!target.to_string().contains("--state done"));
         assert!(target.to_string().contains("mine"));
     }
 
+    /// The destructive case ownership-by-comment exists to prevent: a user who
+    /// wired their *own* hook to `thurbox-cli session signal` — which
+    /// `extensions/hooks/README.md` tells them to do for an agent thurbox does
+    /// not instrument — must not have it deleted when thurbox uninstalls.
     #[test]
-    fn prune_removes_exactly_our_marked_entries() {
-        let mut target = doc("model = \"kimi-for-coding\"\n\n\
-             [[hooks]]\nevent = \"Stop\"\ncommand = \"notify-send done\"\n");
-        merge(&mut target, &ours());
-        prune_marked(&mut target, M);
+    fn uninstall_keeps_a_user_hook_that_calls_the_signal_command_itself() {
+        let users_own = format!(
+            "model = \"kimi-for-coding\"\n\n\
+             [[hooks]]\nevent = \"Stop\"\ncommand = \"{SIGNAL} --state done || true\"\n"
+        );
+        let mut target = doc(&users_own);
+        merge(&mut target, &ours("Stop", "done", 10));
+        assert_eq!(hooks_len(&target.to_string()), 2, "ours sits beside theirs");
+
+        prune_owned(&mut target, OWNED);
         let out = target.to_string();
-        assert!(!out.contains(M), "ours gone: {out}");
-        assert!(out.contains("notify-send done"), "user hook survived");
-        assert!(out.contains("model = \"kimi-for-coding\""));
+        assert_eq!(hooks_len(&out), 1, "exactly one entry removed: {out}");
+        assert!(
+            out.contains(SIGNAL),
+            "the user's own signal hook survived: {out}"
+        );
+        // Nothing of ours is left, and their file is back as it was.
+        assert!(!out.contains(OWNED));
+        assert_eq!(out, users_own);
+    }
+
+    /// The other half of the same rule: our entry stays ours after its content
+    /// changes, so an update replaces it instead of stacking a second copy.
+    #[test]
+    fn a_changed_payload_replaces_our_previous_entry_instead_of_accumulating() {
+        let mut target = doc("[[hooks]]\nevent = \"Stop\"\ncommand = \"mine\"\n");
+        merge(&mut target, &ours("Stop", "done", 10));
+
+        // A later payload renames the event and changes the timeout — nothing
+        // of its content matches the entry already on disk.
+        let installed = target.to_string();
+        let mut updated = doc(&installed);
+        prune_owned(&mut updated, OWNED);
+        merge(&mut updated, &ours("SessionEnd", "idle", 30));
+
+        let out = updated.to_string();
+        assert_eq!(hooks_len(&out), 2, "the user's plus exactly one of ours");
+        assert!(!out.contains("--state done"), "stale entry gone: {out}");
+        assert!(!out.contains("timeout = 10"));
+        assert!(out.contains("--state idle") && out.contains("timeout = 30"));
+        assert!(out.contains("command = \"mine\""), "user hook untouched");
+
+        // And re-applying the same payload changes nothing (no churn on the
+        // startup/heartbeat re-install).
+        let mut again = doc(&out);
+        prune_owned(&mut again, OWNED);
+        merge(&mut again, &ours("SessionEnd", "idle", 30));
+        assert_eq!(again.to_string(), out);
     }
 
     #[test]
     fn prune_drops_a_key_it_emptied_but_not_one_the_user_left_empty() {
         let mut target = doc("");
-        merge(&mut target, &ours());
-        prune_marked(&mut target, M);
+        merge(&mut target, &ours("Stop", "done", 10));
+        prune_owned(&mut target, OWNED);
         assert!(!target.to_string().contains("hooks"));
 
         let mut users_empty = doc("hooks = []\n");
-        prune_marked(&mut users_empty, M);
+        prune_owned(&mut users_empty, OWNED);
         assert!(users_empty.to_string().contains("hooks = []"));
     }
 
     #[test]
-    fn prune_is_a_no_op_for_marker_free_content() {
+    fn prune_is_a_no_op_for_content_we_do_not_own() {
         let mut target = doc("[[hooks]]\nevent = \"Stop\"\ncommand = \"mine\"\n");
         let before = target.to_string();
-        prune_marked(&mut target, M);
+        prune_owned(&mut target, OWNED);
         assert_eq!(target.to_string(), before);
     }
 }

--- a/src/agent/toml_merge.rs
+++ b/src/agent/toml_merge.rs
@@ -1,0 +1,196 @@
+//! Reversible, non-destructive **TOML** deep-merge — [`crate::agent::json_merge`]'s
+//! sibling for a `[[config_merges]]` whose target is TOML rather than JSON.
+//!
+//! It exists because kimi (Kimi Code CLI) reads its hooks from one shared file,
+//! `~/.kimi-code/config.toml`, and offers no drop-in hooks directory: dropping a
+//! managed file there would clobber the user's whole configuration, and the JSON
+//! merge cannot read it. The semantics are deliberately the same as the JSON
+//! one, so a manifest author reasons about one mechanism:
+//!
+//! - [`merge`]: tables merge recursively; arrays (both `[[array of tables]]` and
+//!   inline arrays) union by rendered equality — an entry the target already has
+//!   is not appended twice. Idempotent, and a **type conflict with the user's
+//!   value is left alone** (never overwritten).
+//! - [`prune_marked`]: remove our entries on uninstall by the **marker** every
+//!   shipped hook command carries, so it stays correct across payload changes.
+//!
+//! The one behaviour JSON does not need: the target is parsed with `toml_edit`
+//! rather than `toml`, so the user's comments, key order and spacing survive a
+//! merge into a file they wrote by hand. The consequence for a manifest author
+//! is that the *shape* has to match — a target spelling kimi's hooks as an
+//! inline `hooks = [{…}]` array where the payload ships `[[hooks]]` tables is a
+//! type conflict, so it is left untouched and the agent goes unreported rather
+//! than having its config rewritten into the other shape.
+
+use toml_edit::{DocumentMut, Item, Value};
+
+/// Deep-merge `source` into `target` in place (see module docs).
+pub fn merge(target: &mut DocumentMut, source: &DocumentMut) {
+    merge_item(target.as_item_mut(), source.as_item());
+}
+
+fn merge_item(target: &mut Item, source: &Item) {
+    match (target, source) {
+        (Item::Table(t), Item::Table(s)) => {
+            for (key, sv) in s.iter() {
+                match t.get_mut(key) {
+                    Some(tv) => merge_item(tv, sv),
+                    None => {
+                        t.insert(key, sv.clone());
+                    }
+                }
+            }
+        }
+        (Item::ArrayOfTables(t), Item::ArrayOfTables(s)) => {
+            for entry in s.iter() {
+                let rendered = entry.to_string();
+                if !t.iter().any(|e| e.to_string() == rendered) {
+                    t.push(entry.clone());
+                }
+            }
+        }
+        (Item::Value(Value::Array(t)), Item::Value(Value::Array(s))) => {
+            for entry in s.iter() {
+                let rendered = entry.to_string();
+                if !t.iter().any(|e| e.to_string() == rendered) {
+                    t.push_formatted(entry.clone());
+                }
+            }
+        }
+        // Type conflict (the user has a different shape here): leave their
+        // value untouched rather than corrupt it.
+        _ => {}
+    }
+}
+
+/// Remove every array entry whose rendered TOML contains `marker`, anywhere in
+/// `doc`, then drop keys whose array *we* emptied. Reverses a [`merge`] of hook
+/// entries on uninstall: every entry we ship carries the marker in its command,
+/// so this removes exactly (and only) ours.
+pub fn prune_marked(doc: &mut DocumentMut, marker: &str) {
+    prune_item(doc.as_item_mut(), marker);
+}
+
+fn prune_item(item: &mut Item, marker: &str) {
+    match item {
+        Item::Table(table) => {
+            let keys: Vec<String> = table.iter().map(|(k, _)| k.to_string()).collect();
+            for key in keys {
+                let Some(value) = table.get_mut(&key) else {
+                    continue;
+                };
+                // Only drop a key that *we* emptied: a user's pre-existing empty
+                // array must survive untouched.
+                let was_empty = is_empty_array(value);
+                prune_item(value, marker);
+                if !was_empty && is_empty_array(value) {
+                    table.remove(&key);
+                }
+            }
+        }
+        Item::ArrayOfTables(entries) => {
+            entries.retain(|e| !e.to_string().contains(marker));
+        }
+        Item::Value(Value::Array(entries)) => {
+            entries.retain(|e| !e.to_string().contains(marker));
+        }
+        _ => {}
+    }
+}
+
+fn is_empty_array(item: &Item) -> bool {
+    match item {
+        Item::ArrayOfTables(entries) => entries.is_empty(),
+        Item::Value(Value::Array(entries)) => entries.is_empty(),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const M: &str = "thurbox-cli session signal";
+
+    fn doc(text: &str) -> DocumentMut {
+        text.parse().expect("valid TOML")
+    }
+
+    fn ours() -> DocumentMut {
+        doc(&format!(
+            "[[hooks]]\nevent = \"Stop\"\ncommand = \"{M} --state done || true\"\n"
+        ))
+    }
+
+    #[test]
+    fn merge_into_empty_takes_source() {
+        let mut target = doc("");
+        merge(&mut target, &ours());
+        assert!(target.to_string().contains("--state done"));
+    }
+
+    #[test]
+    fn merge_preserves_user_entries_comments_and_unrelated_keys() {
+        let mut target = doc("# my config\nmodel = \"kimi-for-coding\"\n\n\
+             [[hooks]]\nevent = \"Stop\"\ncommand = \"notify-send done\"\n");
+        merge(&mut target, &ours());
+        let out = target.to_string();
+        assert!(out.contains("# my config"), "comment survived: {out}");
+        assert!(out.contains("model = \"kimi-for-coding\""));
+        assert!(out.contains("notify-send done"), "user hook survived");
+        assert!(out.contains("--state done"), "ours appended");
+        assert_eq!(doc(&out)["hooks"].as_array_of_tables().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn merge_is_idempotent() {
+        let mut target = doc("");
+        merge(&mut target, &ours());
+        let once = target.to_string();
+        merge(&mut target, &ours());
+        assert_eq!(target.to_string(), once);
+    }
+
+    #[test]
+    fn a_type_conflict_leaves_the_users_value_alone() {
+        // The user spells hooks as an inline array of inline tables; we ship
+        // `[[hooks]]`. Rewriting their file into the other shape is not ours to
+        // do, so nothing is merged.
+        let mut target = doc("hooks = [{ event = \"Stop\", command = \"mine\" }]\n");
+        merge(&mut target, &ours());
+        assert!(!target.to_string().contains("--state done"));
+        assert!(target.to_string().contains("mine"));
+    }
+
+    #[test]
+    fn prune_removes_exactly_our_marked_entries() {
+        let mut target = doc("model = \"kimi-for-coding\"\n\n\
+             [[hooks]]\nevent = \"Stop\"\ncommand = \"notify-send done\"\n");
+        merge(&mut target, &ours());
+        prune_marked(&mut target, M);
+        let out = target.to_string();
+        assert!(!out.contains(M), "ours gone: {out}");
+        assert!(out.contains("notify-send done"), "user hook survived");
+        assert!(out.contains("model = \"kimi-for-coding\""));
+    }
+
+    #[test]
+    fn prune_drops_a_key_it_emptied_but_not_one_the_user_left_empty() {
+        let mut target = doc("");
+        merge(&mut target, &ours());
+        prune_marked(&mut target, M);
+        assert!(!target.to_string().contains("hooks"));
+
+        let mut users_empty = doc("hooks = []\n");
+        prune_marked(&mut users_empty, M);
+        assert!(users_empty.to_string().contains("hooks = []"));
+    }
+
+    #[test]
+    fn prune_is_a_no_op_for_marker_free_content() {
+        let mut target = doc("[[hooks]]\nevent = \"Stop\"\ncommand = \"mine\"\n");
+        let before = target.to_string();
+        prune_marked(&mut target, M);
+        assert_eq!(target.to_string(), before);
+    }
+}

--- a/src/cli/automations.rs
+++ b/src/cli/automations.rs
@@ -776,6 +776,19 @@ mod tests {
         let temp = tempfile::TempDir::new().unwrap();
         let _guard = crate::paths::TestPathGuard::new(temp.path());
         let db = Database::open_in_memory().unwrap();
+        // The tick self-heals the built-in extensions, whose outside-reaching
+        // payloads resolve against `$HOME` — which `TestPathGuard` does not
+        // redirect, because they target the *agent's* config dir rather than
+        // thurbox's. Without opting out, running the test suite installs hook
+        // files into the developer's own `~/.codex`, `~/.grok`, … Opt both
+        // built-ins out: this test is about what `tick` reports, not about
+        // what an install does.
+        for name in [
+            crate::session_ops::builtin_hooks::HOOKS_EXTENSION_NAME,
+            crate::session_ops::builtin_ui_skill::UI_SKILL_EXTENSION_NAME,
+        ] {
+            db.set_builtin_extension_optout(name, true).unwrap();
+        }
         let v = tick(&db).unwrap();
         assert_eq!(v["fired"], json!([]));
         assert_eq!(v["skipped"], json!([]));

--- a/src/session/extension_def.rs
+++ b/src/session/extension_def.rs
@@ -118,19 +118,32 @@ pub struct AgentPatch {
     pub append_args: Vec<String>,
 }
 
-/// A **non-destructive, reversible JSON merge** into a config file an agent owns
+/// How a [`ConfigMerge`]'s target (and the shipped source) is encoded.
+///
+/// The merge semantics are the same either way — recurse into tables/objects,
+/// union arrays, leave a type conflict with the user's value alone — so this
+/// only picks which parser reads the two documents.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ConfigMergeFormat {
+    #[default]
+    Json,
+    Toml,
+}
+
+/// A **non-destructive, reversible merge** into a config file an agent owns
 /// (e.g. `~/.gemini/settings.json`). Unlike [`ExternalFile`] (which writes a
 /// whole file and would clobber the user's config), this deep-merges the shipped
-/// `source` JSON into the target in place: objects recurse, arrays union by
-/// deep-equality, and uninstall removes exactly our entries (see
-/// `agent::json_merge`). For agents whose hooks live in a *shared* config file
-/// that has no drop-in plugin location.
+/// `source` document into the target in place: objects/tables recurse, arrays
+/// union, and uninstall removes exactly our entries (see `agent::json_merge`,
+/// and `agent::toml_merge` for `format = "toml"`). For agents whose hooks live
+/// in a *shared* config file that has no drop-in plugin location.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ConfigMerge {
     /// Target config file: absolute, `~`-relative, or containing [`HOME_TOKEN`].
     pub path: String,
-    /// Source path (relative to the install source) of the JSON to merge in;
-    /// defaults to `path`'s file name.
+    /// Source path (relative to the install source) of the document to merge
+    /// in; defaults to `path`'s file name.
     #[serde(default)]
     pub source: Option<String>,
     /// Only merge when this directory exists (absolute / `~`) — skips the merge
@@ -138,10 +151,14 @@ pub struct ConfigMerge {
     /// [`ExternalFile::requires_dir`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub requires_dir: Option<String>,
+    /// Encoding of both the target and the shipped source. JSON unless the
+    /// agent's shared config is TOML (kimi's `~/.kimi-code/config.toml`).
+    #[serde(default)]
+    pub format: ConfigMergeFormat,
 }
 
 impl ConfigMerge {
-    /// Source-relative path to read the JSON-to-merge from (defaults to the
+    /// Source-relative path to read the document-to-merge from (defaults to the
     /// destination's file name).
     pub fn source_path(&self) -> &str {
         source_or_dest_filename(&self.source, &self.path)
@@ -664,6 +681,7 @@ prompt = "tick"
             path: "~/.gemini/settings.json".into(),
             source: Some("gemini-hooks.json".into()),
             requires_dir: None,
+            format: ConfigMergeFormat::Json,
         };
         assert_eq!(explicit.source_path(), "gemini-hooks.json");
         // Unset source falls back to the destination's file name (not its full
@@ -672,8 +690,21 @@ prompt = "tick"
             path: "~/.gemini/settings.json".into(),
             source: None,
             requires_dir: None,
+            format: ConfigMergeFormat::Json,
         };
         assert_eq!(defaulted.source_path(), "settings.json");
+    }
+
+    #[test]
+    fn config_merge_format_defaults_to_json_and_parses_toml() {
+        let def: ExtensionDef = toml::from_str(
+            "name = \"hooks\"\n\
+             [[config_merges]]\npath = \"~/.codex/hooks.json\"\n\
+             [[config_merges]]\npath = \"~/.kimi-code/config.toml\"\nformat = \"toml\"\n",
+        )
+        .expect("manifest parses");
+        assert_eq!(def.config_merges[0].format, ConfigMergeFormat::Json);
+        assert_eq!(def.config_merges[1].format, ConfigMergeFormat::Toml);
     }
 
     #[test]

--- a/src/session/hook_status.rs
+++ b/src/session/hook_status.rs
@@ -54,9 +54,10 @@ pub enum HookDelivery {
     /// Args appended to the agent's launch command (`[[agent_patches]]`).
     /// Wired at spawn, so it covers only agents thurbox itself launches.
     Args,
-    /// A reversible JSON deep-merge into a config file the agent and its user
-    /// share (`[[config_merges]]`).
-    MergeJson,
+    /// A reversible deep-merge into a config file the agent and its user share
+    /// (`[[config_merges]]`) — JSON, or TOML for an agent whose shared config is
+    /// TOML (kimi).
+    ConfigMerge,
     /// A standalone thurbox-managed file dropped into the agent's own config
     /// directory (`[[external_files]]`).
     File,
@@ -67,7 +68,7 @@ impl HookDelivery {
     pub fn as_str(self) -> &'static str {
         match self {
             HookDelivery::Args => "args",
-            HookDelivery::MergeJson => "config-merge",
+            HookDelivery::ConfigMerge => "config-merge",
             HookDelivery::File => "config-file",
         }
     }
@@ -139,14 +140,14 @@ pub const AGENT_HOOK_COVERAGE: &[AgentHookCoverage] = &[
     AgentHookCoverage {
         agent: "codex",
         states: &["working", "done", "idle"],
-        delivery: HookDelivery::MergeJson,
+        delivery: HookDelivery::ConfigMerge,
         hook_file: Some("~/.codex/hooks.json"),
         blocked_is_heuristic: false,
     },
     AgentHookCoverage {
         agent: "antigravity",
         states: &["working", "blocked", "done", "idle"],
-        delivery: HookDelivery::MergeJson,
+        delivery: HookDelivery::ConfigMerge,
         hook_file: Some("~/.gemini/settings.json"),
         // agy adopted claude's schema, including the text match.
         blocked_is_heuristic: true,
@@ -184,6 +185,24 @@ pub const AGENT_HOOK_COVERAGE: &[AgentHookCoverage] = &[
         states: &["working", "blocked", "done", "idle"],
         delivery: HookDelivery::File,
         hook_file: Some("~/.omp/agent/extensions/thurbox-status.ts"),
+        blocked_is_heuristic: false,
+    },
+    AgentHookCoverage {
+        agent: "grok",
+        states: &["working", "blocked", "done", "idle"],
+        delivery: HookDelivery::File,
+        hook_file: Some("~/.grok/hooks/thurbox-status.json"),
+        // grok is claude-shaped, including the `Notification` text match.
+        blocked_is_heuristic: true,
+    },
+    AgentHookCoverage {
+        agent: "kimi",
+        states: &["working", "blocked", "done", "idle"],
+        delivery: HookDelivery::ConfigMerge,
+        hook_file: Some("~/.kimi-code/config.toml"),
+        // kimi has a real `PermissionRequest` event (and a `PermissionResult`
+        // to clear it), so the block edge is structured rather than a text
+        // match on a notification body.
         blocked_is_heuristic: false,
     },
 ];
@@ -1288,17 +1307,20 @@ mod tests {
 
     #[test]
     fn claude_and_antigravity_are_flagged_as_matching_notification_text() {
-        // Both grep the notification body for *permission*/*approval*, so a
+        // These grep the notification body for *permission*/*approval*, so a
         // reworded upstream notification stops `blocked` silently. A consumer
-        // has to be able to see that from the data.
-        for name in ["claude", "antigravity"] {
+        // has to be able to see that from the data. kimi is the counter-case
+        // that makes the flag worth publishing: it has a real
+        // `PermissionRequest` event, so its silence about `blocked` means the
+        // agent is not blocked rather than "the wording may have moved".
+        for name in ["claude", "antigravity", "grok"] {
             let c = AGENT_HOOK_COVERAGE
                 .iter()
                 .find(|c| c.agent == name)
                 .expect("covered");
             assert!(c.blocked_is_heuristic, "{name}");
         }
-        for name in ["opencode", "copilot", "codex", "vibe"] {
+        for name in ["opencode", "copilot", "codex", "vibe", "kimi"] {
             let c = AGENT_HOOK_COVERAGE
                 .iter()
                 .find(|c| c.agent == name)

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -18,8 +18,8 @@ pub use automation::{
     AutomationSchedule, ExtraRepo, SchedulePreset,
 };
 pub use extension_def::{
-    AgentPatch, ConfigMerge, ExtensionAutomation, ExtensionDef, ExtensionFile, ExtensionSession,
-    ExtensionSymlink, ExternalFile,
+    AgentPatch, ConfigMerge, ConfigMergeFormat, ExtensionAutomation, ExtensionDef, ExtensionFile,
+    ExtensionSession, ExtensionSymlink, ExternalFile,
 };
 pub use hook_def::{
     HookContext, HookEvent, HookWorktree, HooksFile, LifecycleHook, DEFAULT_HOOK_TIMEOUT_SECS,

--- a/src/session_ops/builtin_hooks.rs
+++ b/src/session_ops/builtin_hooks.rs
@@ -229,13 +229,28 @@ mod tests {
         // A remote grok/kimi session reports through the tmux pane option, so
         // the rewrite has to survive each payload's own syntax — JSON string
         // escaping for grok, TOML for kimi.
+        // Checked on the *commands*, not the raw text: a payload may mention
+        // `thurbox-cli` in a comment (kimi's does, explaining the ownership
+        // marker), and a comment is not something the agent runs.
         let grok = rewrite_hook_signals_for_remote(GROK_HOOKS);
-        assert!(!grok.contains("thurbox-cli"));
-        serde_json::from_str::<serde_json::Value>(&grok).expect("grok stays valid JSON");
+        let grok_doc: serde_json::Value =
+            serde_json::from_str(&grok).expect("grok stays valid JSON");
+        for command in json_hook_commands(&grok_doc) {
+            assert!(
+                !command.contains("thurbox-cli"),
+                "grok command still calls the local CLI: {command}"
+            );
+        }
 
         let kimi = rewrite_hook_signals_for_remote(KIMI_HOOKS);
-        assert!(!kimi.contains("thurbox-cli"));
-        toml::from_str::<toml::Value>(&kimi).expect("kimi stays valid TOML");
+        let kimi_doc: toml::Value = toml::from_str(&kimi).expect("kimi stays valid TOML");
+        for hook in kimi_doc["hooks"].as_array().expect("[[hooks]]") {
+            let command = hook["command"].as_str().expect("hook has a command");
+            assert!(
+                !command.contains("thurbox-cli"),
+                "kimi command still calls the local CLI: {command}"
+            );
+        }
 
         for state in ["idle", "working", "blocked", "done"] {
             let option = format!("tmux set-option -p @thurbox_state {state}");
@@ -490,6 +505,48 @@ mod tests {
         assert!(mapped("PermissionResult").contains("--state working"));
         assert!(mapped("SessionStart").contains("--state idle"));
         assert!(mapped("Stop").contains("--state done"));
+    }
+
+    /// kimi's entries are merged into a file the user also writes hooks in, so
+    /// uninstall has to tell ours from theirs. It does that by the ownership
+    /// comment on each entry (`agent::toml_merge`) — an entry shipped without
+    /// one would be installed and then never pruned, and an update would stack a
+    /// second copy beside it.
+    #[test]
+    fn every_kimi_entry_carries_the_ownership_marker() {
+        let doc: toml_edit::DocumentMut = KIMI_HOOKS.parse().expect("kimi payload is valid TOML");
+        let entries = doc["hooks"]
+            .as_array_of_tables()
+            .expect("[[hooks]] table array");
+        assert!(!entries.is_empty());
+        for entry in entries.iter() {
+            let event = entry["event"].as_str().unwrap_or("<no event>");
+            let prefix = entry
+                .decor()
+                .prefix()
+                .and_then(|d| d.as_str())
+                .unwrap_or_default();
+            assert!(
+                prefix.contains(super::super::extensions::MANAGED_MARKER),
+                "kimi hook `{event}` ships without the ownership comment, so \
+                 uninstall would leave it behind"
+            );
+        }
+
+        // And the marker really does round-trip through a render + re-parse,
+        // which is what makes it usable as ownership at uninstall time.
+        let reparsed: toml_edit::DocumentMut = doc.to_string().parse().expect("re-parses");
+        assert_eq!(
+            reparsed["hooks"].as_array_of_tables().unwrap().len(),
+            entries.len()
+        );
+        for entry in reparsed["hooks"].as_array_of_tables().unwrap().iter() {
+            assert!(entry
+                .decor()
+                .prefix()
+                .and_then(|d| d.as_str())
+                .is_some_and(|p| p.contains(super::super::extensions::MANAGED_MARKER)));
+        }
     }
 
     #[test]

--- a/src/session_ops/builtin_hooks.rs
+++ b/src/session_ops/builtin_hooks.rs
@@ -30,6 +30,8 @@ pub(crate) const VIBE_HOOKS: &str = include_str!("../../extensions/hooks/vibe-ho
 pub(crate) const COPILOT_HOOKS: &str = include_str!("../../extensions/hooks/copilot-hooks.json");
 pub(crate) const PI_STATUS: &str = include_str!("../../extensions/hooks/pi-status.ts");
 pub(crate) const OMP_STATUS: &str = include_str!("../../extensions/hooks/omp-status.ts");
+pub(crate) const GROK_HOOKS: &str = include_str!("../../extensions/hooks/grok-hooks.json");
+pub(crate) const KIMI_HOOKS: &str = include_str!("../../extensions/hooks/kimi-hooks.toml");
 
 /// Marker prefix of every thurbox-managed hook command; the state word
 /// (`working`/`blocked`/`done`/`idle`) follows it directly.
@@ -159,6 +161,8 @@ pub(crate) static HOOKS: Builtin = Builtin {
         ("copilot-hooks.json", COPILOT_HOOKS),
         ("pi-status.ts", PI_STATUS),
         ("omp-status.ts", OMP_STATUS),
+        ("grok-hooks.json", GROK_HOOKS),
+        ("kimi-hooks.toml", KIMI_HOOKS),
     ],
     home_dir: "hooks",
     notices: hooks_notices,
@@ -221,6 +225,26 @@ mod tests {
     }
 
     #[test]
+    fn remote_rewrite_covers_the_config_dir_payloads_and_keeps_them_parseable() {
+        // A remote grok/kimi session reports through the tmux pane option, so
+        // the rewrite has to survive each payload's own syntax — JSON string
+        // escaping for grok, TOML for kimi.
+        let grok = rewrite_hook_signals_for_remote(GROK_HOOKS);
+        assert!(!grok.contains("thurbox-cli"));
+        serde_json::from_str::<serde_json::Value>(&grok).expect("grok stays valid JSON");
+
+        let kimi = rewrite_hook_signals_for_remote(KIMI_HOOKS);
+        assert!(!kimi.contains("thurbox-cli"));
+        toml::from_str::<toml::Value>(&kimi).expect("kimi stays valid TOML");
+
+        for state in ["idle", "working", "blocked", "done"] {
+            let option = format!("tmux set-option -p @thurbox_state {state}");
+            assert!(grok.contains(&option), "grok is missing rewritten {state}");
+            assert!(kimi.contains(&option), "kimi is missing rewritten {state}");
+        }
+    }
+
+    #[test]
     fn remote_rewrite_is_idempotent_and_passes_through() {
         let once = rewrite_hook_signals_for_remote(CLAUDE_SETTINGS);
         assert_eq!(rewrite_hook_signals_for_remote(&once), once);
@@ -244,6 +268,8 @@ mod tests {
             ("copilot-hooks.json", COPILOT_HOOKS),
             ("pi-status.ts", PI_STATUS),
             ("omp-status.ts", OMP_STATUS),
+            ("grok-hooks.json", GROK_HOOKS),
+            ("kimi-hooks.toml", KIMI_HOOKS),
             ("extension.toml", MANIFEST), // aider's literal --notifications-command arg
         ] {
             // Key on the invocation-with-flags form (`thurbox-cli session
@@ -350,6 +376,120 @@ mod tests {
         assert!(OMP_STATUS.contains("thurbox-cli session signal"));
         assert!(OMP_STATUS.contains("thurbox `extension install`"));
         assert!(OMP_STATUS.contains("\"ask\""));
+        // grok's standalone file carries the signal command and the managed
+        // marker (external-file uninstall, see `is_user_modified`).
+        assert!(GROK_HOOKS.contains("thurbox-cli session signal"));
+        assert!(GROK_HOOKS.contains("thurbox `extension install`"));
+        // kimi's entries are merged into the user's own config.toml, so they
+        // are pruned by the signal marker rather than by a managed marker.
+        assert!(KIMI_HOOKS.contains("thurbox-cli session signal"));
+    }
+
+    #[test]
+    fn embedded_manifest_parses_with_grok_and_kimi_wiring() {
+        let def: crate::session::ExtensionDef =
+            toml::from_str(MANIFEST).expect("embedded manifest parses");
+
+        // grok drops a managed standalone file into its ALWAYS-TRUSTED global
+        // hooks dir. A project `<repo>/.grok/hooks` would additionally need the
+        // folder granted trust in grok's own trusted_folders.toml, so a drop
+        // there would load for nobody who had not already opted in by hand.
+        let grok = def
+            .external_files
+            .iter()
+            .find(|f| f.path.contains(".grok"))
+            .expect("grok external file present");
+        assert_eq!(grok.source_path(), "grok-hooks.json");
+        assert_eq!(grok.requires_dir.as_deref(), Some("~/.grok"));
+        assert_eq!(grok.path, "~/.grok/hooks/thurbox-status.json");
+
+        // The payload is valid JSON in grok's own (claude-shaped) schema, so a
+        // typo can't ship a file grok would reject.
+        let grok_payload: serde_json::Value =
+            serde_json::from_str(GROK_HOOKS).expect("grok payload is valid JSON");
+        for event in [
+            "SessionStart",
+            "UserPromptSubmit",
+            "PreToolUse",
+            "PostToolUse",
+            "Notification",
+            "Stop",
+        ] {
+            assert!(
+                grok_payload["hooks"][event].is_array(),
+                "grok hook event {event} missing"
+            );
+        }
+        // grok refuses to load a hook file whose command references `$VAR`
+        // without an inline `:-default` — silently, taking the whole file with
+        // it. Every command here must therefore stay `$`-free, which is why the
+        // blocked edge pipes stdin through `grep` rather than reusing claude's
+        // `case "$(cat)"`.
+        for command in json_hook_commands(&grok_payload) {
+            assert!(
+                !command.contains('$'),
+                "grok hook command references a variable: {command}"
+            );
+        }
+
+        // kimi has no drop-in hooks dir — its hooks live in the `[[hooks]]`
+        // array of the user's own ~/.kimi-code/config.toml — so it is a
+        // reversible TOML merge, never a managed file that would clobber the
+        // user's whole configuration.
+        let kimi = def
+            .config_merges
+            .iter()
+            .find(|m| m.path.contains(".kimi-code"))
+            .expect("kimi config merge present");
+        assert_eq!(kimi.source_path(), "kimi-hooks.toml");
+        assert_eq!(kimi.requires_dir.as_deref(), Some("~/.kimi-code"));
+        assert_eq!(kimi.format, crate::session::ConfigMergeFormat::Toml);
+        assert!(
+            def.external_files.iter().all(|f| !f.path.contains(".kimi")),
+            "kimi's config.toml must never be written as a whole file"
+        );
+
+        // The payload is valid TOML, and every entry carries ONLY the four keys
+        // kimi accepts: a fifth makes kimi refuse to load the entire config
+        // file, which would break the user's agent rather than merely leave it
+        // unreported.
+        let kimi_payload: toml::Value =
+            toml::from_str(KIMI_HOOKS).expect("kimi payload is valid TOML");
+        let kimi_hooks = kimi_payload["hooks"]
+            .as_array()
+            .expect("kimi payload declares a [[hooks]] table array");
+        assert!(!kimi_hooks.is_empty());
+        let allowed = ["event", "command", "matcher", "timeout"];
+        let mut events = Vec::new();
+        for hook in kimi_hooks {
+            let table = hook.as_table().expect("hook entry is a table");
+            for key in table.keys() {
+                assert!(
+                    allowed.contains(&key.as_str()),
+                    "kimi hook entry carries `{key}`, which is not one of {allowed:?}"
+                );
+            }
+            let event = table["event"].as_str().expect("hook has an event");
+            assert!(
+                table["command"].as_str().is_some_and(|c| !c.is_empty()),
+                "kimi hook `{event}` has a non-empty command"
+            );
+            events.push((event.to_string(), table["command"].as_str().unwrap()));
+        }
+        // The block edge is structured (a real permission event) and has a real
+        // clearing event, unlike claude's text-matched Notification.
+        let mapped = |event: &str| -> String {
+            events
+                .iter()
+                .find(|(e, _)| e == event)
+                .unwrap_or_else(|| panic!("kimi hook for {event} missing"))
+                .1
+                .to_string()
+        };
+        assert!(mapped("PermissionRequest").contains("--state blocked"));
+        assert!(mapped("PermissionResult").contains("--state working"));
+        assert!(mapped("SessionStart").contains("--state idle"));
+        assert!(mapped("Stop").contains("--state done"));
     }
 
     #[test]
@@ -684,6 +824,8 @@ mod tests {
             ("vibe", VIBE_HOOKS, PayloadKind::Toml),
             ("pi", PI_STATUS, PayloadKind::Script),
             ("omp", OMP_STATUS, PayloadKind::Script),
+            ("grok", GROK_HOOKS, PayloadKind::Json),
+            ("kimi", KIMI_HOOKS, PayloadKind::Toml),
         ];
         for (agent, payload, kind) in payloads {
             let claimed = AGENT_HOOK_COVERAGE

--- a/src/session_ops/extensions/install.rs
+++ b/src/session_ops/extensions/install.rs
@@ -11,7 +11,7 @@ use crate::storage::Database;
 
 use super::fs::{
     ensure_safe_relative, guard_removable_dir, is_user_modified, make_symlink,
-    remove_dir_all_resilient, safe_join, set_executable,
+    remove_dir_all_resilient, safe_join, set_executable, MANAGED_MARKER,
 };
 use super::lifecycle::{activate_extension, deactivate_extension, DeactivateReport, EnsureReport};
 
@@ -310,26 +310,32 @@ fn install_external_file(
 /// rewritten form's [`crate::session::REMOTE_HOOK_STATE_OPTION`] marker.
 pub(crate) const HOOK_SIGNAL_MARKER: &str = "thurbox-cli session signal";
 
-/// Read the JSON config at `path` (or `{}` when absent), parsed. A malformed
-/// file is an error rather than a silent overwrite — we never clobber config we
-/// can't safely round-trip.
+/// Read the JSON config at `path` (or `{}` when it does not exist), parsed.
+///
+/// Only a **missing** file is an empty document. A file that exists but cannot
+/// be read or parsed is an error the caller soft-skips, because the merged
+/// result is written straight back: treating an unreadable file as empty would
+/// replace the user's whole config with our hook entries alone. A file we cannot
+/// read is not an empty file, and the only safe answer is to refuse and say so.
 fn read_json_or_empty(path: &Path) -> Result<serde_json::Value, String> {
     match std::fs::read_to_string(path) {
         Ok(s) if s.trim().is_empty() => Ok(serde_json::json!({})),
         Ok(s) => serde_json::from_str(&s).map_err(|e| format!("parse {}: {e}", path.display())),
-        Err(_) => Ok(serde_json::json!({})),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(serde_json::json!({})),
+        Err(e) => Err(format!("read {}: {e}", path.display())),
     }
 }
 
-/// [`read_json_or_empty`] for a TOML target: a missing or blank file is an empty
-/// document, and a malformed one is an error the caller soft-skips.
+/// [`read_json_or_empty`] for a TOML target, with the same rule: absent is an
+/// empty document, present-but-unreadable refuses.
 fn read_toml_or_empty(path: &Path) -> Result<toml_edit::DocumentMut, String> {
     match std::fs::read_to_string(path) {
         Ok(s) if s.trim().is_empty() => Ok(toml_edit::DocumentMut::new()),
         Ok(s) => s
             .parse()
             .map_err(|e| format!("parse {}: {e}", path.display())),
-        Err(_) => Ok(toml_edit::DocumentMut::new()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(toml_edit::DocumentMut::new()),
+        Err(e) => Err(format!("read {}: {e}", path.display())),
     }
 }
 
@@ -407,6 +413,13 @@ fn merged_config(
                 .parse()
                 .map_err(|e| format!("parse merge source {source_name}: {e}"))?;
             let mut doc = read_toml_or_empty(dest)?;
+            // Prune, then merge. Our entries are identified by an ownership
+            // comment rather than by their content, so a payload that renamed an
+            // event or edited a command replaces the entry already on disk
+            // instead of stacking a second copy beside it. (The JSON sibling
+            // cannot do this: a content match would delete a user hook it never
+            // wrote and then not put it back.)
+            crate::agent::toml_merge::prune_owned(&mut doc, MANAGED_MARKER);
             crate::agent::toml_merge::merge(&mut doc, &to_merge);
             Ok(doc.to_string())
         }
@@ -434,7 +447,7 @@ fn revert_config_merge(m: &crate::session::ConfigMerge) -> Result<bool, String> 
         },
         crate::session::ConfigMergeFormat::Toml => match read_toml_or_empty(&dest) {
             Ok(mut doc) => {
-                crate::agent::toml_merge::prune_marked(&mut doc, HOOK_SIGNAL_MARKER);
+                crate::agent::toml_merge::prune_owned(&mut doc, MANAGED_MARKER);
                 Ok(doc.to_string())
             }
             Err(e) => Err(e),

--- a/src/session_ops/extensions/install.rs
+++ b/src/session_ops/extensions/install.rs
@@ -321,13 +321,23 @@ fn read_json_or_empty(path: &Path) -> Result<serde_json::Value, String> {
     }
 }
 
-/// Write `value` as pretty JSON to `path` only when it differs from the current
-/// contents (the merge runs every startup + heartbeat tick, so a no-op write
-/// would be churn). Returns whether it wrote.
-fn write_json_if_changed(path: &Path, value: &serde_json::Value) -> Result<bool, String> {
-    let content = serde_json::to_string_pretty(value)
-        .map_err(|e| format!("serialize {}: {e}", path.display()))?;
-    if file_has_content(path, &content) {
+/// [`read_json_or_empty`] for a TOML target: a missing or blank file is an empty
+/// document, and a malformed one is an error the caller soft-skips.
+fn read_toml_or_empty(path: &Path) -> Result<toml_edit::DocumentMut, String> {
+    match std::fs::read_to_string(path) {
+        Ok(s) if s.trim().is_empty() => Ok(toml_edit::DocumentMut::new()),
+        Ok(s) => s
+            .parse()
+            .map_err(|e| format!("parse {}: {e}", path.display())),
+        Err(_) => Ok(toml_edit::DocumentMut::new()),
+    }
+}
+
+/// Write `content` to `path` only when it differs from the current contents (the
+/// merge runs every startup + heartbeat tick, so a no-op write would be churn).
+/// Returns whether it wrote.
+fn write_if_changed(path: &Path, content: &str) -> Result<bool, String> {
+    if file_has_content(path, content) {
         return Ok(false);
     }
     if let Some(parent) = path.parent() {
@@ -353,28 +363,54 @@ fn install_config_merge(
         }
     }
     let dest = crate::agent::extension_config::expand_tilde(&m.path);
-    let to_merge: serde_json::Value = serde_json::from_str(
-        &crate::agent::extension_config::fetch_file(source, m.source_path())?,
-    )
-    .map_err(|e| format!("parse merge source {}: {e}", m.source_path()))?;
+    let source_text = crate::agent::extension_config::fetch_file(source, m.source_path())?;
     // A user's malformed target must NOT abort the whole install: this runs every
     // startup + heartbeat tick, so one broken file would degrade every agent's
     // wiring. Soft-skip it (mirroring the `requires_dir` guard) and carry on.
-    let mut doc = match read_json_or_empty(&dest) {
-        Ok(doc) => doc,
+    let merged = match merged_config(m.format, &dest, &source_text, m.source_path()) {
+        Ok(merged) => merged,
         Err(e) => {
             tracing::warn!("skipping config merge into {}: {e}", dest.display());
             report.config_merges_skipped.push(m.path.clone());
             return Ok(());
         }
     };
-    crate::agent::json_merge::merge(&mut doc, &to_merge);
-    if write_json_if_changed(&dest, &doc)? {
+    if write_if_changed(&dest, &merged)? {
         report.config_merges_applied.push(m.path.clone());
     } else {
         report.config_merges_skipped.push(m.path.clone());
     }
     Ok(())
+}
+
+/// The full text `dest` should hold once `source_text` is merged into it, in
+/// whichever encoding this merge declares. A parse failure of the *source* is a
+/// hard error (thurbox shipped it); one of the *target* is the user's file and
+/// is reported for the soft-skip above.
+fn merged_config(
+    format: crate::session::ConfigMergeFormat,
+    dest: &Path,
+    source_text: &str,
+    source_name: &str,
+) -> Result<String, String> {
+    match format {
+        crate::session::ConfigMergeFormat::Json => {
+            let to_merge: serde_json::Value = serde_json::from_str(source_text)
+                .map_err(|e| format!("parse merge source {source_name}: {e}"))?;
+            let mut doc = read_json_or_empty(dest)?;
+            crate::agent::json_merge::merge(&mut doc, &to_merge);
+            serde_json::to_string_pretty(&doc)
+                .map_err(|e| format!("serialize {}: {e}", dest.display()))
+        }
+        crate::session::ConfigMergeFormat::Toml => {
+            let to_merge: toml_edit::DocumentMut = source_text
+                .parse()
+                .map_err(|e| format!("parse merge source {source_name}: {e}"))?;
+            let mut doc = read_toml_or_empty(dest)?;
+            crate::agent::toml_merge::merge(&mut doc, &to_merge);
+            Ok(doc.to_string())
+        }
+    }
 }
 
 /// Reverse an [`install_config_merge`]: prune our marked hook entries out of the
@@ -387,15 +423,30 @@ fn revert_config_merge(m: &crate::session::ConfigMerge) -> Result<bool, String> 
     }
     // A malformed target can't be safely pruned; leave it rather than abort the
     // rest of the uninstall (consistent with the install soft-skip).
-    let mut doc = match read_json_or_empty(&dest) {
-        Ok(doc) => doc,
+    let pruned = match m.format {
+        crate::session::ConfigMergeFormat::Json => match read_json_or_empty(&dest) {
+            Ok(mut doc) => {
+                crate::agent::json_merge::prune_marked(&mut doc, HOOK_SIGNAL_MARKER);
+                serde_json::to_string_pretty(&doc)
+                    .map_err(|e| format!("serialize {}: {e}", dest.display()))
+            }
+            Err(e) => Err(e),
+        },
+        crate::session::ConfigMergeFormat::Toml => match read_toml_or_empty(&dest) {
+            Ok(mut doc) => {
+                crate::agent::toml_merge::prune_marked(&mut doc, HOOK_SIGNAL_MARKER);
+                Ok(doc.to_string())
+            }
+            Err(e) => Err(e),
+        },
+    };
+    match pruned {
+        Ok(pruned) => write_if_changed(&dest, &pruned),
         Err(e) => {
             tracing::warn!("skipping config-merge revert in {}: {e}", dest.display());
-            return Ok(false);
+            Ok(false)
         }
-    };
-    crate::agent::json_merge::prune_marked(&mut doc, HOOK_SIGNAL_MARKER);
-    write_json_if_changed(&dest, &doc)
+    }
 }
 
 /// Create one symlink under the home dir, replacing an existing symlink but

--- a/src/session_ops/extensions/tests.rs
+++ b/src/session_ops/extensions/tests.rs
@@ -747,8 +747,9 @@ requires_dir = '{agent_dir}'
             "{name}: nothing may be applied to a file we could not read"
         );
 
-        // And the user's file is untouched — the thing that matters.
-        std::fs::set_permissions(&config, std::fs::Permissions::from_mode(0o644)).unwrap();
+        // And the user's file is untouched — the thing that matters. Restore
+        // owner-only access (not world-readable) so cleanup can read it back.
+        std::fs::set_permissions(&config, std::fs::Permissions::from_mode(0o600)).unwrap();
         assert_eq!(
             std::fs::read_to_string(&config).unwrap(),
             users_own,

--- a/src/session_ops/extensions/tests.rs
+++ b/src/session_ops/extensions/tests.rs
@@ -480,6 +480,148 @@ requires_dir = '{missing}'
     );
 }
 
+/// The whole point of a TOML `[[config_merges]]`: kimi's hooks live in the same
+/// file as the rest of the user's configuration, and thurbox's entries have to
+/// come back out without taking anything of theirs with them — including a hook
+/// they wired to `thurbox-cli session signal` themselves, which
+/// `extensions/hooks/README.md` tells them to do for an agent thurbox does not
+/// instrument. Identifying our entries by that command's presence deleted it.
+#[test]
+fn toml_config_merge_uninstall_keeps_a_user_hook_that_calls_the_signal_command() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let _guard = crate::paths::TestPathGuard::new(temp.path());
+    let db = Database::open_in_memory().unwrap();
+
+    let agent_dir = temp.path().join("dotkimi");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+    let config = agent_dir.join("config.toml");
+    let users_own = "# my config\n\
+                     model = \"kimi-code/k3\"\n\n\
+                     [[hooks]]\n\
+                     event = \"Stop\"\n\
+                     command = \"thurbox-cli session signal --state done || true\"\n";
+    std::fs::write(&config, users_own).unwrap();
+    let home = temp.path().join("hookshome");
+
+    let src = tempfile::TempDir::new().unwrap();
+    std::fs::write(
+        src.path().join("extension.toml"),
+        format!(
+            r#"name = "hooks"
+home = '{home}'
+
+[[config_merges]]
+path = '{config}'
+source = "kimi-hooks.toml"
+requires_dir = '{agent_dir}'
+format = "toml"
+"#,
+            home = home.display(),
+            config = config.display(),
+            agent_dir = agent_dir.display(),
+        ),
+    )
+    .unwrap();
+    std::fs::write(
+        src.path().join("kimi-hooks.toml"),
+        "# managed by thurbox `extension install`\n\
+         [[hooks]]\n\
+         event = \"SessionStart\"\n\
+         command = \"thurbox-cli session signal --state idle || true\"\n",
+    )
+    .unwrap();
+
+    let target = src.path().to_string_lossy().to_string();
+    let report = install_extension(&db, &target, None, false).unwrap();
+    assert_eq!(report.config_merges_applied, [config.to_string_lossy()]);
+    let merged = std::fs::read_to_string(&config).unwrap();
+    assert!(merged.contains("--state idle"), "ours merged in: {merged}");
+    assert!(merged.contains("--state done"), "theirs still there");
+
+    // Uninstall takes exactly ours back out and restores their file verbatim.
+    let un = uninstall_extension(&db, "hooks", false).unwrap();
+    assert_eq!(un.config_merges_reverted, [config.to_string_lossy()]);
+    let restored = std::fs::read_to_string(&config).unwrap();
+    assert_eq!(
+        restored, users_own,
+        "the user's own signal hook and settings must survive verbatim"
+    );
+}
+
+/// An update whose payload renames an event or edits a command must replace our
+/// entry, not stack a second copy beside it: nothing in the new entry's content
+/// matches the one already on disk, so only ownership can recognise it.
+#[test]
+fn toml_config_merge_update_replaces_our_entry_instead_of_accumulating() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let _guard = crate::paths::TestPathGuard::new(temp.path());
+    let db = Database::open_in_memory().unwrap();
+
+    let agent_dir = temp.path().join("dotkimi");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+    let config = agent_dir.join("config.toml");
+    std::fs::write(&config, "model = \"kimi-code/k3\"\n").unwrap();
+    let home = temp.path().join("hookshome");
+
+    let src = tempfile::TempDir::new().unwrap();
+    let manifest = format!(
+        r#"name = "hooks"
+home = '{home}'
+
+[[config_merges]]
+path = '{config}'
+source = "kimi-hooks.toml"
+requires_dir = '{agent_dir}'
+format = "toml"
+"#,
+        home = home.display(),
+        config = config.display(),
+        agent_dir = agent_dir.display(),
+    );
+    std::fs::write(src.path().join("extension.toml"), &manifest).unwrap();
+    let payload = |event: &str, state: &str, timeout: u32| {
+        format!(
+            "# managed by thurbox `extension install`\n\
+             [[hooks]]\nevent = \"{event}\"\n\
+             command = \"thurbox-cli session signal --state {state} || true\"\n\
+             timeout = {timeout}\n"
+        )
+    };
+    std::fs::write(
+        src.path().join("kimi-hooks.toml"),
+        payload("Stop", "done", 10),
+    )
+    .unwrap();
+
+    let target = src.path().to_string_lossy().to_string();
+    install_extension(&db, &target, None, false).unwrap();
+
+    // A later version of the payload renames the event and retimes it.
+    std::fs::write(
+        src.path().join("kimi-hooks.toml"),
+        payload("SessionEnd", "idle", 30),
+    )
+    .unwrap();
+    let report = install_extension(&db, &target, None, false).unwrap();
+    assert_eq!(report.config_merges_applied, [config.to_string_lossy()]);
+
+    let updated = std::fs::read_to_string(&config).unwrap();
+    let doc: toml::Value = toml::from_str(&updated).expect("still valid TOML");
+    assert_eq!(
+        doc["hooks"].as_array().unwrap().len(),
+        1,
+        "the stale entry must be gone, not sitting beside the new one: {updated}"
+    );
+    assert!(!updated.contains("--state done"));
+    assert!(updated.contains("--state idle") && updated.contains("timeout = 30"));
+    assert!(updated.contains("model = \"kimi-code/k3\""));
+
+    // Re-installing the same payload writes nothing (no churn on every tick).
+    let again = install_extension(&db, &target, None, false).unwrap();
+    assert!(again.config_merges_applied.is_empty());
+    assert_eq!(again.config_merges_skipped, [config.to_string_lossy()]);
+}
+
 #[test]
 fn config_merge_soft_skips_a_malformed_user_target() {
     let temp = tempfile::TempDir::new().unwrap();
@@ -524,6 +666,95 @@ requires_dir = '{agent_dir}'
         std::fs::read_to_string(&settings).unwrap(),
         "{ this is not valid json"
     );
+}
+
+/// A config file that exists but cannot be **read** is not an empty config.
+/// Treating it as one merged our hooks into `{}` and wrote that back, replacing
+/// everything the user had. The merged result goes straight to disk, so the only
+/// safe response to an unreadable-but-present file is to refuse and say so.
+///
+/// Runs for both encodings: the JSON and TOML readers share the rule.
+#[cfg(unix)]
+#[test]
+fn config_merge_refuses_an_unreadable_target_instead_of_overwriting_it() {
+    use std::os::unix::fs::PermissionsExt;
+
+    for (name, file, source, payload, format) in [
+        (
+            "json",
+            "settings.json",
+            "gemini-hooks.json",
+            r#"{"hooks":{"Stop":[{"command":"thurbox-cli session signal --state done"}]}}"#,
+            "",
+        ),
+        (
+            "toml",
+            "config.toml",
+            "kimi-hooks.toml",
+            "# managed by thurbox `extension install`\n[[hooks]]\nevent = \"Stop\"\n\
+             command = \"thurbox-cli session signal --state done\"\n",
+            "format = \"toml\"",
+        ),
+    ] {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let agent_dir = temp.path().join("agentdir");
+        std::fs::create_dir_all(&agent_dir).unwrap();
+        let config = agent_dir.join(file);
+        let users_own = "EVERYTHING THE USER CONFIGURED";
+        std::fs::write(&config, users_own).unwrap();
+        std::fs::set_permissions(&config, std::fs::Permissions::from_mode(0o000)).unwrap();
+        // Running as root ignores the mode bits, so there is nothing to prove.
+        if std::fs::read_to_string(&config).is_ok() {
+            continue;
+        }
+
+        let home = temp.path().join("hookshome");
+        let src = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            src.path().join("extension.toml"),
+            format!(
+                r#"name = "hooks"
+home = '{home}'
+
+[[config_merges]]
+path = '{config}'
+source = "{source}"
+requires_dir = '{agent_dir}'
+{format}
+"#,
+                home = home.display(),
+                config = config.display(),
+                agent_dir = agent_dir.display(),
+            ),
+        )
+        .unwrap();
+        std::fs::write(src.path().join(source), payload).unwrap();
+
+        // The install still succeeds (it runs every startup + tick) but the
+        // merge is refused rather than applied.
+        let target = src.path().to_string_lossy().to_string();
+        let report = install_extension(&db, &target, None, false).unwrap();
+        assert_eq!(
+            report.config_merges_skipped,
+            [config.to_string_lossy()],
+            "{name}: an unreadable target must be soft-skipped"
+        );
+        assert!(
+            report.config_merges_applied.is_empty(),
+            "{name}: nothing may be applied to a file we could not read"
+        );
+
+        // And the user's file is untouched — the thing that matters.
+        std::fs::set_permissions(&config, std::fs::Permissions::from_mode(0o644)).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(&config).unwrap(),
+            users_own,
+            "{name}: the user's configuration was overwritten"
+        );
+    }
 }
 
 #[test]

--- a/src/session_ops/remote_hooks.rs
+++ b/src/session_ops/remote_hooks.rs
@@ -390,8 +390,11 @@ fn merged_remote_toml_doc(existing: &str, payload: &str) -> Result<Option<String
         .map_err(|e| format!("payload is not valid TOML: {e}"))?;
 
     let mut doc = before.clone();
-    crate::agent::toml_merge::prune_marked(&mut doc, HOOK_SIGNAL_MARKER);
-    crate::agent::toml_merge::prune_marked(&mut doc, crate::session::REMOTE_HOOK_STATE_OPTION);
+    // One marker covers both command forms here, unlike the JSON sibling: the
+    // ownership comment is on the entry, and the remote rewrite only touches the
+    // command inside it, so a stale un-rewritten entry is recognised as ours
+    // just the same.
+    crate::agent::toml_merge::prune_owned(&mut doc, MANAGED_MARKER);
     crate::agent::toml_merge::merge(&mut doc, &to_merge);
 
     let after = doc.to_string();
@@ -653,19 +656,44 @@ mod tests {
     #[test]
     fn merged_toml_doc_preserves_the_remote_users_config_and_replaces_stale_entries() {
         let payload = builtin_hooks::rewrite_hook_signals_for_remote(builtin_hooks::KIMI_HOOKS);
+        // The host's file carries the remote user's own settings and hook, plus
+        // a *stale* thurbox entry an older thurbox shipped in the un-rewritten
+        // local command form. Ownership is the comment, so that entry is
+        // recognised as ours whichever command form it holds — which is why one
+        // prune call replaces the two the JSON sibling needs.
         let existing = "# theirs\nmodel = \"kimi-code/k3\"\n\n\
-                        [[hooks]]\nevent = \"Stop\"\ncommand = \"notify-send hi\"\n\n\
                         [[hooks]]\nevent = \"Stop\"\n\
+                        command = \"notify-send hi; thurbox-cli session signal --state done\"\n\n\
+                        # managed by thurbox `extension install`\n\
+                        [[hooks]]\nevent = \"Retired\"\n\
                         command = \"thurbox-cli session signal --state done || true\"\n";
         let merged = merged_remote_toml_doc(existing, &payload)
             .expect("merges")
             .expect("writes");
-        // Their config and their own hook survive; the stale un-rewritten
-        // thurbox entry is replaced rather than accumulated beside the new one.
+
+        // The remote user's config and their own hook survive untouched — even
+        // though that hook calls `thurbox-cli session signal` itself.
         assert!(merged.contains("# theirs"));
-        assert!(merged.contains("notify-send hi"));
-        assert!(!merged.contains("thurbox-cli"));
+        assert!(merged.contains("notify-send hi; thurbox-cli session signal --state done"));
+        // The stale entry is gone rather than sitting beside the new one, and
+        // ours now reports through the pane option.
+        assert!(
+            !merged.contains("Retired"),
+            "stale entry replaced: {merged}"
+        );
         assert!(merged.contains("tmux set-option -p @thurbox_state done"));
+
+        // Every command we ship reports remotely; the only one still naming the
+        // local CLI is the user's own.
+        let doc: toml::Value = toml::from_str(&merged).expect("merged doc is valid TOML");
+        for hook in doc["hooks"].as_array().expect("[[hooks]]") {
+            let command = hook["command"].as_str().expect("hook has a command");
+            assert!(
+                !command.contains("thurbox-cli") || command.starts_with("notify-send hi"),
+                "a shipped command still calls the local CLI: {command}"
+            );
+        }
+
         // Idempotent: merging into the just-written doc is a no-op.
         assert_eq!(merged_remote_toml_doc(&merged, &payload).unwrap(), None);
     }

--- a/src/session_ops/remote_hooks.rs
+++ b/src/session_ops/remote_hooks.rs
@@ -41,6 +41,8 @@ use super::extensions::{HOOK_SIGNAL_MARKER, MANAGED_MARKER};
 enum RemoteAssetKind {
     /// Deep-merge into a shared JSON config the agent (and its user) own.
     MergeJson,
+    /// The same, for an agent whose shared config is TOML (kimi).
+    MergeToml,
     /// Write a standalone thurbox-managed file (refused if a user-owned file
     /// — one without [`MANAGED_MARKER`] — already sits there).
     WriteFile,
@@ -104,6 +106,18 @@ fn remote_asset_for(agent: &str) -> Option<RemoteHookAsset> {
             remote_path: "~/.omp/agent/extensions/thurbox-status.ts",
             requires_dir: "~/.omp/agent",
             payload: builtin_hooks::OMP_STATUS,
+        }),
+        "grok" => Some(RemoteHookAsset {
+            kind: RemoteAssetKind::WriteFile,
+            remote_path: "~/.grok/hooks/thurbox-status.json",
+            requires_dir: "~/.grok",
+            payload: builtin_hooks::GROK_HOOKS,
+        }),
+        "kimi" => Some(RemoteHookAsset {
+            kind: RemoteAssetKind::MergeToml,
+            remote_path: "~/.kimi-code/config.toml",
+            requires_dir: "~/.kimi-code",
+            payload: builtin_hooks::KIMI_HOOKS,
         }),
         _ => None,
     }
@@ -280,8 +294,13 @@ fn provision_uncached(host: &HostDef, asset: &RemoteHookAsset) -> ProvisionOutco
     let rewritten = builtin_hooks::rewrite_hook_signals_for_remote(asset.payload);
 
     let to_write = match asset.kind {
-        RemoteAssetKind::MergeJson => {
-            match merged_remote_doc(existing.as_deref().unwrap_or(""), &rewritten) {
+        RemoteAssetKind::MergeJson | RemoteAssetKind::MergeToml => {
+            let existing = existing.as_deref().unwrap_or("");
+            let merged = match asset.kind {
+                RemoteAssetKind::MergeToml => merged_remote_toml_doc(existing, &rewritten),
+                _ => merged_remote_doc(existing, &rewritten),
+            };
+            match merged {
                 Ok(Some(merged)) => merged,
                 // Already up to date — record success without a write.
                 Ok(None) => return Provisioned,
@@ -353,6 +372,33 @@ fn merged_remote_doc(existing: &str, payload: &str) -> Result<Option<String>, St
     serde_json::to_string_pretty(&doc)
         .map(Some)
         .map_err(|e| format!("serialize merged doc: {e}"))
+}
+
+/// [`merged_remote_doc`] for a TOML target (kimi's `~/.kimi-code/config.toml`):
+/// same prune-then-merge contract, `toml_edit` so the remote user's comments and
+/// key order survive.
+fn merged_remote_toml_doc(existing: &str, payload: &str) -> Result<Option<String>, String> {
+    let before: toml_edit::DocumentMut = if existing.trim().is_empty() {
+        toml_edit::DocumentMut::new()
+    } else {
+        existing
+            .parse()
+            .map_err(|e| format!("existing file is not valid TOML: {e}"))?
+    };
+    let to_merge: toml_edit::DocumentMut = payload
+        .parse()
+        .map_err(|e| format!("payload is not valid TOML: {e}"))?;
+
+    let mut doc = before.clone();
+    crate::agent::toml_merge::prune_marked(&mut doc, HOOK_SIGNAL_MARKER);
+    crate::agent::toml_merge::prune_marked(&mut doc, crate::session::REMOTE_HOOK_STATE_OPTION);
+    crate::agent::toml_merge::merge(&mut doc, &to_merge);
+
+    let after = doc.to_string();
+    if after == before.to_string() {
+        return Ok(None);
+    }
+    Ok(Some(after))
 }
 
 /// The hook states a headless poll may write — the same allow-list the TUI's
@@ -546,6 +592,10 @@ mod tests {
                 "omp"
             } else if path.contains(".pi") {
                 "pi"
+            } else if path.contains(".grok") {
+                "grok"
+            } else if path.contains(".kimi-code") {
+                "kimi"
             } else {
                 panic!("unknown config-dir wiring path in manifest: {path}")
             }
@@ -555,7 +605,12 @@ mod tests {
         for m in &def.config_merges {
             let agent = agent_for_path(&m.path);
             let asset = remote_asset_for(agent).expect("merge agent has a remote asset");
-            assert!(matches!(asset.kind, RemoteAssetKind::MergeJson), "{agent}");
+            let expected_toml = m.format == crate::session::ConfigMergeFormat::Toml;
+            assert_eq!(
+                matches!(asset.kind, RemoteAssetKind::MergeToml),
+                expected_toml,
+                "{agent}: local and remote merge formats disagree"
+            );
             assert_eq!(asset.remote_path, m.path, "{agent} destination drifted");
             assert_eq!(
                 Some(asset.requires_dir),
@@ -577,7 +632,7 @@ mod tests {
             covered += 1;
         }
         // Every table entry is reachable from the manifest (no orphan assets).
-        assert_eq!(covered, 7, "manifest wiring count changed — sync the table");
+        assert_eq!(covered, 9, "manifest wiring count changed — sync the table");
         // claude/aider stay arg-handled.
         assert!(remote_asset_for("claude").is_none());
         assert!(remote_asset_for("aider").is_none());
@@ -593,6 +648,26 @@ mod tests {
         assert!(!merged.contains("thurbox-cli"));
         // Idempotent: merging into the just-written doc is a no-op.
         assert_eq!(merged_remote_doc(&merged, &payload).unwrap(), None);
+    }
+
+    #[test]
+    fn merged_toml_doc_preserves_the_remote_users_config_and_replaces_stale_entries() {
+        let payload = builtin_hooks::rewrite_hook_signals_for_remote(builtin_hooks::KIMI_HOOKS);
+        let existing = "# theirs\nmodel = \"kimi-code/k3\"\n\n\
+                        [[hooks]]\nevent = \"Stop\"\ncommand = \"notify-send hi\"\n\n\
+                        [[hooks]]\nevent = \"Stop\"\n\
+                        command = \"thurbox-cli session signal --state done || true\"\n";
+        let merged = merged_remote_toml_doc(existing, &payload)
+            .expect("merges")
+            .expect("writes");
+        // Their config and their own hook survive; the stale un-rewritten
+        // thurbox entry is replaced rather than accumulated beside the new one.
+        assert!(merged.contains("# theirs"));
+        assert!(merged.contains("notify-send hi"));
+        assert!(!merged.contains("thurbox-cli"));
+        assert!(merged.contains("tmux set-option -p @thurbox_state done"));
+        // Idempotent: merging into the just-written doc is a no-op.
+        assert_eq!(merged_remote_toml_doc(&merged, &payload).unwrap(), None);
     }
 
     #[test]


### PR DESCRIPTION
## Intent

Add thurbox status-hook implementation support for four agents that currently
have none: cursor, kimi, grok and muse.

These are the four coding agents a driver like firstmate uses that thurbox does
not instrument, so their sessions can never report working / blocked / done /
idle no matter who launches them. The captain wants that gap closed.

He has authorized this implementation and requires it to go through the
no-mistakes pipeline. He approves every merge himself - do not merge.

Context: PR 1081 just merged, which made the interface render thurbox's honest
state vocabulary instead of collapsing everything to idle, and publish a
best-effort detected agent. That fixed how thurbox DISPLAYS what it knows. This
task is about giving it something to know for these four.

## Scope: two of the four, deliberately

**Delivered: `grok` and `kimi`.** Both now report the full
idle/working/blocked/done lifecycle, wired into the agent's own config dir so
they report no matter who launches the agent — including a driver that opens a
shell and starts it itself.

**Left uncovered: `cursor` and `muse`.** This is the deliberate outcome, not an
omission or an unfinished half. Neither has a hook surface reachable by any of
the three delivery mechanisms, and both are left out of `AGENT_HOOK_COVERAGE`
entirely so they keep reporting `uncovered` — the honest answer for an agent
thurbox cannot instrument. A coverage entry that does not fire would be strictly
worse than no entry, because it turns "we cannot know" back into a confident
claim, which is the exact defect #1081 just removed.

| Agent | What blocks it | What would unblock it |
|---|---|---|
| `cursor` | The only scope its CLI is known to fire `stop`/`sessionStart` from is per-project `<repo>/.cursor/hooks.json`, **and** only when launched with `--trust`. That is a per-repo file plus a launch flag — no config dir to write to, and it would cover nothing an outside driver starts. User-scope `~/.cursor/hooks.json` is documented for the IDE; in the CLI it is reported to run only the shell/MCP/file-edit hooks, none of which can say `done`, so wiring it there would latch every cursor session at `working` forever. | Confirmation that `stop`/`sessionStart` fire from user scope in `cursor-agent`. It then becomes an ordinary `[[config_merges]]` into `~/.cursor/hooks.json` — no new mechanism. |
| `muse` | Its hooks exist only as capabilities of a native plugin that must be installed **and approved** (`muse plugins install` / `muse plugins approve`, the management CLI itself gated behind `MUSE_EXPERIMENTAL_PLUGINS`). A dropped-in config file is silently ignored. An extension manifest writes files; it does not run an agent's install-and-approve commands, so there is nothing to ship. | Either muse shipping the documented `muse hooks` file-based surface, or thurbox growing a **fourth** delivery mechanism. Muse does keep a durable per-session event log (`${XDG_DATA_HOME:-~/.local/share}/muse/sessions/YYYY/MM/DD/<uuid>/session.jsonl`) whose `run` `started`/`terminal` events bracket every turn, so reading it would work — but that is a poller, not a hook, and a separate decision. Deliberately not built here. |

Both are written up in `docs/AGENTS.md` (*Deliberately uninstrumented*) and
`extensions/hooks/README.md` (*Agents this extension does not wire*), so the
reasoning lives with the code rather than only in this PR.

### Verification honesty

None of these four CLIs is installed on the machine this was built on, and there
are no credentials for any of them, so **the agent-side half — that grok and kimi
actually invoke these events — could not be observed here** and is not claimed.
Both are marked *Experimental*, as codex/copilot/pi/omp were.

What was verified end-to-end, against an isolated thurbox instance with its own
HOME, config dir, data dir and tmux socket: both payloads install to the right
paths; `requires_dir` holds; **every command string in the installed files, run
with `THURBOX_SESSION` set, lands its expected state on the session row** (all
six grok events, all seven kimi events); grok's `Notification` on a non-permission
nudge does *not* flip to blocked; uninstall leaves the user's files byte-identical;
a user-owned file at grok's path is refused rather than clobbered; and
`session doctor` resolves both.

## What Changed

- Add TOML support to the `config_merges` hook-delivery mechanism (new `agent::toml_merge`, `ConfigMergeFormat` enum, `format = "toml"` on `ConfigMerge`) so hooks can be reversibly merged into a TOML-based shared config file, and wire kimi's hooks into `~/.kimi-code/config.toml` via a `[[hooks]]` array whose entries carry an ownership comment (used by uninstall to distinguish thurbox's entries from the user's own).
- Add a standalone `grok-hooks.json` payload dropped into `~/.grok/hooks/thurbox-status.json` (claude-shaped schema, `$`-free commands to satisfy grok's hook-loading constraints), embedded and registered in `builtin_hooks.rs`/`extensions/hooks/extension.toml`.
- Extend `remote_hooks.rs` to rewrite and deliver the grok/kimi payloads for remote sessions, and add both agents to `hook_status::AGENT_HOOK_COVERAGE` (renaming `HookDelivery::MergeJson` to `ConfigMerge` to reflect the added TOML path) and to `extensions/extensions/install.rs`'s merge logic.
- Document in `docs/AGENTS.md`/`docs/ARCHITECTURE.md`/`docs/CONFIG.md` and the `thurbox-agents`/`thurbox-extensions`/`thurbox-remote-hosts` skills why `cursor` and `muse` remain deliberately uninstrumented (no config-dir/hook surface thurbox can reach with the existing mechanisms) rather than wiring in unreliable coverage for them.
- Isolate the automation-tick test (`src/cli/automations.rs`) from installing built-in extension payloads into the real `$HOME` by opting the hooks/ui-skill built-ins out for that test.

## Risk Assessment

✅ Low: The diff adds grok (managed external file) and kimi (reversible TOML config-merge) status hooks, plus a genuine bug fix (own kimi's merged entries by an ownership comment instead of a content marker, and refuse rather than silently empty an unreadable target). Every new code path (toml_merge merge/prune, format dispatch in install.rs, remote_hooks TOML variant, the automations test fix) is covered by targeted regression tests that fail before the fix and pass after, docs/skills were updated in step with the code, and module boundaries/architecture rules are respected. The only scope question (cursor/muse left unimplemented) was already raised and declined in a prior review round on this same branch, so it is not re-flagged.

## Testing

Baseline `cargo nextest run --all` had already passed; on top of that I ran the specific test modules the target commits touched (55 tests, all exercising real file I/O via install_extension/uninstall_extension against temp files, plus typed parsing of the shipped grok/kimi payloads) and then manually drove the real thurbox-cli binary against an isolated fake HOME to install and uninstall the actual embedded 'hooks' extension — confirming grok's hook file and kimi's merged config.toml are written correctly on install and fully/cleanly reverted on uninstall, which is the real end-user experience of this change. No test failures or issues found.

<details>
<summary>Evidence: Manual end-to-end CLI transcript (tick/reinstall/uninstall against a fake HOME)</summary>

```text
== automation tick (registers the builtin 'hooks' extension; ~/.grok and ~/.kimi-code don't exist yet, so their payloads are soft-skipped) ==
{"fired":[],"healed":[],"reaped":[],"skipped":[],"synced":[]}
== a user now installs grok and kimi (dirs appear); reinstall picks them up ==
{"agents_added":[],"automations_created":[],"files_written":[],"home":"/tmp/tmp.uIXkzWaMue/config/hooks","home_removed":null,"ok":true,"reinstalled":"hooks","sessions_created":[],"summary":"Reinstalled 'hooks' 1.8.0 → /tmp/tmp.uIXkzWaMue/config/hooks","version":"1.8.0"}
== grok hook file (~/.grok/hooks/thurbox-status.json) ==
{
  "hooks": {
    "SessionStart": [
      {
        "hooks": [
          {
            "type": "command",
            "command": "thurbox-cli session signal --state idle || true  # managed by thurbox `extension install` — do not edit",
            "timeout": 10
          }
        ]
      }
    ],
    "UserPromptSubmit": [
      {
        "hooks": [
          {
            "type": "command",
            "command": "thurbox-cli session signal --state working || true",
            "timeout": 10
          }
        ]
      }
    ],
    "PreToolUse": [
      {
        "matcher": ".*",
        "hooks": [
          {
            "type": "command",
            "command": "thurbox-cli session signal --state working || true",
            "timeout": 10
          }
        ]
      }
    ],
    "PostToolUse": [
      {
        "matcher": ".*",
        "hooks": [
          {
            "type": "command",
            "command": "thurbox-cli session signal --state working || true",
            "timeout": 10
          }
        ]
      }
    ],
    "Notification": [
      {
        "hooks": [
          {
            "type": "command",
            "command": "if cat | grep -qiE 'permission|approval|approve'; then thurbox-cli session signal --state blocked ; fi; true",
            "timeout": 10
          }
        ]
      }
    ],
    "Stop": [
      {
        "hooks": [
          {
            "type": "command",
            "command": "thurbox-cli session signal --state done || true",
            "timeout": 10
          }
        ]
      }
    ]
  }
}
== kimi config.toml after merge (user's own model= line preserved alongside our hooks) ==
model = "kimi-code/k3"
# Kimi Code CLI status hooks, merged into the user's own ~/.kimi-code/config.toml.
#
# The comment above each entry is its ownership record, not decoration: it is how
# uninstall tells these entries from a hook the user wrote themselves (which may
# legitimately call `thurbox-cli session signal` too), and how an update
# recognises an entry of ours whose event or command has since changed. Every
# entry must carry it — see `agent::toml_merge`.
#
# Kimi accepts exactly four keys per entry (event/command/matcher/timeout) and
# refuses to load the whole config file when it sees a fifth, which is why
# ownership lives in a comment rather than in a field.

# managed by thurbox `extension install` — do not edit
[[hooks]]
event = "SessionStart"
command = "thurbox-cli session signal --state idle || true"
timeout = 10

# managed by thurbox `extension install` — do not edit
[[hooks]]
event = "UserPromptSubmit"
command = "thurbox-cli session signal --state working || true"
timeout = 10

# managed by thurbox `extension install` — do not edit
[[hooks]]
event = "PreToolUse"
command = "thurbox-cli session signal --state working || true"
timeout = 10

# managed by thurbox `extension install` — do not edit
[[hooks]]
event = "PostToolUse"
command = "thurbox-cli session signal --state working || true"
timeout = 10

# managed by thurbox `extension install` — do not edit
[[hooks]]
event = "PermissionRequest"
command = "thurbox-cli session signal --state blocked || true"
timeout = 10

# managed by thurbox `extension install` — do not edit
[[hooks]]
event = "PermissionResult"
command = "thurbox-cli session signal --state working || true"
timeout = 10

# managed by thurbox `extension install` — do not edit
[[hooks]]
event = "Stop"
command = "thurbox-cli session signal --state done || true"
timeout = 10
== extension uninstall hooks ==
{"agents_removed":[],"automations_deleted":[],"home_removed":null,"manifest_removed":true,"ok":true,"sessions_deleted":[],"summary":"Uninstalled extension 'hooks'","uninstalled":"hooks"}
== grok hooks dir after uninstall (file must be gone) ==
== kimi config.toml after uninstall (must equal the user's original exactly) ==
model = "kimi-code/k3"
```
</details>
<details>
<summary>Evidence: grok hooks file actually installed to ~/.grok/hooks/thurbox-status.json</summary>

```text
{
  "hooks": {
    "SessionStart": [
      {
        "hooks": [
          {
            "type": "command",
            "command": "thurbox-cli session signal --state idle || true  # managed by thurbox `extension install` — do not edit",
            "timeout": 10
          }
        ]
      }
    ],
    "UserPromptSubmit": [
      {
        "hooks": [
          {
            "type": "command",
            "command": "thurbox-cli session signal --state working || true",
            "timeout": 10
          }
        ]
      }
    ],
    "PreToolUse": [
      {
        "matcher": ".*",
        "hooks": [
          {
            "type": "command",
            "command": "thurbox-cli session signal --state working || true",
            "timeout": 10
          }
        ]
      }
    ],
    "PostToolUse": [
      {
        "matcher": ".*",
        "hooks": [
          {
            "type": "command",
            "command": "thurbox-cli session signal --state working || true",
            "timeout": 10
          }
        ]
      }
    ],
    "Notification": [
      {
        "hooks": [
          {
            "type": "command",
            "command": "if cat | grep -qiE 'permission|approval|approve'; then thurbox-cli session signal --state blocked ; fi; true",
            "timeout": 10
          }
        ]
      }
    ],
    "Stop": [
      {
        "hooks": [
          {
            "type": "command",
            "command": "thurbox-cli session signal --state done || true",
            "timeout": 10
          }
        ]
      }
    ]
  }
}
```
</details>
<details>
<summary>Evidence: kimi ~/.kimi-code/config.toml after the merge (user&#39;s model= line preserved alongside our hooks)</summary>

```text
model = "kimi-code/k3"
# Kimi Code CLI status hooks, merged into the user's own ~/.kimi-code/config.toml.
#
# The comment above each entry is its ownership record, not decoration: it is how
# uninstall tells these entries from a hook the user wrote themselves (which may
# legitimately call `thurbox-cli session signal` too), and how an update
# recognises an entry of ours whose event or command has since changed. Every
# entry must carry it — see `agent::toml_merge`.
#
# Kimi accepts exactly four keys per entry (event/command/matcher/timeout) and
# refuses to load the whole config file when it sees a fifth, which is why
# ownership lives in a comment rather than in a field.

# managed by thurbox `extension install` — do not edit
[[hooks]]
event = "SessionStart"
command = "thurbox-cli session signal --state idle || true"
timeout = 10

# managed by thurbox `extension install` — do not edit
[[hooks]]
event = "UserPromptSubmit"
command = "thurbox-cli session signal --state working || true"
timeout = 10

# managed by thurbox `extension install` — do not edit
[[hooks]]
event = "PreToolUse"
command = "thurbox-cli session signal --state working || true"
timeout = 10

# managed by thurbox `extension install` — do not edit
[[hooks]]
event = "PostToolUse"
command = "thurbox-cli session signal --state working || true"
timeout = 10

# managed by thurbox `extension install` — do not edit
[[hooks]]
event = "PermissionRequest"
command = "thurbox-cli session signal --state blocked || true"
timeout = 10

# managed by thurbox `extension install` — do not edit
[[hooks]]
event = "PermissionResult"
command = "thurbox-cli session signal --state working || true"
timeout = 10

# managed by thurbox `extension install` — do not edit
[[hooks]]
event = "Stop"
command = "thurbox-cli session signal --state done || true"
timeout = 10
```
</details>
<details>
<summary>Evidence: kimi ~/.kimi-code/config.toml after uninstall (byte-identical to the user&#39;s original)</summary>

```text
model = "kimi-code/k3"
```
</details>

- Evidence: grok hooks dir listing after uninstall (empty — file removed) (local file: <code>grok-hooks-dir-after-uninstall.txt</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"e41d93a5ae4684d53a163915fdbc37e3924e2616","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `cargo nextest run --all`
- `cargo nextest run --lib agent::toml_merge session_ops::builtin_hooks session_ops::extensions::tests (55 passed)`
- <code>manual: THURBOX_CONFIG_DIR/THURBOX_DATA_DIR/HOME pointed at a throwaway temp dir; ran `thurbox-cli --json automation tick`, then created fake ~/.grok and ~/.kimi-code dirs and ran `thurbox-cli --json extension reinstall hooks`</code>
- `manual: inspected the real written ~/.grok/hooks/thurbox-status.json and ~/.kimi-code/config.toml for correct thurbox-cli session signal wiring`
- <code>manual: ran `thurbox-cli --json extension uninstall hooks` and confirmed grok&#39;s file was removed and kimi&#39;s config.toml was restored to the exact pre-install content</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

