### PR TITLE
fix(core): stop a latched blocked status from outliving a finished turn

### DIFF
--- a/.agents/skills/thurbox-cli/SKILL.md
+++ b/.agents/skills/thurbox-cli/SKILL.md
@@ -413,10 +413,21 @@ genuinely impossible: a backend with no `hosts.toml` entry, or one whose
 
 `session create --command <exe>` makes a session *anything*, and the row is
 named after the command's file stem. A driver that opens a shell and then starts
-`claude` in it (the `agent launch-args claude` shape) leaves thurbox reading hook
-coverage against `bash`: `hook_coverage: "none"`, no reportable states, and —
-worst of all — `hook_blocked_is_heuristic: false`, asserting the block signal is
-structured when it is claude's text match on a notification body.
+`claude` in it (the `agent launch-args claude` shape) used to leave thurbox
+reading hook coverage against `bash`: `hook_coverage: "none"`, no reportable
+states, and — worst of all — `hook_blocked_is_heuristic: false`, asserting the
+block signal is structured when it is claude's text match on a notification
+body.
+
+When the pane probe has already named the agent, that name is now what coverage
+resolves against: `hook_coverage: "presumed"`, `hook_coverage_source:
+"detection"`, and the reportable states and heuristic flag of the agent actually
+in the pane. `presumed` is a fourth word rather than `full`, and the distinction
+is the point — coverage says what wiring *can* report, and seeing claude in a
+pane is evidence about the process, never about whether anything wired its
+hooks. It is also the one coverage answer that is a **live** reading, so it
+comes and goes with the probe (`--no-verify` leaves it `none`) and a declaration
+always outranks it.
 
 `session create --reports-as <agent>` and `session reports-as <ref> <agent>`
 (`--clear` to take it back) are how the driver says what is in there. The

--- a/.agents/skills/thurbox-session-status/SKILL.md
+++ b/.agents/skills/thurbox-session-status/SKILL.md
@@ -24,7 +24,7 @@ module exists to prevent:
 | `done` | blue | `●` (filled) | a turn just finished; shown until you switch away (hook) |
 | `idle` | green | `○` (hollow) | acknowledged (you moved off a Done), never active, or at rest |
 | `unreachable` | muted grey | `⊘` | remote host down/offline; the ordinary row, derived from a live attach failure, awaiting reconnect |
-| `running` | `status_running` (accent) | `◍` | an agent holds the pane and nothing has signalled — an observation, never a claim about what it is doing |
+| `running` | `status_running` (accent) | `◉` | an agent holds the pane and nothing has signalled — an observation, never a claim about what it is doing |
 | `uncovered` | `status_unknown` (muted) | `◌` | this agent is wired to report nothing, so its silence means nothing |
 | `unreported` | `status_unknown` (muted) | `◌` | the agent *can* report and has not yet |
 | `stopped` | — | — | parked by `session stop`: no process at all, which is why it outranks whatever the hook columns still hold |
@@ -213,7 +213,7 @@ own, which is the point.
   |---|---|---|
   | `derive_state` (incl. the `done → idle` acknowledgment) | `hook_state`, `hook_state_at`, `seen_at` — all stored | everyone |
   | `classify_foreground` → `Assessment::with_corroboration` | the pane's foreground process group | anyone who can run `ps` |
-  | `with_output_quiescence` | terminal output age | the interface only |
+  | `with_output_quiescence` (incl. the latched-`blocked` fold) | terminal output age, against `hook_state_at` | the interface only |
   | `with_reachability` | a live attach error | the interface only |
 
   `seen_at` being a **stored fact** rather than a timeout is why the CLI applies
@@ -248,6 +248,25 @@ own, which is the point.
   (whose cadence is the database's) and re-derived from `hook_state` each pass,
   so it reverses itself when output resumes. The DB row is left untouched — the
   override is purely per-tick derivation.
+- **Latched-`blocked` fallback.** `blocked` is still never time-gated: a session
+  waiting on you is quiet for exactly as long as it waits, so no clock may end
+  one and an hour-long block stays `blocked`. What ends one is evidence —
+  `session::outlived_by_output`, in the same tick pass. A block edge stops the
+  pane printing, so a real block keeps `millis_since_output` within measurement
+  slop of `hook_state_age`; a block the agent resolved by itself leaves the two
+  diverging, because the turn goes on printing. When the pane has printed more
+  than `WORKING_QUIET_MS` past the edge the block is over, and what is left runs
+  through the `working` rule above: still printing reads `working`, gone quiet
+  reads `idle`. The margin is `WORKING_QUIET_MS` rather than a new constant
+  because it is the same claim that one already makes. Why it is needed at all:
+  claude's `blocked` is a **text match on a `Notification` body**
+  (`blocked_is_heuristic`), that hook also fires for advisories an autonomous
+  agent answers on its own, and — unlike kimi's `PermissionRequest` /
+  `PermissionResult` pair — nothing in the payload clears it. A false block that
+  landed as the newest word therefore stood for the rest of the session's life.
+  Only the interface can apply this: `session get` has no terminal to ask and
+  keeps reporting the latched word, which is the same line the CLI already draws
+  at the two folds it cannot make.
 - **Per-session only.** Status renders on the session's own row (and in the
   ` Sessions ` panel border title, one dot per session). Repo-group headers
   (`group_header_line` in `10_sessions.lua`) carry **no** status — a rolled-up

--- a/.agents/skills/thurbox-session-status/SKILL.md
+++ b/.agents/skills/thurbox-session-status/SKILL.md
@@ -24,7 +24,7 @@ module exists to prevent:
 | `done` | blue | `●` (filled) | a turn just finished; shown until you switch away (hook) |
 | `idle` | green | `○` (hollow) | acknowledged (you moved off a Done), never active, or at rest |
 | `unreachable` | muted grey | `⊘` | remote host down/offline; the ordinary row, derived from a live attach failure, awaiting reconnect |
-| `running` | `status_running` (accent) | `◉` | an agent holds the pane and nothing has signalled — an observation, never a claim about what it is doing |
+| `running` | `status_running` (accent) | `◉`, animated while its pane prints | an agent holds the pane and nothing has signalled — an observation, never a claim about what it is doing |
 | `uncovered` | `status_unknown` (muted) | `◌` | this agent is wired to report nothing, so its silence means nothing |
 | `unreported` | `status_unknown` (muted) | `◌` | the agent *can* report and has not yet |
 | `stopped` | — | — | parked by `session stop`: no process at all, which is why it outranks whatever the hook columns still hold |
@@ -77,7 +77,29 @@ connection; both sets are appended after the user's `ssh_opts`, whose first
 occurrence wins), which stops a broken host
 from prompting for a password on the TUI's terminal or hanging the render loop.
 
-The live session list **animates** the `Working` spinner. The frames are
+The live session list **animates** the `Working` spinner, and `Running` too —
+but only on evidence. `running` says an agent holds the pane and has not
+signalled, which cannot by itself distinguish a turn in flight from a prompt
+waiting for input, so a spinner there would assert what the observation cannot
+support. Terminal output can tell them apart, and it is the same signal the
+stuck-`working` fallback trusts in the other direction: a `running` session
+whose pane printed within `WORKING_QUIET_MS` animates, and one that has gone
+quiet falls back to the static `◉`. `uncovered` and `unreported` are absences
+and never animate, whatever their pane is doing.
+
+That evidence reaches Lua as `thurbox.printing`, a set of session ids filled by
+`Terminals::sync_printing` and published in **a group of its own**
+(`epoch.printing`, `Terminals::printing_version`, which moves only when the set
+gains or loses a member). Its own group because the `sessions` group is the
+largest one published — a table per session with ~30 named fields — and what is
+printing moves with an agent's output: gating those rows on it would rebuild all
+of them many times a second, which is the cost ADR-P16's gating exists to
+prevent. `tests/kernel_frame_cost.rs` pins that a printing change rebuilds
+exactly one group. Only a surface holding the terminals can fill it, so a
+headless reader publishes none and `ui.status` falls back to the static answer —
+the same line the CLI already draws at the folds it cannot make.
+
+ The frames are
 `theme.spinner` in `ui/lib/theme.lua` and the pane picks one from the elapsed
 time it is handed (`status_glyph` in `10_sessions.lua`); the clock behind that is
 the kernel's shared **animation tick** (`kernel::host::ANIMATION_HZ` = 8), which

--- a/.agents/skills/thurbox-session-status/SKILL.md
+++ b/.agents/skills/thurbox-session-status/SKILL.md
@@ -99,8 +99,7 @@ exactly one group. Only a surface holding the terminals can fill it, so a
 headless reader publishes none and `ui.status` falls back to the static answer —
 the same line the CLI already draws at the folds it cannot make.
 
- The frames are
-`theme.spinner` in `ui/lib/theme.lua` and the pane picks one from the elapsed
+The frames are `theme.spinner` in `ui/lib/theme.lua` and the pane picks one from the elapsed
 time it is handed (`status_glyph` in `10_sessions.lua`); the clock behind that is
 the kernel's shared **animation tick** (`kernel::host::ANIMATION_HZ` = 8), which
 the loop advances **only while something is actually animating** — a free-running

--- a/benches/frame_cost.rs
+++ b/benches/frame_cost.rs
@@ -184,6 +184,7 @@ impl World {
             wants: &Default::default(),
             focus: None,
             hovered: None,
+            printing: &Default::default(),
         })
         .expect("publish");
     }

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -260,10 +260,14 @@ expected** rather than broken wiring.
 
 **A pane can run an agent thurbox did not launch.** A `--command` session is
 named after the command's file stem, so a driver that opens a shell and starts
-`claude` inside it leaves every field above resolved against `bash` — coverage
-`none`, no reportable states, and `hook_blocked_is_heuristic: false`, which
-asserts the block signal is structured when it is claude's text match on a
-notification body. `session create --reports-as <agent>` and
+`claude` inside it has no declared agent for the fields above to resolve
+against. When the pane probe has already named one, that name is used and
+coverage reads `presumed` (`hook_coverage_source: "detection"`) — deliberately
+not `full`, because seeing an agent in a pane is evidence about the process and
+never about whether its hooks are wired. Undeclared and unprobed, it stays
+coverage `none` with `hook_blocked_is_heuristic: false`, which asserts the block
+signal is structured when it is claude's text match on a notification
+message. `session create --reports-as <agent>` and
 `thurbox-cli session reports-as <ref> <agent>` (`--clear` to take it back) let
 the driver name the agent that actually reports; it is stored on the row
 (`sessions.reports_as`, schema v44), survives restart, and changes nothing about

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -200,11 +200,11 @@ embedded hook assets live in
     own `~/.grok/trusted_folders.toml` (or a `--trust` launch flag, which would
     only cover sessions thurbox itself launches). grok is Claude-Code-compatible,
     so the mapping mirrors claude: SessionStart→idle,
-    UserPromptSubmit/PreToolUse/PostToolUse→working, Notification (payload
+    UserPromptSubmit/PreToolUse/PostToolUse→working, Notification (its `message`
     matched to permission/approval)→blocked, Stop→done. Every command is
     deliberately `$`-free: a `$VAR` reference without an inline `:-default` makes
     grok silently refuse to load the whole hook file, so the blocked edge pipes
-    stdin through `grep` instead of reusing claude's `case "$(cat)"` (a test pins
+    the extracted message through `grep` instead of claude's `case` (a test pins
     it). *Experimental.*
   - `omp`: a TypeScript extension at `~/.omp/agent/extensions/thurbox-status.ts`,
     mirroring pi's but mapping OMP's structured user-question tool — named `ask`

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -103,7 +103,14 @@ costs nothing.
 
 A `Done` session becomes `Idle` once you move focus off it (you've
 acknowledged it); a `working` session that goes quiet for 10 s is
-treated as `Idle` so an interrupted turn never spins forever. A remote
+treated as `Idle` so an interrupted turn never spins forever. A `blocked`
+session is never time-gated the same way — a standing request for input
+says nothing about output — but one the agent quietly resolved itself
+(no hook clears a heuristic `blocked`) is retired the same way once the
+pane is caught printing well past the block edge, so a finished turn does
+not read `blocked` for the rest of the session's life; see the
+`thurbox-session-status` skill's *Latched-`blocked` fallback* for the
+evidence this relies on. A remote
 session whose host is unreachable is shown as a **placeholder** tagged
 `Unreachable` — it never silently vanishes from the list, and the host
 is retried in the background (or on demand via restart) until the session

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -82,7 +82,7 @@ persisted columns onto a `SessionState` once per tick:
 | `done` | blue | `●` | a turn just finished; shown until you switch away |
 | `idle` | green | `○` | acknowledged, never active, or at rest |
 | `unreachable` | muted grey | `⊘` | remote host is down/offline; placeholder row awaiting reconnect |
-| `running` | accent | `◍` | an agent holds the pane and nothing has signalled — observed, never a claim about the turn |
+| `running` | accent | `◉` | an agent holds the pane and nothing has signalled — observed, never a claim about the turn |
 | `uncovered` | muted grey | `◌` | this agent is wired to report nothing, so its silence means nothing |
 | `unreported` | muted grey | `◌` | the agent *can* report and has not yet |
 
@@ -1957,8 +1957,13 @@ Uncommitted work went with the force delete and does not return.
 ### Saying which agent a pane actually runs
 
 A `--command` session is named after the command's file stem, so a driver that
-opens a shell and starts `claude` in it leaves thurbox reading hook coverage
-against `bash`. `session create --reports-as <agent>` and `session reports-as
+opens a shell and starts `claude` in it leaves thurbox with no declared agent to
+read hook coverage against. The pane probe answers when nothing else does —
+coverage then reads `presumed` with `hook_coverage_source: "detection"`, which
+is deliberately not `full`: seeing claude in a pane is evidence about the
+process, never about whether anything wired its hooks. Declaring it is still
+better, because a declaration is durable where a probe is a live reading.
+`session create --reports-as <agent>` and `session reports-as
 <ref> <agent>` (`--clear` to take it back) record which agent reports;
 `hook_coverage`, `hook_states_reportable`, `hook_delivery` and
 `hook_blocked_is_heuristic` are then read against it, and `reports_as` is

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -82,7 +82,7 @@ persisted columns onto a `SessionState` once per tick:
 | `done` | blue | `●` | a turn just finished; shown until you switch away |
 | `idle` | green | `○` | acknowledged, never active, or at rest |
 | `unreachable` | muted grey | `⊘` | remote host is down/offline; placeholder row awaiting reconnect |
-| `running` | accent | `◉` | an agent holds the pane and nothing has signalled — observed, never a claim about the turn |
+| `running` | accent | `◉`, spinner while its pane prints | an agent holds the pane and nothing has signalled — observed, never a claim about the turn |
 | `uncovered` | muted grey | `◌` | this agent is wired to report nothing, so its silence means nothing |
 | `unreported` | muted grey | `◌` | the agent *can* report and has not yet |
 

--- a/docs/ORCHESTRATION.md
+++ b/docs/ORCHESTRATION.md
@@ -236,6 +236,7 @@ gone — and each one comes with what it takes to judge it:
 | `hook_state_at`, `hook_state_age_secs` | when it was made, and how long ago |
 | `hook_reported` | whether anything has *ever* reported (silence ≠ idle) |
 | `hook_coverage`, `hook_states_reportable` | what this agent can report at all |
+| `hook_coverage_source` | which name that answer came from: `name`, `hook_schema`, or `detection` (the pane, for a row that declares no agent — coverage then reads `presumed`, never `full`) |
 | `hook_blocked_is_heuristic` | whether its `blocked` is a text match on a notification body |
 | `hook_corroboration`, `hook_state_contradicted` | what actually holds the pane, and whether it agrees |
 | `detected_agent` | which registered agent is in the pane, when it is not the row's own |

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -923,16 +923,26 @@ the work wasted only after paying for it.
 
 - **Signals** live with the mutation, never with the caller:
   `SnapshotStore::version`, `Themes::version`, `Registry::version`,
-  `Terminals::meta_version` and `failed_version`, plus one loop-side
-  `data_epoch` fed by the `changed` flag each worker store's `poll` already
-  returns. Deriving that last one from an existing return value means it cannot
-  drift from it.
+  `Terminals::meta_version`, `failed_version` and `printing_version`, plus one
+  loop-side `data_epoch` fed by the `changed` flag each worker store's `poll`
+  already returns. Deriving that last one from an existing return value means it
+  cannot drift from it. `printing_version` shows what a signal must be careful
+  to measure: what a pane is doing changes on every byte of output, so it counts
+  **set membership** — which sessions are printing — rather than the output
+  clock itself, since a group gated on the clock would rebuild on every frame
+  under a working agent and be worth nothing.
 - **Gated publish**: each `thurbox.*` group names the versions it is built from
   and is rebuilt only when one moves. The outer table is still assembled fresh
   every frame, so a gating mistake can produce a stale *group* but never a torn
   table. Keys are compared exactly (`[u64; 4]`), not hashed — a collision here
   would serve a stale group, and "astronomically unlikely" is the wrong
-  guarantee for a wrong answer nobody can see.
+  guarantee for a wrong answer nobody can see. A signal that moves fast belongs
+  in a group **sized to it**: `printing` is one id per printing session, and it
+  is separate from `sessions` (a table per session with ~30 named fields)
+  precisely so the fast signal never rebuilds the slow rows.
+  `tests/kernel_frame_cost.rs` pins that a printing change rebuilds exactly one
+  group, counted against a control rather than a literal so it survives the next
+  group anyone adds.
 - **Pure panes**: a pane may declare `pure = true`, asserting its render is a
   function of the published tables and its context. The kernel then reuses the
   tree it last returned, keyed on the epoch, the rect, focus, an animation tick

--- a/extensions/hooks/README.md
+++ b/extensions/hooks/README.md
@@ -39,8 +39,12 @@ passed by hand) and is suffixed `|| true` so it can never break the agent.
   session isn't shown as working), `UserPromptSubmit`/`PreToolUse`/`PostToolUse`
   → working, `Stop` → done. `Notification` → blocked **only for
   permission/approval prompts** — claude also fires `Notification` for its
-  "waiting for your input" idle nudge, which the hook ignores (parses the
-  payload) so an idle session doesn't flip to red. `PostToolUse` is what clears
+  "waiting for your input" idle nudge, which the hook ignores (matches the
+  notification's `message` field alone, not the whole payload — `cwd` and
+  `transcript_path` are the operator's own directory names, and globbing them
+  too false-fired `blocked` on that idle nudge whenever the checkout path
+  happened to contain a word like "permission") so an idle session doesn't
+  flip to red. `PostToolUse` is what clears
   that block: claude has no "permission granted" event, so the tool finishing is
   the first thing it reports after the prompt is answered — without it an
   approved session stayed red until the *next* tool call, or until `Stop` if the
@@ -98,11 +102,13 @@ passed by hand) and is suffixed `|| true` so it can never break the agent.
   own `~/.grok/trusted_folders.toml`. grok is Claude-Code-compatible, so the
   mapping mirrors claude: `SessionStart` → idle,
   `UserPromptSubmit`/`PreToolUse`/`PostToolUse` → working, `Notification` →
-  blocked **only for permission/approval prompts** (the payload is matched, so
-  an idle nudge doesn't flip the dot red), `Stop` → done. Every command here is
+  blocked **only for permission/approval prompts** (the `message` field alone
+  is matched, not the whole payload, so an idle nudge doesn't flip the dot
+  red), `Stop` → done. Every command here is
   `$`-free: grok silently refuses to load a whole hook file whose command
-  references `$VAR` without an inline `:-default`, so the blocked edge pipes
-  stdin through `grep` rather than reusing claude's `case "$(cat)"`. **Caveat:**
+  references `$VAR` without an inline `:-default`, so the blocked edge
+  extracts the message and pipes it through `grep` rather than reusing
+  claude's `case`. **Caveat:**
   if a future grok renames its events, edit `grok-hooks.json` (no code change).
 - **kimi** *(experimental)* — Kimi Code CLI reads hooks from a `[[hooks]]` array
   in `~/.kimi-code/config.toml`. That one file is your whole kimi configuration
@@ -124,8 +130,9 @@ passed by hand) and is suffixed `|| true` so it can never break the agent.
   your settings; uninstall prunes exactly ours back out. `agy` adopted Claude
   Code's hook schema (verified against agy 1.0.9), so the mapping mirrors claude:
   `SessionStart` → idle, `PreToolUse`/`PostToolUse` → working, `Stop` → done, and
-  `Notification` → blocked **only for permission/approval prompts** (the payload
-  is parsed, same as claude, so an idle `Notification` doesn't flip the dot red);
+  `Notification` → blocked **only for permission/approval prompts** (the
+  `message` field alone is matched, same as claude, so an idle `Notification`
+  doesn't flip the dot red);
   `PostToolUse` clears the block, for claude's reason. It has no
   `UserPromptSubmit`, so working is signaled at the first tool call rather than on
   prompt submit. **Caveat:** if agy sanitizes the hook environment,

--- a/extensions/hooks/antigravity-hooks.json
+++ b/extensions/hooks/antigravity-hooks.json
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "case \"$(cat)\" in *permission*|*Permission*|*approval*|*approve*) thurbox-cli session signal --state blocked ;; esac; true"
+            "command": "case \"$(cat | sed -n 's/.*\"message\":\"\\([^\"]*\\)\".*/\\1/p')\" in *permission*|*Permission*|*approval*|*approve*) thurbox-cli session signal --state blocked ;; esac; true"
           }
         ]
       }

--- a/extensions/hooks/claude.json
+++ b/extensions/hooks/claude.json
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "case \"$(cat)\" in *permission*|*Permission*|*approval*|*approve*) thurbox-cli session signal --state blocked ;; esac; true",
+            "command": "case \"$(cat | sed -n 's/.*\"message\":\"\\([^\"]*\\)\".*/\\1/p')\" in *permission*|*Permission*|*approval*|*approve*) thurbox-cli session signal --state blocked ;; esac; true",
             "timeout": 10
           }
         ]

--- a/extensions/hooks/extension.toml
+++ b/extensions/hooks/extension.toml
@@ -14,7 +14,7 @@
 name = "hooks"
 description = "Report each agent's lifecycle state (working/blocked/done) to thurbox via agent hooks."
 config_version = 1
-version = "1.8.0"  # v1.8: grok (global ~/.grok/hooks drop) + kimi (TOML merge into ~/.kimi-code/config.toml) status hooks; v1.7: omp (Oh My Pi) status extension (ask/ask_user_question → blocked); v1.6: vibe hooks rewritten to vibe 2.21.0's real schema (pre_tool/post_agent); v1.5: pi (pi.dev) status extension
+version = "1.9.0"  # v1.9: claude/antigravity/grok match the *message* of a Notification rather than the whole payload — a checkout path carrying "permission" signalled a permanent `blocked` on the idle notification that ends every turn; v1.8: grok (global ~/.grok/hooks drop) + kimi (TOML merge into ~/.kimi-code/config.toml) status hooks; v1.7: omp (Oh My Pi) status extension (ask/ask_user_question → blocked); v1.6: vibe hooks rewritten to vibe 2.21.0's real schema (pre_tool/post_agent); v1.5: pi (pi.dev) status extension
 # Default home; the auto-activation path overrides this with *this build's*
 # resolved config dir (`~/.config/thurbox` or `~/.config/thurbox-dev`) so dev and
 # release installs stay isolated. See `session_ops::builtin_hooks::hooks_home`.
@@ -22,6 +22,15 @@ home = "~/.config/thurbox/hooks"
 
 # claude reads hooks from a settings file we pass via --settings (merged with the
 # user's own settings, never clobbering them). The file lives under the home dir.
+#
+# Its `Notification` hook matches permission/approval against the payload's
+# `message` and nothing else. Globbing the whole payload looked equivalent and is
+# not: `cwd` and `transcript_path` are the operator's own directory names, so a
+# checkout under a path with "permission" in it signalled `blocked` on the idle
+# notification that fires a minute after every turn ends — and that notification
+# is the last hook such a session ever fires, so the state stood for good. The
+# block edge stays a text match either way (`blocked_is_heuristic`); what changed
+# is which text.
 [[files]]
 path = "claude.json"
 
@@ -152,8 +161,9 @@ requires_dir = "~/.copilot"
 #
 # `agy` adopted Claude Code's hook schema (verified against agy 1.0.9): the event
 # names live in antigravity-hooks.json and map SessionStart→idle, PreToolUse→
-# working, Stop→done, and Notification→blocked (payload-parsed for permission/
-# approval, like claude, so an idle Notification doesn't flip the dot red). It has
+# working, Stop→done, and Notification→blocked (the notification's `message`
+# matched for permission/approval, like claude, so an idle Notification doesn't
+# flip the dot red). It has
 # no UserPromptSubmit, so working is signaled at the first tool call. If a future
 # agy changes the schema, fix antigravity-hooks.json (no code change needed).
 # Identity needs $THURBOX_SESSION to reach the hook process; if agy sanitizes the
@@ -174,7 +184,8 @@ requires_dir = "~/.gemini"
 #
 # Grok is Claude-Code-compatible, so the mapping mirrors claude.json:
 # SessionStart → idle, UserPromptSubmit/PreToolUse/PostToolUse → working,
-# Notification (payload matched to permission/approval) → blocked, Stop → done.
+# Notification (its `message` matched to permission/approval) → blocked,
+# Stop → done.
 # The blocked command deliberately contains no `$` — a `$VAR` reference in a
 # grok hook command must carry an inline `:-default` or grok silently refuses to
 # load the whole hook file — so it pipes stdin through `grep` instead of

--- a/extensions/hooks/extension.toml
+++ b/extensions/hooks/extension.toml
@@ -188,8 +188,8 @@ requires_dir = "~/.gemini"
 # Stop → done.
 # The blocked command deliberately contains no `$` — a `$VAR` reference in a
 # grok hook command must carry an inline `:-default` or grok silently refuses to
-# load the whole hook file — so it pipes stdin through `grep` instead of
-# claude's `case "$(cat)"`.
+# load the whole hook file — so it pipes the extracted message through `grep`
+# instead of claude's `case`.
 #
 # EXPERIMENTAL: the event names are grok's documented set; if a future grok
 # renames them, edit grok-hooks.json (no code change).

--- a/extensions/hooks/grok-hooks.json
+++ b/extensions/hooks/grok-hooks.json
@@ -51,7 +51,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if cat | grep -qiE 'permission|approval|approve'; then thurbox-cli session signal --state blocked ; fi; true",
+            "command": "if cat | sed -n 's/.*\"message\":\"\\([^\"]*\\)\".*/\\1/p' | grep -qiE 'permission|approval|approve'; then thurbox-cli session signal --state blocked ; fi; true",
             "timeout": 10
           }
         ]

--- a/src/agent/backend.rs
+++ b/src/agent/backend.rs
@@ -241,6 +241,12 @@ pub struct AdoptedSession {
     pub output: Box<dyn Read + Send>,
     /// Input write handle to send bytes to the session.
     pub input: Box<dyn Write + Send>,
+    /// Bytes at the front of `output` that are replayed history rather than
+    /// live pane activity (0 when there was none to replay). The reader loop
+    /// uses it to hold `last_output_at` back for exactly that many bytes, so a
+    /// scrollback replay can't masquerade as fresh output — see
+    /// [`Session::reader_loop`].
+    pub seed_len: usize,
 }
 
 /// Trait that all session backends implement. The app layer interacts only through this trait.
@@ -408,6 +414,9 @@ struct SessionIo {
     backend_id: String,
     /// Whether these handles came from a fresh spawn or an adopt.
     mode: WireMode,
+    /// Replayed-history bytes at the front of `output`, from
+    /// [`AdoptedSession::seed_len`] (always 0 for a spawn).
+    seed_len: usize,
 }
 
 /// Whether we are wiring a freshly-spawned process or reconnecting to an
@@ -617,6 +626,7 @@ impl ProgramPane {
                 input: spawned.input,
                 backend_id: spawned.backend_id,
                 mode: WireMode::Spawn,
+                seed_len: 0,
             },
             "Program",
         );
@@ -646,6 +656,7 @@ impl ProgramPane {
                 input: adopted.input,
                 backend_id: backend_id.to_string(),
                 mode: WireMode::Adopt,
+                seed_len: adopted.seed_len,
             },
             "Program",
         );
@@ -776,6 +787,7 @@ impl Session {
                 input: spawned.input,
                 backend_id: spawned.backend_id,
                 mode: WireMode::Spawn,
+                seed_len: 0,
             },
             backend,
             provider,
@@ -820,6 +832,7 @@ impl Session {
                 input: adopted.input,
                 backend_id: backend_id.to_string(),
                 mode: WireMode::Adopt,
+                seed_len: adopted.seed_len,
             },
             backend,
             provider,
@@ -856,8 +869,9 @@ impl Session {
         let parser_clone = Arc::clone(&parser);
         let exited_clone = Arc::clone(&exited);
         let last_output_clone = Arc::clone(&last_output_at);
+        let seed_len = io.seed_len;
         tokio::task::spawn_blocking(move || {
-            Self::reader_loop(io.output, parser_clone, exited_clone, last_output_clone);
+            Self::reader_loop(io.output, parser_clone, exited_clone, last_output_clone, seed_len);
         });
 
         let wired = WiredPane {
@@ -970,11 +984,21 @@ impl Session {
     /// `kill()`/`detach()` so the backend unregisters the pane and this
     /// thread sees EOF — a silent drop leaks the thread (blocked in a read)
     /// for the process lifetime.
+    ///
+    /// `seed_len` is the number of bytes at the front of `reader` that are
+    /// replayed history (an adopt's scrollback seed, chained ahead of the
+    /// live stream — see [`crate::agent::tmux::TmuxBackend::adopt`]) rather
+    /// than genuine pane activity. Those bytes still reach the parser, but
+    /// must not stamp `last_output_at`: a restart/reattach replaying hours of
+    /// scrollback would otherwise look identical to the agent having just
+    /// printed, defeating [`initial_output_at`]'s deliberate staleness for
+    /// `WireMode::Adopt` the instant the reader's first bytes arrive.
     fn reader_loop(
         mut reader: Box<dyn Read + Send>,
         parser: Arc<Mutex<SessionParser>>,
         exited: Arc<AtomicBool>,
         last_output_at: Arc<AtomicU64>,
+        mut seed_len: usize,
     ) {
         let mut buf = [0u8; 4096];
         // Bytes of a trailing, not-yet-complete UTF-8 character held back from
@@ -992,7 +1016,12 @@ impl Session {
                     break;
                 }
                 Ok(n) => {
-                    last_output_at.store(now_millis(), Ordering::Relaxed);
+                    // Bytes beyond the seed boundary are live activity; a chunk
+                    // that is entirely within the seed is not.
+                    if seed_len < n {
+                        last_output_at.store(now_millis(), Ordering::Relaxed);
+                    }
+                    seed_len = seed_len.saturating_sub(n);
                     let mut data = std::mem::take(&mut carry);
                     data.extend_from_slice(&buf[..n]);
                     let ready = utf8_ready_prefix_len(&data);
@@ -1188,6 +1217,7 @@ impl Session {
                 input: spawned.input,
                 backend_id: spawned.backend_id,
                 mode: WireMode::Spawn,
+                seed_len: 0,
             },
             "Session",
         );
@@ -1270,6 +1300,7 @@ impl Session {
                 input: spawned.input,
                 backend_id: spawned.backend_id,
                 mode: WireMode::Spawn,
+                seed_len: 0,
             },
             "Shell",
         );
@@ -1299,6 +1330,7 @@ impl Session {
                 input: adopted.input,
                 backend_id: backend_id.to_string(),
                 mode: WireMode::Adopt,
+                seed_len: adopted.seed_len,
             },
             "Shell",
         );
@@ -1392,6 +1424,8 @@ impl Session {
 
 #[cfg(test)]
 mod tests {
+    use std::io::Cursor;
+
     use super::*;
 
     #[test]
@@ -1628,6 +1662,105 @@ mod tests {
         // Spawn: "now" so a fresh process counts as active → busy.
         let spawn = initial_output_at(WireMode::Spawn);
         assert!(now_millis().saturating_sub(spawn) <= ACTIVITY_TIMEOUT_MS);
+    }
+
+    /// The staleness `wire_mode_adopt_starts_stale_spawn_starts_fresh` sets up
+    /// used to be destroyed the instant the reader thread's first read landed,
+    /// because that read is the replayed scrollback seed on an adopt — see
+    /// [`Session::reader_loop`]'s `seed_len` doc. Replaying only the seed must
+    /// leave `last_output_at` untouched.
+    #[test]
+    fn reader_loop_does_not_stamp_output_for_replayed_scrollback() {
+        let parser = Arc::new(Mutex::new(vt100::Parser::new_with_callbacks(
+            24,
+            80,
+            0,
+            TermSignals::default(),
+        )));
+        let exited = Arc::new(AtomicBool::new(false));
+        let last_output_at = Arc::new(AtomicU64::new(initial_output_at(WireMode::Adopt)));
+
+        let seed = b"replayed history\r\n$ ".to_vec();
+        let seed_len = seed.len();
+        Session::reader_loop(
+            Box::new(Cursor::new(seed)),
+            Arc::clone(&parser),
+            Arc::clone(&exited),
+            Arc::clone(&last_output_at),
+            seed_len,
+        );
+
+        assert_eq!(
+            last_output_at.load(Ordering::Relaxed),
+            initial_output_at(WireMode::Adopt),
+            "scrollback replay alone must not read as activity"
+        );
+    }
+
+    /// The other half: once the seed is exhausted, genuinely live bytes still
+    /// stamp `last_output_at` normally.
+    #[test]
+    fn reader_loop_stamps_output_for_live_bytes_after_the_seed() {
+        let parser = Arc::new(Mutex::new(vt100::Parser::new_with_callbacks(
+            24,
+            80,
+            0,
+            TermSignals::default(),
+        )));
+        let exited = Arc::new(AtomicBool::new(false));
+        let last_output_at = Arc::new(AtomicU64::new(initial_output_at(WireMode::Adopt)));
+
+        let seed = b"replayed history\r\n$ ".to_vec();
+        let seed_len = seed.len();
+        let reader = Cursor::new(seed).chain(Cursor::new(b"fresh agent output\r\n".to_vec()));
+        Session::reader_loop(
+            Box::new(reader),
+            Arc::clone(&parser),
+            Arc::clone(&exited),
+            Arc::clone(&last_output_at),
+            seed_len,
+        );
+
+        let stamped = last_output_at.load(Ordering::Relaxed);
+        assert!(
+            now_millis().saturating_sub(stamped) < 5_000,
+            "live output past the seed boundary must stamp fresh activity"
+        );
+    }
+
+    /// The fold-level consequence of the two tests above: a session that has
+    /// genuinely been `blocked` for hours must still read `blocked` after a
+    /// restart/reattach replays its scrollback with no new live output —
+    /// composing the reader-loop fix with `with_output_quiescence` the way
+    /// `Terminals::sync_printing`'s consumer (`apply_output_quiescence`) does.
+    /// Before the fix, the seed replay stamped `last_output_at` to "now",
+    /// making the pane look quiet for ~0ms against an hours-old `hook_state_at`
+    /// and folding `Blocked` into `Working`/`Idle`.
+    #[test]
+    fn adopted_scrollback_replay_does_not_outlive_a_standing_blocked_state() {
+        use crate::session::{with_output_quiescence, SessionState};
+
+        let parser = Arc::new(Mutex::new(vt100::Parser::new_with_callbacks(
+            24,
+            80,
+            0,
+            TermSignals::default(),
+        )));
+        let exited = Arc::new(AtomicBool::new(false));
+        let last_output_at = Arc::new(AtomicU64::new(initial_output_at(WireMode::Adopt)));
+
+        let seed = b"...\r\nPermission needed to run `rm -rf build`\r\n".to_vec();
+        let seed_len = seed.len();
+        Session::reader_loop(Box::new(Cursor::new(seed)), parser, exited, Arc::clone(&last_output_at), seed_len);
+
+        let quiet_for_ms = now_millis().saturating_sub(last_output_at.load(Ordering::Relaxed));
+        let state_age_ms = 3 * 60 * 60 * 1000; // hook_state_at stamped 3 hours ago
+
+        assert_eq!(
+            with_output_quiescence(SessionState::Blocked, Some(quiet_for_ms), Some(state_age_ms)),
+            SessionState::Blocked,
+            "a restart replaying scrollback must not make a genuinely blocked session look done"
+        );
     }
 
     #[test]

--- a/src/agent/backend.rs
+++ b/src/agent/backend.rs
@@ -871,7 +871,13 @@ impl Session {
         let last_output_clone = Arc::clone(&last_output_at);
         let seed_len = io.seed_len;
         tokio::task::spawn_blocking(move || {
-            Self::reader_loop(io.output, parser_clone, exited_clone, last_output_clone, seed_len);
+            Self::reader_loop(
+                io.output,
+                parser_clone,
+                exited_clone,
+                last_output_clone,
+                seed_len,
+            );
         });
 
         let wired = WiredPane {
@@ -1751,13 +1757,23 @@ mod tests {
 
         let seed = b"...\r\nPermission needed to run `rm -rf build`\r\n".to_vec();
         let seed_len = seed.len();
-        Session::reader_loop(Box::new(Cursor::new(seed)), parser, exited, Arc::clone(&last_output_at), seed_len);
+        Session::reader_loop(
+            Box::new(Cursor::new(seed)),
+            parser,
+            exited,
+            Arc::clone(&last_output_at),
+            seed_len,
+        );
 
         let quiet_for_ms = now_millis().saturating_sub(last_output_at.load(Ordering::Relaxed));
         let state_age_ms = 3 * 60 * 60 * 1000; // hook_state_at stamped 3 hours ago
 
         assert_eq!(
-            with_output_quiescence(SessionState::Blocked, Some(quiet_for_ms), Some(state_age_ms)),
+            with_output_quiescence(
+                SessionState::Blocked,
+                Some(quiet_for_ms),
+                Some(state_age_ms)
+            ),
             SessionState::Blocked,
             "a restart replaying scrollback must not make a genuinely blocked session look done"
         );

--- a/src/agent/backend.rs
+++ b/src/agent/backend.rs
@@ -245,7 +245,7 @@ pub struct AdoptedSession {
     /// live pane activity (0 when there was none to replay). The reader loop
     /// uses it to hold `last_output_at` back for exactly that many bytes, so a
     /// scrollback replay can't masquerade as fresh output — see
-    /// [`Session::reader_loop`].
+    /// `Session::reader_loop`.
     pub seed_len: usize,
 }
 

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -1347,6 +1347,7 @@ impl TmuxBackend {
         Ok(AdoptedSession {
             output: Box::new(reader),
             input: Box::new(writer),
+            seed_len: 0,
         })
     }
 
@@ -1598,10 +1599,15 @@ impl SessionBackend for TmuxBackend {
             return Ok(connected);
         }
         // Prepend the captured history to the live stream — the reader loop
-        // feeds it into the parser first, populating the UI scrollback.
+        // feeds it into the parser first, populating the UI scrollback. It
+        // must not be mistaken for live activity either, which is what
+        // `seed_len` tells the reader loop to guard against (see
+        // `Session::reader_loop`).
+        let seed_len = seed.len();
         Ok(AdoptedSession {
             output: Box::new(Cursor::new(seed).chain(connected.output)),
             input: connected.input,
+            seed_len,
         })
     }
 

--- a/src/cli/session_doctor.rs
+++ b/src/cli/session_doctor.rs
@@ -274,7 +274,10 @@ fn diagnose(
             key: "coverage",
             level: Level::Warn,
             detail: format!(
-                "nothing declares an agent for this session, but its pane is running                  '{}' — which can report {} once its hooks are wired. Declare it with                  `thurbox-cli session reports-as {} {}` so coverage stops depending on                  what a process listing happens to see",
+                "nothing declares an agent for this session, but its pane is running \
+                 '{}' — which can report {} once its hooks are wired. Declare it with \
+                 `thurbox-cli session reports-as {} {}` so coverage stops depending on \
+                 what a process listing happens to see",
                 hook.detected_agent().unwrap_or(agent),
                 hook.states_reportable().join(", "),
                 session.name,

--- a/src/cli/session_doctor.rs
+++ b/src/cli/session_doctor.rs
@@ -274,8 +274,8 @@ fn diagnose(
             key: "coverage",
             level: Level::Warn,
             detail: format!(
-                "nothing declares an agent for this session, but its pane is running \
-                 '{}' — which can report {} once its hooks are wired. Declare it with \
+                "no agent thurbox recognises is declared for this session, but its pane is \
+                 running '{}' — which can report {} once its hooks are wired. Declare it with \
                  `thurbox-cli session reports-as {} {}` so coverage stops depending on \
                  what a process listing happens to see",
                 hook.detected_agent().unwrap_or(agent),
@@ -789,5 +789,50 @@ mod tests {
         // hooks really do shell out to it.
         let local = diagnose_agent(&row("s", "claude", "local-tmux"), &hook, true, None);
         assert_eq!(level_of(&local, "cli"), Level::Fail);
+    }
+
+    #[test]
+    fn a_command_session_with_a_detected_agent_still_expects_no_hooks() {
+        // A detected identity is evidence about the process, not a declaration
+        // — so it must not turn a `--command` session's carve-out into a
+        // warning or failure. The advice should still name what was actually
+        // found running, though, rather than a placeholder.
+        let hook = Assessment::from_hooks(&registry(), "bash", None, None, None, 0)
+            .with_corroboration(Corroboration::ForeignAgent(Some("claude".into())));
+        assert_eq!(hook.coverage, Coverage::Presumed);
+        let report = diagnose(&row("s", "bash", "local-tmux"), false, &hook, true, Some("/x"));
+        assert_eq!(level_of(&report, "coverage"), Level::Ok);
+        let detail = &report
+            .findings
+            .iter()
+            .find(|f| f.key == "coverage")
+            .unwrap()
+            .detail;
+        assert!(detail.contains("claude"), "got {detail}");
+    }
+
+    #[test]
+    fn an_uncovered_agent_with_a_detected_identity_warns_and_names_it() {
+        // The row's own agent ("shell") has no coverage of its own, but its
+        // pane was found running a recognised claude — hooks are expected
+        // here, so this must warn (not silently pass as `Ok`, and not fail as
+        // though nothing was learned about the pane at all), and the advice
+        // must name the agent that was actually detected together with what
+        // it can report.
+        let hook = Assessment::from_hooks(&registry(), "shell", None, None, None, 0)
+            .with_corroboration(Corroboration::ForeignAgent(Some("claude".into())));
+        assert_eq!(hook.coverage, Coverage::Presumed);
+        let report = diagnose_agent(&row("s", "shell", "local-tmux"), &hook, true, Some("/x"));
+        assert_eq!(level_of(&report, "coverage"), Level::Warn);
+        let detail = &report
+            .findings
+            .iter()
+            .find(|f| f.key == "coverage")
+            .unwrap()
+            .detail;
+        assert!(detail.contains("claude"), "got {detail}");
+        for state in hook.states_reportable() {
+            assert!(detail.contains(state), "got {detail}");
+        }
     }
 }

--- a/src/cli/session_doctor.rs
+++ b/src/cli/session_doctor.rs
@@ -800,7 +800,13 @@ mod tests {
         let hook = Assessment::from_hooks(&registry(), "bash", None, None, None, 0)
             .with_corroboration(Corroboration::ForeignAgent(Some("claude".into())));
         assert_eq!(hook.coverage, Coverage::Presumed);
-        let report = diagnose(&row("s", "bash", "local-tmux"), false, &hook, true, Some("/x"));
+        let report = diagnose(
+            &row("s", "bash", "local-tmux"),
+            false,
+            &hook,
+            true,
+            Some("/x"),
+        );
         assert_eq!(level_of(&report, "coverage"), Level::Ok);
         let detail = &report
             .findings

--- a/src/cli/session_doctor.rs
+++ b/src/cli/session_doctor.rs
@@ -227,15 +227,19 @@ fn diagnose(
         // is no breakage here to report, and reporting one made bare `doctor`
         // fail the whole machine over the exact session shape thurbox
         // advertises for drivers.
-        Coverage::None if !hooks_expected => Finding {
+        // Presumed alongside None: the pane naming an agent does not make hooks
+        // expected. Nothing declared one, so there is still no wiring thurbox
+        // owns here — only a better guess at who to name in the advice.
+        Coverage::None | Coverage::Presumed if !hooks_expected => Finding {
             key: "coverage",
             level: Level::Ok,
             detail: format!(
                 "'{agent}' is this session's own command, not an agent from agents.toml, so \
                  thurbox wired no hooks and none are expected — declare what actually runs \
-                 in the pane with `thurbox-cli session reports-as {} <agent>` if it is a \
+                 in the pane with `thurbox-cli session reports-as {} {}` if it is a \
                  coding agent, or have your driver call `thurbox-cli session signal`",
-                session.name
+                session.name,
+                hook.detected_agent().unwrap_or("<agent>"),
             ),
         },
         // Nothing thurbox ships wires this agent — but a driver that owns the
@@ -260,6 +264,21 @@ fn diagnose(
                  agents.toml if it speaks a built-in's hook format, or have your driver call \
                  `thurbox-cli session signal --state <s>` (identity comes from the injected \
                  $THURBOX_SESSION, so it needs no arguments)"
+            ),
+        },
+        // Resolved from the agent found holding the pane, not from either name
+        // the row carries — so what those states are worth depends on whether
+        // the driver that launched it wired anything, which thurbox cannot see.
+        // Warn rather than Ok for exactly that gap, and name the fix.
+        Coverage::Presumed => Finding {
+            key: "coverage",
+            level: Level::Warn,
+            detail: format!(
+                "nothing declares an agent for this session, but its pane is running                  '{}' — which can report {} once its hooks are wired. Declare it with                  `thurbox-cli session reports-as {} {}` so coverage stops depending on                  what a process listing happens to see",
+                hook.detected_agent().unwrap_or(agent),
+                hook.states_reportable().join(", "),
+                session.name,
+                hook.detected_agent().unwrap_or(agent),
             ),
         },
         Coverage::Partial => Finding {

--- a/src/coordinator/mod.rs
+++ b/src/coordinator/mod.rs
@@ -231,12 +231,20 @@ impl App {
     /// costs one cache miss, while saying "not animating" when something is
     /// would freeze it on screen.
     pub(crate) fn advance_animation(&mut self) {
+        let printing = self.terminals.printing();
         let animating = self
             .snapshots
             .current()
             .sessions
             .iter()
-            .any(|row| row.status == thurbox::session::SessionState::Working)
+            .any(|row| {
+                row.status == thurbox::session::SessionState::Working
+                    // A `running` session animates only while its pane is
+                    // printing, so the clock has to run for that case too —
+                    // otherwise the spinner it gates freezes mid-turn.
+                    || (row.status == thurbox::session::SessionState::Running
+                        && printing.contains(&row.id))
+            })
             || self.commands.has_inflight()
             // The creation flow spins over the repo store's reads too, and it
             // is a pure pane: without the clock its "listing…"/"fetching…"

--- a/src/coordinator/publish.rs
+++ b/src/coordinator/publish.rs
@@ -14,6 +14,10 @@ impl App {
     /// Called just before a paint and before dispatching input — the only two
     /// moments Lua runs — rather than once per loop iteration.
     pub(crate) fn republish(&mut self) {
+        // Before `advance_animation`, which asks whether a printing `running`
+        // session is on screen — a stale set there would freeze the very
+        // spinner it gates.
+        self.terminals.sync_printing();
         self.advance_animation();
         let sessions: Vec<String> = self
             .snapshots
@@ -75,9 +79,11 @@ impl App {
                 failed: self.terminals.failed_version(),
                 data: self.data_epoch,
                 animation: self.animation_tick,
+                printing: self.terminals.printing_version(),
             },
             snapshot: self.snapshots.current(),
             attach_errors: &attach_errors,
+            printing: self.terminals.printing(),
             inflight: &inflight,
             themes: &self.themes,
             registry: &self.registry,

--- a/src/kernel/host/mod.rs
+++ b/src/kernel/host/mod.rs
@@ -464,6 +464,16 @@ pub struct Epoch {
     /// neither its groups nor its panes; a clock that never stops makes that
     /// impossible to satisfy.
     pub animation: u64,
+    /// `Terminals::printing_version` — moves only when the set of sessions
+    /// producing output gains or loses a member.
+    ///
+    /// Its own slot rather than a field on the session rows: what is printing
+    /// changes with an agent's output, and the `sessions` group is the largest
+    /// one published. Gating that group on this would rebuild a table per
+    /// session on every change of output, which is the cost the gating exists
+    /// to prevent — so the fact travels in a group of its own that costs one
+    /// small table.
+    pub printing: u64,
 }
 
 /// The versions one group is built from, compared exactly.
@@ -566,6 +576,7 @@ impl Epoch {
             failed: n,
             data: n,
             animation: n,
+            printing: n,
         }
     }
 }
@@ -577,6 +588,13 @@ pub struct Published<'a> {
     pub snapshot: &'a Snapshot,
     /// Why a session's terminal is not live, keyed by session.
     pub attach_errors: &'a std::collections::HashMap<String, String>,
+    /// The sessions whose pane is producing output right now.
+    ///
+    /// The evidence a `running` session's indicator animates on: process
+    /// inspection alone cannot tell a turn in flight from a prompt waiting for
+    /// input, and this can. Only a surface holding the terminals can answer it,
+    /// which is why it is published rather than derived in a pane.
+    pub printing: &'a std::collections::HashSet<String>,
     pub inflight: &'a [InFlight],
     pub themes: &'a Themes,
     pub registry: &'a Registry,

--- a/src/kernel/host/publish.rs
+++ b/src/kernel/host/publish.rs
@@ -57,6 +57,7 @@ impl LuaHost {
             settings,
             repos: repo_store,
             wants,
+            printing,
         } = world;
 
         let table = self.lua.create_table().map_err(|e| e.to_string())?;
@@ -84,6 +85,26 @@ impl LuaHost {
         }
 
         set(&table, "sessions", sessions)?;
+
+        // Which sessions are producing output, as a set keyed by session id.
+        //
+        // A group of its own, and a deliberately tiny one: the answer moves
+        // with an agent's output, so gating the `sessions` group on it would
+        // rebuild a ~30-field table per session every time a pane started or
+        // stopped printing. One id per printing session is the whole payload,
+        // and it is the only thing that lets a pane animate `running` on
+        // evidence rather than assert a turn it cannot see.
+        let printing_value = self.group("printing", [epoch.printing, 0, 0, 0], || {
+            let table = self
+                .lua
+                .create_table_with_capacity(0, printing.len())
+                .map_err(|e| e.to_string())?;
+            for session in printing.iter() {
+                set(&table, session.as_str(), true)?;
+            }
+            Ok(Value::Table(table))
+        })?;
+        set(&table, "printing", printing_value)?;
 
         // What a creation flow can choose among. Reads, so picking is plugin
         // state and only committing is a command.

--- a/src/kernel/snapshot.rs
+++ b/src/kernel/snapshot.rs
@@ -568,6 +568,14 @@ pub struct SnapshotStore {
     /// A focus request another process left, claimed during [`Self::refresh`]
     /// and handed out by [`Self::take_focus_request`].
     pending_focus: Option<String>,
+    /// When each row's `hook_state` was stamped, by session id.
+    ///
+    /// Beside the rows rather than on [`SessionRow`] because it is an input to
+    /// a fold, not something a pane draws: [`Self::apply_output_quiescence`]
+    /// needs the block edge to tell a standing block from one the pane has
+    /// since printed past, and every other consumer of that stamp already
+    /// reads it from the database.
+    hook_state_at: std::collections::HashMap<String, i64>,
 }
 
 /// A remote hook event waiting for the session it names to appear.
@@ -613,6 +621,7 @@ impl SnapshotStore {
             pending_hooks: Vec::new(),
             version: 0,
             pending_focus: None,
+            hook_state_at: std::collections::HashMap::new(),
         };
         store.refresh();
         store
@@ -636,6 +645,7 @@ impl SnapshotStore {
             pending_hooks: Vec::new(),
             version: 0,
             pending_focus: None,
+            hook_state_at: std::collections::HashMap::new(),
         };
         store.refresh();
         store
@@ -923,7 +933,9 @@ impl SnapshotStore {
             // is cleared here rather than left to that (absent) refresh, because
             // this path never reaches `assess` at all — it writes the row
             // directly, which is the one case its hook.state gate cannot cover.
-            row.status = derive_state(Some(&event.state), Some(now_ms()), None);
+            let stamped = now_ms();
+            self.hook_state_at.insert(row.id.clone(), stamped);
+            row.status = derive_state(Some(&event.state), Some(stamped), None);
             row.hook_state = Some(event.state);
             row.detected_agent = None;
             applied += 1;
@@ -934,8 +946,8 @@ impl SnapshotStore {
         applied
     }
 
-    /// Re-derive every `working` row against terminal quiescence, returning how
-    /// many rows changed.
+    /// Re-derive every `working` and `blocked` row against terminal quiescence,
+    /// returning how many rows changed.
     ///
     /// Called each tick rather than folded into `refresh`, because the answer
     /// moves with the agent's output and `refresh` runs on the database's
@@ -946,17 +958,42 @@ impl SnapshotStore {
     /// pass is idempotent and reverses itself: a session that goes quiet and
     /// then prints again is `working` once more without a database read.
     ///
-    /// `quiet_for` is asked only about the rows that are actually `working`, and
-    /// answers `None` for a session with no live pane. A closure rather than a
-    /// map because the answer is one atomic load and a map would allocate every
-    /// tick to carry the sessions nobody asked about (ADR-P10).
+    /// `blocked` is here for the opposite reason to `working` and on the same
+    /// evidence. It is never time-gated — a real block is quiet for as long as
+    /// it stands — but a block the pane has gone on printing past is over, and
+    /// this is the only surface that can see that: `state_at` alone cannot say
+    /// it, which is why the CLI still reports the latched word.
+    ///
+    /// `quiet_for` is asked only about the rows that are actually in one of
+    /// those two states, and answers `None` for a session with no live pane. A
+    /// closure rather than a map because the answer is one atomic load and a map
+    /// would allocate every tick to carry the sessions nobody asked about
+    /// (ADR-P10).
     pub fn apply_output_quiescence(&mut self, quiet_for: impl Fn(&str) -> Option<u64>) -> usize {
+        let now = crate::sync::current_time_millis() as i64;
         let mut changed = 0;
         for row in &mut self.current.sessions {
-            if row.hook_state.as_deref() != Some("working") {
+            // A parked session has no process to be working or blocked in, and
+            // `Stopped` outranks both — see `Assessment::state`. Its hook
+            // columns still hold whatever stood before `session stop`, so
+            // without this the pass would talk over the one state thurbox
+            // knows first-hand.
+            if row.stopped {
                 continue;
             }
-            let derived = with_output_quiescence(SessionState::Working, quiet_for(&row.id));
+            let Some(state) = row
+                .hook_state
+                .as_deref()
+                .and_then(SessionState::from_hook_state)
+                .filter(|s| matches!(s, SessionState::Working | SessionState::Blocked))
+            else {
+                continue;
+            };
+            let age = self
+                .hook_state_at
+                .get(&row.id)
+                .map(|at| u64::try_from((now - at).max(0)).unwrap_or(0));
+            let derived = with_output_quiescence(state, quiet_for(&row.id), age);
             if row.status != derived {
                 row.status = derived;
                 changed += 1;
@@ -1112,6 +1149,10 @@ impl SnapshotStore {
             }
         };
         let hooks = database.load_hook_states().unwrap_or_default();
+        self.hook_state_at = hooks
+            .iter()
+            .filter_map(|(id, row)| Some((id.to_string(), row.state_at?)))
+            .collect();
         let bases = database.load_base_branches().unwrap_or_default();
         let stopped = database.load_stopped_sessions().unwrap_or_default();
         // What a driver declared this row runs. Read here for the same reason
@@ -1666,6 +1707,85 @@ mod tests {
             None,
             "a row that now reports its own hook state must leave the probed cache"
         );
+    }
+
+    /// The captain's report, end to end on the surface he was looking at: a
+    /// session reading `blocked` long after its agent finished.
+    ///
+    /// Driven through the store rather than the pure fold because the part that
+    /// can be wrong is that the tick pass reaches `blocked` rows at all — it
+    /// used to filter to `working` and nothing else, so no amount of evidence
+    /// could retire a latched block.
+    #[test]
+    fn a_block_the_pane_printed_past_stops_being_drawn() {
+        let temp = tempfile::NamedTempFile::new().expect("temp file");
+        let database = Database::open(temp.path()).expect("open store connection");
+        let row = crate::sync::SharedSession {
+            id: SessionId::default(),
+            name: "crewmate".into(),
+            agent: "zsh".into(),
+            backend_id: "%7".into(),
+            backend_type: "local-tmux".into(),
+            agent_session_id: None,
+            cwd: None,
+            additional_dirs: Vec::new(),
+            worktrees: Vec::new(),
+            shell_backend_id: None,
+            parent_session_id: None,
+            display_order: None,
+            tombstone: false,
+            tombstone_at: None,
+        };
+        database.upsert_session(&row).expect("upsert");
+        database.set_hook_state(row.id, "blocked").expect("signal");
+        let mut store = SnapshotStore::with_database(database);
+        store.refresh();
+        let id = row.id.to_string();
+        assert_eq!(status_of(&store, &id), SessionState::Blocked);
+
+        // A fresh block is quiet from its own edge, so nothing here moves it —
+        // however long the operator leaves it standing.
+        assert_eq!(store.apply_output_quiescence(|_| Some(60_000)), 0);
+        assert_eq!(status_of(&store, &id), SessionState::Blocked);
+
+        // Age the edge to what the captain saw: stamped 2547s ago, and the
+        // pane printed all the way to 17s ago.
+        let stamped = crate::sync::current_time_millis() as i64 - 2_547_000;
+        store.hook_state_at.insert(id.clone(), stamped);
+
+        assert_eq!(store.apply_output_quiescence(|_| Some(17_000)), 1);
+        assert_eq!(
+            status_of(&store, &id),
+            SessionState::Idle,
+            "an agent that printed for 42 minutes after the block edge was not waiting on anyone"
+        );
+        // The stored column is never touched: the fold is read-time, and the
+        // agent's own last word stays readable.
+        assert_eq!(
+            store
+                .current()
+                .sessions
+                .iter()
+                .find(|s| s.id == id)
+                .expect("row published")
+                .hook_state
+                .as_deref(),
+            Some("blocked")
+        );
+
+        // Reversible, like the `working` half: printing again is a turn.
+        assert_eq!(store.apply_output_quiescence(|_| Some(0)), 1);
+        assert_eq!(status_of(&store, &id), SessionState::Working);
+    }
+
+    fn status_of(store: &SnapshotStore, id: &str) -> SessionState {
+        store
+            .current()
+            .sessions
+            .iter()
+            .find(|s| s.id == id)
+            .expect("row published")
+            .status
     }
 
     /// The local path: an agent's own `thurbox-cli session signal` writes the

--- a/src/kernel/terminal/mod.rs
+++ b/src/kernel/terminal/mod.rs
@@ -31,6 +31,7 @@ use tui_term::widget::PseudoTerminal;
 
 use super::paint::SurfaceProvider;
 use super::snapshot::Snapshot;
+use crate::session::WORKING_QUIET_MS;
 
 pub mod links;
 mod programs;
@@ -312,6 +313,22 @@ pub struct Terminals {
     /// Moves whenever the set of attach failures does. Published on each
     /// session row, so it gates that group alongside `meta_version`.
     failed_version: u64,
+    /// The sessions whose pane is **currently producing output**, refreshed by
+    /// [`Self::sync_printing`] once per publish.
+    ///
+    /// Membership only, and deliberately nothing else: it is the single fact
+    /// the interface needs to animate a `running` session on evidence rather
+    /// than on assumption, and it is published in a group of its own because
+    /// the answer moves with the agent's output while the session rows do not
+    /// (see `kernel::host::publish`).
+    printing: std::collections::HashSet<String>,
+    /// Moves only when [`Self::printing`] gains or loses a session.
+    ///
+    /// The reason this is a set-membership version rather than the raw output
+    /// clock: `millis_since_output` changes on every byte, and gating a group
+    /// on that would rebuild it on every frame under a printing agent — the
+    /// exact cost the group gating exists to avoid.
+    printing_version: u64,
     /// Attaches running on workers: session id → the backend it is on.
     ///
     /// Attaching is the one thing here that blocks for a *long* time — an ssh
@@ -370,6 +387,8 @@ impl Terminals {
             meta: HashMap::new(),
             meta_version: 0,
             failed_version: 0,
+            printing: std::collections::HashSet::new(),
+            printing_version: 0,
             attaching: HashMap::new(),
             attached: std::sync::mpsc::channel(),
             adopted: Vec::new(),
@@ -1375,6 +1394,41 @@ impl Terminals {
         self.live
             .get(session)
             .map(|live| live.session.millis_since_last_output())
+    }
+
+    /// Recompute which sessions are producing output, bumping
+    /// [`Self::printing_version`] only when the *set* changes.
+    ///
+    /// The same signal and the same bound the stuck-`working` fallback uses
+    /// ([`WORKING_QUIET_MS`]), for the same reason: a TUI agent animates its
+    /// in-progress line while a turn runs, so "printed within the window" is
+    /// what separates a turn in flight from a prompt waiting for input. No
+    /// process listing can make that distinction, which is why an interface
+    /// may animate a `running` session and a headless reader may not.
+    ///
+    /// Only live panes are considered — a session thurbox has not attached
+    /// cannot be observed printing, so it is simply absent and draws static.
+    pub fn sync_printing(&mut self) {
+        let printing: std::collections::HashSet<String> = self
+            .live
+            .iter()
+            .filter(|(_, live)| live.session.millis_since_last_output() <= WORKING_QUIET_MS)
+            .map(|(session, _)| session.clone())
+            .collect();
+        if printing != self.printing {
+            self.printing = printing;
+            self.printing_version = self.printing_version.wrapping_add(1);
+        }
+    }
+
+    /// The sessions producing output as of the last [`Self::sync_printing`].
+    pub fn printing(&self) -> &std::collections::HashSet<String> {
+        &self.printing
+    }
+
+    /// Moves only when [`Self::printing`]'s membership does.
+    pub fn printing_version(&self) -> u64 {
+        self.printing_version
     }
 
     /// The activity text and attention notification each live agent last

--- a/src/session/hook_status.rs
+++ b/src/session/hook_status.rs
@@ -125,7 +125,8 @@ pub const AGENT_HOOK_COVERAGE: &[AgentHookCoverage] = &[
         states: &["working", "blocked", "done", "idle"],
         delivery: HookDelivery::Args,
         hook_file: Some("claude.json"),
-        // `Notification` bodies are matched against *permission*/*approval*.
+        // A `Notification`'s `message` is matched against
+        // *permission*/*approval* — the words, not a structured event.
         blocked_is_heuristic: true,
     },
     AgentHookCoverage {
@@ -208,12 +209,34 @@ pub const AGENT_HOOK_COVERAGE: &[AgentHookCoverage] = &[
 ];
 
 /// How an agent came to have (or not have) hook coverage.
+// The shared `By` prefix is the meaning, not noise: each variant names the
+// *route* the answer took, and the three routes are what a reader has to tell
+// apart — two declarations and one observation.
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CoverageSource {
     /// The agent's own name is one the hooks extension knows.
     ByName,
     /// A custom agent asserted the family with `hook_schema` in agents.toml.
     BySchema,
+    /// Neither name resolved, but the pane is observably held by an agent that
+    /// does have coverage — [`Corroboration::ForeignAgent`]'s payload.
+    ///
+    /// The only one of the three that is an **observation** rather than a
+    /// declaration, which is why it is spelled apart from them and why what it
+    /// yields is [`Coverage::Presumed`] rather than the row's own verdict.
+    ByDetection,
+}
+
+impl CoverageSource {
+    /// The stable word a record carries.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            CoverageSource::ByName => "name",
+            CoverageSource::BySchema => "hook_schema",
+            CoverageSource::ByDetection => "detection",
+        }
+    }
 }
 
 /// The coverage of the agent named `agent`, resolved the way the hooks
@@ -242,10 +265,24 @@ pub fn coverage_for(
 ///
 /// `Partial` is the honest middle: `aider` reports `blocked` and nothing else,
 /// so its silence about `working` carries no information.
+///
+/// `Full` and `Partial` are both claims about wiring thurbox *declared* — the
+/// row's own agent, or the family a `hook_schema` asserted. `Presumed` is the
+/// fourth word for the one case where neither name answers and the pane does:
+/// see [`Coverage::presumed`].
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum Coverage {
     Full,
     Partial,
+    /// The states below belong to an agent thurbox **observed** in the pane
+    /// rather than one the row declares, so they say what that agent's payload
+    /// *would* report — not that anything installed it.
+    ///
+    /// Deliberately not folded into `Full`/`Partial`: coverage answers "what
+    /// can this wiring report", and a detected identity is evidence about the
+    /// process, never about the wiring. Reporting a driver-launched claude as
+    /// `full` would promise a `done` that may never come.
+    Presumed,
     #[default]
     None,
 }
@@ -255,6 +292,7 @@ impl Coverage {
         match self {
             Coverage::Full => "full",
             Coverage::Partial => "partial",
+            Coverage::Presumed => "presumed",
             Coverage::None => "none",
         }
     }
@@ -267,6 +305,27 @@ impl Coverage {
             Some(_) => Coverage::Partial,
         }
     }
+
+    /// The verdict for a row whose coverage came from the pane rather than
+    /// from either name — always [`Coverage::Presumed`], whatever the found
+    /// agent's payload can do.
+    pub fn presumed(found: Option<&AgentHookCoverage>) -> Self {
+        match found {
+            None => Coverage::None,
+            Some(_) => Coverage::Presumed,
+        }
+    }
+}
+
+/// The coverage of the agent **observed** holding a pane.
+///
+/// Resolved by name alone, unlike [`coverage_for`]: the name in a
+/// [`Corroboration::ForeignAgent`] came from matching a process against the
+/// registry, and a `hook_schema` an entry asserts is a claim about the agent
+/// thurbox would *launch* under that name — not about a process a foreign
+/// driver started, which is all this has seen.
+pub fn coverage_of_detected(agent: &str) -> Option<&'static AgentHookCoverage> {
+    AGENT_HOOK_COVERAGE.iter().find(|c| c.agent == agent)
 }
 
 /// Seconds between `state_at` (epoch ms) and `now` (epoch ms).
@@ -782,7 +841,7 @@ pub fn derive_state(
 /// what the fallback exists to avoid.
 pub const WORKING_QUIET_MS: u64 = 10_000;
 
-/// Fold terminal quiescence into a `working` session's state.
+/// Fold terminal quiescence into a session's state.
 ///
 /// Agents fire no hook when a turn is **interrupted** (Esc / Ctrl+C) and none
 /// when they return to the idle prompt, so a `working` state can stand forever
@@ -794,18 +853,57 @@ pub const WORKING_QUIET_MS: u64 = 10_000;
 /// `quiet_for_ms` is `None` when the session has no live pane — nothing can be
 /// producing output, so that reads as quiet too. This is where v1's `exited →
 /// Idle` branch lands: a pane whose stream ended is dropped from the live set.
-/// Only `working` is time-gated; `blocked` is a standing request for input and
-/// says nothing about output.
+///
+/// `blocked` is **not** time-gated, and for the reason this fold used to say it
+/// was exempt altogether: a standing request for input says nothing about
+/// output, so a quiet blocked session is exactly what a real block looks like
+/// and no clock may end one. What ends one is [`outlived_by_output`] — evidence
+/// rather than a bound. A block that has been overtaken by output is folded
+/// through the `working` rule above, because the pane has been active since and
+/// the only remaining question is whether it still is.
 ///
 /// Only a caller with a live terminal can answer this, which is why it is a
 /// fold a surface opts into rather than part of [`derive_state`]: headless,
 /// there is nothing to ask, and guessing a bound would report a running turn
 /// as finished.
-pub fn with_output_quiescence(state: SessionState, quiet_for_ms: Option<u64>) -> SessionState {
+pub fn with_output_quiescence(
+    state: SessionState,
+    quiet_for_ms: Option<u64>,
+    state_age_ms: Option<u64>,
+) -> SessionState {
+    if state == SessionState::Blocked && outlived_by_output(quiet_for_ms, state_age_ms) {
+        return with_output_quiescence(SessionState::Working, quiet_for_ms, None);
+    }
     if state == SessionState::Working && quiet_for_ms.unwrap_or(u64::MAX) > WORKING_QUIET_MS {
         return SessionState::Idle;
     }
     state
+}
+
+/// Whether the pane went on printing well after the state was stamped.
+///
+/// The one fact that can retire a `blocked` without guessing a bound. An agent
+/// that is waiting for input is not writing to its pane, so the two clocks move
+/// together for a real block: the dialog draws at the block edge and the pane
+/// is quiet from that moment, leaving `quiet_for_ms` within measurement slop of
+/// `state_age_ms` however long the wait runs — an hour-long block stays
+/// `blocked`, which is the whole point.
+///
+/// A block the agent resolved by itself — claude's `blocked` is a text match on
+/// a `Notification` body, and the advisories an autonomous agent answers on its
+/// own fire the same hook — leaves the two clocks diverging instead, because
+/// the turn goes on printing. The margin is [`WORKING_QUIET_MS`] rather than a
+/// new constant, and it is the same claim that constant already makes: output
+/// this long after the edge is a turn animating, not a dialog that drew once.
+///
+/// Both `None`s are "cannot tell", never "stale": a session with no live pane
+/// has nothing that could have printed, and a state with no stamp has no edge
+/// to have printed after.
+pub fn outlived_by_output(quiet_for_ms: Option<u64>, state_age_ms: Option<u64>) -> bool {
+    let (Some(quiet), Some(age)) = (quiet_for_ms, state_age_ms) else {
+        return false;
+    };
+    age.saturating_sub(quiet) > WORKING_QUIET_MS
 }
 
 /// Fold what the terminal store knows about the host into a session's state.
@@ -1042,6 +1140,7 @@ impl Assessment {
     /// the argv it was read from is not carried back.
     pub fn with_corroboration(mut self, corroboration: Corroboration) -> Self {
         self.contradicted = Some(contradicts(self.hook_state.as_deref(), &corroboration));
+        self.adopt_detected_coverage(&corroboration);
         if let Some((state, source)) = best_state(
             self.hook_state.as_deref(),
             self.state_at,
@@ -1061,6 +1160,39 @@ impl Assessment {
     pub fn pane_unavailable(mut self) -> Self {
         self.corroboration = Some(Corroboration::Unavailable);
         self
+    }
+
+    /// Take the coverage of the agent the pane was found running, for a row
+    /// whose **own** name resolved to none.
+    ///
+    /// The row's `agent` is a durable declaration and this is a live
+    /// observation, so the metadata it yields can change under a reader
+    /// between calls. That is accepted here, and narrowly: every other field
+    /// this same fold writes (`corroboration`, `contradicted`, and `state`
+    /// itself when nothing reported) has exactly that lifetime already, the
+    /// record says which it is through [`CoverageSource::ByDetection`], and a
+    /// driver that wants a durable answer has `session reports-as` — which is
+    /// consulted first and is never overridden here.
+    ///
+    /// Only ever *adds*: a row that already resolved coverage by name or by
+    /// schema keeps it, because a declaration outranks an observation. What it
+    /// fixes is the inversion in the other direction — a shell row running a
+    /// detected `claude` reported `blocked_is_heuristic: false`, the default
+    /// for "no coverage row", which reads as an authoritative block on the one
+    /// agent whose block edge is a text match.
+    fn adopt_detected_coverage(&mut self, corroboration: &Corroboration) {
+        if self.covered.is_some() {
+            return;
+        }
+        let Some(found) = corroboration
+            .detected_agent()
+            .and_then(coverage_of_detected)
+        else {
+            return;
+        };
+        self.covered = Some(found);
+        self.coverage = Coverage::presumed(Some(found));
+        self.coverage_source = Some(CoverageSource::ByDetection);
     }
 
     /// Record that the session is parked — `session stop` killed its pane and
@@ -1155,7 +1287,7 @@ mod tests {
         // Agents fire no hook on interrupt, so without this a cancelled turn
         // would spin forever. v1 guards the same way, on the same signal.
         assert_eq!(
-            with_output_quiescence(SessionState::Working, Some(WORKING_QUIET_MS + 1)),
+            with_output_quiescence(SessionState::Working, Some(WORKING_QUIET_MS + 1), None),
             SessionState::Idle
         );
     }
@@ -1163,11 +1295,11 @@ mod tests {
     #[test]
     fn a_printing_working_session_stays_working() {
         assert_eq!(
-            with_output_quiescence(SessionState::Working, Some(0)),
+            with_output_quiescence(SessionState::Working, Some(0), None),
             SessionState::Working
         );
         assert_eq!(
-            with_output_quiescence(SessionState::Working, Some(WORKING_QUIET_MS)),
+            with_output_quiescence(SessionState::Working, Some(WORKING_QUIET_MS), None),
             SessionState::Working
         );
     }
@@ -1177,7 +1309,7 @@ mod tests {
         // Nothing can be producing output, which is where v1's exited → Idle
         // branch lands: a pane whose stream ended leaves the live set.
         assert_eq!(
-            with_output_quiescence(SessionState::Working, None),
+            with_output_quiescence(SessionState::Working, None, None),
             SessionState::Idle
         );
     }
@@ -1190,13 +1322,125 @@ mod tests {
         );
         // A session waiting on you produces no output while it waits.
         assert_eq!(
-            with_output_quiescence(SessionState::Blocked, None),
+            with_output_quiescence(SessionState::Blocked, None, None),
             SessionState::Blocked
         );
         assert_eq!(
-            with_output_quiescence(SessionState::Done, Some(WORKING_QUIET_MS * 10)),
+            with_output_quiescence(SessionState::Done, Some(WORKING_QUIET_MS * 10), None),
             SessionState::Done
         );
+    }
+
+    /// The captain's report: a session whose agent finished minutes ago still
+    /// reading `blocked`. The block edge is 42 minutes old and the pane printed
+    /// throughout, so the wait it claims never happened.
+    #[test]
+    fn a_block_the_pane_printed_past_is_over() {
+        // Quiet for 17s, stamped 2547s ago — the agent worked for the whole
+        // gap between the two and has just stopped.
+        assert_eq!(
+            with_output_quiescence(SessionState::Blocked, Some(17_000), Some(2_547_000)),
+            SessionState::Idle
+        );
+        // Still printing: it is a turn, not a wait. The word comes from the
+        // same rule `working` is held to, not from the latched column.
+        assert_eq!(
+            with_output_quiescence(SessionState::Blocked, Some(0), Some(2_547_000)),
+            SessionState::Working
+        );
+    }
+
+    /// The case the fold must not touch, and the reason it is not a timeout: an
+    /// agent waiting on a permission prompt is quiet for exactly as long as it
+    /// has been waiting, however long that runs.
+    #[test]
+    fn a_standing_block_survives_any_age() {
+        for age in [30_000u64, 600_000, 3_600_000, 86_400_000] {
+            // The dialog drew at the edge and nothing has printed since, so the
+            // two clocks move together — bar the slop between a hook's stamp
+            // and the pane's own reckoning.
+            assert_eq!(
+                with_output_quiescence(SessionState::Blocked, Some(age - 200), Some(age)),
+                SessionState::Blocked,
+                "a {age}ms block went stale on measurement slop"
+            );
+        }
+    }
+
+    /// Both silences are "cannot tell", never "stale".
+    #[test]
+    fn a_block_with_nothing_to_compare_stands() {
+        // No live pane: nothing could have printed past the edge.
+        assert_eq!(
+            with_output_quiescence(SessionState::Blocked, None, Some(2_547_000)),
+            SessionState::Blocked
+        );
+        // No stamp: no edge to have printed after.
+        assert_eq!(
+            with_output_quiescence(SessionState::Blocked, Some(17_000), None),
+            SessionState::Blocked
+        );
+    }
+
+    /// Defect the captain's record showed twice over: a `shell` row whose pane
+    /// is observably claude reported `hook_coverage: none`, an empty reportable
+    /// list, and — the inversion — `blocked_is_heuristic: false`, the default
+    /// for a row with no coverage at all, on the one agent whose block edge is
+    /// a text match.
+    #[test]
+    fn coverage_falls_back_to_the_agent_the_pane_is_running() {
+        let registry = registry(vec![agent("shell", "zsh", None)]);
+        let bare = Assessment::from_hooks(&registry, "shell", Some("blocked"), Some(0), None, NOW);
+        assert_eq!(bare.coverage, Coverage::None);
+        assert!(!bare.blocked_is_heuristic());
+        assert!(bare.states_reportable().is_empty());
+
+        let seen = bare.with_corroboration(Corroboration::ForeignAgent(Some("claude".into())));
+        assert_eq!(seen.coverage_source, Some(CoverageSource::ByDetection));
+        assert!(
+            seen.blocked_is_heuristic(),
+            "claude's block edge is a Notification text match, whoever launched it"
+        );
+        assert!(seen.states_reportable().contains(&"done"));
+    }
+
+    /// Coverage describes what wiring *can* report, and a detected identity is
+    /// evidence about the process rather than about the wiring — so it never
+    /// promises the `full` that a declared claude does.
+    #[test]
+    fn detected_coverage_is_never_full() {
+        let registry = registry(vec![agent("shell", "zsh", None)]);
+        let seen = Assessment::from_hooks(&registry, "shell", Some("blocked"), Some(0), None, NOW)
+            .with_corroboration(Corroboration::ForeignAgent(Some("claude".into())));
+        assert_eq!(seen.coverage, Coverage::Presumed);
+        assert_eq!(seen.coverage.as_str(), "presumed");
+
+        // Declared, the same agent is the real thing.
+        let declared =
+            Assessment::from_hooks(&registry, "claude", Some("blocked"), Some(0), None, NOW);
+        assert_eq!(declared.coverage, Coverage::Full);
+    }
+
+    /// A declaration outranks an observation: `reports_as` already resolved the
+    /// coverage, and a passing process must not redraw it.
+    #[test]
+    fn a_declared_agent_keeps_its_own_coverage() {
+        let registry = registry(vec![agent("aider", "aider", None)]);
+        let seen = Assessment::from_hooks(&registry, "aider", Some("blocked"), Some(0), None, NOW)
+            .with_corroboration(Corroboration::ForeignAgent(Some("claude".into())));
+        assert_eq!(seen.coverage_source, Some(CoverageSource::ByName));
+        assert_eq!(seen.states_reportable(), &["blocked"]);
+    }
+
+    /// The `ForeignAgent` that names nobody — one executable several profiles
+    /// share — resolves nothing, exactly as before.
+    #[test]
+    fn an_unnamed_foreign_agent_adds_no_coverage() {
+        let registry = registry(vec![agent("shell", "zsh", None)]);
+        let seen = Assessment::from_hooks(&registry, "shell", Some("blocked"), Some(0), None, NOW)
+            .with_corroboration(Corroboration::ForeignAgent(None));
+        assert_eq!(seen.coverage, Coverage::None);
+        assert_eq!(seen.coverage_source, None);
     }
 
     #[test]
@@ -1307,7 +1551,7 @@ mod tests {
 
     #[test]
     fn claude_and_antigravity_are_flagged_as_matching_notification_text() {
-        // These grep the notification body for *permission*/*approval*, so a
+        // These match a notification's `message` for *permission*/*approval*, so a
         // reworded upstream notification stops `blocked` silently. A consumer
         // has to be able to see that from the data. kimi is the counter-case
         // that makes the flag worth publishing: it has a real

--- a/src/session_ops/builtin_hooks.rs
+++ b/src/session_ops/builtin_hooks.rs
@@ -870,6 +870,7 @@ mod tests {
     ///
     /// It is the last hook a finished session ever fires, which is what makes a
     /// false `blocked` here permanent: nothing comes after it to overwrite one.
+    #[cfg(unix)]
     const IDLE_NOTIFICATION: &str = concat!(
         r#"{"session_id":"d626fdf7","transcript_path":"/home/dev/.claude/projects/-srv-app/x.jsonl","#,
         r#""cwd":"/srv/app","prompt_id":"7da65910","hook_event_name":"Notification","#,
@@ -878,6 +879,7 @@ mod tests {
 
     /// The same, from a checkout whose own path carries one of the words the
     /// matcher looks for. Nothing about the notification changed.
+    #[cfg(unix)]
     const IDLE_NOTIFICATION_IN_A_PERMISSIONS_REPO: &str = concat!(
         r#"{"session_id":"d626fdf7","transcript_path":"/home/dev/.claude/projects/-srv-permissions-service/x.jsonl","#,
         r#""cwd":"/srv/permissions-service","prompt_id":"7da65910","hook_event_name":"Notification","#,
@@ -885,6 +887,7 @@ mod tests {
     );
 
     /// The notification that *is* a block: a tool waiting on approval.
+    #[cfg(unix)]
     const PERMISSION_NOTIFICATION: &str = concat!(
         r#"{"session_id":"5e3579cc","transcript_path":"/home/dev/.claude/projects/-srv-app/x.jsonl","#,
         r#""cwd":"/srv/app","prompt_id":"bcf28ba6","hook_event_name":"Notification","#,

--- a/src/session_ops/builtin_hooks.rs
+++ b/src/session_ops/builtin_hooks.rs
@@ -863,6 +863,113 @@ mod tests {
             .collect()
     }
 
+    // --- what the block matcher actually matches -----------------------------
+
+    /// A real `Notification` payload from Claude Code, verbatim, for the
+    /// notification that fires ~60s after a turn ends and nobody typed.
+    ///
+    /// It is the last hook a finished session ever fires, which is what makes a
+    /// false `blocked` here permanent: nothing comes after it to overwrite one.
+    const IDLE_NOTIFICATION: &str = concat!(
+        r#"{"session_id":"d626fdf7","transcript_path":"/home/dev/.claude/projects/-srv-app/x.jsonl","#,
+        r#""cwd":"/srv/app","prompt_id":"7da65910","hook_event_name":"Notification","#,
+        r#""message":"Claude is waiting for your input","notification_type":"idle_prompt"}"#
+    );
+
+    /// The same, from a checkout whose own path carries one of the words the
+    /// matcher looks for. Nothing about the notification changed.
+    const IDLE_NOTIFICATION_IN_A_PERMISSIONS_REPO: &str = concat!(
+        r#"{"session_id":"d626fdf7","transcript_path":"/home/dev/.claude/projects/-srv-permissions-service/x.jsonl","#,
+        r#""cwd":"/srv/permissions-service","prompt_id":"7da65910","hook_event_name":"Notification","#,
+        r#""message":"Claude is waiting for your input","notification_type":"idle_prompt"}"#
+    );
+
+    /// The notification that *is* a block: a tool waiting on approval.
+    const PERMISSION_NOTIFICATION: &str = concat!(
+        r#"{"session_id":"5e3579cc","transcript_path":"/home/dev/.claude/projects/-srv-app/x.jsonl","#,
+        r#""cwd":"/srv/app","prompt_id":"bcf28ba6","hook_event_name":"Notification","#,
+        r#""message":"Claude needs your permission","notification_type":"permission_prompt"}"#
+    );
+
+    /// Run a payload's own `Notification` command against `stdin`, with the
+    /// signal call replaced by `echo` so the test observes the decision instead
+    /// of writing to a database.
+    ///
+    /// The shipped command, not a re-implementation of it: what is under test
+    /// is a shell glob against JSON, and the only honest way to check one is to
+    /// let a shell run it.
+    #[cfg(unix)]
+    fn signalled_state(payload: &str, kind: PayloadKind, stdin: &str) -> Option<String> {
+        use std::io::Write;
+
+        let doc: serde_json::Value = match kind {
+            PayloadKind::Json => serde_json::from_str(payload).expect("valid JSON"),
+            _ => unreachable!("only the JSON payloads carry a Notification hook"),
+        };
+        let command = json_hook_commands(&doc)
+            .into_iter()
+            .find(|c| c.contains("--state blocked"))
+            .expect("payload has a blocked command")
+            .replace(SIGNAL_MARKER, "echo ");
+
+        let mut child = std::process::Command::new("sh")
+            .arg("-c")
+            .arg(&command)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn sh");
+        child
+            .stdin
+            .take()
+            .expect("stdin")
+            .write_all(stdin.as_bytes())
+            .expect("write payload");
+        let out = child.wait_with_output().expect("run the hook command");
+        let printed = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        (!printed.is_empty()).then_some(printed)
+    }
+
+    /// The regression: the matcher globbed the **whole payload**, so anything
+    /// in it carrying one of the words signalled `blocked` — including the
+    /// `cwd` and `transcript_path`, which are the operator's own directory
+    /// names. A session checked out under a path with "permission" in it went
+    /// `blocked` on the idle notification that arrives a minute after every
+    /// turn ends, and stayed there, because that notification is the last hook
+    /// such a session ever fires.
+    ///
+    /// The words are matched against the notification's `message` — the
+    /// "notification body" the coverage table has always claimed they were.
+    #[cfg(unix)]
+    #[test]
+    fn only_a_permission_notification_signals_blocked() {
+        for (agent, payload) in [
+            ("claude", CLAUDE_SETTINGS),
+            ("antigravity", ANTIGRAVITY_HOOKS),
+            ("grok", GROK_HOOKS),
+        ] {
+            assert_eq!(
+                signalled_state(payload, PayloadKind::Json, PERMISSION_NOTIFICATION).as_deref(),
+                Some("blocked"),
+                "{agent} stopped reporting a real permission prompt"
+            );
+            assert_eq!(
+                signalled_state(payload, PayloadKind::Json, IDLE_NOTIFICATION),
+                None,
+                "{agent} reports the idle notification as a block"
+            );
+            assert_eq!(
+                signalled_state(
+                    payload,
+                    PayloadKind::Json,
+                    IDLE_NOTIFICATION_IN_A_PERMISSIONS_REPO
+                ),
+                None,
+                "{agent} blocks on a directory name rather than on the notification"
+            );
+        }
+    }
+
     /// The one thing `session::hook_status`'s coverage table asserts about the
     /// world: that each agent's shipped payload really does signal exactly the
     /// states the table promises. A reader trusting `hook_states_reportable` is

--- a/src/session_ops/mirror.rs
+++ b/src/session_ops/mirror.rs
@@ -154,10 +154,7 @@ pub fn session_to_json_assessed(
     put("hook_coverage", json!(hook.coverage.as_str()));
     put(
         "hook_coverage_source",
-        json!(hook.coverage_source.map(|s| match s {
-            crate::session::CoverageSource::ByName => "name",
-            crate::session::CoverageSource::BySchema => "hook_schema",
-        })),
+        json!(hook.coverage_source.map(|s| s.as_str())),
     );
     put("hook_states_reportable", json!(hook.states_reportable()));
     put("hook_delivery", json!(hook.delivery().map(|d| d.as_str())));

--- a/tests/chrome.rs
+++ b/tests/chrome.rs
@@ -121,6 +121,7 @@ fn publish_with(
         wants: &Default::default(),
         focus: None,
         hovered: None,
+        printing: &Default::default(),
     })
     .expect("publish");
 }

--- a/tests/core_settings.rs
+++ b/tests/core_settings.rs
@@ -331,6 +331,7 @@ fn publish_with(host: &thurbox::kernel::host::LuaHost, settings: &Settings) {
         wants: &Default::default(),
         focus: None,
         hovered: None,
+        printing: &Default::default(),
     })
     .expect("publish");
 }

--- a/tests/events.rs
+++ b/tests/events.rs
@@ -91,6 +91,7 @@ fn publish(host: &LuaHost, snapshot: &Snapshot) {
         wants: &Default::default(),
         focus: None,
         hovered: None,
+        printing: &Default::default(),
     })
     .expect("publish");
 }

--- a/tests/frames.rs
+++ b/tests/frames.rs
@@ -118,6 +118,7 @@ fn publish_inner(
         wants: &Default::default(),
         focus: None,
         hovered,
+        printing: &Default::default(),
     })
     .expect("publish");
 }

--- a/tests/hover.rs
+++ b/tests/hover.rs
@@ -64,6 +64,7 @@ fn chip_backgrounds(host: &LuaHost, hovered: Option<&Identity>) -> Vec<(String, 
         wants: &Default::default(),
         focus: Some("agent"),
         hovered,
+        printing: &Default::default(),
     })
     .expect("publish");
 
@@ -290,6 +291,7 @@ fn a_hovered_row_is_banded_and_keeps_its_own_colours() {
             wants: &Default::default(),
             focus: Some("sessions"),
             hovered,
+            printing: &Default::default(),
         })
         .expect("publish");
         let index = host

--- a/tests/kernel_frame_cost.rs
+++ b/tests/kernel_frame_cost.rs
@@ -196,6 +196,17 @@ fn publish_at_with(
     themes: &Themes,
     inflight: &[thurbox::kernel::command::InFlight],
 ) {
+    publish_at_printing(host, epoch, snapshot, themes, inflight, &Default::default());
+}
+
+fn publish_at_printing(
+    host: &LuaHost,
+    epoch: Epoch,
+    snapshot: &Snapshot,
+    themes: &Themes,
+    inflight: &[thurbox::kernel::command::InFlight],
+    printing: &std::collections::HashSet<String>,
+) {
     let mut registry = Registry::default();
     let (bindings, settings) = host.declarations();
     registry.declare(bindings, settings);
@@ -222,6 +233,7 @@ fn publish_at_with(
         wants: &Default::default(),
         focus: None,
         hovered: None,
+        printing,
     })
     .expect("publish");
 }
@@ -242,6 +254,56 @@ fn probe(host: &LuaHost) -> String {
         .expect("render")
         .node;
     format!("{node:?}")
+}
+
+/// What is printing changes with an agent's output, and the session rows must
+/// not move with it.
+///
+/// This is the cost that decided the shape: the `sessions` group is a table per
+/// session with ~30 named fields, so gating it on the printing set would rebuild
+/// all of that every time a pane started or stopped producing output — many
+/// times a second under a working agent. The fact travels in a group of its own
+/// instead, and this pins that it stayed one group wide.
+///
+/// Counted against a control rather than against a literal, so the assertion
+/// survives the next group anyone adds: a republish at an unchanged epoch reuses
+/// everything, and bumping `printing` may reuse exactly one fewer.
+#[test]
+fn a_change_of_what_is_printing_rebuilds_one_group_and_no_others() {
+    let (_dir, host) = interface();
+    let themes = Themes::load(None);
+    let rows = Snapshot {
+        sessions: vec![row("s1", "one"), row("s2", "two")],
+        ..Snapshot::default()
+    };
+    let epoch = Epoch::always_fresh();
+
+    // Warm every group at this epoch.
+    publish_at(&host, epoch, &rows, &themes);
+
+    // Control: the same epoch again reuses all of them.
+    let before = host.reused_groups();
+    publish_at(&host, epoch, &rows, &themes);
+    let all_groups = host.reused_groups() - before;
+    assert!(
+        all_groups > 1,
+        "expected several gated groups, saw {all_groups}"
+    );
+
+    // The printing set moves and nothing else does.
+    let printing: std::collections::HashSet<String> = ["s1".to_string()].into_iter().collect();
+    let mut moved = epoch;
+    moved.printing = epoch.printing.wrapping_add(1);
+    let before = host.reused_groups();
+    publish_at_printing(&host, moved, &rows, &themes, &[], &printing);
+    let reused = host.reused_groups() - before;
+
+    assert_eq!(
+        reused,
+        all_groups - 1,
+        "a printing change rebuilt {} groups; it may rebuild only its own",
+        all_groups - reused
+    );
 }
 
 #[test]

--- a/tests/kernel_mvp.rs
+++ b/tests/kernel_mvp.rs
@@ -341,8 +341,8 @@ fn a_session_with_no_reported_status_never_draws_the_idle_dot() {
 
     // Not one row claims the agent said it is at rest.
     assert!(!screen.contains('○'), "an idle dot survived:\n{screen}");
-    // An agent IS there (◍), and the two silences read as absences (◌).
-    assert!(screen.contains('◍'), "no running glyph in:\n{screen}");
+    // An agent IS there (◉), and the two silences read as absences (◌).
+    assert!(screen.contains('◉'), "no running glyph in:\n{screen}");
     assert!(screen.contains('◌'), "no silence glyph in:\n{screen}");
     // And the row says which agent, without saying what it is doing.
     assert!(screen.contains("claude"), "{screen}");
@@ -372,7 +372,7 @@ fn a_running_session_with_no_determined_agent_says_so_without_a_name() {
     let screen = paint(&host, index_of(&host, "sessions"), 64, 12).join("\n");
 
     assert!(!screen.contains('○'), "an idle dot survived:\n{screen}");
-    assert!(screen.contains('◍'), "no running glyph in:\n{screen}");
+    assert!(screen.contains('◉'), "no running glyph in:\n{screen}");
     assert!(
         screen.contains("agent running · no status reported"),
         "{screen}"

--- a/tests/kernel_mvp.rs
+++ b/tests/kernel_mvp.rs
@@ -38,12 +38,30 @@ fn publish(host: &LuaHost, snapshot: &Snapshot) {
     publish_with(host, snapshot, &Default::default(), &[]);
 }
 
+/// [`publish`], naming the sessions whose panes are producing output — the
+/// evidence a `running` indicator animates on.
+fn publish_printing(host: &LuaHost, snapshot: &Snapshot, printing: &[&str]) {
+    let printing: std::collections::HashSet<String> =
+        printing.iter().map(|s| (*s).to_string()).collect();
+    publish_full(host, snapshot, &Default::default(), &[], &printing);
+}
+
 /// Publish with attach errors and in-flight commands spelled out.
 fn publish_with(
     host: &LuaHost,
     snapshot: &Snapshot,
     attach_errors: &std::collections::HashMap<String, String>,
     inflight: &[thurbox::kernel::command::InFlight],
+) {
+    publish_full(host, snapshot, attach_errors, inflight, &Default::default());
+}
+
+fn publish_full(
+    host: &LuaHost,
+    snapshot: &Snapshot,
+    attach_errors: &std::collections::HashMap<String, String>,
+    inflight: &[thurbox::kernel::command::InFlight],
+    printing: &std::collections::HashSet<String>,
 ) {
     let themes = themes();
     let registry = registry(host);
@@ -70,6 +88,7 @@ fn publish_with(
         wants: &Default::default(),
         focus: None,
         hovered: None,
+        printing,
     })
     .expect("publish");
 }
@@ -353,6 +372,101 @@ fn a_session_with_no_reported_status_never_draws_the_idle_dot() {
     let title = paint(&host, index_of(&host, "agent"), 90, 8).join("\n");
     assert!(title.contains("zsh → claude"), "{title}");
     assert!(title.contains("Running"), "{title}");
+}
+
+/// A `running` indicator moves only on proof that something is moving.
+///
+/// The distinction the whole state exists to keep: no process listing can tell
+/// a turn in flight from a prompt waiting for input, so `running` on its own
+/// may not claim a spinner. Terminal output can tell them apart, and it is the
+/// same signal the stuck-`working` fallback already trusts — so the dot
+/// animates exactly while the pane is printing and is static the moment it
+/// stops.
+#[test]
+fn a_running_session_animates_only_while_its_pane_prints() {
+    let host = host();
+    let mut driven = row("fm-worker", "thurbox", "idle");
+    driven.agent = "zsh".to_string();
+    driven.status = SessionState::Running;
+    let id = driven.id.clone();
+    let rows = snapshot(vec![driven]);
+
+    // Nothing is printing: the static fisheye, and not a spinner frame.
+    publish_printing(&host, &rows, &[]);
+    let quiet = paint(&host, index_of(&host, "sessions"), 48, 12).join("\n");
+    assert!(quiet.contains('◉'), "no static running glyph in:\n{quiet}");
+    assert!(
+        !quiet.chars().any(is_spinner_frame),
+        "a quiet pane animated, which claims a turn nobody observed:\n{quiet}"
+    );
+
+    // The same row, with its pane producing output: the spinner, and the
+    // static glyph gone.
+    publish_printing(&host, &rows, &[&id]);
+    let busy = paint(&host, index_of(&host, "sessions"), 48, 12).join("\n");
+    assert!(
+        busy.chars().any(is_spinner_frame),
+        "a printing pane stayed static:\n{busy}"
+    );
+    assert!(!busy.contains('◉'), "the static glyph survived:\n{busy}");
+}
+
+/// The blast radius of the evidence, checked at its edges: `running` is the
+/// only status output can set in motion.
+///
+/// `uncovered` and `unreported` are absences — one agent reports nothing, the
+/// other has not reported yet — and an absence that spun would be asserting
+/// exactly the knowledge it lacks. A pane can print under either (a shell
+/// echoing, a session still booting), so the printing set alone must not move
+/// them.
+#[test]
+fn output_animates_running_and_nothing_else() {
+    let host = host();
+    let mut uncovered = row("bare-shell", "thurbox", "idle");
+    uncovered.agent = "zsh".to_string();
+    uncovered.status = SessionState::Uncovered;
+    let mut unreported = row("just-spawned", "thurbox", "idle");
+    unreported.status = SessionState::Unreported;
+    let mut resting = row("finished", "thurbox", "idle");
+    resting.status = SessionState::Idle;
+    let ids: Vec<String> = [&uncovered, &unreported, &resting]
+        .iter()
+        .map(|r| r.id.clone())
+        .collect();
+    let rows = snapshot(vec![uncovered, unreported, resting]);
+
+    // Every one of them printing, and not one of them animating.
+    let printing: Vec<&str> = ids.iter().map(String::as_str).collect();
+    publish_printing(&host, &rows, &printing);
+    let screen = paint(&host, index_of(&host, "sessions"), 48, 12).join("\n");
+    assert!(
+        !screen.chars().any(is_spinner_frame),
+        "output set a status other than `running` in motion:\n{screen}"
+    );
+    assert!(screen.contains('◌'), "no silence glyph in:\n{screen}");
+    assert!(screen.contains('○'), "no idle glyph in:\n{screen}");
+}
+
+/// `working` is the agent's own report that a turn is running, so it animates
+/// whatever the pane is doing — the half that must not regress while `running`
+/// gains its own, narrower rule.
+#[test]
+fn a_working_session_animates_without_needing_the_pane() {
+    let host = host();
+    let working = row("mid-turn", "thurbox", "working");
+    let rows = snapshot(vec![working]);
+
+    publish_printing(&host, &rows, &[]);
+    let screen = paint(&host, index_of(&host, "sessions"), 48, 12).join("\n");
+    assert!(
+        screen.chars().any(is_spinner_frame),
+        "a working row stopped animating:\n{screen}"
+    );
+}
+
+/// One frame of `theme.spinner`, whichever the elapsed clock landed on.
+fn is_spinner_frame(c: char) -> bool {
+    "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏".contains(c)
 }
 
 /// The follow-up: an agent IS in the pane (status `running`), but two

--- a/tests/keymap.rs
+++ b/tests/keymap.rs
@@ -103,6 +103,7 @@ fn publish(host: &LuaHost, snapshot: &Snapshot) {
         wants: &Default::default(),
         focus: None,
         hovered: None,
+        printing: &Default::default(),
     })
     .expect("publish");
 }

--- a/tests/modals.rs
+++ b/tests/modals.rs
@@ -103,6 +103,7 @@ fn publish(host: &LuaHost, registry: &Registry, themes: &Themes) {
         wants: &Default::default(),
         focus: None,
         hovered: None,
+        printing: &Default::default(),
     })
     .expect("publish");
 }

--- a/tests/mouse.rs
+++ b/tests/mouse.rs
@@ -94,6 +94,7 @@ fn hits_of(plugin: &str, width: u16, height: u16) -> Vec<Hit> {
         wants: &Default::default(),
         focus: None,
         hovered: None,
+        printing: &Default::default(),
     })
     .expect("publish");
 
@@ -554,6 +555,7 @@ fn clicking_a_session_row_selects_that_session() {
         wants: &Default::default(),
         focus: None,
         hovered: None,
+        printing: &Default::default(),
     })
     .expect("publish");
 

--- a/tests/new_session.rs
+++ b/tests/new_session.rs
@@ -171,6 +171,7 @@ fn publish(host: &LuaHost, world: &World) {
         wants: &world.wants,
         focus: None,
         hovered: None,
+        printing: &Default::default(),
     })
     .expect("publish");
 }

--- a/tests/palette.rs
+++ b/tests/palette.rs
@@ -82,6 +82,7 @@ fn publish(host: &LuaHost, registry: &Registry) {
         wants: &Default::default(),
         focus: None,
         hovered: None,
+        printing: &Default::default(),
     })
     .expect("publish");
 }

--- a/tests/plugin_programs.rs
+++ b/tests/plugin_programs.rs
@@ -319,6 +319,7 @@ fn a_plugin_can_read_the_platform_it_is_running_on() {
         wants: &Default::default(),
         focus: Some("probe"),
         hovered: None,
+        printing: &Default::default(),
     })
     .expect("publish");
 

--- a/tests/plugin_settings.rs
+++ b/tests/plugin_settings.rs
@@ -109,6 +109,7 @@ fn session_list_of(host: &LuaHost, registry: &Registry, sessions: Vec<SessionRow
         wants: &Default::default(),
         focus: Some("sessions"),
         hovered: None,
+        printing: &Default::default(),
     })
     .expect("publish");
 

--- a/tests/render_props.rs
+++ b/tests/render_props.rs
@@ -101,6 +101,7 @@ fn publish(host: &LuaHost, rows: Vec<SessionRow>) {
         wants: &Default::default(),
         focus: None,
         hovered: None,
+        printing: &Default::default(),
     })
     .expect("publish");
 }

--- a/tests/restore.rs
+++ b/tests/restore.rs
@@ -111,6 +111,7 @@ fn publish_with(host: &LuaHost, snapshot: &Snapshot, registry: Registry) {
         wants: &Default::default(),
         focus: None,
         hovered: None,
+        printing: &Default::default(),
     })
     .expect("publish");
 }

--- a/tests/search.rs
+++ b/tests/search.rs
@@ -102,6 +102,7 @@ fn publish_with(host: &LuaHost, content: &std::collections::HashMap<String, Stri
         wants: &Default::default(),
         focus: None,
         hovered: None,
+        printing: &Default::default(),
     })
     .expect("publish");
 }
@@ -520,6 +521,7 @@ fn every_match_still_paints_when_the_results_fill_the_strip() {
             wants: &Default::default(),
             focus: None,
             hovered: None,
+            printing: &Default::default(),
         })
         .expect("publish");
 

--- a/tests/session_list.rs
+++ b/tests/session_list.rs
@@ -96,6 +96,7 @@ fn publish_with(host: &LuaHost, snapshot: &Snapshot, registry: &Registry) {
         wants: &Default::default(),
         focus: None,
         hovered: None,
+        printing: &Default::default(),
     })
     .expect("publish");
 }

--- a/tests/terminal_pane.rs
+++ b/tests/terminal_pane.rs
@@ -99,6 +99,7 @@ fn publish(host: &LuaHost) {
         wants: &Default::default(),
         focus: None,
         hovered: None,
+        printing: &Default::default(),
     })
     .expect("publish");
 }

--- a/thurbox.yml
+++ b/thurbox.yml
@@ -319,6 +319,13 @@ globals:
   # frame.
   thurbox.content:
     property: read-only
+  # Which sessions are producing output right now, keyed by session id. Its own
+  # tiny group rather than a field on each session row: the answer moves with an
+  # agent's output, and the rows must not be rebuilt at that rate. It is what
+  # lets a `running` dot animate on evidence instead of asserting a turn no
+  # process listing can see.
+  thurbox.printing:
+    property: read-only
   # Answers to the programs THIS plugin asked to be run. Set per plugin as it is
   # entered, so a pane reads its own and no other's.
   thurbox.runs:

--- a/ui/README.md
+++ b/ui/README.md
@@ -165,7 +165,8 @@ to `widgets` for the piece it does not cover.
 | `ui.empty{title, width, hint, hint_action}` | the one empty state — a blank line, the sentence centred, and the chord that fixes it, shown only while something is bound to it |
 | `ui.modal{title, cols, children, crumbs, border}` | a float sized from what is in it |
 | `ui.footer{actions, primary, cancel}` | key hints resolved **from the registry**, plus the confirm/dismiss pills |
-| `ui.status(name, elapsed)` / `ui.dots(items, elapsed, status_of)` | a status glyph, spinner included; and the strip of them a panel puts on its border |
+| `ui.status(name, elapsed, printing)` / `ui.dots(items, elapsed, status_of, id_of)` | a status glyph, spinner included; and the strip of them a panel puts on its border. `working` always animates; `running` animates only while `printing` says its pane is producing output |
+| `ui.printing(session_id)` | whether that session's pane is producing output, from `thurbox.printing` |
 | `ui.rule(label, width)` | `── label ────`, the group heading |
 | `ui.chord(action)` / `ui.describe(action)` / `ui.follow(key, id)` / `ui.reset(key)` | the registry lookups, and a cursor addressed without holding one |
 

--- a/ui/lib/theme.lua
+++ b/ui/lib/theme.lua
@@ -99,7 +99,12 @@ local STATUS_GLYPHS = {
   -- An agent holds the pane and has reported nothing. Filled, because
   -- something IS there; not the working spinner, because no process listing
   -- can tell a turn in flight from a prompt waiting for input.
-  running = "◍",
+  --
+  -- FISHEYE rather than CIRCLE WITH VERTICAL FILL (U+25CD), which is rare
+  -- enough that monospace fonts routinely have no glyph for it and draw a
+  -- fallback box. Still distinct from done's solid circle and idle's hollow
+  -- one, which is the whole job of this row.
+  running = "◉",
   -- The two silences. Dotted, because the content of both is an absence: no
   -- hooks are wired (`uncovered`), or none have fired yet (`unreported`).
   -- Kept visibly apart from `idle`'s green hollow circle, which is a claim

--- a/ui/lib/theme.lua
+++ b/ui/lib/theme.lua
@@ -97,8 +97,10 @@ local STATUS_GLYPHS = {
   error = "✗",
   unreachable = "⊘",
   -- An agent holds the pane and has reported nothing. Filled, because
-  -- something IS there; not the working spinner, because no process listing
-  -- can tell a turn in flight from a prompt waiting for input.
+  -- something IS there. This is the STATIC half: a process listing cannot tell
+  -- a turn in flight from a prompt waiting for input, so the dot only moves
+  -- when `ui.status` is handed the one thing that can — `thurbox.printing`,
+  -- saying that pane is producing output right now. Quiet, it stays this glyph.
   --
   -- FISHEYE rather than CIRCLE WITH VERTICAL FILL (U+25CD), which is rare
   -- enough that monospace fonts routinely have no glyph for it and draw a

--- a/ui/lib/thurbox.d.lua
+++ b/ui/lib/thurbox.d.lua
@@ -625,6 +625,7 @@
 ---@field diffs table<string, thurbox.Diff>
 ---@field links table<string, thurbox.Link[]>
 ---@field content table<string, string> Served while `store.want_content` asks.
+---@field printing table<string, boolean> Sessions whose pane is producing output right now, keyed by id. The evidence `running` animates on — see `ui.status`.
 ---@field runs table<string, thurbox.Run> Answers to THIS plugin's runs.
 ---@field granted thurbox.Granted
 ---@field metrics thurbox.Metrics

--- a/ui/lib/ui.lua
+++ b/ui/lib/ui.lua
@@ -39,36 +39,69 @@ local ui = {}
 
 -- ── Status ──────────────────────────────────────────────────────────────────
 
---- Glyph and colour for a session status, with `working` animated.
+--- Glyph and colour for a session status, with the moving ones animated.
 ---
---- `theme.status` answers the static half; the spinner is the one status whose
---- glyph depends on the frame, and every pane that draws a status was choosing
---- between the two itself.
+--- `theme.status` answers the static half; the spinner is for the statuses
+--- whose glyph depends on the frame, and every pane that draws a status was
+--- choosing between the two itself.
+---
+--- Two statuses animate, on different evidence. `working` is the agent's own
+--- report that a turn is running. `running` is thurbox's observation that an
+--- agent holds the pane and has said nothing — which on its own cannot tell a
+--- turn in flight from a prompt waiting for input, so it animates only while
+--- `printing` says that pane is actually producing output. That is the same
+--- signal `with_output_quiescence` trusts in the other direction, and it is
+--- what keeps the spinner a report rather than a guess: quiet, it falls back
+--- to the static glyph.
+---
+--- `printing` comes from `thurbox.printing`, which only a surface holding the
+--- terminals can fill. A caller that passes nothing gets the static answer,
+--- which is the honest one when nobody looked.
 ---@param name thurbox.Status
 ---@param elapsed number?
+---@param printing boolean?
 ---@return { glyph: string, color: thurbox.Color? }
-function ui.status(name, elapsed)
+function ui.status(name, elapsed, printing)
   local spec = theme.status(name)
-  if name == "working" then
+  if name == "working" or (name == "running" and printing) then
     return { glyph = theme.spinner_frame(elapsed), color = spec.color }
   end
   return spec
 end
 
+--- Whether `session_id`'s pane is producing output right now.
+---
+--- The published set is keyed by session id, so a missing entry is "not
+--- printing" and an absent table (a surface that publishes none) is the same
+--- answer — never an error.
+---@param session_id string?
+---@return boolean
+function ui.printing(session_id)
+  if not session_id then
+    return false
+  end
+  local set = thurbox and thurbox.printing
+  return set ~= nil and set[session_id] == true
+end
+
 --- One status glyph per item, in render order — a panel's border strip.
 ---
 --- `status_of` returns the status to draw, or nil for an item the strip skips
---- (work in flight has no status of its own yet).
+--- (work in flight has no status of its own yet). `id_of` names the session a
+--- row stands for, so a `running` dot animates on the same evidence its row
+--- does; a strip whose items are not sessions omits it and draws static.
 ---@param items table[]
 ---@param elapsed number?
 ---@param status_of fun(item: table): string?
+---@param id_of (fun(item: table): string?)?
 ---@return thurbox.Span[]
-function ui.dots(items, elapsed, status_of)
+function ui.dots(items, elapsed, status_of, id_of)
   local runs = {}
   for _, item in ipairs(items) do
     local status = status_of(item)
     if status then
-      local spec = ui.status(status, elapsed)
+      local printing = id_of ~= nil and ui.printing(id_of(item)) or false
+      local spec = ui.status(status, elapsed, printing)
       runs[#runs + 1] = { text = spec.glyph, style = { fg = spec.color } }
     end
   end

--- a/ui/plugins/10_sessions.lua
+++ b/ui/plugins/10_sessions.lua
@@ -161,7 +161,7 @@ end
 --- the bar speaks for all of them.
 local function session_line(item, width, elapsed, is_selected, work, search)
   local session = item.session
-  local spec = ui.status(session.status, elapsed)
+  local spec = ui.status(session.status, elapsed, ui.printing(session.id))
   local glyph, glyph_color = spec.glyph, spec.color
   -- A blocked row's text is an attention message, so it keeps the dot's colour;
   -- plain activity is muted, leaving the name the row's visual anchor. v1 draws
@@ -596,6 +596,8 @@ return {
       -- them a border cell, so none costs a row.
       overlay_right = ui.dots(items, ctx.elapsed, function(item)
         return item.kind == "session" and item.session.status or nil
+      end, function(item)
+        return item.kind == "session" and item.session.id or nil
       end),
       body = ui.list({
         items = items,


### PR DESCRIPTION
## Intent

Captain's words, 2026-09-06, on seeing a live session in his interface:

"Current status is showing 'blocked' for thurbox frozen bug fix related session. Is it expected behavior ? it should show idle/done instead ?"

and then, authorizing the fix:

"Fix the blocked bug if possible"

No, it is not expected. It should read idle or done. A session whose agent has finished must not read 'blocked'. He approves every merge himself - do not merge.

Later words from the captain, on the running-state glyph in the same interface: he can see the new running glyph, but 'it is a bit ugly and do not render nicely in the UI', and he asked why it is not the animated glyph. He then approved the recommendation put to him with 'Go with recommended way !' - that recommendation was to replace the running glyph with a better-supported codepoint, and to animate the running state only when the pane is actually producing output (reusing the existing spinner), so the indicator never claims knowledge it lacks.

Later still, asked whether that animation should be built now or as a separate change, the captain said: 'I want greptile confident to be 5/5'. The greptile review holds this PR at 4/5 and calls it not yet safe to merge for exactly one outstanding reason, with nothing else on its list: a running session whose pane is producing output still shows a static indicator instead of the approved output-gated spinner. So the animation is to land in this PR rather than as a follow-up.

## What Changed

- Fixed the root cause of a session showing `blocked` forever after its turn ended: the Claude/Antigravity/Grok `Notification` hook commands matched permission/approval keywords against the **entire** payload (including `cwd`/`transcript_path`), so a checkout path containing a word like "permission" made the idle notification that fires after every turn falsely signal `blocked` — with no later hook to overwrite it. The commands now extract and match only the payload's `message` field (`extensions/hooks/claude.json`, `antigravity-hooks.json`, `grok-hooks.json`, bumped to hooks extension v1.9.0).
- Extended `with_output_quiescence` with an `outlived_by_output` check that folds a `blocked` state back to `working`/`idle` once its pane keeps printing well past the state's stamped age, and fixed the reader loop (`src/agent/backend.rs`) to stop counting an adopted session's replayed tmux scrollback as fresh output (`AdoptedSession::seed_len`), which previously made a real hours-long block look instantly quiet and get folded away.
- Added `Coverage::Presumed` / `CoverageSource::ByDetection` so a session whose own agent name resolves to no coverage, but whose pane is observed running a recognized agent, is diagnosed and reported accordingly (`src/session/hook_status.rs`, `src/cli/session_doctor.rs`).
- Replaced the static `running` glyph with a more widely-supported codepoint and made it animate (reusing the existing working spinner) only while `thurbox.printing` reports the pane is actually producing output, so the indicator never claims a turn is in flight when it can't tell (`ui/lib/theme.lua`, `ui/lib/ui.lua`, `ui/plugins/10_sessions.lua`).
- Plumbed a `printing` set/version end-to-end (`Terminals::sync_printing`/`printing_version`, `Epoch::printing`, `Published::printing`, published as `thurbox.printing`) and gated the render-loop animation clock on it so a printing `running` session keeps ticking (`src/kernel/host/mod.rs`, `src/kernel/host/publish.rs`, `src/kernel/snapshot.rs`, `src/coordinator/mod.rs`, `src/coordinator/publish.rs`).
- Updated docs and skills (`docs/AGENTS.md`, `docs/FEATURES.md`, `docs/PERFORMANCE.md`, `docs/ORCHESTRATION.md`, `.agents/skills/thurbox-session-status/SKILL.md`, `.agents/skills/thurbox-cli/SKILL.md`, `extensions/hooks/README.md`) and test suites (`src/session_ops/builtin_hooks.rs`, `tests/kernel_mvp.rs`, `tests/kernel_frame_cost.rs`, plus per-test `thurbox.printing` publish updates across `tests/*.rs`) to match.

## Design note: where the animation had to hook in

The greptile review named `ui/lib/ui.lua`'s `ui.status` as the place `running`
stayed static. That is where the *symptom* shows, but the blocker sat one layer
down, and it is worth recording because it decided the shape of this change.

`ui.status` could not animate `running` on evidence because no evidence reached
Lua: nothing per-row said whether a pane was printing. `src/kernel/host/publish.rs`
gates the `sessions` group on `[epoch.snapshot, epoch.meta, epoch.failed, 0]` and
**deliberately not** on the animation clock — the source calls it "the largest
group by a distance", a table per session with ~30 named fields. Hanging a
printing flag on those rows would have rebuilt all of them every time any pane
started or stopped producing output, which is the cost that gating exists to
prevent (ADR-P16).

So the fact travels in a group of its own: `thurbox.printing`, one session id per
printing session, gated on `epoch.printing` /
`Terminals::printing_version`. That version counts **set membership**, not the
output clock — the clock moves on every byte, and a group gated on it would
rebuild on every frame under a working agent and be worth nothing.
`tests/kernel_frame_cost.rs` pins that a printing change rebuilds exactly one
group, counted against a control rather than a literal so it survives the next
group anyone adds.

Two consequences fall out of that seam rather than being chosen separately.
Only a surface holding the terminals can fill the set, so a headless reader
publishes none, `ui.printing` answers false, and the glyph is static — the same
line `session get` already draws at the folds it cannot make. And
`advance_animation` had to learn the new case, or the clock it gates would stop
and freeze the spinner mid-turn.

## Risk Assessment

✅ Low: The two reviewed commits (9e495b5b: output-gated running-state animation; b730de33: reader_loop seed_len fix for the blocked-latch scrollback-replay bug) are well-scoped, match established architectural patterns (single-signal published groups, change-signal-not-value-signal gating), are covered by targeted tests including a regression test reproducing the original blocked-latch bug, and satisfy the authoritative user intent (running glyph now animates only on output evidence, addressing the sole outstanding greptile concern). Traced the seed_len byte-accounting against std::io::Chain's actual read semantics (it never mixes bytes from two sources within one read() call) and confirmed the fix correctly gates last_output_at stamping on live vs. replayed bytes in all boundary cases.

## Testing

Baseline `cargo nextest run --all` already passed per the pipeline; on top of that I ran the 54 tests directly targeting this change's two fixes (the blocked-latch output-quiescence fold, the scrollback-replay guard on last_output_at, and the running-glyph output-gated animation), all passing, and additionally produced a rendered-TUI text artifact (via a temporary, since-reverted test) showing the running indicator drawing as a static ◉ glyph while the pane is quiet and as an animated spinner frame while the pane is printing — directly demonstrating the exact behavior the greptile review was blocking on. The working tree is clean (only evidence file written outside it).

<details>
<summary>Evidence: Rendered TUI frames: running-status glyph static vs. animated on pane output</summary>

```text
=== running, pane quiet (static glyph, no spinner) ===
╭ Sessions ───────────────────────────────────◉╮
│── thurbox ───────────────────────────────────│
│ ◉ ⑂ fm-worker  agent running · no status rep…│
│                                              │
│                                              │
│                                              │
│                                              │
│                                              │
│                                              │
│                                              │
│                                              │
╰──────────────────────────────────────────────╯

=== running, pane printing (animated spinner) ===
╭ Sessions ───────────────────────────────────⠇╮
│── thurbox ───────────────────────────────────│
│ ⠇ ⑂ fm-worker  agent running · no status rep…│
│                                              │
│                                              │
│                                              │
│                                              │
│                                              │
│                                              │
│                                              │
│                                              │
╰──────────────────────────────────────────────╯
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (6m7s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"1c8aaf25c4743e5550e04c29909d926dc79609d9","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `src/session/hook_status.rs:902` - `outlived_by_output` (and its caller `apply_output_quiescence` in src/kernel/snapshot.rs:996) trusts `quiet_for_ms` (derived from `Terminals::millis_since_output`, ultimately `WiredPane::last_output_at`) as evidence that a pane is genuinely producing fresh output, and compares it against `state_age_ms` (the DB&#39;s `hook_state_at`, an absolute historical timestamp) to decide a standing `blocked` is stale. But `last_output_at` is stamped on *every* successful read from the pane&#39;s reader thread (src/agent/backend.rs:995), and that reader is fed `Cursor::new(seed).chain(connected.output)` (src/agent/tmux.rs:1600-1605) — i.e. on every session *adopt* (which is exactly what happens for every already-running session across a thurbox restart, crash+respawn, or first-attach), the captured tmux scrollback (`capture_history_seed`) is replayed through the same reader and immediately bumps `last_output_at` to &#39;now&#39;, indistinguishable from real live output. `initial_output_at(WireMode::Adopt)` deliberately starts at 0 specifically to avoid a post-adopt repaint reading as activity (see the `wire_mode_adopt_starts_stale_spawn_starts_fresh` test/comment in backend.rs), but that protection is defeated the instant the seed bytes are read, which is normally the very first read the reader thread performs.

Concrete failing sequence: a session enters `blocked` at t0 (hook_state_at = t0, e.g. a real permission prompt) and stays genuinely blocked for hours with no further pane output. Thurbox restarts (or the session panel is (re)attached) at t1 = t0 + 3h. `Terminals::sync` adopts the pane, replaying scrollback; `last_output_at` becomes ~t1. On the very next tick, `apply_output_quiescence` computes `age = t1 - t0` (~3h) and `quiet ≈ 0`, so `age.saturating_sub(quiet) &gt; WORKING_QUIET_MS` is true, and `with_output_quiescence` folds `Blocked` into `Working`/`Idle`. Because nothing ever re-stamps `hook_state_at` (no new hook fires) and nothing further prints (the session really is waiting on the user), `age` and `quiet` grow at the same rate afterward, so the gap never closes — the misclassification is permanent, not a transient blip like the analogous `working`→`idle` case (which is purely window-based and self-corrects). The session silently and durably stops showing `blocked` even though the user still needs to respond — the same &#39;agent needs my attention but the UI won&#39;t show it&#39; failure class this PR set out to fix, just reached from the opposite direction and, unlike the original bug, invisible until someone happens to check the pane directly.

Earliest shared boundary to fix this: distinguish genuine live output from scrollback replay at the one place both consumers of `last_output_at` (`sync_printing`&#39;s animation gate and `outlived_by_output`&#39;s blocked fold) rely on it — e.g. don&#39;t stamp `last_output_at` for bytes read from the `Cursor::new(seed)` half of the chained reader in src/agent/tmux.rs / src/agent/backend.rs&#39;s `reader_loop`, only for bytes from the live `connected.output` stream.

🔧 Fix: wait for verification: agent:: test suite running in background
✅ Re-checked - no issues remain.
</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- 🚨 tests failed with exit code 101
- `cargo nextest run --all`

🔧 Fix: fix: clear stale incremental build artifacts causing link failure
✅ Re-checked - no issues remain.
- `cargo nextest run --all`
- `cargo nextest run -E 'test(hook_status) or test(apply_output_quiescence) or test(reader_loop) or test(outlived) or test(a_block_the_pane) or test(coverage_falls_back) or test(detected_coverage) or test(a_declared_agent_keeps) or test(an_unnamed_foreign_agent) or test(a_standing_block) or test(scrollback)' — 44 passed`
- `cargo nextest run -E 'test(a_running_session_animates_only_while_its_pane_prints) or test(output_animates_running_and_nothing_else) or test(a_working_session_animates_without_needing_the_pane) or test(a_change_of_what_is_printing_rebuilds_one_group_and_no_others) or test(a_block_the_pane_printed_past_stops_being_drawn) or test(hooks_expected) or test(a_partial_agent_warns_without_failing) or test(an_agent_with_no_wiring_fails_and_says_how_to_wire_it) or test(a_session_with_no_reported_status_never_draws_the_idle_dot) or test(a_running_session_with_no_determined_agent_says_so_without_a_name)' — 10 passed`
- <code>manual: appended a temporary #[test] to tests/kernel_mvp.rs that renders the actual ratatui TUI frame for a `running` session via publish_printing()+paint() with the pane quiet vs. printing, wrote both rendered frames to the evidence file, ran it, then reverted the temporary test with `git checkout -- tests/kernel_mvp.rs` (confirmed clean working tree afterward)</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed (2) ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: {&#34;summary&#34;: &#34;style: fmt reader_loop and assert_eq call sites in backend.rs&#34;}
1 warning still open:

- ⚠️ linter found issues (exit code 101)

🔧 Fix: docs: replace private intra-doc link with plain code span
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

