### PR TITLE
fix(core): stop transient SQLite lock contention from freezing sessions

### DIFF
--- a/.agents/skills/thurbox-testing/SKILL.md
+++ b/.agents/skills/thurbox-testing/SKILL.md
@@ -90,6 +90,12 @@ kernel over the real `ui/`** rather than a harness that imitates either:
   window, a teardown spares a live namesake's companion shell, and a teardown
   never brings a tmux server into being (the `ensure_ready` side effect this
   path must not trigger).
+- **`tests/concurrent_respawn.rs`** — six sessions relaunching onto a tmux
+  server that does not exist yet, against a *real* tmux on a throwaway socket
+  (skipped when tmux is absent): every worker's `ensure_session_configured`
+  sees "no session" and races `new-session`, and the regression this pins is
+  that a loser must not abort its whole respawn over tmux's `duplicate
+  session` — it has to notice the winner's session and continue.
 - **`tests/session_state_agreement.rs`** — one row, four independent readers
   (`session get`, `session list`, `watch --initial` via the real binary, and
   `SnapshotStore` in-process): all four must answer the same `SessionState`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1475,6 +1475,16 @@ renumbering are now one `BEGIN IMMEDIATE` transaction
 (`Database::reorder_sessions`) with the write a single `UPDATE … CASE`, which is
 what the mutex was reaching for and could not have.
 
+Every targeted setter now opens through the same `BEGIN IMMEDIATE`
+(`Database::write_transaction`), not only `reorder_sessions`. A `BEGIN
+DEFERRED` transaction that reads before it writes — `set_backend_id` among
+them, and `set_hook_state`, the path every agent hook takes — upgrades to a
+write lock mid-flight, and in WAL mode an upgrade whose read snapshot a peer
+has already overtaken fails `SQLITE_BUSY` immediately, without consulting
+`busy_timeout`. The database is shared by the TUI, `thurbox-cli` and every
+agent hook, so that upgrade race is not rare; taking the lock at `BEGIN`
+instead makes the write wait out a peer rather than fail in front of one.
+
 **Rejected**:
 
 - *Keeping the in-memory reaper for its cadence.* It costs nothing per tick,
@@ -1493,8 +1503,12 @@ loop no longer holds a list of ids it is waiting on. A restart whose row is
 deleted underneath it now fails to record its pane instead of reviving the row,
 and says so; the sweep only collects a *soft*-deleted row, so a concurrent
 *force* delete would otherwise orphan the window it spawned — the caller kills
-that window itself when the record fails, rather than leaning on a sweep that
-cannot see it. `upsert_session` replaces the worktree rows unconditionally,
+that window itself when the record says the row is genuinely gone, rather than
+leaning on a sweep that cannot see it. A record that merely *failed to write*
+says nothing about the row: the agent that was just spawned is a live process,
+and killing it over a transient storage error — which `BEGIN IMMEDIATE` makes
+rarer but does not eliminate — is a defect the record's caller must not commit
+regardless. `upsert_session` replaces the worktree rows unconditionally,
 so a session that loses every worktree stops listing the ones it no longer owns
 — it used to skip the replacement for an empty list and keep them forever. And
 the reads that fed a relaunch stopped failing open: the `stop` guard, the launch

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -999,7 +999,7 @@ impl TmuxBackend {
                 self.session,
                 self.socket()
             );
-            self.run_tmux(&[
+            if let Err(e) = self.run_tmux(&[
                 "new-session",
                 "-d",
                 "-s",
@@ -1008,8 +1008,23 @@ impl TmuxBackend {
                 "80",
                 "-y",
                 "24",
-            ])
-            .context("Failed to create tmux session")?;
+            ]) {
+                // The check above is not a lock, and after a reboot every
+                // session's relaunch runs it at once: one wins and the rest are
+                // told `duplicate session`. Failing them is how a machine came
+                // back with all but one of its agents missing — each loser
+                // aborted its whole respawn, kept the pane id the dead server
+                // had given it, and that id then named whichever window the
+                // winner got. The session we wanted exists either way, so ask
+                // rather than assume, and only report a failure that left none.
+                if !self.session_exists() {
+                    return Err(e).context("Failed to create tmux session");
+                }
+                debug!(
+                    "tmux session '{}' was created by a peer; continuing",
+                    self.session
+                );
+            }
             // Cheap defensiveness on Windows: poll until the freshly-created
             // session answers `has-session` before applying options. (The
             // `no server running on 'thurbox__thurbox'` failure that originally

--- a/src/coordinator/commands.rs
+++ b/src/coordinator/commands.rs
@@ -277,6 +277,15 @@ impl App {
                     thurbox::kernel::messages::failed(kind, label.as_deref(), &error),
                     Level::Error,
                 );
+                // A relaunch that failed has to be allowed to happen again.
+                // `respawn_missing_agents` marks a session the moment it
+                // dispatches, so without this the one attempt a session gets per
+                // process is spent on an attempt that did nothing — and a
+                // session whose agent is still missing sits there with no pane
+                // and no further try until thurbox is restarted.
+                if kind == "restart" && !tracked.session.is_empty() {
+                    self.respawned.remove(&tracked.session);
+                }
                 self.note_command_failed(&tracked, &error);
             }
         }

--- a/src/coordinator/mod.rs
+++ b/src/coordinator/mod.rs
@@ -529,8 +529,12 @@ impl App {
     /// v1's `respawn_stale_session`, reached differently. v1 asks the question
     /// once, synchronously, during restore; here discovery is a worker, so the
     /// answer arrives a moment later and the question is asked each frame until
-    /// it can be answered. Once per session per run either way — a session that
-    /// cannot be relaunched must not be relaunched forever.
+    /// it can be answered. At most one dispatch in flight per session either
+    /// way — `self.respawned` is what stops every frame from redispatching a
+    /// restart that has not resolved yet. It is not a lifetime cap: a restart
+    /// that fails clears its entry (`report_finished_commands`), so a session
+    /// still missing its agent gets tried again next time it is seen, rather
+    /// than sitting frozen until thurbox restarts.
     ///
     /// It goes through `restart`, which is exactly a respawn once killing a
     /// window that is not there stopped being an error: same session id, same

--- a/src/main.rs
+++ b/src/main.rs
@@ -489,8 +489,10 @@ struct App {
     /// settings modal's Interface tab lists it too — one join per frame, read
     /// by both.
     inventory: Vec<thurbox::kernel::inventory::Row>,
-    /// Sessions already asked to relaunch, so a respawn is attempted once per
-    /// session per run rather than every frame its window is still missing.
+    /// Sessions with a relaunch in flight, so a respawn is dispatched once per
+    /// session rather than every frame its window is still missing. A failed
+    /// restart clears its entry, so a session still missing its agent is tried
+    /// again rather than stuck until thurbox restarts.
     respawned: std::collections::HashSet<String>,
     /// When the loop last asked the database for soft-deleted sessions whose
     /// undo window has closed, so their agents are let go rather than left

--- a/src/session_ops/restart.rs
+++ b/src/session_ops/restart.rs
@@ -584,24 +584,16 @@ mod tests {
 
         let stored = session(None, None);
         db.upsert_session(&stored).unwrap();
-        assert!(matches!(
-            record_pane(&db, &stored, "%1"),
-            Recorded::Stored
-        ));
+        assert!(matches!(record_pane(&db, &stored, "%1"), Recorded::Stored));
 
         let gone = session(None, None);
         db.upsert_session(&gone).unwrap();
         db.soft_delete_session(gone.id).unwrap();
-        assert!(matches!(
-            record_pane(&db, &gone, "%2"),
-            Recorded::RowGone
-        ));
+        assert!(matches!(record_pane(&db, &gone, "%2"), Recorded::RowGone));
 
         let live = session(None, None);
         db.upsert_session(&live).unwrap();
-        db.conn_ref()
-            .execute_batch("DROP TABLE sessions")
-            .unwrap();
+        db.conn_ref().execute_batch("DROP TABLE sessions").unwrap();
         assert!(matches!(
             record_pane(&db, &live, "%3"),
             Recorded::WriteFailed(_)

--- a/src/session_ops/restart.rs
+++ b/src/session_ops/restart.rs
@@ -203,6 +203,29 @@ fn refuse_if_deleted(db: &Database, session: &crate::sync::SharedSession) -> Res
     }
 }
 
+/// What recording a restart's new pane on its row came to.
+///
+/// Two ways of not succeeding, and the caller must not treat them alike: only
+/// one of them means the window it just spawned is nobody's.
+enum Recorded {
+    /// The row took the new pane id.
+    Stored,
+    /// The row is **gone** — deleted while the restart was in flight. Nothing
+    /// will ever attach to the window just spawned.
+    RowGone,
+    /// The write itself failed, which says nothing about the row. The window
+    /// stays up; see [`record_pane`].
+    WriteFailed(String),
+}
+
+impl Recorded {
+    /// What a caller reports when the row turned out to be gone. The window it
+    /// just spawned is killed on the way out, on both transports.
+    fn deleted_mid_restart(name: &str) -> String {
+        format!("'{name}' was deleted while it was restarting; its new window is being killed")
+    }
+}
+
 /// Persist the pane a restart just spawned.
 ///
 /// A targeted [`Database::set_backend_id`] rather than the full-row
@@ -213,25 +236,26 @@ fn refuse_if_deleted(db: &Database, session: &crate::sync::SharedSession) -> Res
 /// deleted row instead — but a *force*-deleted row is never reaped (both
 /// [`reap_overdue_soft_deletes`](crate::session_ops::reap_overdue_soft_deletes)
 /// and [`reap_soft_deleted`](crate::session_ops::reap_soft_deleted) skip
-/// `force_deleted` rows unconditionally), so this failing is not on its own
-/// proof the window will ever be collected. The caller kills the window it
-/// just spawned when this returns `Err`, rather than leaning on a sweep that
-/// only covers the soft-delete case.
-fn record_pane(
-    db: &Database,
-    session: &crate::sync::SharedSession,
-    pane: &str,
-) -> Result<(), String> {
-    if db
-        .set_backend_id(session.id, pane)
-        .map_err(|e| format!("Failed to record the new pane: {e}"))?
-    {
-        return Ok(());
+/// `force_deleted` rows unconditionally), so [`Recorded::RowGone`] is not on
+/// its own proof the window will ever be collected. The caller kills it, rather
+/// than leaning on a sweep that only covers the soft-delete case.
+///
+/// [`Recorded::WriteFailed`] is the case that must **not** kill anything. The
+/// storage error it carries — a peer holding the write lock, a full disk — is
+/// about the write, not about the row, and the agent that was just launched is
+/// a live process with a conversation in it. Left alone, the window is found
+/// again on its own: `spawn_window` stamps it with this session's id, so the
+/// interface resolves it by stamp when the row's stale pane id is contradicted
+/// by a listing (`Terminals::sync` → `pane_by_name`) and writes the id back
+/// (`drain_adopted_panes`). Killing the agent to tidy up after a transient
+/// failure is the worse of the two mistakes, and it is the one that left a
+/// session with no window at all.
+fn record_pane(db: &Database, session: &crate::sync::SharedSession, pane: &str) -> Recorded {
+    match db.set_backend_id(session.id, pane) {
+        Ok(true) => Recorded::Stored,
+        Ok(false) => Recorded::RowGone,
+        Err(e) => Recorded::WriteFailed(format!("Failed to record the new pane: {e}")),
     }
-    Err(format!(
-        "'{}' was deleted while it was restarting; its new window is being killed",
-        session.name
-    ))
 }
 
 /// What a restart has to say beyond having happened.
@@ -404,20 +428,25 @@ pub fn restart_session_headless_with(
             // interface at a pane that no longer exists. (Empty on psmux, where
             // the spawn can't report an id; the interface then resolves by
             // window name as before.)
-            if let Err(e) = record_pane(db, &session, &pane) {
-                // The row lost the race (deleted between the load above and
-                // here), so nothing will ever attach to this window — a
-                // force-deleted row is never reaped. Kill what was just
-                // spawned rather than leave it running forever.
-                if let Err(kill_err) =
-                    crate::agent::tmux::kill_window(&session.id.to_string(), &plan.window_name)
-                {
-                    tracing::warn!(
-                        "could not kill orphaned restart window for '{}': {kill_err:#}",
-                        session.name
-                    );
+            match record_pane(db, &session, &pane) {
+                Recorded::Stored => {}
+                Recorded::RowGone => {
+                    // The row lost the race (deleted between the load above and
+                    // here), so nothing will ever attach to this window — a
+                    // force-deleted row is never reaped. Kill what was just
+                    // spawned rather than leave it running forever.
+                    if let Err(kill_err) =
+                        crate::agent::tmux::kill_window(&session.id.to_string(), &plan.window_name)
+                    {
+                        tracing::warn!(
+                            "could not kill orphaned restart window for '{}': {kill_err:#}",
+                            session.name
+                        );
+                    }
+                    return Err(Recorded::deleted_mid_restart(&session.name));
                 }
-                return Err(e);
+                // The agent is running; only the row lags. Reported, not killed.
+                Recorded::WriteFailed(e) => return Err(e),
             }
         }
         Some(host) => {
@@ -456,23 +485,28 @@ pub fn restart_session_headless_with(
             // The new pane is a different one, and the id is how every later
             // read finds it — leaving the old one persisted would point the
             // interface at a pane that no longer exists.
-            if let Err(e) = record_pane(db, &session, &pane) {
-                // Same race as the local branch: a force-deleted row is never
-                // reaped, so the window this just spawned on the host has to
-                // be killed here or it runs forever.
-                if let Err(kill_err) = crate::agent::tmux::kill_remote_windows(
-                    host,
-                    &session.id.to_string(),
-                    &plan.window_name,
-                    crate::agent::tmux::SessionPanes::agent(&pane),
-                ) {
-                    tracing::warn!(
-                        "could not kill orphaned restart window for '{}' on '{}': {kill_err:#}",
-                        session.name,
-                        host.name
-                    );
+            match record_pane(db, &session, &pane) {
+                Recorded::Stored => {}
+                Recorded::RowGone => {
+                    // Same race as the local branch: a force-deleted row is never
+                    // reaped, so the window this just spawned on the host has to
+                    // be killed here or it runs forever.
+                    if let Err(kill_err) = crate::agent::tmux::kill_remote_windows(
+                        host,
+                        &session.id.to_string(),
+                        &plan.window_name,
+                        crate::agent::tmux::SessionPanes::agent(&pane),
+                    ) {
+                        tracing::warn!(
+                            "could not kill orphaned restart window for '{}' on '{}': {kill_err:#}",
+                            session.name,
+                            host.name
+                        );
+                    }
+                    return Err(Recorded::deleted_mid_restart(&session.name));
                 }
-                return Err(e);
+                // The agent is running on the host; only the row lags.
+                Recorded::WriteFailed(e) => return Err(e),
             }
         }
     }

--- a/src/session_ops/restart.rs
+++ b/src/session_ops/restart.rs
@@ -572,6 +572,42 @@ mod tests {
         );
     }
 
+    /// [`record_pane`] must tell a row that is genuinely gone apart from a write
+    /// that merely failed — only the former means the window it just spawned is
+    /// nobody's. The peer-lock trick the storage tests use to force `SQLITE_BUSY`
+    /// no longer reaches this path: `set_backend_id` takes the write lock up
+    /// front and waits it out. Dropping the table out from under the connection
+    /// forces a real, non-deletion storage error instead.
+    #[test]
+    fn record_pane_distinguishes_a_deleted_row_from_a_failed_write() {
+        let db = Database::open_in_memory().unwrap();
+
+        let stored = session(None, None);
+        db.upsert_session(&stored).unwrap();
+        assert!(matches!(
+            record_pane(&db, &stored, "%1"),
+            Recorded::Stored
+        ));
+
+        let gone = session(None, None);
+        db.upsert_session(&gone).unwrap();
+        db.soft_delete_session(gone.id).unwrap();
+        assert!(matches!(
+            record_pane(&db, &gone, "%2"),
+            Recorded::RowGone
+        ));
+
+        let live = session(None, None);
+        db.upsert_session(&live).unwrap();
+        db.conn_ref()
+            .execute_batch("DROP TABLE sessions")
+            .unwrap();
+        assert!(matches!(
+            record_pane(&db, &live, "%3"),
+            Recorded::WriteFailed(_)
+        ));
+    }
+
     #[test]
     fn restart_plan_requires_agent_session_id() {
         let temp = tempfile::TempDir::new().unwrap();

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -186,6 +186,30 @@ impl Database {
         &self.conn
     }
 
+    /// Begin a transaction that takes the write lock **up front**.
+    ///
+    /// Every write here must start this way, and `BEGIN DEFERRED` — what
+    /// `Connection::unchecked_transaction` gives — must not be used for one.
+    /// A deferred transaction takes no lock, so one that reads before it writes
+    /// upgrades mid-flight; and in WAL mode an upgrade whose read snapshot
+    /// another connection has already overtaken fails with `SQLITE_BUSY`
+    /// **without consulting `busy_timeout`** — immediately, however long
+    /// [`schema::BUSY_TIMEOUT`] is. The database is shared by the TUI,
+    /// `thurbox-cli` and every agent hook, so that is not a rare interleaving:
+    /// it is what a restart recording its new pane hits while a hook reports a
+    /// state change.
+    ///
+    /// Taking the lock at `BEGIN` costs nothing — these writes are short
+    /// single-row updates — and it is the difference between waiting out a
+    /// peer and failing in front of one. `reorder_sessions` has spelled the
+    /// same rule out with a raw `BEGIN IMMEDIATE` since it was written.
+    ///
+    /// Unchecked because `Database` methods take `&self`; the connection is
+    /// not shared across threads.
+    pub(crate) fn write_transaction(&self) -> rusqlite::Result<rusqlite::Transaction<'_>> {
+        rusqlite::Transaction::new_unchecked(&self.conn, rusqlite::TransactionBehavior::Immediate)
+    }
+
     /// Open an in-memory database (for testing).
     pub fn open_in_memory() -> rusqlite::Result<Self> {
         let conn = Connection::open_in_memory()?;
@@ -230,5 +254,174 @@ mod tests {
         let db1 = Database::open_in_memory().unwrap();
         let db2 = Database::open_in_memory().unwrap();
         assert_ne!(db1.instance_id, db2.instance_id);
+    }
+
+    fn session_row(name: &str) -> crate::sync::SharedSession {
+        crate::sync::SharedSession {
+            id: crate::session::SessionId::default(),
+            name: name.to_string(),
+            agent: "claude".to_string(),
+            backend_id: "%1".to_string(),
+            backend_type: "tmux".to_string(),
+            agent_session_id: None,
+            cwd: None,
+            additional_dirs: Vec::new(),
+            worktrees: Vec::new(),
+            shell_backend_id: None,
+            parent_session_id: None,
+            display_order: None,
+            tombstone: false,
+            tombstone_at: None,
+        }
+    }
+
+    /// A session write must wait out a peer that commits underneath it.
+    ///
+    /// This is the interleaving a restart hits on a busy machine: another
+    /// process is mid-write when the restart records the pane it just spawned.
+    /// A `BEGIN DEFERRED` transaction that reads before it writes upgrades
+    /// against a snapshot that peer has since superseded, and WAL answers that
+    /// with `SQLITE_BUSY` **without consulting `busy_timeout`** — so it fails
+    /// outright, however long the timeout is. `session_ops::restart` read that
+    /// failure as "the row was deleted", killed the agent window it had just
+    /// spawned, and left the session with no window at all.
+    ///
+    /// Deterministic rather than a load test, which matters for a defect that
+    /// only shows under concurrency: the peer takes the lock **before** the
+    /// write starts and commits only once the call is proven to be in flight,
+    /// so there is no interleaving to get lucky about. Under WAL nothing but
+    /// the write itself can block — reads and `BEGIN` do not — so a call that
+    /// has not returned while the lock is held is a call whose snapshot is
+    /// already older than the commit that follows.
+    #[test]
+    fn a_session_write_waits_out_a_peer_that_commits_underneath_it() {
+        use std::sync::mpsc;
+        use std::time::{Duration, Instant};
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("thurbox.db");
+        let db = Database::open(&path).unwrap();
+        let subject = session_row("restarting");
+        let peer_row = session_row("peer");
+        db.upsert_session(&subject).unwrap();
+        db.upsert_session(&peer_row).unwrap();
+
+        // The peer holds the write lock and has not committed yet.
+        let peer = rusqlite::Connection::open(&path).unwrap();
+        peer.busy_timeout(schema::BUSY_TIMEOUT).unwrap();
+        peer.execute_batch("BEGIN IMMEDIATE").unwrap();
+
+        let (started, call_started) = mpsc::channel();
+        let (done, call_done) = mpsc::channel();
+        let write_path = path.clone();
+        let id = subject.id;
+        let writer = std::thread::spawn(move || {
+            let db = Database::open_existing(&write_path).unwrap();
+            started.send(()).unwrap();
+            let outcome = db.set_backend_id(id, "%42");
+            let _ = done.send(());
+            outcome
+        });
+
+        // In flight: the call has begun and, with the lock held, cannot have
+        // finished. Both halves are checked — the second is what says the
+        // snapshot below is genuinely the older one.
+        call_started.recv().unwrap();
+        let deadline = Instant::now() + Duration::from_millis(300);
+        while Instant::now() < deadline {
+            assert!(
+                call_done.try_recv().is_err(),
+                "the write returned while the peer held the lock, so it never blocked"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        peer.execute(
+            "UPDATE sessions SET name = 'renamed' WHERE id = ?1",
+            rusqlite::params![peer_row.id.to_string()],
+        )
+        .unwrap();
+        peer.execute_batch("COMMIT").unwrap();
+
+        let stored = writer
+            .join()
+            .unwrap()
+            .expect("a peer's commit must not fail this write");
+        assert!(
+            stored,
+            "the row is still there, so the write must have hit it"
+        );
+        assert_eq!(
+            db.get_session_by_id(subject.id)
+                .unwrap()
+                .unwrap()
+                .backend_id,
+            "%42",
+            "the pane a restart spawned must be what the row ends up naming"
+        );
+    }
+
+    /// The same rule under ordinary load rather than a staged interleaving.
+    ///
+    /// Weaker than the test above by design — it can only under-report, since a
+    /// scheduler that never runs the peer between two of these writes simply
+    /// finds nothing — so it is the load-shaped second opinion, not the gate.
+    /// It is here because this is the shape the defect was found in: one peer
+    /// writing session rows the way an agent hook does was enough to fail
+    /// roughly one in eight of these.
+    #[test]
+    fn session_writes_survive_a_peer_writing_continuously() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("thurbox.db");
+        let db = Database::open(&path).unwrap();
+        let subject = session_row("restarting");
+        let peer_row = session_row("chatty");
+        db.upsert_session(&subject).unwrap();
+        db.upsert_session(&peer_row).unwrap();
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let peer_stop = Arc::clone(&stop);
+        let peer_path = path.clone();
+        let peer_id = peer_row.id;
+        // What every agent hook does: `thurbox-cli session signal`, on its own
+        // connection, as often as the agent changes state.
+        let peer = std::thread::spawn(move || {
+            let db = Database::open_existing(&peer_path).unwrap();
+            let mut n = 0u64;
+            let mut refused = 0u64;
+            while !peer_stop.load(Ordering::Relaxed) {
+                let state = if n % 2 == 0 { "working" } else { "done" };
+                if db.set_hook_state(peer_id, state).is_err() {
+                    refused += 1;
+                }
+                n += 1;
+            }
+            refused
+        });
+
+        let mut refused = Vec::new();
+        for i in 0..500 {
+            if let Err(e) = db.set_backend_id(subject.id, &format!("%{i}")) {
+                refused.push(format!("write {i}: {e}"));
+            }
+        }
+        stop.store(true, Ordering::Relaxed);
+        let peer_refused = peer.join().unwrap();
+
+        assert!(
+            refused.is_empty(),
+            "{} of 500 pane writes were refused under one peer; each one is a \
+             restart killing the agent window it just spawned:\n{}",
+            refused.len(),
+            refused.join("\n")
+        );
+        assert_eq!(
+            peer_refused, 0,
+            "the peer's own status writes were refused {peer_refused} times; \
+             a dropped hook report is a session whose status stops moving"
+        );
     }
 }

--- a/src/storage/sessions.rs
+++ b/src/storage/sessions.rs
@@ -102,9 +102,9 @@ impl Database {
     /// The whole write — row, audits, worktree replacement, the watch event —
     /// is one transaction: each statement in autocommit was its own WAL commit,
     /// so a single upsert cost N+5 `data_version` bumps and re-triggered every
-    /// peer process's refresh that many times. (`unchecked_transaction` because
-    /// `Database` methods take `&self`; the connection is not shared across
-    /// threads.)
+    /// peer process's refresh that many times. It takes the write lock up
+    /// front, which is what keeps the read below and the write after it from
+    /// failing over a peer's commit.
     pub fn upsert_session(&self, session: &SharedSession) -> rusqlite::Result<()> {
         self.upsert_session_as(session, EventReason::Spawned)
     }
@@ -121,7 +121,7 @@ impl Database {
         session: &SharedSession,
         created_as: EventReason,
     ) -> rusqlite::Result<()> {
-        let tx = self.conn.unchecked_transaction()?;
+        let tx = self.write_transaction()?;
         let now = current_time_millis() as i64;
         let id_str = session.id.to_string();
 
@@ -258,7 +258,7 @@ impl Database {
     }
 
     fn delete_session(&self, id: SessionId, reason: EventReason) -> rusqlite::Result<()> {
-        let tx = self.conn.unchecked_transaction()?;
+        let tx = self.write_transaction()?;
         let now = current_time_millis() as i64;
         let id_str = id.to_string();
 
@@ -295,7 +295,7 @@ impl Database {
     /// Deleting *and* marking in one go is
     /// [`force_delete_session`](Self::force_delete_session).
     pub fn mark_session_force_deleted(&self, id: SessionId) -> rusqlite::Result<()> {
-        let tx = self.conn.unchecked_transaction()?;
+        let tx = self.write_transaction()?;
         let marked = self.conn.execute(
             "UPDATE sessions SET force_deleted = 1 \
              WHERE id = ?1 AND deleted_at IS NOT NULL AND force_deleted = 0",
@@ -315,7 +315,7 @@ impl Database {
 
     /// Restore a soft-deleted session.
     pub fn restore_session(&self, id: SessionId) -> rusqlite::Result<()> {
-        let tx = self.conn.unchecked_transaction()?;
+        let tx = self.write_transaction()?;
         let now = current_time_millis() as i64;
         let id_str = id.to_string();
 
@@ -569,7 +569,7 @@ impl Database {
     /// same rule [`set_hook_state`](Self::set_hook_state) enforces from the
     /// other side.
     pub fn set_session_stopped(&self, id: SessionId, stopped: bool) -> rusqlite::Result<()> {
-        let tx = self.conn.unchecked_transaction()?;
+        let tx = self.write_transaction()?;
         let now = current_time_millis() as i64;
         let id_str = id.to_string();
 
@@ -885,7 +885,7 @@ impl Database {
     /// a session that has no process to be in it, and every watcher of that row
     /// would see a transition that did not happen.
     pub fn set_hook_state(&self, id: SessionId, state: &str) -> rusqlite::Result<bool> {
-        let tx = self.conn.unchecked_transaction()?;
+        let tx = self.write_transaction()?;
         let now = current_time_millis() as i64;
         let id_str = id.to_string();
 
@@ -977,7 +977,7 @@ impl Database {
     /// ordinary spawns persist theirs through
     /// [`upsert_session`](Self::upsert_session). Returns whether a row matched.
     pub fn set_backend_id(&self, id: SessionId, pane: &str) -> rusqlite::Result<bool> {
-        let tx = self.conn.unchecked_transaction()?;
+        let tx = self.write_transaction()?;
         let id_str = id.to_string();
         let before: Option<String> = self
             .conn
@@ -1120,7 +1120,7 @@ impl Database {
     /// [`set_session_stopped`](Self::set_session_stopped), which reports the
     /// park rather than a bare state change; this is the restart edge alone.
     pub fn clear_hook_state(&self, id: SessionId) -> rusqlite::Result<()> {
-        let tx = self.conn.unchecked_transaction()?;
+        let tx = self.write_transaction()?;
         let id_str = id.to_string();
         let previous: Option<Option<String>> = self
             .conn

--- a/tests/concurrent_respawn.rs
+++ b/tests/concurrent_respawn.rs
@@ -1,0 +1,112 @@
+//! Relaunching every session at once, onto a tmux server that is not there yet.
+//!
+//! This is the first thing thurbox does on a machine that has just rebooted:
+//! `missing_agents` finds every session unplaced and `respawn_missing_agents`
+//! hands each one to its own worker, so N spawns arrive together at a server
+//! with no thurbox session on it. `ensure_session_configured` used to check
+//! `session_exists()` and then create — which is not a lock, so every worker
+//! saw "no session", every worker ran `new-session`, one won and the rest were
+//! told `duplicate session`. A loser's whole respawn aborted: no window, and a
+//! row still naming the pane id the *dead* server had given it — an id the new
+//! server had by then reissued to whichever session won. That session sat with
+//! no agent, and because `respawned` marks a session the moment it dispatches,
+//! nothing tried again for the life of the process.
+//!
+//! Driven against a real tmux server on a private socket, because the race is
+//! in tmux's answer and nothing in-process can stand in for it. Skipped where
+//! tmux is not installed, like `tests/attach_by_name.rs`.
+
+use std::collections::HashMap;
+use std::process::Command;
+
+/// A socket of this test's own, so it can never see — or kill — a real session.
+const SOCKET: &str = "thurbox-respawn-test";
+
+/// How many sessions come back at once. Six is the shape the defect was found
+/// in and enough for every thread to reach `new-session` together; the loser
+/// count does not change the assertion, which is that there are none.
+const SESSIONS: usize = 6;
+
+fn have_tmux() -> bool {
+    Command::new("tmux")
+        .arg("-V")
+        .output()
+        .map(|out| out.status.success())
+        .unwrap_or(false)
+}
+
+fn tmux(args: &[&str]) -> std::process::Output {
+    Command::new("tmux")
+        .arg("-L")
+        .arg(SOCKET)
+        .args(args)
+        .output()
+        .expect("run tmux")
+}
+
+#[test]
+fn every_session_relaunching_at_once_gets_its_own_window() {
+    if !have_tmux() {
+        eprintln!("skipping: tmux is not installed");
+        return;
+    }
+    // Private socket directory as well as a private socket name: the sandbox
+    // pattern, so nothing here can reach a real thurbox server.
+    let home = tempfile::tempdir().expect("tempdir");
+    std::env::set_var("TMUX_TMPDIR", home.path());
+    std::env::set_var(thurbox::agent::tmux::SOCKET_OVERRIDE_ENV, SOCKET);
+    // No server and no session: the state a reboot leaves behind, and the only
+    // state in which the create races at all.
+    tmux(&["kill-server"]);
+
+    let barrier = std::sync::Arc::new(std::sync::Barrier::new(SESSIONS));
+    let spawns: Vec<_> = (0..SESSIONS)
+        .map(|i| {
+            let barrier = std::sync::Arc::clone(&barrier);
+            std::thread::spawn(move || {
+                let id = format!("00000000-0000-0000-0000-00000000000{i}");
+                let name = format!("relaunch-{i}");
+                // Released together, so the `session_exists()` checks overlap
+                // instead of being serialised by thread startup.
+                barrier.wait();
+                thurbox::agent::tmux::spawn_window(
+                    &id,
+                    &name,
+                    "sh",
+                    &["-c".to_string(), "while :; do sleep 1; done".to_string()],
+                    None,
+                    &HashMap::new(),
+                )
+                .map_err(|e| format!("{name}: {e:#}"))
+            })
+        })
+        .collect();
+
+    let outcomes: Vec<Result<String, String>> = spawns
+        .into_iter()
+        .map(|t| t.join().expect("join"))
+        .collect();
+    let windows =
+        String::from_utf8_lossy(&tmux(&["list-windows", "-a", "-F", "#{window_name}"]).stdout)
+            .to_string();
+    tmux(&["kill-server"]);
+
+    let refused: Vec<&String> = outcomes.iter().filter_map(|o| o.as_ref().err()).collect();
+    assert!(
+        refused.is_empty(),
+        "{} of {SESSIONS} relaunches were refused; each is a session left with no \
+         agent and a pane id the new server has given to somebody else:\n{}",
+        refused.len(),
+        refused
+            .iter()
+            .map(|e| e.as_str())
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+    for i in 0..SESSIONS {
+        assert!(
+            windows.lines().any(|w| w == format!("tb-relaunch-{i}")),
+            "relaunch-{i} reported success but has no window; server holds:\n{windows}"
+        );
+    }
+}


### PR DESCRIPTION
## Intent

The captain commissioned this work on 2026-09-06, in his words:

"I want to try and find bugs in thurbox repo. I do have some feedback about 'frozen' sessions. This usually seems to happen because of some mistakes in ids. Can you investigate ?"

An investigation followed and put three shipping options to him. After reading its report he authorized implementation with: "A first, then B" - ship option A now as one pull request, ship option B afterwards as a separate second pull request, and decline option C (ship nothing). This change is option A only.

Option A, in the terms the report put to him:

Fix the frozen sessions. A session stops responding and stops updating, and does not come back until thurbox is restarted. The investigation established the cause, and it is not primarily the identifier mistakes the captain suspected - those are the visible wreckage. A session restart records the pane it has just spawned by writing the row; that write intermittently fails with SQLite "database is locked" under the ordinary write load of the TUI, thurbox-cli and every agent hook sharing one database. The restart path misreads that transient failure as "this row was deleted underneath me" and answers it by killing the agent window it just created - destroying a live agent and its conversation. The session is then left with no tmux window at all, and its row still names a stale pane id that a restarted tmux server has by then reissued to a different session, which is the id confusion the captain noticed. The interface relaunches a session that has no pane at most once per process, so that single retry is often spent on the same failure and the session stays frozen.

The smallest fix, as the report put it to him:

- Move the eight deferred transactions in src/storage/sessions.rs onto a transaction that takes the write lock up front, so a peer's commit makes these writes wait rather than fail outright. Five of them read before they write, including set_hook_state, which is the path every agent hook takes to report status.
- Make record_pane in src/session_ops/restart.rs distinguish a row that was genuinely deleted from a write that merely failed, so a transient storage error stops killing the agent window that was just spawned.
- Clear the session's entry from the never-cleared respawned set when a restart fails, so the one automatic relaunch a session gets per process is not spent on an attempt that did nothing. The report listed this as optional and recommended it; the captain's "A" includes it.
- Fix the check-then-act race in ensure_session_configured that aborts all but one session's respawn after a reboot: every session's relaunch runs "tmux new-session" at once, one wins and the losers are told "duplicate session" and give up entirely.

Deliberately not in this change, because the captain asked for it separately and afterwards: option B, the identifier fix where an adopted session stamps its companion shell window with a randomly generated UUID instead of its own session id, and the orphan tbs- windows that leak as a result.

## What Changed

- Switch eight session-write paths in `src/storage/sessions.rs` (`upsert_session_as`, `delete_session`, `mark_session_force_deleted`, `restore_session`, `set_session_stopped`, `set_hook_state`, `set_backend_id`, `clear_hook_state`) from `unchecked_transaction` (`BEGIN DEFERRED`) to a new `Database::write_transaction` helper (`src/storage/mod.rs`) that opens with `BEGIN IMMEDIATE`, so a write that reads before it writes waits out a concurrent peer commit instead of failing outright with `SQLITE_BUSY`.
- In `src/session_ops/restart.rs`, replace `record_pane`'s boolean/`Err` return with a three-way `Recorded` enum (`Stored` / `RowGone` / `WriteFailed`) so the caller only kills the just-spawned agent window when the session row was genuinely deleted mid-restart, not when the write merely failed transiently; add a regression test covering all three outcomes.
- In `src/coordinator/commands.rs`, clear a failed restart's entry from `App.respawned` (`src/main.rs`) so the single per-process automatic relaunch isn't consumed by an attempt that made no progress; update related doc comments in `src/coordinator/mod.rs`.
- In `src/agent/tmux.rs`, tolerate a `new-session` failure in `ensure_session_configured` by checking `session_exists` before erroring, fixing a check-then-act race where a post-reboot mass respawn left every losing session's relaunch aborted with "duplicate session".
- Add `tests/concurrent_respawn.rs` and update `docs/ARCHITECTURE.md` / `.agents/skills/thurbox-testing/SKILL.md` to document the new coverage.

## Risk Assessment

✅ Low: Both previously-accepted findings were correctly addressed: the new record_pane test forces a genuine non-deletion storage error (dropping the sessions table causes a real SQL error distinct from the zero-rows-updated deletion case) and correctly asserts the WriteFailed variant, and the ADR-26 update accurately documents both the write_transaction rationale and the corrected kill-on-RowGone-only behavior without duplicating the code comment; the rest of the diff (write_transaction adoption across all 8 setters, the tmux duplicate-session race fix, the respawned-set clear-on-failure fix) was unchanged from the already-reviewed original commit and holds up under re-inspection.

## Testing

Baseline cargo nextest run --all already passed; targeted re-verification of the two review-round fixes (new record_pane classification test and ADR-26 doc update) confirms both satisfy the reviewer's exact guidance — the new unit test is a genuine behavioral test against a real Database (not a source-text check) covering the previously-uncovered WriteFailed case, and the surrounding storage/tmux tests for the underlying fix (write_transaction lock-waiting, concurrent respawn race) all pass. No issues found.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"df239abb85b48478d918ca6ea1789322e70f02ad","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `src/session_ops/restart.rs:253` - The `record_pane` split into `Recorded::{Stored,RowGone,WriteFailed}` (src/session_ops/restart.rs:210-258) is the second explicitly-required piece of this fix — a genuine storage error must not kill the window a restart just spawned, only a real row deletion may. No test exercises this distinction: the file&#39;s own `#[cfg(test)] mod tests` (already using `Database::open_in_memory()` and a `session()` helper) has nothing that forces `set_backend_id` to fail for a reason other than deletion and asserts the restart path does not call `kill_window`/`kill_remote_windows` in that case. The storage-level tests in src/storage/mod.rs only prove the write no longer fails under lock contention — they don&#39;t cover this function at all, so the case this sub-fix targets (a write that fails for some other reason) is currently unverified. Per this repo&#39;s test-driven convention (&#34;a bug fix starts with a test that reproduces the bug ... what is missing is a fix that adds neither&#34;), this sub-fix is missing its regression test.
- ℹ️ `docs/ARCHITECTURE.md:1474` - docs/ARCHITECTURE.md ADR-26 documents the prior decision that only `reorder_sessions` needed `BEGIN IMMEDIATE` and that other setters are targeted single-column UPDATEs; this change extends that decision by making `BEGIN IMMEDIATE` (via the new `Database::write_transaction`) the rule for every session write, for the reason ADR-26 didn&#39;t need to cover (deferred-transaction upgrade failing SQLITE_BUSY without consulting busy_timeout). No doc file changed in this diff. The rationale is thoroughly captured in the `write_transaction` doc comment itself (src/storage/mod.rs:190-207), so this is a minor documentation-placement gap rather than a missing explanation, but it is exactly the kind of decision-extension CLAUDE.md&#39;s &#34;Rule&#34; asks to fold into the same PR.

🔧 Fix: Add record_pane classification test; extend ADR-26 for write_transaction
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `cargo nextest run --all`
- `cargo nextest run --lib record_pane_distinguishes_a_deleted_row_from_a_failed_write`
- `cargo nextest run --lib session_ops::restart:: storage::sessions:: (49 tests)`
- `cargo nextest run --test concurrent_respawn (every_session_relaunching_at_once_gets_its_own_window, real tmux server)`
- `cargo nextest run --lib a_session_write_waits_out_a_peer_that_commits_underneath_it session_writes_survive_a_peer_writing_continuously`
- `manual code inspection of set_backend_id (src/storage/sessions.rs:979) confirming Ok(false) only on deleted_at IS NOT NULL vs Err on real storage failure`
- `manual diff review of docs/ARCHITECTURE.md ADR-26 edits against the reviewer's required wording/placement`
- `git status --porcelain confirmed clean working tree after tests`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: {&#34;summary&#34;: &#34;fmt: apply rustfmt to restart.rs test assertions&#34;}
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
