### PR TITLE
fix(core): finish remote session teardown when a host is unreachable at delete time

### DIFF
--- a/.agents/skills/thurbox-cli/SKILL.md
+++ b/.agents/skills/thurbox-cli/SKILL.md
@@ -481,10 +481,16 @@ the worktrees **thurbox created** + the symlink workspace, disables `send`
 automations targeting the session, and clears its `session meta` key/value space
 (the row is unrestorable, so the meta would otherwise outlive it) — for headless
 cleanup with no TUI running. Teardown is best-effort
-(failures land in the JSON report); the row is always marked deleted last, in
-one write — a force delete stamps `deleted_at` and `force_deleted` together
-rather than soft-deleting first, so a watcher of `session_events` never sees an
-intermediate state that reads as restorable. A worktree the session merely
+(failures land in the JSON report), but a *remote* teardown that never reached
+its host is also written onto the row (`remote_teardown_owed`, schema v46's
+`teardown_owed`, shown by `session list --deleted`) and finished by
+`session_ops::retry_owed_remote_teardowns` on the next tick or `Command::Reap`
+once that host answers — the same two drivers as the reap, and the reason
+force-deleting against a machine that is down is allowed to keep working. The
+row is always marked deleted last, in one write — a force delete stamps
+`deleted_at` and `force_deleted` together rather than soft-deleting first, so a
+watcher of `session_events` never sees an intermediate state that reads as
+restorable. A worktree the session merely
 **opened** (`created_by_thurbox = 0`, schema v42) is
 left on disk and listed in the report's `kept_worktrees`: `git worktree remove
 --force` would take the uncommitted work in it too, which is thurbox's to discard

--- a/.agents/skills/thurbox-remote-hosts/SKILL.md
+++ b/.agents/skills/thurbox-remote-hosts/SKILL.md
@@ -336,13 +336,13 @@ session), never on the loop, ADR-P12).
   teardown instead of erroring: a fork minted here, a pre-ADR-24 row, or one a
   peer already deleted there all make the host answer "Session not found", and
   aborting left the local row active and attached. The fall-through is recorded
-  in `ForceDeleteReport.host_unknown`. A call that never reached the host at
-  all — a connection failure, not a reply (`host_never_answered` in
-  `session_ops::delete`) — falls through the same way, recorded in
-  `host_unreachable` instead: the row is still marked, and the local teardown
-  that runs in the host's place owes its own retry (`remote_teardown_owed`)
-  when it cannot reach the same down host either. Any *other* host error still
-  aborts — the session may still be running there.
+  in `ForceDeleteReport.host_unknown`. A call whose `host_cli::Reach` is not
+  `Answered` — `Unreached` or `Undetermined` — falls through the same way,
+  recorded in `host_unreachable` instead: the row is still marked, and the
+  local teardown that runs in the host's place owes its own retry
+  (`remote_teardown_owed`) when it cannot reach the same down host either.
+  Only `Answered` still aborts — the host heard the question and refused, and
+  the session may still be running there.
 - **Local e2e**: `scripts/dev/e2e/linux-container.sh up` spins a throwaway Podman
   container (sshd + tmux + git) and `… test` asserts a session lands on the
   `ssh:podman` backend (state under `target/`, never touches your real

--- a/.agents/skills/thurbox-remote-hosts/SKILL.md
+++ b/.agents/skills/thurbox-remote-hosts/SKILL.md
@@ -251,13 +251,17 @@ session), never on the loop, ADR-P12).
   but `ssh` exits non-zero for a refused connection, a timeout and a rejected
   key alike — so a force delete taken while a host was briefly down found
   nothing to kill and recorded *no error at all*. `TmuxBackend::
-  discover_answered` (used by `kill_remote_windows` and `remote_window_index`)
-  answers empty only on the multiplexer's own refusal — tmux's `error
-  connecting to` / `no server running on` / `can't find session`, psmux's
-  `session not found` (`mux_answered_absent`) — and errors otherwise. An
-  unrecognised failure counts as unanswered on purpose. It also drops the
-  `has-session` round trip: `list-windows` on an absent server gives exactly
-  that refusal.
+  discover_answered` (used by `kill_remote_windows`, `remote_window_index`,
+  and `agent_window`) answers empty only on the multiplexer's own refusal —
+  tmux's `error connecting to` / `no server running on` / `can't find
+  session`, psmux's `session not found` (`mux_answered_absent`) — and errors
+  otherwise. An unrecognised failure counts as unanswered on purpose. It also
+  drops the `has-session` round trip: `list-windows` on an absent server gives
+  exactly that refusal. `agent_window` backs `agent_window_alive`, which
+  `restart --if-missing` uses to decide whether to relaunch after a reboot —
+  an unreachable host now aborts the relaunch instead of reading as "no
+  window", which used to start a second agent beside the one still running
+  once the host answered again (`restart_if_missing_probe`).
 - **A session owns two windows**, and every teardown takes both: the agent
   (`tb-`) and the companion shell (`tbs-`). The shell is found by its stamp
   (`@thurbox_role = shell`) rather than by `sessions.shell_backend_id`, which is
@@ -269,7 +273,7 @@ session), never on the loop, ADR-P12).
   multiplexer server *and* the thurbox session as a side effect, so a one-shot
   `thurbox-cli` tearing a session down used to leave an empty server on the
   host. `kill_remote_windows` / `remote_window_index` / `agent_window` read one
-  `list-windows` (guarded by `has-session`) and kill with a one-shot
+  `list-windows` (`discover_answered`, above) and kill with a one-shot
   `kill-pane`. And they only act on a socket the host has vouched for:
   `known_host_socket` takes `hosts.toml`'s `socket`, else what the host's own
   CLI reported (`learn_host_socket`), else — for a host with `share_sessions =
@@ -304,8 +308,13 @@ session), never on the loop, ADR-P12).
   teardown instead of erroring: a fork minted here, a pre-ADR-24 row, or one a
   peer already deleted there all make the host answer "Session not found", and
   aborting left the local row active and attached. The fall-through is recorded
-  in `ForceDeleteReport.host_unknown`. Any *other* host error still aborts — the
-  session may still be running there.
+  in `ForceDeleteReport.host_unknown`. A call that never reached the host at
+  all — a connection failure, not a reply (`host_never_answered` in
+  `session_ops::delete`) — falls through the same way, recorded in
+  `host_unreachable` instead: the row is still marked, and the local teardown
+  that runs in the host's place owes its own retry (`remote_teardown_owed`)
+  when it cannot reach the same down host either. Any *other* host error still
+  aborts — the session may still be running there.
 - **Local e2e**: `scripts/dev/e2e/linux-container.sh up` spins a throwaway Podman
   container (sshd + tmux + git) and `… test` asserts a session lands on the
   `ssh:podman` backend (state under `target/`, never touches your real
@@ -316,4 +325,9 @@ session), never on the loop, ADR-P12).
   reaped the pid it was running. It keeps sharing off throughout — with it on,
   a host whose CLI has vouched for no socket is refused by
   `known_host_socket`, which is a different behaviour and would hide this one.
+  `restart_if_missing_probe` covers the sibling fix: create a session, point
+  `hosts.toml` at a dead port, assert `restart --if-missing` refuses rather
+  than relaunching against a host it cannot reach, then bring the host back
+  and assert exactly one agent window exists — never a second one started
+  while the host looked absent.
 

--- a/.agents/skills/thurbox-remote-hosts/SKILL.md
+++ b/.agents/skills/thurbox-remote-hosts/SKILL.md
@@ -248,20 +248,48 @@ session), never on the loop, ADR-P12).
 - **"The host holds nothing" and "the host did not answer" are different
   answers**, and the teardown is where confusing them costs the most.
   `discover` gates on `has-session` and reads its failure as an empty server,
-  but `ssh` exits non-zero for a refused connection, a timeout and a rejected
-  key alike — so a force delete taken while a host was briefly down found
-  nothing to kill and recorded *no error at all*. `TmuxBackend::
-  discover_answered` (used by `kill_remote_windows`, `remote_window_index`,
-  and `agent_window`) answers empty only on the multiplexer's own refusal —
-  tmux's `error connecting to` / `no server running on` / `can't find
-  session`, psmux's `session not found` (`mux_answered_absent`) — and errors
-  otherwise. An unrecognised failure counts as unanswered on purpose. It also
-  drops the `has-session` round trip: `list-windows` on an absent server gives
-  exactly that refusal. `agent_window` backs `agent_window_alive`, which
-  `restart --if-missing` uses to decide whether to relaunch after a reboot —
-  an unreachable host now aborts the relaunch instead of reading as "no
-  window", which used to start a second agent beside the one still running
+  so a force delete taken while a host was briefly down found nothing to kill
+  and recorded *no error at all*. `TmuxBackend::discover_answered` (used by
+  `kill_remote_windows`, `remote_window_index` and `agent_window`) answers
+  empty only on the multiplexer's own refusal, and drops the `has-session`
+  round trip while it is there. `agent_window` backs `agent_window_alive`,
+  which `restart --if-missing` uses to decide whether to relaunch after a
+  reboot — an unreachable host now aborts the relaunch instead of reading as
+  "no window", which used to start a second agent beside the one still running
   once the host answered again (`restart_if_missing_probe`).
+- **The layer decides, not the wording.** Both classifiers started as substring
+  matches, which is the same conflation one level down: the first unanticipated
+  message lands in the wrong branch silently. `ssh` exits **255** for its own
+  failures and passes a remote command's status through untouched, and
+  `thurbox-cli` only ever exits 1/2/3 — so 255 means the question never
+  arrived, whatever stderr says (`listing_is_absence`,
+  `host_cli::classify_failure`). `host_cli::Reach` names the three answers —
+  `Unreached` / `Answered` / `Undetermined` — and the third is its own answer,
+  never rounded to the nearest of the other two. `wsl.exe` has no 255
+  convention, so a WSL host is never `Unreached` on a status alone.
+  **Do not widen `mux_answered_absent`**: it is narrowed to the exact answers
+  tmux and psmux are documented to give, and each extra string makes it more
+  confidently wrong about the next one nobody anticipated. In particular
+  `error connecting to` is not a prefix match — only `(No such file or
+  directory)` is absence; `(Permission denied)` / `(Connection refused)` /
+  `(Connection reset by peer)` are a server that may be alive behind a socket
+  that cannot be opened right now.
+- **An unclassifiable failure takes whichever branch destroys nothing**, which
+  is not the same branch in both places. A listing must not turn "unanswered"
+  into "holds nothing", so it errors and the teardown is owed. A *delegated
+  delete* is the reverse — aborting reaches nothing and records nothing, which
+  made a session on a host with a broken CLI undeletable — so `Undetermined`
+  falls back to the local teardown beside `Unreached`, and only `Answered`
+  aborts (the host heard the question and refused; the session may still be
+  running there). An older host that reports failures on stderr rather than as
+  the structured document still reads as `Answered`, from its exit code.
+- **Known limit**: tmux's absence is a claim about the *socket*, not the
+  machine — a server with live panes whose socket is moved reports `(No such
+  file or directory)`, verified against a real host with two processes still
+  running. thurbox reaches sessions only through that socket, so no retry could
+  ever discharge such an owed teardown; closing it would need a session's
+  processes to be identifiable without the multiplexer (a recorded OS pid per
+  remote pane, or a scan by worktree cwd), which nothing here has today.
 - **A session owns two windows**, and every teardown takes both: the agent
   (`tb-`) and the companion shell (`tbs-`). The shell is found by its stamp
   (`@thurbox_role = shell`) rather than by `sessions.shell_backend_id`, which is

--- a/.agents/skills/thurbox-remote-hosts/SKILL.md
+++ b/.agents/skills/thurbox-remote-hosts/SKILL.md
@@ -218,13 +218,46 @@ session), never on the loop, ADR-P12).
   Every kill is resolved from the window's own `@thurbox_session` stamp, not the
   row's pane id or its name (ADR-25) — the host's tmux server reissues pane ids
   when it restarts, so a remembered `%N` there can be a live namesake's pane; the
-  `SessionPanes` argument is the psmux fallback only. Best-effort: an
-  unreachable host or a missing `hosts.toml` entry is recorded in
+  `SessionPanes` argument is the psmux fallback only. An unreachable host or a
+  missing `hosts.toml` entry is recorded in
   `ForceDeleteReport.remote_teardown_error` (surfaced in the CLI JSON) and the
-  row is still soft-/force-deleted. Like local force-delete it removes the
-  worktree *directory* only, leaving the branch. `wsl.exe`'s exact arg-passing
-  isn't verified in CI (no WSL runner); the construction is unit-tested
-  (`transport::tests::wsl_*`, `git_command_wsl_*`).
+  row is still soft-/force-deleted — a host that is down is often *why* someone
+  force-deletes, and refusing there would be the worse answer. Like local
+  force-delete it removes the worktree *directory* only, leaving the branch.
+  `wsl.exe`'s exact arg-passing isn't verified in CI (no WSL runner); the
+  construction is unit-tested (`transport::tests::wsl_*`, `git_command_wsl_*`).
+- **A remote teardown that never reached its host is owed, not abandoned.**
+  Recording the failure used to be the end of it, and for a `force_deleted`
+  row that meant forever: every reaper skips such a row, and the mirror's
+  tombstone push needs a shareable host with a usable CLI — so on the legacy
+  path the agent, its window and its worktree survived the session for good.
+  `finish_locally_with` now writes the failure onto the row (schema v46's
+  `sessions.teardown_owed`, `ForceDeleteReport.remote_teardown_owed`,
+  `session list --deleted`'s `teardown_owed`) and
+  `session_ops::retry_owed_remote_teardowns` finishes the kill and the worktree
+  removals when the host next answers — delegating `session delete --force` to
+  a host that runs its own thurbox, killing through the stamp otherwise, and
+  falling through to the direct kill when the host answers "Session not found".
+  Driven beside `reap_overdue_soft_deletes` (`automation tick` and the
+  interface's `Command::Reap`), reading `hosts.toml` afresh so adding the
+  missing entry is enough to make the job possible again, and asking a silent
+  host **once per pass** so a machine that is still down costs one connect
+  timeout rather than one per orphan. Force-deleted rows only: a soft-deleted
+  one is restorable and its windows are the reaper's at the end of the undo
+  window — ADR-24, ADR-26.
+- **"The host holds nothing" and "the host did not answer" are different
+  answers**, and the teardown is where confusing them costs the most.
+  `discover` gates on `has-session` and reads its failure as an empty server,
+  but `ssh` exits non-zero for a refused connection, a timeout and a rejected
+  key alike — so a force delete taken while a host was briefly down found
+  nothing to kill and recorded *no error at all*. `TmuxBackend::
+  discover_answered` (used by `kill_remote_windows` and `remote_window_index`)
+  answers empty only on the multiplexer's own refusal — tmux's `error
+  connecting to` / `no server running on` / `can't find session`, psmux's
+  `session not found` (`mux_answered_absent`) — and errors otherwise. An
+  unrecognised failure counts as unanswered on purpose. It also drops the
+  `has-session` round trip: `list-windows` on an absent server gives exactly
+  that refusal.
 - **A session owns two windows**, and every teardown takes both: the agent
   (`tb-`) and the companion shell (`tbs-`). The shell is found by its stamp
   (`@thurbox_role = shell`) rather than by `sessions.shell_backend_id`, which is
@@ -276,5 +309,11 @@ session), never on the loop, ADR-P12).
 - **Local e2e**: `scripts/dev/e2e/linux-container.sh up` spins a throwaway Podman
   container (sshd + tmux + git) and `… test` asserts a session lands on the
   `ssh:podman` backend (state under `target/`, never touches your real
-  `~/.ssh`/`~/.config`).
+  `~/.ssh`/`~/.config`). Its `remote_teardown_probe` is where the owed teardown
+  is proven end to end on a real process: create a session on the container,
+  point `hosts.toml` at a dead port, force-delete (which must still work),
+  bring the host back, and assert the tick's sweep killed the window *and*
+  reaped the pid it was running. It keeps sharing off throughout — with it on,
+  a host whose CLI has vouched for no socket is refused by
+  `known_host_socket`, which is a different behaviour and would hide this one.
 

--- a/.agents/skills/thurbox-testing/SKILL.md
+++ b/.agents/skills/thurbox-testing/SKILL.md
@@ -89,7 +89,12 @@ kernel over the real `ui/`** rather than a harness that imitates either:
   force delete and reap both collect the companion shell alongside the agent's
   window, a teardown spares a live namesake's companion shell, and a teardown
   never brings a tmux server into being (the `ensure_ready` side effect this
-  path must not trigger).
+  path must not trigger). The owed-teardown sweep
+  (`retry_owed_remote_teardowns`) is unit-tested against `host_cli::fake` in
+  `session_ops::delete` — that a failed remote teardown is written onto the
+  row, that a soft-deleted row is never on its worklist (the undo window), and
+  that a silent host is asked once per pass — and proven end to end on a real
+  process by `linux-container.sh`'s `remote_teardown_probe`.
 - **`tests/concurrent_respawn.rs`** — six sessions relaunching onto a tmux
   server that does not exist yet, against a *real* tmux on a throwaway socket
   (skipped when tmux is absent): every worker's `ensure_session_configured`

--- a/.agents/skills/thurbox-testing/SKILL.md
+++ b/.agents/skills/thurbox-testing/SKILL.md
@@ -94,7 +94,12 @@ kernel over the real `ui/`** rather than a harness that imitates either:
   `session_ops::delete` — that a failed remote teardown is written onto the
   row, that a soft-deleted row is never on its worklist (the undo window), and
   that a silent host is asked once per pass — and proven end to end on a real
-  process by `linux-container.sh`'s `remote_teardown_probe`.
+  process by `linux-container.sh`'s `remote_teardown_probe`. The same file
+  covers a delegated delete whose host never answers at all: it falls back to
+  the local teardown and owes a retry, while any *other* host error still
+  aborts. `restart --if-missing` refusing to relaunch against an unreachable
+  host (rather than reading it as "no window" and starting a second agent) is
+  proven end to end by `linux-container.sh`'s `restart_if_missing_probe`.
 - **`tests/concurrent_respawn.rs`** — six sessions relaunching onto a tmux
   server that does not exist yet, against a *real* tmux on a throwaway socket
   (skipped when tmux is absent): every worker's `ensure_session_configured`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1356,8 +1356,13 @@ follow from the host owning the record, none of which the first cut had:
   pre-ADR-24 row, and one a peer already deleted all answer "Session not
   found". Aborting on it left the local row active and attached. It falls
   through to the local teardown instead, recorded in the report's
-  `host_unknown`; any other host error still aborts, because the session may
-  still be running there.
+  `host_unknown`. A delegated call that never reached the host at all — a
+  transport failure, not a reply — falls through the same way, recorded in
+  `host_unreachable` instead: the alternative left the local row active with
+  nothing recorded for the owed-teardown sweep (below) to retry, the same
+  orphan that sweep exists to stop, reached through the delegated door instead
+  of the legacy one. Any *other* host error still aborts, because the session
+  may still be running there.
 - **A soft delete is reaped on the host.** Nothing reaps a soft-deleted row but
   the sweep (`session_ops::reap_overdue_soft_deletes`), and a host running only
   `thurbox-cli` runs it only on its heartbeat — so on a host with neither the
@@ -1392,14 +1397,19 @@ follow from the host owning the record, none of which the first cut had:
   refused connection, a timeout and a rejected key alike. A force delete taken
   while a host was briefly down therefore found nothing to kill, recorded *no
   error at all*, and reported success — the leak above, with the operator told
-  nothing. `TmuxBackend::discover_answered` (used by `kill_remote_windows` and
-  `remote_window_index`) returns an empty listing only when the multiplexer
-  itself refused — tmux's `error connecting to` / `no server running on` /
-  `can't find session`, psmux's `session not found` — and an error otherwise.
-  An unrecognised failure counts as *unanswered* on purpose: over-reporting a
-  live host costs one cheap retry, while the reverse costs an orphaned agent
-  nobody ever looks for again. It also replaces the `has-session` round trip,
-  since `list-windows` on an absent server gives exactly that refusal.
+  nothing. `TmuxBackend::discover_answered` (used by `kill_remote_windows`,
+  `remote_window_index`, and `agent_window`) returns an empty listing only when
+  the multiplexer itself refused — tmux's `error connecting to` / `no server
+  running on` / `can't find session`, psmux's `session not found` — and an
+  error otherwise. An unrecognised failure counts as *unanswered* on purpose:
+  over-reporting a live host costs one cheap retry, while the reverse costs an
+  orphaned agent nobody ever looks for again. It also replaces the
+  `has-session` round trip, since `list-windows` on an absent server gives
+  exactly that refusal. `agent_window` backs `agent_window_alive`, which
+  `restart_session`'s `--if-missing` path uses to decide whether the agent is
+  gone and needs relaunching — an unreachable host now aborts the relaunch
+  instead of reading as "no window", which used to start a second agent beside
+  the one still running once the host answered again.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1368,6 +1368,38 @@ follow from the host owning the record, none of which the first cut had:
   teardown also never calls `ensure_ready`, which would *create* the server
   and the thurbox session on the host as a side effect of tearing one down,
   and acts only on a socket the host has vouched for (`known_host_socket`).
+- **A teardown that never reached its host is owed, not abandoned.** Killing
+  something on a machine you cannot reach is not a promise software can make,
+  and an unreachable host is often *why* someone force-deletes — so the delete
+  still goes through. What it stopped doing is writing the loss off at that
+  moment: schema v46's `sessions.teardown_owed` records it, and
+  `session_ops::retry_owed_remote_teardowns` — driven by the same two callers
+  as the reap — finishes the kill and the worktree removals when the host next
+  answers. Without it that one best-effort attempt was the only one anything
+  would ever make: every reaper skips a `force_deleted` row, and the tombstone
+  push above needs a shareable host with a usable CLI, so a host on the legacy
+  path kept the agent running for good. Force-deleted rows only — a
+  soft-deleted one is restorable and its windows are the reaper's to take at
+  the end of the undo window, and a second sweep killing them on its own
+  schedule would make the undo hand back a session with nothing running in it.
+  The mark is only ever set by an attempt that failed, never by a migration:
+  an upgraded database cannot say which of its past force deletes left
+  something behind, and inventing owed teardowns for all of them would send
+  the sweep after windows that are long gone.
+- **"The host holds nothing" and "the host did not answer" are different
+  answers.** `discover` gates its listing on `has-session` and reads its
+  failure as an empty server, but over a transport `ssh` exits non-zero for a
+  refused connection, a timeout and a rejected key alike. A force delete taken
+  while a host was briefly down therefore found nothing to kill, recorded *no
+  error at all*, and reported success — the leak above, with the operator told
+  nothing. `TmuxBackend::discover_answered` (used by `kill_remote_windows` and
+  `remote_window_index`) returns an empty listing only when the multiplexer
+  itself refused — tmux's `error connecting to` / `no server running on` /
+  `can't find session`, psmux's `session not found` — and an error otherwise.
+  An unrecognised failure counts as *unanswered* on purpose: over-reporting a
+  live host costs one cheap retry, while the reverse costs an orphaned agent
+  nobody ever looks for again. It also replaces the `has-session` round trip,
+  since `list-windows` on an absent server gives exactly that refusal.
 
 ---
 
@@ -1445,7 +1477,12 @@ rather than through a column that is usually NULL.
 `deleted_at` is older than `UNDO_WINDOW` and that still owns a window by its
 ADR-25 stamp — and both drivers call it: the interface's loop on a slow cadence
 (`REAP_INTERVAL`, a `Command::Reap` that names no session) and `thurbox-cli`'s
-heartbeat on its tick. `Command::Reap` is the one command the bus keeps no
+heartbeat on its tick. `retry_owed_remote_teardowns` (ADR-24) rides the same two
+drivers and is deliberately a *separate* sweep rather than a branch inside this
+one: it asks a different durable question (`teardown_owed`, not
+`deleted_at + UNDO_WINDOW`) of a disjoint set of rows (force-deleted, which this
+sweep skips), and folding the two would put a kill that must not wait for the
+undo window in the same pass as one that must. `Command::Reap` is the one command the bus keeps no
 in-flight record of — it recurs forever with nobody waiting on it, and a row
 there is drawn, captioned and counted as activity (ADR-P22 in
 `docs/PERFORMANCE.md`). Alongside it, a caller that changes **one column** of a

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1399,17 +1399,60 @@ follow from the host owning the record, none of which the first cut had:
   error at all*, and reported success — the leak above, with the operator told
   nothing. `TmuxBackend::discover_answered` (used by `kill_remote_windows`,
   `remote_window_index`, and `agent_window`) returns an empty listing only when
-  the multiplexer itself refused — tmux's `error connecting to` / `no server
-  running on` / `can't find session`, psmux's `session not found` — and an
-  error otherwise. An unrecognised failure counts as *unanswered* on purpose:
-  over-reporting a live host costs one cheap retry, while the reverse costs an
-  orphaned agent nobody ever looks for again. It also replaces the
-  `has-session` round trip, since `list-windows` on an absent server gives
-  exactly that refusal. `agent_window` backs `agent_window_alive`, which
+  the multiplexer itself refused. It also replaces the `has-session` round
+  trip, since `list-windows` on an absent server gives exactly that refusal.
+  `agent_window` backs `agent_window_alive`, which
   `restart_session`'s `--if-missing` path uses to decide whether the agent is
   gone and needs relaunching — an unreachable host now aborts the relaunch
   instead of reading as "no window", which used to start a second agent beside
   the one still running once the host answered again.
+- **The layer that failed decides, not the words it used.** Both classifications
+  above began as substring matches over an error message, and a message is
+  written for a person: the first unanticipated wording lands in the wrong
+  branch, silently, in whichever direction happens to be worse. So the question
+  is asked of the layer instead. `ssh` exits **255** for its own failures and
+  passes a remote command's status through untouched (a remote `exit 7` exits
+  7), and `thurbox-cli` only ever exits 1, 2 or 3 — so 255 is ssh saying the
+  question never arrived, whatever the stderr underneath resembles
+  (`agent::tmux::listing_is_absence`, `session_ops::host_cli::classify_failure`).
+  `session_ops::host_cli::Reach` names the three answers a failed remote call
+  can have — `Unreached`, `Answered`, `Undetermined` — and `Undetermined` is
+  deliberately its own answer rather than being rounded to the nearest of the
+  other two. Where a substring test is still the only signal (tmux's own
+  refusals) it is narrowed to the exact answers the tool is documented to give;
+  widening that list is the trap it looks like a fix, since each new string
+  makes the classifier more confidently wrong about the next one nobody
+  anticipated. `wsl.exe` has no 255 convention, so a WSL host is never called
+  `Unreached` on a status alone — the honest limit rather than a guess, and a
+  cheap one, since `wsl.exe` runs on this machine.
+- **What an unclassifiable failure does depends on which branch destroys
+  nothing**, and that is not the same branch everywhere. For a listing,
+  "unanswered" must not become "the server holds nothing", so it is an error
+  and the teardown is recorded as owed. For a *delegated delete* it is the
+  reverse: aborting reaches nothing and records nothing, which is how a session
+  on a host with a broken CLI became undeletable, so `Undetermined` falls back
+  to the local teardown alongside `Unreached` — stamp-addressed, so on a host
+  that is up (exit 127, reached it and found no `thurbox-cli`) it still takes
+  exactly this session's windows, and on one that is not it records the owed
+  teardown. Only `Answered` aborts: the host is up, heard the question and
+  refused, so the session may still be running there. A host too old to write
+  the structured `{"error": …}` document is still read as having answered, from
+  its exit code being one of the CLI's own.
+- **Known limit: tmux's absence is a claim about the socket, not the machine.**
+  A tmux server with live panes whose socket file is moved or replaced reports
+  `error connecting to <path> (No such file or directory)` — verified against a
+  real host with two live processes still running behind it. thurbox addresses
+  sessions only through that socket, so there is no command it could issue to
+  reach those windows and no retry that would ever discharge such an owed
+  teardown; treating it as absence is therefore the right answer, but it is the
+  narrower claim *nothing is reachable through this socket*. Closing the gap
+  would need a way to identify a session's processes without the multiplexer —
+  a recorded OS pid per remote pane, or a scan by worktree cwd — which nothing
+  here has today. What the narrowing does buy is the case where a retry *does*
+  help: `(Permission denied)` / `(Connection refused)` / `(Connection reset by
+  peer)` behind that same `error connecting to` prefix are a server that may be
+  alive and reachable once the condition clears, and those are no longer read
+  as absence.
 
 ---
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -624,7 +624,10 @@ has the rationale; the shape:
   pushed to it on the next mirror pass, so the two converge instead of
   undoing each other. And a delete the host answers "no such session"
   to is taken from here rather than failing: a fork, a row from before
-  sharing, or one a peer already deleted there.
+  sharing, or one a peer already deleted there. A delete the host never
+  answers at all — a connection failure, not a reply — is also taken from
+  here, and a force delete owes a retry for what it could not reach either.
+  Any other host error still fails the delete outright.
 - **Windows hosts** share through the same path: the probe, the
   provisioning (the release zip) and every delegated command go
   through the PowerShell path the probes already use.

--- a/scripts/dev/e2e/linux-container.sh
+++ b/scripts/dev/e2e/linux-container.sh
@@ -213,6 +213,84 @@ shared_sessions_probe() {
   fi
 }
 
+# The remote-teardown half of the e2e: a force delete taken while the host is
+# unreachable must still finish the kill once the host answers. Sharing is
+# turned off for this probe so the delete takes the LEGACY teardown path — the
+# one with no host CLI to delegate to and no mirror to push a tombstone, i.e.
+# the one where a one-shot best-effort attempt was the only attempt anything
+# would ever make. Runs inside cmd_test's isolated XDG home, and puts
+# `hosts.toml` back exactly as it found it on the way out.
+remote_teardown_probe() {
+  log "asserting an owed remote teardown is finished when the host comes back"
+  local hosts="$XDG_CONFIG_HOME/thurbox-dev/hosts.toml"
+  local shared up down
+  shared="$(cat "$hosts")"
+  # The same host with sharing off, reachable and not. Sharing stays off for
+  # the whole probe: with it on, a host whose CLI has vouched for no socket is
+  # refused outright by `known_host_socket`, which is a different (deliberate)
+  # behaviour and would hide the one under test.
+  up="$(printf '%s\n' "$shared" \
+    | sed 's/^name = "podman"$/name = "podman"\nshare_sessions = false/')"
+  down="$(printf '%s\n' "$up" | sed "s/\"$PORT\"/\"59999\"/")"
+  printf '%s\n' "$up" > "$hosts"
+
+  local id
+  id="$(e2e_cli session create --name e2e-teardown --host podman --repo-path "$REMOTE_REPO" \
+    --agent shell --worktree-branch test/e2e-teardown --base-branch main | json_field id)"
+  [ -n "$id" ] || { bad "could not create the session for the teardown probe"; return; }
+
+  # The pane pid of the session's OWN window: killing the window has to reap
+  # what was running in it, which is what the captain's "processes" means. The
+  # tmux session's initial `bash` window is server furniture and not this
+  # session's to take.
+  local pid
+  pid="$(ssh_remote 'tmux -L thurbox-dev list-panes -a -F "#{window_name} #{pane_pid}" 2>/dev/null' \
+    | sed -n 's/^tb-e2e-teardown //p' | head -n1)"
+  if [ -n "$pid" ] && ssh_remote "kill -0 $pid 2>/dev/null"; then
+    ok "the agent process ($pid) is running on the container"
+  else
+    bad "no agent process found for the teardown probe"
+    return
+  fi
+
+  # The host goes away, and the operator force-deletes anyway — which is the
+  # ordinary reason to force-delete, and must keep working.
+  printf '%s\n' "$down" > "$hosts"
+  local out
+  if out="$(e2e_cli session delete "$id" --force)"; then
+    ok "force-delete still works against a host that is down"
+  else
+    bad "force-delete failed against a down host (it must not)"
+  fi
+  case "$out" in
+    *'"remote_teardown_owed":true'*) ok "the delete says the teardown is owed, not merely failed" ;;
+    *) bad "the delete did not record an owed teardown (got: $out)" ;;
+  esac
+
+  # The host comes back. The sweep the heartbeat drives is what finishes it.
+  printf '%s\n' "$up" > "$hosts"
+  e2e_cli automation tick >/dev/null || die "automation tick failed"
+
+  local windows
+  windows="$(ssh_remote 'tmux -L thurbox-dev list-windows -a -F "#{window_name}" 2>/dev/null' \
+    | grep -c '^tb-e2e-teardown$' || true)"
+  if [ "$windows" = "0" ]; then
+    ok "the orphaned window was killed once the host answered"
+  else
+    bad "the window survived the delete ($windows still there)"
+  fi
+  if ssh_remote "kill -0 $pid 2>/dev/null"; then
+    bad "the agent process $pid survived the delete"
+  else
+    ok "and the agent process it was running is gone"
+  fi
+  case "$(e2e_cli session list --deleted)" in
+    *'"teardown_owed":true'*) bad "the row still owes a teardown after the sweep" ;;
+    *) ok "the row no longer owes a teardown" ;;
+  esac
+  printf '%s\n' "$shared" > "$hosts"
+}
+
 cmd_test() {
   command -v cargo >/dev/null || die "cargo not found"
   ssh_remote true 2>/dev/null || die "container not reachable — run '$0 up' first"
@@ -327,10 +405,11 @@ EOF
     *) bad "hook_state lost after a steady-state tick" ;;
   esac
 
+  remote_teardown_probe
   shared_sessions_probe
 
   if [ "$FAILS" -gt 0 ]; then
-    fail "remote hook provisioning / shared sessions checks failed ($FAILS)"
+    fail "remote hook provisioning / shared sessions / teardown checks failed ($FAILS)"
     return 1
   fi
   e2e_assert "ssh:podman" "$backend" "$remote_window" "$remote_wt" \

--- a/scripts/dev/e2e/linux-container.sh
+++ b/scripts/dev/e2e/linux-container.sh
@@ -225,6 +225,10 @@ remote_teardown_probe() {
   local hosts="$XDG_CONFIG_HOME/thurbox-dev/hosts.toml"
   local shared up down
   shared="$(cat "$hosts")"
+  # Every exit path, including the early `return`s below, must leave
+  # hosts.toml as it found it — a probe that dies partway through must not
+  # cascade a patched host into shared_sessions_probe right after it.
+  trap 'printf "%s\n" "$shared" > "$hosts"' RETURN
   # The same host with sharing off, reachable and not. Sharing stays off for
   # the whole probe: with it on, a host whose CLI has vouched for no socket is
   # refused outright by `known_host_socket`, which is a different (deliberate)
@@ -288,7 +292,50 @@ remote_teardown_probe() {
     *'"teardown_owed":true'*) bad "the row still owes a teardown after the sweep" ;;
     *) ok "the row no longer owes a teardown" ;;
   esac
-  printf '%s\n' "$shared" > "$hosts"
+}
+
+# `session restart --if-missing` must refuse rather than relaunch when the
+# host cannot be reached at the moment it checks: an unreachable host and a
+# host that genuinely holds no such window read identically as an empty
+# `list-windows`, and treating the former as the latter starts a second agent
+# beside the one still running once the host answers again. Runs inside
+# cmd_test's isolated XDG home, and puts `hosts.toml` back on every exit.
+restart_if_missing_probe() {
+  log "asserting --if-missing refuses to relaunch when the host cannot be reached"
+  local hosts="$XDG_CONFIG_HOME/thurbox-dev/hosts.toml"
+  local shared up down
+  shared="$(cat "$hosts")"
+  trap 'printf "%s\n" "$shared" > "$hosts"' RETURN
+  up="$(printf '%s\n' "$shared" \
+    | sed 's/^name = "podman"$/name = "podman"\nshare_sessions = false/')"
+  down="$(printf '%s\n' "$up" | sed "s/\"$PORT\"/\"59999\"/")"
+  printf '%s\n' "$up" > "$hosts"
+
+  local id
+  id="$(e2e_cli session create --name e2e-ifmissing --host podman --repo-path "$REMOTE_REPO" \
+    --agent shell --worktree-branch test/e2e-ifmissing --base-branch main | json_field id)"
+  [ -n "$id" ] || { bad "could not create the session for the if-missing probe"; return; }
+
+  printf '%s\n' "$down" > "$hosts"
+  if e2e_cli session restart "$id" --if-missing >/dev/null 2>&1; then
+    bad "restart --if-missing succeeded against a host it could not reach"
+  else
+    ok "restart --if-missing refuses rather than guessing when the host is unreachable"
+  fi
+
+  # The host answers again: exactly the one window from the original spawn,
+  # never a second one started while the host looked absent.
+  printf '%s\n' "$up" > "$hosts"
+  local windows
+  windows="$(ssh_remote 'tmux -L thurbox-dev list-windows -a -F "#{window_name}" 2>/dev/null' \
+    | grep -c '^tb-e2e-ifmissing$' || true)"
+  if [ "$windows" = "1" ]; then
+    ok "no second agent window was started while the host looked unreachable"
+  else
+    bad "expected exactly one tb-e2e-ifmissing window, found ${windows:-0}"
+  fi
+
+  e2e_cli session delete "$id" --force >/dev/null || true
 }
 
 cmd_test() {
@@ -406,6 +453,7 @@ EOF
   esac
 
   remote_teardown_probe
+  restart_if_missing_probe
   shared_sessions_probe
 
   if [ "$FAILS" -gt 0 ]; then

--- a/scripts/dev/e2e/linux-container.sh
+++ b/scripts/dev/e2e/linux-container.sh
@@ -270,6 +270,20 @@ remote_teardown_probe() {
     *'"remote_teardown_owed":true'*) ok "the delete says the teardown is owed, not merely failed" ;;
     *) bad "the delete did not record an owed teardown (got: $out)" ;;
   esac
+  # The classification, proven against a real transport rather than a mocked
+  # string: ssh exited 255 on its own account, so the empty listing that came
+  # back must NOT have been read as "the server holds nothing". Claiming a kill
+  # here — or simply moving on — is the reachable-failure-mistaken-for-absence
+  # bug, and the window still standing is what makes the difference visible.
+  case "$out" in
+    *'"killed_window":true'*) bad "the delete claimed a kill it could not have made" ;;
+    *) ok "no kill was claimed for a question the host never received" ;;
+  esac
+  if ssh_remote "kill -0 $pid 2>/dev/null"; then
+    ok "the agent is still running, and thurbox knows it has unfinished business"
+  else
+    bad "the agent died without thurbox ever reaching the host"
+  fi
 
   # The host comes back. The sweep the heartbeat drives is what finishes it.
   printf '%s\n' "$up" > "$hosts"

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -642,8 +642,32 @@ pub fn local_window_index() -> Result<WindowIndex> {
 pub fn remote_window_index(host: &crate::session::HostDef) -> Result<WindowIndex> {
     known_host_socket(host)?;
     Ok(WindowIndex::from_listing(
-        TmuxBackend::from_host(host).discover()?,
+        TmuxBackend::from_host(host).discover_answered()?,
     ))
+}
+
+/// Whether a failed one-shot mux command is the multiplexer's *own* answer that
+/// there is nothing to act on, rather than the transport failing to deliver the
+/// question at all.
+///
+/// The distinction the remote teardown rests on. `ssh` exits non-zero for a
+/// refused connection, a timeout and a rejected key alike, and a caller that
+/// reads any of those as "the server holds no windows" concludes there is
+/// nothing to kill on a host it never reached. So only tmux's and psmux's own
+/// refusals count as an answer, and everything else is an error:
+/// over-reporting a live host as unanswered costs one cheap retry, while the
+/// reverse costs an orphaned agent nobody ever looks for again.
+fn mux_answered_absent(error: &str) -> bool {
+    const REFUSALS: [&str; 4] = [
+        // tmux/psmux: the socket has no server behind it.
+        "error connecting to",
+        // tmux < 3.4 phrasing for the same thing.
+        "no server running on",
+        // The server is up but holds no session by that name.
+        "can't find session",
+        "session not found",
+    ];
+    REFUSALS.iter().any(|refusal| error.contains(refusal))
 }
 
 /// Whether the local multiplexer is psmux, which has no usable window options
@@ -851,6 +875,30 @@ impl TmuxBackend {
     fn tmux_run(&self, args: &[&str]) -> Result<()> {
         self.run_tmux(args)?;
         Ok(())
+    }
+
+    /// One `list-windows`, with an empty answer only when the multiplexer
+    /// itself said there is nothing to list.
+    ///
+    /// [`discover`](SessionBackend::discover) gates on `has-session` and reads
+    /// its failure as "no windows", which over a transport conflates the two
+    /// answers a teardown must never confuse: *the host says it holds nothing*
+    /// and *the host did not answer*. A force delete taken while a host was
+    /// briefly unreachable therefore reported nothing to kill, recorded no
+    /// error, and left the agent running there for good. Here an unrecognised
+    /// failure is an error, so the caller can say so and come back later.
+    ///
+    /// Also one round trip instead of two: `list-windows` on an absent server
+    /// gives exactly the refusal `has-session` was asked for.
+    fn discover_answered(&self) -> Result<Vec<DiscoveredSession>> {
+        match self.run_tmux(&["list-windows", "-t", &self.session, "-F", DISCOVER_FORMAT]) {
+            Ok(output) => Ok(String::from_utf8_lossy(&output.stdout)
+                .lines()
+                .filter_map(parse_discovered)
+                .collect()),
+            Err(e) if mux_answered_absent(&format!("{e:#}")) => Ok(Vec::new()),
+            Err(e) => Err(e),
+        }
     }
 
     /// Kill a pane with a one-shot command rather than through control mode.
@@ -2876,7 +2924,7 @@ pub fn kill_remote_windows(
 ) -> Result<bool> {
     known_host_socket(host)?;
     let backend = TmuxBackend::from_host(host);
-    let index = WindowIndex::from_listing(backend.discover()?);
+    let index = WindowIndex::from_listing(backend.discover_answered()?);
     let killed = kill_located(
         &backend,
         index.agent_window(session_id, session_name),
@@ -3014,6 +3062,43 @@ mod tests {
     use crate::agent::control_mode::{
         decode_octal, format_send_keys, parse_notification, shell_escape, Notification,
     };
+
+    /// The one distinction the remote teardown rests on. Each refusal below is
+    /// what tmux 3.5/3.7 actually printed when asked for a listing it could not
+    /// give (captured against the linux-container e2e host); each failure below
+    /// is the transport never delivering the question. Reading the second group
+    /// as the first is what let a force delete against a host that was down for
+    /// a minute report nothing to kill and leave the agent running there.
+    #[test]
+    fn only_the_multiplexers_own_refusal_counts_as_an_empty_answer() {
+        let answers = [
+            "error connecting to /tmp/tmux-0/thurbox (No such file or directory)",
+            "no server running on /tmp/tmux-0/thurbox",
+            "can't find session: thurbox",
+            "session not found: thurbox",
+        ];
+        for answer in answers {
+            let error = format!("tmux list-windows failed: {answer}");
+            assert!(
+                mux_answered_absent(&error),
+                "the multiplexer answered: {error}"
+            );
+        }
+        let unanswered = [
+            "ssh: connect to host devbox port 22: Connection refused",
+            "ssh: connect to host devbox port 22: Operation timed out",
+            "Permission denied (publickey).",
+            "bash: line 1: tmux: command not found",
+        ];
+        for failure in unanswered {
+            let error = format!("tmux list-windows failed: {failure}");
+            assert!(!mux_answered_absent(&error), "nothing answered: {error}");
+        }
+        assert!(
+            !mux_answered_absent("Failed to run tmux command"),
+            "not even the launch succeeded"
+        );
+    }
 
     // The control-mode primitives are re-exported through this module. Their
     // behavior is covered exhaustively in `control_mode`'s own test module;

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -646,28 +646,68 @@ pub fn remote_window_index(host: &crate::session::HostDef) -> Result<WindowIndex
     ))
 }
 
-/// Whether a failed one-shot mux command is the multiplexer's *own* answer that
-/// there is nothing to act on, rather than the transport failing to deliver the
-/// question at all.
+/// `ssh`'s own failure code — see [`crate::session_ops::host_cli::Reach`],
+/// which draws the same distinction one layer up.
+const SSH_ERROR_EXIT: i32 = 255;
+
+/// Whether a failed listing means the server genuinely holds nothing, given
+/// the layer that failed (`is_ssh` + the exit `code`) and what it said.
 ///
-/// The distinction the remote teardown rests on. `ssh` exits non-zero for a
-/// refused connection, a timeout and a rejected key alike, and a caller that
-/// reads any of those as "the server holds no windows" concludes there is
-/// nothing to kill on a host it never reached. So only tmux's and psmux's own
-/// refusals count as an answer, and everything else is an error:
-/// over-reporting a live host as unanswered costs one cheap retry, while the
-/// reverse costs an orphaned agent nobody ever looks for again.
+/// **Layer before text**, and the order is the point. `ssh` exits 255 for its
+/// own failures and passes a remote command's status through untouched
+/// (a remote `exit 7` exits 7), so 255 is ssh saying the question never
+/// arrived — no matter what the stderr underneath happens to resemble.
+/// Only once the transport is ruled out does the multiplexer's own answer get
+/// to speak, and then only in the exact words it is documented to use
+/// ([`mux_answered_absent`]).
+///
+/// Everything else is "could not tell", which the caller must treat as the
+/// unanswered question it is: an empty listing here means *there is nothing to
+/// kill*, and that is not a conclusion to reach by guessing.
+fn listing_is_absence(is_ssh: bool, code: Option<i32>, stderr: &str) -> bool {
+    match code {
+        // ssh's own error, so nothing on the host ever saw the question.
+        Some(SSH_ERROR_EXIT) if is_ssh => false,
+        // Killed by a signal: it did not finish, and whatever reached stderr
+        // before that is a fragment of an answer rather than one. There is no
+        // layer to reason from, so there is nothing to conclude.
+        None => false,
+        _ => mux_answered_absent(stderr),
+    }
+}
+
+/// Whether a multiplexer's stderr is its *own* answer that there is nothing to
+/// act on, rather than any of the ways a question can fail to be answered.
+///
+/// The distinction the remote teardown rests on, and the reason this list is
+/// as short as it is. Only the exact answers tmux and psmux are documented to
+/// give for "there is no server" and "there is no such session" count;
+/// everything else — including a failure whose wording merely resembles one —
+/// is unanswered. Over-reporting a live host as unanswered costs one cheap
+/// retry, while the reverse costs an orphaned agent nobody ever looks for
+/// again.
+///
+/// `error connecting to` is the trap and the reason this is not a prefix
+/// match: tmux prints it for a socket that is not there
+/// (`(No such file or directory)`) **and** for one it cannot open while a
+/// server is very much alive behind it — `(Permission denied)` on another
+/// user's socket, `(Connection refused)` on a stale one. Only the first is an
+/// answer; reading the others as absence is exactly the "reachable failure
+/// mistaken for absence" this whole path exists to stop. Widening this list to
+/// cover more wordings is the trap it looks like a fix: each new string makes
+/// the classifier more confidently wrong about the next one nobody anticipated.
 fn mux_answered_absent(error: &str) -> bool {
-    const REFUSALS: [&str; 4] = [
-        // tmux/psmux: the socket has no server behind it.
-        "error connecting to",
-        // tmux < 3.4 phrasing for the same thing.
-        "no server running on",
-        // The server is up but holds no session by that name.
-        "can't find session",
-        "session not found",
-    ];
-    REFUSALS.iter().any(|refusal| error.contains(refusal))
+    // The socket has no server behind it. tmux ≥ 3.4 words this as "error
+    // connecting to <path> (<reason>)", and only this reason means absence.
+    if error.contains("error connecting to") {
+        return error.contains("(No such file or directory)");
+    }
+    // tmux < 3.4's wording for the same thing, which carries no reason at all.
+    if error.contains("no server running on") {
+        return true;
+    }
+    // The server is up and holds no session by that name — tmux, then psmux.
+    error.contains("can't find session") || error.contains("session not found")
 }
 
 /// Whether the local multiplexer is psmux, which has no usable window options
@@ -891,14 +931,33 @@ impl TmuxBackend {
     /// Also one round trip instead of two: `list-windows` on an absent server
     /// gives exactly the refusal `has-session` was asked for.
     fn discover_answered(&self) -> Result<Vec<DiscoveredSession>> {
-        match self.run_tmux(&["list-windows", "-t", &self.session, "-F", DISCOVER_FORMAT]) {
-            Ok(output) => Ok(String::from_utf8_lossy(&output.stdout)
+        let args = ["list-windows", "-t", &self.session, "-F", DISCOVER_FORMAT];
+        // Run it here rather than through `run_tmux`, which formats the
+        // failure into a message: the whole point is to keep the exit status,
+        // because that is the layer talking and the message is only text.
+        let output = self
+            .transport
+            .tmux_command(&self.socket(), &args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            // The launcher would not even start — no `ssh`/`wsl.exe`/`tmux` on
+            // this machine. Nothing was asked, so nothing was answered.
+            .context("Failed to run tmux command")?;
+        if output.status.success() {
+            return Ok(String::from_utf8_lossy(&output.stdout)
                 .lines()
                 .filter_map(parse_discovered)
-                .collect()),
-            Err(e) if mux_answered_absent(&format!("{e:#}")) => Ok(Vec::new()),
-            Err(e) => Err(e),
+                .collect());
         }
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if listing_is_absence(self.transport.is_ssh(), output.status.code(), stderr.trim()) {
+            return Ok(Vec::new());
+        }
+        // Plain stderr, as `run_tmux` reports it: `agent` may not reach into
+        // `git` (its stderr cleaner lives there), and the architecture test
+        // enforces that.
+        bail!("tmux {} failed: {}", args.join(" "), stderr.trim())
     }
 
     /// Kill a pane with a one-shot command rather than through control mode.
@@ -3065,12 +3124,12 @@ mod tests {
         decode_octal, format_send_keys, parse_notification, shell_escape, Notification,
     };
 
-    /// The one distinction the remote teardown rests on. Each refusal below is
+    /// The one distinction the remote teardown rests on. Each answer below is
     /// what tmux 3.5/3.7 actually printed when asked for a listing it could not
     /// give (captured against the linux-container e2e host); each failure below
-    /// is the transport never delivering the question. Reading the second group
-    /// as the first is what let a force delete against a host that was down for
-    /// a minute report nothing to kill and leave the agent running there.
+    /// is a question that was never answered. Reading the second group as the
+    /// first is what let a force delete against a host that was down for a
+    /// minute report nothing to kill and leave the agent running there.
     #[test]
     fn only_the_multiplexers_own_refusal_counts_as_an_empty_answer() {
         let answers = [
@@ -3080,10 +3139,9 @@ mod tests {
             "session not found: thurbox",
         ];
         for answer in answers {
-            let error = format!("tmux list-windows failed: {answer}");
             assert!(
-                mux_answered_absent(&error),
-                "the multiplexer answered: {error}"
+                mux_answered_absent(answer),
+                "the multiplexer answered: {answer}"
             );
         }
         let unanswered = [
@@ -3091,14 +3149,68 @@ mod tests {
             "ssh: connect to host devbox port 22: Operation timed out",
             "Permission denied (publickey).",
             "bash: line 1: tmux: command not found",
+            "Failed to run tmux command",
         ];
         for failure in unanswered {
-            let error = format!("tmux list-windows failed: {failure}");
-            assert!(!mux_answered_absent(&error), "nothing answered: {error}");
+            assert!(!mux_answered_absent(failure), "nothing answered: {failure}");
         }
+    }
+
+    /// The trap `error connecting to` sets, and the reason it is not a prefix
+    /// match. tmux prints it both for a socket that is not there and for one it
+    /// cannot open **while a server is alive behind it** — the `(Permission
+    /// denied)` line below is what a live server on another user's socket
+    /// actually prints (reproduced by chmod-ing a running server's socket dir).
+    /// Reading that as absence is a reachable failure mistaken for "nothing to
+    /// kill", which is the orphan this whole path exists to prevent.
+    #[test]
+    fn a_socket_that_cannot_be_opened_is_not_a_server_that_is_not_there() {
         assert!(
-            !mux_answered_absent("Failed to run tmux command"),
-            "not even the launch succeeded"
+            mux_answered_absent(
+                "error connecting to /tmp/tmux-0/thurbox (No such file or directory)"
+            ),
+            "no socket at all is the one reason that means absence"
+        );
+        for live in [
+            "error connecting to /tmp/tmux-1000/thurbox (Permission denied)",
+            "error connecting to /tmp/tmux-1000/thurbox (Connection refused)",
+            "error connecting to /tmp/tmux-1000/thurbox (Connection reset by peer)",
+        ] {
+            assert!(
+                !mux_answered_absent(live),
+                "a server may be alive behind this socket: {live}"
+            );
+        }
+    }
+
+    /// Layer before text. `ssh` exits 255 for its own failures and passes a
+    /// remote command's status through untouched, so 255 means the question
+    /// never arrived — even when the bytes on stderr happen to read exactly
+    /// like tmux answering, which is the case no amount of message-matching
+    /// can get right on its own.
+    #[test]
+    fn ssh_failing_on_its_own_account_is_never_absence() {
+        let tmux_said_absent = "no server running on /tmp/tmux-0/thurbox";
+
+        assert!(
+            listing_is_absence(true, Some(1), tmux_said_absent),
+            "ssh passed through tmux's own answer"
+        );
+        assert!(
+            !listing_is_absence(true, Some(255), tmux_said_absent),
+            "255 is ssh's own failure; nothing on the host answered"
+        );
+        assert!(
+            listing_is_absence(false, Some(255), tmux_said_absent),
+            "without ssh in the path, 255 carries none of that meaning"
+        );
+        assert!(
+            !listing_is_absence(true, Some(127), "bash: tmux: command not found"),
+            "reached the host, but nothing there answered the question"
+        );
+        assert!(
+            !listing_is_absence(true, None, tmux_said_absent),
+            "killed by a signal: no status to reason from"
         );
     }
 

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -2808,8 +2808,10 @@ pub fn agent_window(
     };
     // A one-shot `list-windows`, and deliberately nothing more: `discover`
     // answers empty for a server that is not there, where starting control
-    // mode would bring one into being.
-    let index = WindowIndex::from_listing(backend.discover()?);
+    // mode would bring one into being. `discover_answered` (not `discover`)
+    // so an unreachable host surfaces as `Err`, not as an empty listing that
+    // reads the same as "no such window" — see `mux_answered_absent`.
+    let index = WindowIndex::from_listing(backend.discover_answered()?);
     Ok(index.live_agent_window(session_id, session_name))
 }
 

--- a/src/agent/transport.rs
+++ b/src/agent/transport.rs
@@ -129,6 +129,19 @@ impl TmuxTransport {
         }
     }
 
+    /// Whether the multiplexer is reached over `ssh`, and so whether ssh's own
+    /// exit conventions apply to a failed command.
+    ///
+    /// Read by the teardown's listing to tell "ssh could not deliver the
+    /// question" (exit 255, ssh's documented own-error code) from "the
+    /// multiplexer answered", which is the one distinction that decides
+    /// whether an empty result means there is nothing to kill. A WSL distro is
+    /// deliberately not included: `wsl.exe` has no such convention, and
+    /// claiming it does would be the guess this exists to avoid.
+    pub fn is_ssh(&self) -> bool {
+        matches!(self, TmuxTransport::Ssh { .. })
+    }
+
     /// Whether the multiplexer is psmux (the native-Windows tmux clone). psmux
     /// lacks tmux's `send-keys -H` hex flag, so the keystroke-encoding path
     /// branches on this — see [`crate::agent::control_mode::send_keys_commands`].

--- a/src/cli/automations.rs
+++ b/src/cli/automations.rs
@@ -508,12 +508,19 @@ fn tick(db: &Database) -> Result<Value, String> {
     // A soft delete asked for headlessly — from a peer, or from this CLI —
     // has no interface here to reap it once the undo window has closed.
     let reaped = crate::session_ops::reap_overdue_soft_deletes(db);
+    // And a force delete whose teardown never reached its host: this is the
+    // pass that finishes it, so an agent orphaned by a machine that was down
+    // for a minute is collected rather than left running there for good.
+    // After the mirror above, which is what may just have taken the delete to
+    // a host that came back on its own.
+    let teardowns = crate::session_ops::retry_owed_remote_teardowns(db);
     Ok(json!({
         "fired": fired,
         "skipped": skipped,
         "healed": healed,
         "synced": synced,
         "reaped": reaped,
+        "teardowns": teardowns,
     }))
 }
 

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -1223,6 +1223,7 @@ fn delete_session(db: &Database, uuid: &str, force: bool) -> Result<CommandOutpu
             "worktree_errors": report.worktree_errors,
             "disabled_automations": report.disabled_automations,
             "remote_teardown_error": report.remote_teardown_error,
+            "remote_teardown_owed": report.remote_teardown_owed,
             "host_unknown": report.host_unknown,
             "hook_failures": report.hook_failures,
         }),
@@ -1256,6 +1257,15 @@ fn force_delete_detail(
     }
     if let Some(err) = &report.remote_teardown_error {
         detail.push(("remote teardown error", err.clone()));
+    }
+    // Said whenever it is true, including for a teardown whose only casualty
+    // was a worktree: "could not reach the host" on its own reads as work
+    // abandoned, and the whole point of the mark is that it is not.
+    if report.remote_teardown_owed {
+        detail.push((
+            "remote teardown",
+            "owed — retried on the host whenever it next answers".to_string(),
+        ));
     }
     detail
 }
@@ -2142,6 +2152,7 @@ fn deleted_session_to_json(r: &crate::storage::DeletedSessionInfo) -> Value {
         "parent_session_id": r.parent_session_id.map(|id| id.to_string()),
         "deleted_at": r.deleted_at,
         "force_deleted": r.force_deleted,
+        "teardown_owed": r.teardown_owed,
         "worktrees": r.worktrees.iter().map(|w| json!({
             "repo_path": w.repo_path.display().to_string(),
             "worktree_path": w.worktree_path.display().to_string(),

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -1205,6 +1205,9 @@ fn delete_session(db: &Database, uuid: &str, force: bool) -> Result<CommandOutpu
     if let Some(note) = &report.host_unknown {
         human.push_str(&format!("\n  {note}"));
     }
+    if let Some(note) = &report.host_unreachable {
+        human.push_str(&format!("\n  {note}"));
+    }
     if force {
         for line in output::kv(&force_delete_detail(&report)).lines() {
             human.push_str(&format!("\n  {line}"));
@@ -1225,6 +1228,7 @@ fn delete_session(db: &Database, uuid: &str, force: bool) -> Result<CommandOutpu
             "remote_teardown_error": report.remote_teardown_error,
             "remote_teardown_owed": report.remote_teardown_owed,
             "host_unknown": report.host_unknown,
+            "host_unreachable": report.host_unreachable,
             "hook_failures": report.hook_failures,
         }),
         human,

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -974,3 +974,26 @@ fn command_arguments_may_start_with_a_dash() {
     assert_eq!(command.as_deref(), Some("/bin/sh"));
     assert_eq!(arg, vec!["-c", "while :; do sleep 1; done"]);
 }
+
+/// The host-CLI classifier decides that a remote failure was *the host's own
+/// thurbox answering* partly from the exit code being one this binary uses.
+/// `session_ops` may not reference `cli` (`tests/architecture_rules.rs`), so it
+/// spells those codes out — and this is the pin that keeps the two copies from
+/// drifting into a classifier that reads a real refusal as "nothing answered".
+#[test]
+fn host_cli_knows_every_exit_code_this_binary_uses() {
+    use crate::session_ops::host_cli::CLI_EXIT_CODES;
+
+    for code in [EXIT_ERROR, EXIT_USAGE, EXIT_AMBIGUOUS] {
+        assert!(
+            CLI_EXIT_CODES.contains(&code),
+            "exit {code} is one thurbox-cli gives, and the remote classifier \
+             has to recognise it as the host answering"
+        );
+    }
+    assert_eq!(
+        CLI_EXIT_CODES.len(),
+        3,
+        "a new exit code needs adding to CLI_EXIT_CODES too"
+    );
+}

--- a/src/kernel/command/execute.rs
+++ b/src/kernel/command/execute.rs
@@ -65,11 +65,15 @@ pub(super) fn execute(
     }
 
     // Asked of the database rather than of a session: the sweep finds every row
-    // whose undo window has closed.
+    // whose undo window has closed, and every force delete still owing a
+    // teardown on a host that was unreachable when it was taken.
     if matches!(command, Command::Reap) {
         let path = crate::paths::database_file().ok_or("could not resolve the database path")?;
         let db = Database::open_existing(&path).map_err(|e| format!("open database: {e}"))?;
         crate::session_ops::reap_overdue_soft_deletes(&db);
+        // The same sweep's other half: force deletes whose teardown never
+        // reached the host they were owed on.
+        crate::session_ops::retry_owed_remote_teardowns(&db);
         return Ok(());
     }
 

--- a/src/kernel/command/mod.rs
+++ b/src/kernel/command/mod.rs
@@ -238,13 +238,16 @@ pub enum Command {
     Theme {
         name: String,
     },
-    /// Let the agents of every session soft-deleted past its undo window go.
+    /// Let the agents of every session soft-deleted past its undo window go,
+    /// and finish the teardowns owed on hosts that were unreachable when a
+    /// force delete was taken.
     ///
     /// Names no session: the question is asked of the database
-    /// (`deleted_at + UNDO_WINDOW`), not of a list the loop kept. Issued by the
-    /// loop on a slow cadence rather than by a plugin — it is a consequence of
-    /// time passing, not of anything anyone pressed. Worktrees are left alone —
-    /// they are what makes the undo lossless.
+    /// (`deleted_at + UNDO_WINDOW`, and the owed-teardown mark), not of a list
+    /// the loop kept. Issued by the loop on a slow cadence rather than by a
+    /// plugin — it is a consequence of time passing, not of anything anyone
+    /// pressed. A soft delete's worktrees are left alone — they are what makes
+    /// the undo lossless.
     Reap,
     /// Write the user's settings back to `settings.toml`.
     ///

--- a/src/session_ops/delete.rs
+++ b/src/session_ops/delete.rs
@@ -87,36 +87,58 @@ pub fn delete_session_headless(
             if force {
                 args.push("--force");
             }
-            let answer = match super::host_cli::run(&host, &cli, &args) {
+            let answer = match super::host_cli::run_classified(&host, &cli, &args) {
                 Ok(answer) => answer,
                 // The host does not know this row, so there is nothing there to
                 // delegate to — but the row here is real and the caller asked
                 // for it to go. Take the delete from here instead: the teardown
                 // is addressed by uuid, so it still reaches exactly this
                 // session's windows on that host if they are there at all.
-                Err(e) if is_unknown_session(&e) => {
+                Err(e) if is_unknown_session(&e.message) => {
                     report.host_unknown = Some(format!(
                         "'{}' does not know this session ({e}); deleted from here",
                         host.name
                     ));
                     return finish_locally(db, &session, force, report, &hook_ctx);
                 }
-                // The host never got the question — a transport failure, not a
-                // reply — so there is nothing there to have deleted. Taken from
+                // The question never arrived — the launcher would not start,
+                // or ssh failed on its own account — so nothing there acted on
+                // it and there is nothing there to have deleted. Taken from
                 // here instead, exactly as the legacy (non-delegated) path
                 // already does for the same host being down: the row is marked
                 // and, on a force delete, `owes_remote_teardown` records what
                 // the local teardown could not reach for the sweep to retry.
-                // Any other error is the host answering with one, and the
-                // session may still be running there — that still aborts.
-                Err(e) if host_never_answered(&e) => {
+                //
+                // Decided by which layer failed, never by reading the message
+                // (`host_cli::Reach`): the two branches here are "delete it
+                // from here anyway" and "leave it alone", and choosing between
+                // them by matching substrings of somebody else's error text
+                // gets the first unanticipated wording wrong, silently.
+                //
+                // `Undetermined` comes here with `Unreached` on purpose. An
+                // error whose layer cannot be told is an unanswered question,
+                // and the one thing an unanswered question must not do is
+                // stand in for the host saying no — which is what aborting
+                // would make it. Falling back is also the branch that still
+                // *does* something about the processes: the teardown is
+                // addressed by the window's own stamp, so on a host that is up
+                // (exit 127 — reached it, found no thurbox-cli there) it
+                // reaches exactly this session's windows, and on one that is
+                // not it records the owed teardown for the sweep. Aborting
+                // reaches nothing and records nothing, which is how a session
+                // on a host with a broken CLI became undeletable.
+                Err(e) if e.reach != crate::session_ops::host_cli::Reach::Answered => {
                     report.host_unreachable = Some(format!(
-                        "could not reach '{}' ({e}); deleted from here",
+                        "'{}' did not answer the delete ({e}); deleted from here",
                         host.name
                     ));
                     return finish_locally(db, &session, force, report, &hook_ctx);
                 }
-                Err(e) => return Err(e),
+                // The host itself refused — a locked database, a worktree it
+                // could not release. It is up, it heard the question, and the
+                // session may still be running there, so this still aborts and
+                // the row is left exactly as it was.
+                Err(e) => return Err(e.message),
             };
             report.killed_window = answer
                 .get("killed_window")
@@ -212,34 +234,6 @@ fn finish_locally_with(
 /// which are cases where the local row still has to go.
 fn is_unknown_session(error: &str) -> bool {
     error.contains("Session not found")
-}
-
-/// Whether a [`super::host_cli::run`] failure means the host was never
-/// reached, rather than answering with an error of its own.
-///
-/// `run_script` (`session_ops::host_cli`) reads stderr before the host CLI's
-/// own structured answer precisely because a transport failure — ssh could
-/// not connect, the remote shell could not exec the binary — never reaches
-/// thurbox-cli at all and so never produces a real `Err`. The signatures below
-/// are what that stderr carries in each case; the same distinction
-/// `agent::tmux::mux_answered_absent` draws for tmux, applied to ssh instead.
-/// Reading "we could not reach it" as "it said no" is what would leave a
-/// force-delete against a host that is merely down erroring out with nothing
-/// recorded for the sweep to retry.
-fn host_never_answered(error: &str) -> bool {
-    const TRANSPORT_FAILURES: [&str; 9] = [
-        "could not start ",
-        "connection refused",
-        "connection timed out",
-        "operation timed out",
-        "could not resolve hostname",
-        "no route to host",
-        "permission denied",
-        "host key verification failed",
-        "kex_exchange_identification",
-    ];
-    let lower = error.to_lowercase();
-    TRANSPORT_FAILURES.iter().any(|f| lower.contains(f))
 }
 
 /// Mark the row gone. A force delete says so in the same statement rather than
@@ -908,35 +902,6 @@ mod tests {
     }
 
     #[test]
-    fn host_never_answered_tells_a_transport_failure_from_a_reply() {
-        for failure in [
-            "could not start thurbox-cli on 'devbox': No such file or directory",
-            "ssh: connect to host devbox port 22: Connection refused",
-            "ssh: connect to host devbox port 22: Operation timed out",
-            "Permission denied (publickey).",
-            "Could not resolve hostname devbox: Name or service not known",
-            "No route to host",
-            "Host key verification failed.",
-            "kex_exchange_identification: read: Connection reset by peer",
-        ] {
-            assert!(
-                super::host_never_answered(failure),
-                "nothing answered: {failure}"
-            );
-        }
-        for answered in [
-            "thurbox-cli on 'devbox' failed (exit 1): database is locked",
-            "Session not found: devbox",
-            "thurbox-cli on 'devbox' printed no JSON for `session delete` (EOF): ",
-        ] {
-            assert!(
-                !super::host_never_answered(answered),
-                "the host answered: {answered}"
-            );
-        }
-    }
-
-    #[test]
     fn soft_delete_without_force_leaves_no_side_effects() {
         let db = Database::open_in_memory().unwrap();
         let id = insert_session(&db, "demo");
@@ -1223,7 +1188,9 @@ mod tests {
             crate::session_ops::host_cli::Usable::Yes(crate::session_ops::host_cli::fake::cli()),
         );
         crate::session_ops::host_cli::fake::install_runner(Box::new(|_, _| {
-            Err("ssh: connect to host devbox port 22: Connection refused".into())
+            Err(crate::session_ops::host_cli::fake::unreached(
+                "ssh: connect to host devbox port 22: Connection refused",
+            ))
         }));
 
         let report = delete_session_headless(&db, id, true).unwrap();
@@ -1251,6 +1218,47 @@ mod tests {
         );
     }
 
+    /// A failure whose layer cannot be told must side with the unanswered
+    /// question, not with the host having refused. Aborting would let "I could
+    /// not tell" stand in for "the host said no", which is how a session on a
+    /// host with a broken CLI became undeletable — and it reaches nothing and
+    /// records nothing, while the fallback is stamp-addressed and records what
+    /// it could not finish.
+    #[test]
+    fn a_delegated_delete_falls_back_on_a_failure_it_cannot_classify() {
+        let _guard = configured_host();
+        let db = Database::open_in_memory().unwrap();
+        let id = insert_session_on(&db, "remote", "ssh:devbox", "%3");
+
+        crate::session_ops::host_cli::fake::force_usable(
+            crate::session_ops::host_cli::Usable::Yes(crate::session_ops::host_cli::fake::cli()),
+        );
+        // Reached the host; nothing thurbox-shaped ran there (exit 127). Its
+        // wording deliberately reads like a connection failure — the point is
+        // that the wording no longer decides anything.
+        crate::session_ops::host_cli::fake::install_runner(Box::new(|_, _| {
+            Err(crate::session_ops::host_cli::fake::undetermined(
+                "bash: line 1: thurbox-cli: command not found (connection refused?)",
+            ))
+        }));
+
+        let report = delete_session_headless(&db, id, true).unwrap();
+        crate::session_ops::host_cli::fake::clear();
+
+        assert!(
+            report.host_unreachable.is_some(),
+            "the caller is told the delete was taken from here"
+        );
+        assert!(
+            db.get_session_by_id(id).unwrap().is_none(),
+            "the row is marked gone rather than the delete failing outright"
+        );
+        assert!(
+            report.remote_teardown_owed,
+            "and what the local teardown could not reach is left for the sweep"
+        );
+    }
+
     /// The counterpart to the test above: any OTHER error the host answers
     /// with — the session may still be running there — must keep aborting the
     /// delete outright, exactly as before. Only a transport failure falls
@@ -1265,7 +1273,9 @@ mod tests {
             crate::session_ops::host_cli::Usable::Yes(crate::session_ops::host_cli::fake::cli()),
         );
         crate::session_ops::host_cli::fake::install_runner(Box::new(|_, _| {
-            Err("thurbox-cli on 'devbox' failed (exit 1): database is locked".into())
+            Err(crate::session_ops::host_cli::fake::answered(
+                "thurbox-cli on 'devbox' failed (exit 1): database is locked",
+            ))
         }));
 
         let err = delete_session_headless(&db, id, true).unwrap_err();
@@ -1340,7 +1350,9 @@ mod tests {
             crate::session_ops::host_cli::Usable::Yes(crate::session_ops::host_cli::fake::cli()),
         );
         crate::session_ops::host_cli::fake::install_runner(Box::new(|_, _| {
-            Err("ssh: connect to host devbox port 22: Connection refused".into())
+            Err(crate::session_ops::host_cli::fake::unreached(
+                "ssh: connect to host devbox port 22: Connection refused",
+            ))
         }));
 
         let finished = retry_owed_remote_teardowns(&db);
@@ -1375,7 +1387,9 @@ mod tests {
             crate::session_ops::host_cli::Usable::Yes(crate::session_ops::host_cli::fake::cli()),
         );
         crate::session_ops::host_cli::fake::install_runner(Box::new(|_, _| {
-            Err("ssh: connect to host devbox port 22: Connection refused".into())
+            Err(crate::session_ops::host_cli::fake::unreached(
+                "ssh: connect to host devbox port 22: Connection refused",
+            ))
         }));
 
         assert!(retry_owed_remote_teardowns(&db).is_empty());

--- a/src/session_ops/delete.rs
+++ b/src/session_ops/delete.rs
@@ -38,6 +38,13 @@ pub struct ForceDeleteReport {
     /// left the local row active and attached, which reads as "delete does
     /// nothing".
     pub host_unknown: Option<String>,
+    /// Set when the host was asked to delete the session and never answered at
+    /// all — a connection failure, not a reply. The delete is then taken from
+    /// here instead of aborting outright: the alternative left the local row
+    /// active and attached with nothing recorded for the sweep to retry, which
+    /// is the exact orphan this whole path exists to stop, just reached by a
+    /// different door than the legacy (non-delegated) teardown.
+    pub host_unreachable: Option<String>,
     /// `session.post_delete` hooks that failed. The delete stands regardless.
     pub hook_failures: Vec<String>,
 }
@@ -91,6 +98,20 @@ pub fn delete_session_headless(
                     report.host_unknown = Some(format!(
                         "'{}' does not know this session ({e}); deleted from here",
                         host.name
+                    ));
+                    return finish_locally(db, &session, force, report, &hook_ctx);
+                }
+                // The host never got the question — a transport failure, not a
+                // reply — so there is nothing there to have deleted. Taken from
+                // here instead, exactly as the legacy (non-delegated) path
+                // already does for the same host being down: the row is marked
+                // and, on a force delete, `owes_remote_teardown` records what
+                // the local teardown could not reach for the sweep to retry.
+                // Any other error is the host answering with one, and the
+                // session may still be running there — that still aborts.
+                Err(e) if host_never_answered(&e) => {
+                    report.host_unreachable = Some(format!(
+                        "could not reach '{}' ({e}); deleted from here", host.name
                     ));
                     return finish_locally(db, &session, force, report, &hook_ctx);
                 }
@@ -190,6 +211,34 @@ fn finish_locally_with(
 /// which are cases where the local row still has to go.
 fn is_unknown_session(error: &str) -> bool {
     error.contains("Session not found")
+}
+
+/// Whether a [`super::host_cli::run`] failure means the host was never
+/// reached, rather than answering with an error of its own.
+///
+/// `run_script` (`session_ops::host_cli`) reads stderr before the host CLI's
+/// own structured answer precisely because a transport failure — ssh could
+/// not connect, the remote shell could not exec the binary — never reaches
+/// thurbox-cli at all and so never produces a real `Err`. The signatures below
+/// are what that stderr carries in each case; the same distinction
+/// `agent::tmux::mux_answered_absent` draws for tmux, applied to ssh instead.
+/// Reading "we could not reach it" as "it said no" is what would leave a
+/// force-delete against a host that is merely down erroring out with nothing
+/// recorded for the sweep to retry.
+fn host_never_answered(error: &str) -> bool {
+    const TRANSPORT_FAILURES: [&str; 9] = [
+        "could not start ",
+        "connection refused",
+        "connection timed out",
+        "operation timed out",
+        "could not resolve hostname",
+        "no route to host",
+        "permission denied",
+        "host key verification failed",
+        "kex_exchange_identification",
+    ];
+    let lower = error.to_lowercase();
+    TRANSPORT_FAILURES.iter().any(|f| lower.contains(f))
 }
 
 /// Mark the row gone. A force delete says so in the same statement rather than
@@ -858,6 +907,35 @@ mod tests {
     }
 
     #[test]
+    fn host_never_answered_tells_a_transport_failure_from_a_reply() {
+        for failure in [
+            "could not start thurbox-cli on 'devbox': No such file or directory",
+            "ssh: connect to host devbox port 22: Connection refused",
+            "ssh: connect to host devbox port 22: Operation timed out",
+            "Permission denied (publickey).",
+            "Could not resolve hostname devbox: Name or service not known",
+            "No route to host",
+            "Host key verification failed.",
+            "kex_exchange_identification: read: Connection reset by peer",
+        ] {
+            assert!(
+                super::host_never_answered(failure),
+                "nothing answered: {failure}"
+            );
+        }
+        for answered in [
+            "thurbox-cli on 'devbox' failed (exit 1): database is locked",
+            "Session not found: devbox",
+            "thurbox-cli on 'devbox' printed no JSON for `session delete` (EOF): ",
+        ] {
+            assert!(
+                !super::host_never_answered(answered),
+                "the host answered: {answered}"
+            );
+        }
+    }
+
+    #[test]
     fn soft_delete_without_force_leaves_no_side_effects() {
         let db = Database::open_in_memory().unwrap();
         let id = insert_session(&db, "demo");
@@ -1126,6 +1204,76 @@ mod tests {
                 .unwrap()
                 .unwrap()
                 .teardown_owed
+        );
+    }
+
+    /// A delegated delete whose host never answers at all — a connection
+    /// failure, not a reply — must not be left as a bare `Err`: the row is
+    /// still real, and the alternative is a hard failure with nothing marked
+    /// and nothing for the sweep to retry. The delegated path's counterpart
+    /// to `a_force_delete_that_could_not_reach_its_host_owes_a_teardown`.
+    #[test]
+    fn a_delegated_delete_falls_back_locally_when_the_host_cannot_be_reached() {
+        let _guard = configured_host();
+        let db = Database::open_in_memory().unwrap();
+        let id = insert_session_on(&db, "remote", "ssh:devbox", "%3");
+
+        crate::session_ops::host_cli::fake::force_usable(
+            crate::session_ops::host_cli::Usable::Yes(crate::session_ops::host_cli::fake::cli()),
+        );
+        crate::session_ops::host_cli::fake::install_runner(Box::new(|_, _| {
+            Err("ssh: connect to host devbox port 22: Connection refused".into())
+        }));
+
+        let report = delete_session_headless(&db, id, true).unwrap();
+        crate::session_ops::host_cli::fake::clear();
+
+        assert!(
+            report.host_unreachable.is_some(),
+            "the caller is told the delete fell back to the local teardown"
+        );
+        assert!(
+            db.get_session_by_id(id).unwrap().is_none(),
+            "the row is still marked gone"
+        );
+        assert!(
+            db.get_deleted_session_by_id(id)
+                .unwrap()
+                .unwrap()
+                .force_deleted,
+            "and the fallback ran the same force teardown the legacy path would"
+        );
+        assert!(
+            report.remote_teardown_owed,
+            "the local teardown could not reach the same down host either, \
+             so the sweep is told to retry"
+        );
+    }
+
+    /// The counterpart to the test above: any OTHER error the host answers
+    /// with — the session may still be running there — must keep aborting the
+    /// delete outright, exactly as before. Only a transport failure falls
+    /// through.
+    #[test]
+    fn a_delegated_delete_still_aborts_when_the_host_answers_with_an_error() {
+        let _guard = configured_host();
+        let db = Database::open_in_memory().unwrap();
+        let id = insert_session_on(&db, "remote", "ssh:devbox", "%3");
+
+        crate::session_ops::host_cli::fake::force_usable(
+            crate::session_ops::host_cli::Usable::Yes(crate::session_ops::host_cli::fake::cli()),
+        );
+        crate::session_ops::host_cli::fake::install_runner(Box::new(|_, _| {
+            Err("thurbox-cli on 'devbox' failed (exit 1): database is locked".into())
+        }));
+
+        let err = delete_session_headless(&db, id, true).unwrap_err();
+        crate::session_ops::host_cli::fake::clear();
+
+        assert!(err.contains("database is locked"), "got {err}");
+        assert!(
+            db.get_session_by_id(id).unwrap().is_some(),
+            "the row is untouched: the session may still be running on the host"
         );
     }
 

--- a/src/session_ops/delete.rs
+++ b/src/session_ops/delete.rs
@@ -19,10 +19,18 @@ pub struct ForceDeleteReport {
     pub disabled_automations: usize,
     /// Set when the session lived on a remote host (SSH/WSL) and its window
     /// could not be torn down there: the host is unreachable, has no
-    /// `hosts.toml` entry, or the session carries no pane id. Best-effort — an
-    /// unreachable host is expected (that's often *why* someone force-deletes),
-    /// so this is recorded rather than aborting the delete.
+    /// `hosts.toml` entry, or does not vouch for a socket. An unreachable host
+    /// is expected — that's often *why* someone force-deletes — so this is
+    /// recorded rather than aborting the delete.
     pub remote_teardown_error: Option<String>,
+    /// Whether that failure was written down on the row, so the sweep will
+    /// come back and finish the teardown once the host answers
+    /// ([`retry_owed_remote_teardowns`]).
+    ///
+    /// The honest half of the sentence above: "could not reach the host" on its
+    /// own reads as work abandoned, and for a `force_deleted` row — which every
+    /// reaper skips — that is exactly what it used to be.
+    pub remote_teardown_owed: bool,
     /// Set when the host was asked to delete the session and answered that it
     /// has no such row — a fork minted here, a row from before ADR-24, or one
     /// a peer already deleted there. The delete is then taken from here
@@ -95,6 +103,10 @@ pub fn delete_session_headless(
             report.removed_worktrees = string_list(&answer, "removed_worktrees");
             report.kept_worktrees = string_list(&answer, "kept_worktrees");
             report.worktree_errors = string_list(&answer, "worktree_errors");
+            // Reported, not adopted: a teardown the *host* could not finish is
+            // owed on the host's own row, and its sweep is the one that can
+            // finish it. Taking the mark here would send this machine after
+            // windows on a third machine it may not even have an entry for.
             report.remote_teardown_error = answer
                 .get("remote_teardown_error")
                 .and_then(serde_json::Value::as_str)
@@ -146,6 +158,21 @@ fn finish_locally_with(
 
     if force {
         teardown(session, &mut report);
+        // What the teardown could not reach is written down rather than
+        // reported and dropped. A `force_deleted` row is skipped by every
+        // reaper, so this one attempt was the only one anything would ever
+        // make: without the mark, a delete taken while a host was down left
+        // that host running the agent for good. Cleared on the same statement
+        // when the teardown did land, so a row force-deleted twice cannot
+        // inherit an owed teardown from the first time.
+        report.remote_teardown_owed = owes_remote_teardown(session, &report);
+        if let Err(e) = db.set_teardown_owed(session.id, report.remote_teardown_owed) {
+            tracing::warn!(
+                "could not record the owed teardown of '{}': {e}",
+                session.name
+            );
+            report.remote_teardown_owed = false;
+        }
         report.disabled_automations = db
             .disable_send_automations_for_session(session.id)
             .map_err(|e| format!("disable_send_automations_for_session: {e}"))?;
@@ -248,6 +275,147 @@ pub fn teardown_runtime_resources(
             tracing::warn!("remove_workspace({asid}) failed: {e}");
         }
     }
+}
+
+/// Whether `report` describes a remote teardown that did not finish, and so
+/// leaves something running on a host for the sweep to collect.
+///
+/// A local session never owes one: its windows are on this machine's server,
+/// which either answered or is not there at all. Worktree failures count
+/// alongside the window kill because both are asked of the same host over the
+/// same connection — the usual reason either fails is that nothing reached it.
+fn owes_remote_teardown(session: &crate::sync::SharedSession, report: &ForceDeleteReport) -> bool {
+    crate::session::is_remote_backend(&session.backend_type)
+        && (report.remote_teardown_error.is_some() || !report.worktree_errors.is_empty())
+}
+
+/// Finish the teardowns that never reached their host: kill the windows a
+/// force-deleted session still owns there and remove the worktrees it left.
+/// Returns the ids finished.
+///
+/// The other half of [`delete_session_headless`]'s best-effort teardown, and
+/// the reason that teardown is allowed to be best-effort at all. A host that is
+/// down is an ordinary reason to force-delete a session, and killing something
+/// on a machine you cannot reach is not a thing software can promise — but
+/// giving up at that moment is a choice, and it was the wrong one: a
+/// `force_deleted` row is skipped by [`reap_overdue_soft_deletes`] and by
+/// [`reap_soft_deleted`], and a host on the legacy path (sharing off, or no
+/// usable CLI) gets no tombstone pushed to it by
+/// [`mirror`](super::mirror) either, so nothing came back. The agent kept
+/// running, kept holding its worktree, and re-creating the name put a second
+/// one beside it.
+///
+/// Driven by the same two callers as the reap — the interface's slow cadence
+/// and the headless heartbeat — so it needs no interface either.
+///
+/// Force-deleted rows only: a soft-deleted one is restorable for its undo
+/// window and belongs to [`reap_overdue_soft_deletes`], which waits that window
+/// out. Killing its windows on this sweep's schedule instead would make the
+/// undo hand back a session with nothing running in it.
+///
+/// One attempt per host per pass: the first row whose host does not answer
+/// takes that host's remaining rows out of the pass, so a machine that is still
+/// down costs one connect timeout rather than one per orphan.
+pub fn retry_owed_remote_teardowns(db: &Database) -> Vec<String> {
+    let Ok(rows) = db.list_owed_teardowns() else {
+        return Vec::new();
+    };
+    if rows.is_empty() {
+        return Vec::new();
+    }
+    // Read afresh rather than through `resolve_host`'s process-lifetime cache:
+    // this sweep is the one caller that wants a `hosts.toml` edit to take
+    // effect, since adding the missing entry for a host is one of the two ways
+    // an owed teardown becomes possible again (the other being the machine
+    // coming back). One read, and only once something is actually owed.
+    let registry = crate::agent::host_config::load_all();
+    let mut finished = Vec::new();
+    let mut silent: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for row in rows {
+        if silent.contains(&row.backend_type) {
+            continue;
+        }
+        // Not in `hosts.toml` (any more): there is no machine to aim at, and
+        // the mark keeps the job on the books for whenever the entry is back.
+        let Some(host) = registry.get_by_backend(&row.backend_type) else {
+            continue;
+        };
+        match finish_remote_teardown(host, &row) {
+            Ok(()) => match db.set_teardown_owed(row.id, false) {
+                Ok(()) => finished.push(row.id.to_string()),
+                Err(e) => {
+                    tracing::warn!("could not clear the owed teardown of '{}': {e}", row.name)
+                }
+            },
+            Err(e) => {
+                tracing::debug!(
+                    "'{}' still owes a teardown on '{}': {e}",
+                    row.name,
+                    host.name
+                );
+                silent.insert(row.backend_type.clone());
+            }
+        }
+    }
+    finished
+}
+
+/// One owed teardown, taken on the host it is owed on. `Err` only when the host
+/// did not answer — the one condition that keeps the row on the books.
+///
+/// Delegated when the host runs a thurbox of its own, exactly as [`reap_remote`]
+/// delegates: the host owns its own row and its own windows, and forcing the
+/// delete there is how both go at once. A host that does not know the id has
+/// nothing to delete but may still be holding the windows, so that answer falls
+/// through to the direct kill rather than counting as done.
+///
+/// Worktree removals are attempted but do not decide the outcome. Once the
+/// window listing has come back the host is reachable by construction, so a
+/// `git worktree remove` that still fails is failing on its own merits — a
+/// checkout someone else's process is holding, a repo that moved — and retrying
+/// that on every sweep forever would never converge. It is logged and the mark
+/// comes off.
+fn finish_remote_teardown(
+    host: &crate::session::HostDef,
+    row: &DeletedSessionInfo,
+) -> Result<(), String> {
+    let id = row.id.to_string();
+    if let Some(cli) = super::host_cli::delegated(host) {
+        match super::host_cli::run(host, &cli, &["session", "delete", &id, "--force"]) {
+            Ok(_) => return Ok(()),
+            Err(e) if is_unknown_session(&e) => {
+                tracing::debug!("'{}' is unknown on '{}': {e}", row.name, host.name);
+            }
+            Err(e) => return Err(e),
+        }
+    }
+
+    let panes = crate::agent::tmux::SessionPanes {
+        agent: row.backend_id.trim(),
+        shell: row
+            .shell_backend_id
+            .as_deref()
+            .map(str::trim)
+            .unwrap_or_default(),
+    };
+    crate::agent::tmux::kill_remote_windows(host, &id, &row.name, panes)
+        .map_err(|e| format!("{e:#}"))?;
+
+    for wt in &row.worktrees {
+        if !wt.created_by_thurbox {
+            continue;
+        }
+        if let Err(e) = crate::git::remove_worktree_on(Some(host), &wt.repo_path, &wt.worktree_path)
+        {
+            tracing::warn!(
+                "'{}': {} was not removed on '{}': {e:#}",
+                row.name,
+                wt.worktree_path.display(),
+                host.name
+            );
+        }
+    }
+    Ok(())
 }
 
 /// How long a soft-deleted session keeps its agent, so the delete can still be
@@ -841,6 +1009,246 @@ mod tests {
             "got {err}"
         );
         assert!(db.get_session_by_id(id).unwrap().is_none());
+    }
+
+    /// The leak this whole path exists to stop, at the seam a unit test can
+    /// see: a force delete whose host could not be reached must leave the job
+    /// on the books. Nothing else would ever come back for it — every reaper
+    /// skips a `force_deleted` row, and a host on the legacy path gets no
+    /// tombstone pushed to it either.
+    #[test]
+    fn a_force_delete_that_could_not_reach_its_host_owes_a_teardown() {
+        let db = Database::open_in_memory().unwrap();
+        let id = insert_session_on(&db, "remote", "ssh:devbox", "%3");
+
+        let report = delete_session_headless(&db, id, true).unwrap();
+
+        assert!(report.remote_teardown_error.is_some());
+        assert!(
+            report.remote_teardown_owed,
+            "the caller is told the teardown is owed, not merely that it failed"
+        );
+        assert!(
+            db.get_deleted_session_by_id(id)
+                .unwrap()
+                .unwrap()
+                .teardown_owed,
+            "and it is written down on the row, so it survives this process"
+        );
+        let owed = db.list_owed_teardowns().unwrap();
+        assert_eq!(owed.len(), 1, "the sweep's worklist has it");
+        assert_eq!(owed[0].id, id);
+    }
+
+    #[test]
+    fn a_local_force_delete_owes_nothing_and_clears_a_stale_mark() {
+        let db = Database::open_in_memory().unwrap();
+        let id = insert_session(&db, "local");
+        // A mark left by an earlier delete of this row: force-deleting again
+        // must not inherit it, or the sweep would chase windows long gone.
+        db.set_teardown_owed(id, true).unwrap();
+
+        let report = delete_session_headless(&db, id, true).unwrap();
+
+        assert!(!report.remote_teardown_owed);
+        assert!(
+            !db.get_deleted_session_by_id(id)
+                .unwrap()
+                .unwrap()
+                .teardown_owed
+        );
+        assert!(db.list_owed_teardowns().unwrap().is_empty());
+    }
+
+    /// The undo window is lossless by design, and this sweep must not be the
+    /// thing that breaks it: a soft-deleted row is restorable and its windows
+    /// belong to [`reap_overdue_soft_deletes`], which waits the window out.
+    #[test]
+    fn the_owed_worklist_never_includes_a_soft_deleted_row() {
+        let db = Database::open_in_memory().unwrap();
+        let id = insert_session_on(&db, "remote", "ssh:devbox", "%3");
+
+        delete_session_headless(&db, id, false).unwrap();
+        // Even marked by hand, a restorable row is not this sweep's to take.
+        db.set_teardown_owed(id, true).unwrap();
+
+        assert!(
+            db.list_owed_teardowns().unwrap().is_empty(),
+            "a session that can still come back keeps its agent until it cannot"
+        );
+        assert!(
+            retry_owed_remote_teardowns(&db).is_empty(),
+            "and the sweep finishes nothing on it"
+        );
+    }
+
+    /// A row that is alive again has no orphan to collect. Left set, the mark
+    /// would be inherited by whatever the row's next delete is, and a *soft*
+    /// one would then have its windows taken without the undo window being
+    /// waited out.
+    #[test]
+    fn restoring_a_row_clears_the_teardown_it_owed() {
+        let db = Database::open_in_memory().unwrap();
+        let id = insert_session_on(&db, "remote", "ssh:devbox", "%3");
+        delete_session_headless(&db, id, true).unwrap();
+        assert!(
+            db.get_deleted_session_by_id(id)
+                .unwrap()
+                .unwrap()
+                .teardown_owed
+        );
+
+        db.restore_session(id).unwrap();
+        db.soft_delete_session(id).unwrap();
+
+        assert!(
+            !db.get_deleted_session_by_id(id)
+                .unwrap()
+                .unwrap()
+                .teardown_owed,
+            "the mark did not survive the restore"
+        );
+        assert!(db.list_owed_teardowns().unwrap().is_empty());
+    }
+
+    #[test]
+    fn an_owed_teardown_whose_host_is_not_configured_stays_on_the_books() {
+        let db = Database::open_in_memory().unwrap();
+        let id = insert_session_on(&db, "remote", "ssh:devbox", "%3");
+        delete_session_headless(&db, id, true).unwrap();
+
+        // (cfg(test) sandboxes the config dir, so hosts.toml is empty and
+        // nothing dials.) There is no machine to aim at — and no reason to
+        // forget the job either.
+        assert!(retry_owed_remote_teardowns(&db).is_empty());
+        assert!(
+            db.get_deleted_session_by_id(id)
+                .unwrap()
+                .unwrap()
+                .teardown_owed
+        );
+    }
+
+    /// The point of the mark: a host that comes back gets the teardown it
+    /// missed, and the row stops owing one.
+    #[test]
+    fn the_sweep_finishes_an_owed_teardown_when_the_host_answers() {
+        let _guard = configured_host();
+        let db = Database::open_in_memory().unwrap();
+        let id = insert_session_on(&db, "remote", "ssh:devbox", "%3");
+
+        // The delete itself finds no CLI, so it takes the legacy teardown and
+        // records what it could not reach.
+        crate::session_ops::host_cli::fake::force_usable(crate::session_ops::host_cli::Usable::No(
+            "no cli".into(),
+        ));
+        delete_session_headless(&db, id, true).unwrap();
+
+        // By the time the sweep runs the host is answering again, and owns the
+        // row: the delete is forced there, which takes its windows with it.
+        crate::session_ops::host_cli::fake::force_usable(
+            crate::session_ops::host_cli::Usable::Yes(crate::session_ops::host_cli::fake::cli()),
+        );
+        crate::session_ops::host_cli::fake::install_runner(Box::new(|_, _| {
+            Ok(serde_json::json!({ "deleted": true }))
+        }));
+
+        let finished = retry_owed_remote_teardowns(&db);
+
+        let calls = crate::session_ops::host_cli::fake::calls();
+        crate::session_ops::host_cli::fake::clear();
+        assert_eq!(finished, vec![id.to_string()]);
+        assert_eq!(
+            calls,
+            vec![vec![
+                "session".to_string(),
+                "delete".to_string(),
+                id.to_string(),
+                "--force".to_string(),
+            ]],
+            "the host is asked to force the delete, so its row and its windows go together"
+        );
+        assert!(
+            !db.get_deleted_session_by_id(id)
+                .unwrap()
+                .unwrap()
+                .teardown_owed,
+            "and the row stops owing one"
+        );
+    }
+
+    #[test]
+    fn the_sweep_keeps_the_mark_when_the_host_still_does_not_answer() {
+        let _guard = configured_host();
+        let db = Database::open_in_memory().unwrap();
+        let id = insert_session_on(&db, "remote", "ssh:devbox", "%3");
+        crate::session_ops::host_cli::fake::force_usable(crate::session_ops::host_cli::Usable::No(
+            "no cli".into(),
+        ));
+        delete_session_headless(&db, id, true).unwrap();
+
+        crate::session_ops::host_cli::fake::force_usable(
+            crate::session_ops::host_cli::Usable::Yes(crate::session_ops::host_cli::fake::cli()),
+        );
+        crate::session_ops::host_cli::fake::install_runner(Box::new(|_, _| {
+            Err("ssh: connect to host devbox port 22: Connection refused".into())
+        }));
+
+        let finished = retry_owed_remote_teardowns(&db);
+        crate::session_ops::host_cli::fake::clear();
+
+        assert!(finished.is_empty());
+        assert!(
+            db.get_deleted_session_by_id(id)
+                .unwrap()
+                .unwrap()
+                .teardown_owed,
+            "a host that is still down keeps the job on the books"
+        );
+    }
+
+    /// A host that was down for two of this machine's sessions costs one
+    /// connect timeout on a pass, not one per orphan.
+    #[test]
+    fn the_sweep_asks_a_silent_host_once_per_pass() {
+        let _guard = configured_host();
+        let db = Database::open_in_memory().unwrap();
+        crate::session_ops::host_cli::fake::force_usable(crate::session_ops::host_cli::Usable::No(
+            "no cli".into(),
+        ));
+        for name in ["one", "two", "three"] {
+            let id = insert_session_on(&db, name, "ssh:devbox", "%3");
+            delete_session_headless(&db, id, true).unwrap();
+        }
+        assert_eq!(db.list_owed_teardowns().unwrap().len(), 3);
+
+        crate::session_ops::host_cli::fake::force_usable(
+            crate::session_ops::host_cli::Usable::Yes(crate::session_ops::host_cli::fake::cli()),
+        );
+        crate::session_ops::host_cli::fake::install_runner(Box::new(|_, _| {
+            Err("ssh: connect to host devbox port 22: Connection refused".into())
+        }));
+
+        assert!(retry_owed_remote_teardowns(&db).is_empty());
+        let calls = crate::session_ops::host_cli::fake::calls();
+        crate::session_ops::host_cli::fake::clear();
+        assert_eq!(calls.len(), 1, "one attempt, not one per row: {calls:?}");
+    }
+
+    /// A `hosts.toml` with one SSH host, for the sweep tests. The caller binds
+    /// the pair for the length of the test: the guard points the config dir at
+    /// the temp dir, and the temp dir has to outlive it.
+    fn configured_host() -> (tempfile::TempDir, crate::paths::TestPathGuard) {
+        let temp = tempfile::TempDir::new().unwrap();
+        let guard = crate::paths::TestPathGuard::new(temp.path());
+        let path = crate::agent::host_config::hosts_config_path().unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            "[[hosts]]\nname = \"devbox\"\ndestination = \"me@devbox\"\n",
+        )
+        .unwrap();
+        (temp, guard)
     }
 
     #[test]

--- a/src/session_ops/delete.rs
+++ b/src/session_ops/delete.rs
@@ -111,7 +111,8 @@ pub fn delete_session_headless(
                 // session may still be running there — that still aborts.
                 Err(e) if host_never_answered(&e) => {
                     report.host_unreachable = Some(format!(
-                        "could not reach '{}' ({e}); deleted from here", host.name
+                        "could not reach '{}' ({e}); deleted from here",
+                        host.name
                     ));
                     return finish_locally(db, &session, force, report, &hook_ctx);
                 }

--- a/src/session_ops/host_cli.rs
+++ b/src/session_ops/host_cli.rs
@@ -393,7 +393,65 @@ pub(crate) fn parse_probe(stdout: &str) -> Result<Option<CliInfo>, String> {
 /// *there*, which is what the caller needs to show: the host's stderr when it
 /// has any (a transport failure that never reached the CLI), otherwise the
 /// message from the structured error document the CLI prints on stdout.
-pub fn run(host: &HostDef, cli: &CliInfo, args: &[&str]) -> Result<Value, String> {
+/// How far a failed host CLI call actually got.
+///
+/// Decided by **which layer failed** — the launcher, the transport, or the CLI
+/// itself — never by what the message says. A message is written for a person
+/// and can say anything; a delete that has to choose between "nothing ran
+/// there" and "the host refused" cannot be deciding it by looking for
+/// substrings, because the first unanticipated wording lands in the wrong
+/// branch silently and in whichever direction happens to be worse.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Reach {
+    /// The question never arrived: the launcher would not start, or `ssh`
+    /// failed on its own account (exit 255 — its documented "an error
+    /// occurred", distinct from the remote command's status, which it passes
+    /// through). Nothing ran on the host, so nothing there acted on it.
+    Unreached,
+    /// `thurbox-cli` ran on the host and answered with an error of its own,
+    /// as the structured document every remote invocation asks for.
+    Answered,
+    /// Something in between failed and the layer cannot be told: no shell on
+    /// the host, a binary that is not there, output in a shape nothing
+    /// recognises. **Not** a synonym for either of the others — a caller must
+    /// treat it as the unanswered question it is, and pick whichever branch
+    /// destroys nothing.
+    Undetermined,
+}
+
+/// A failed [`run`], with the layer that failed alongside the message.
+#[derive(Clone, Debug)]
+pub struct RunFailure {
+    pub message: String,
+    pub reach: Reach,
+}
+
+impl RunFailure {
+    fn new(message: String, reach: Reach) -> Self {
+        Self { message, reach }
+    }
+}
+
+impl std::fmt::Display for RunFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl From<RunFailure> for String {
+    fn from(failure: RunFailure) -> Self {
+        failure.message
+    }
+}
+
+/// [`run`], keeping the layer that failed instead of flattening it to a
+/// message.
+///
+/// Only the delete path needs it, and it needs it badly: falling back to a
+/// local teardown is destructive when the host was in fact fine, and aborting
+/// leaves nothing recorded when the host was in fact gone. Which of those is
+/// safe depends entirely on whether the question arrived — see [`Reach`].
+pub fn run_classified(host: &HostDef, cli: &CliInfo, args: &[&str]) -> Result<Value, RunFailure> {
     #[cfg(test)]
     if let Some(answer) = fake::run_override(host, args) {
         return answer;
@@ -403,15 +461,24 @@ pub fn run(host: &HostDef, cli: &CliInfo, args: &[&str]) -> Result<Value, String
     } else {
         cli_script_posix(&cli.path, args)
     };
-    let stdout = run_script(host, &script, "thurbox-cli")?;
+    let stdout = run_script_classified(host, &script, "thurbox-cli")?;
     serde_json::from_str(&stdout).map_err(|e| {
-        format!(
-            "thurbox-cli on '{}' printed no JSON for `{}` ({e}): {}",
-            host.name,
-            args.join(" "),
-            stdout.trim()
+        // It ran and said something; that something is not what this build
+        // knows how to read. The host may well have done the thing.
+        RunFailure::new(
+            format!(
+                "thurbox-cli on '{}' printed no JSON for `{}` ({e}): {}",
+                host.name,
+                args.join(" "),
+                stdout.trim()
+            ),
+            Reach::Undetermined,
         )
     })
+}
+
+pub fn run(host: &HostDef, cli: &CliInfo, args: &[&str]) -> Result<Value, String> {
+    run_classified(host, cli, args).map_err(String::from)
 }
 
 /// The `sh` line for one CLI invocation. Every argument is POSIX-quoted, and
@@ -436,6 +503,32 @@ pub(crate) fn cli_script_windows(cli: &str, args: &[&str]) -> String {
 /// Run a script on the host in its own dialect and return stdout, with a
 /// failure carrying the host's cleaned stderr.
 fn run_script(host: &HostDef, script: &str, action: &str) -> Result<String, String> {
+    run_script_classified(host, script, action).map_err(String::from)
+}
+
+/// [`run_script`] keeping the layer that failed. See [`Reach`].
+///
+/// The classification is entirely structural:
+///
+/// - the launcher would not start at all — no `ssh`/`wsl.exe` on this machine,
+///   or it could not be executed — so nothing left this machine: `Unreached`.
+/// - `ssh` exited **255**, which is its documented code for "an error
+///   occurred" *in ssh*. It passes a remote command's own status through
+///   untouched (a remote `exit 7` exits 7), and `thurbox-cli` only ever exits
+///   1, 2 or 3 ([`crate::cli::EXIT_ERROR`] and friends), so 255 cannot be the
+///   host CLI answering: `Unreached`.
+/// - the host CLI answered on stdout with the structured `{"error": …}` every
+///   remote invocation asks for: `Answered`.
+/// - anything else — a shell that could not find the binary (127), a host
+///   running something that is not thurbox, stderr from a layer nobody here
+///   owns: `Undetermined`.
+///
+/// `wsl.exe` has no 255 convention of its own, so a WSL host is never
+/// classified `Unreached` by exit status — only by a launcher that would not
+/// start. That is the honest limit rather than a guess, and it costs little:
+/// `wsl.exe` runs on this machine, so "could not reach it" is a far narrower
+/// condition there than it is over a network.
+fn run_script_classified(host: &HostDef, script: &str, action: &str) -> Result<String, RunFailure> {
     let mut command = if host.is_windows() {
         crate::git::host_powershell_c(host, script)
     } else {
@@ -445,7 +538,12 @@ fn run_script(host: &HostDef, script: &str, action: &str) -> Result<String, Stri
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .output()
-        .map_err(|e| format!("could not start {action} on '{}': {e}", host.name))?;
+        .map_err(|e| {
+            RunFailure::new(
+                format!("could not start {action} on '{}': {e}", host.name),
+                Reach::Unreached,
+            )
+        })?;
     if !output.status.success() {
         let stderr = crate::git::reportable_stderr(&output.stderr);
         let stderr = stderr
@@ -459,24 +557,70 @@ fn run_script(host: &HostDef, script: &str, action: &str) -> Result<String, Stri
         // value of delegating to the host in the first place. stderr is still
         // read first: a transport failure — ssh could not connect, the shell
         // could not find the binary — never reaches the CLI at all.
+        let answered = reported_error(&output.stdout);
         let reported = if stderr.is_empty() {
-            reported_error(&output.stdout)
+            answered.clone()
         } else {
             Some(stderr.to_string())
         };
-        return Err(reported.unwrap_or_else(|| {
-            format!(
-                "{action} on '{}' failed (exit {})",
-                host.name,
-                output
-                    .status
-                    .code()
-                    .map_or("?".to_string(), |c| c.to_string())
-            )
-        }));
+        let code = output.status.code();
+        let reach = classify_failure(host.is_wsl(), code, answered.is_some());
+        return Err(RunFailure::new(
+            reported.unwrap_or_else(|| {
+                format!(
+                    "{action} on '{}' failed (exit {})",
+                    host.name,
+                    code.map_or("?".to_string(), |c| c.to_string())
+                )
+            }),
+            reach,
+        ));
     }
     Ok(String::from_utf8_lossy(&output.stdout).into_owned())
 }
+
+/// `ssh`'s own failure code. ssh(1): "exits with the exit status of the remote
+/// command or with 255 if an error occurred" — so this value, and only this
+/// value, is ssh saying the failure was its own rather than the host's.
+const SSH_ERROR_EXIT: i32 = 255;
+
+/// Which layer a failed remote invocation failed at, from the exit status and
+/// whether the host CLI wrote its structured answer. See [`Reach`].
+///
+/// Structural, in this order:
+///
+/// 1. only `ssh` owns 255, and `wsl.exe` has no such convention, so a WSL host
+///    is never called `Unreached` on a status alone;
+/// 2. the `{"error": …}` document is positive proof `thurbox-cli` ran;
+/// 3. failing that, an exit code that is one of the CLI's *own*
+///    ([`CLI_EXIT_CODES`]) still says something thurbox-shaped ran and refused
+///    — which matters because a host on an older build reported its failures
+///    on stderr rather than as that document, and reading such a refusal as
+///    "nothing answered" is what would let it be overridden.
+///
+/// Anything left over — 127 from a shell that could not find the binary, a
+/// host running something else entirely, no status at all — is
+/// [`Reach::Undetermined`]: its own answer, never rounded to the nearest of
+/// the other two.
+fn classify_failure(is_wsl: bool, code: Option<i32>, answered: bool) -> Reach {
+    if !is_wsl && code == Some(SSH_ERROR_EXIT) {
+        return Reach::Unreached;
+    }
+    if answered || code.is_some_and(|c| CLI_EXIT_CODES.contains(&c)) {
+        return Reach::Answered;
+    }
+    Reach::Undetermined
+}
+
+/// Every code `thurbox-cli` exits with of its own accord. A status outside
+/// this set did not come from the host's thurbox.
+///
+/// Spelled out rather than imported: `session_ops` may not reference `cli`
+/// (`tests/architecture_rules.rs`). These are `cli::EXIT_ERROR`,
+/// `cli::EXIT_USAGE` and `cli::EXIT_AMBIGUOUS`, and
+/// `cli::tests::host_cli_knows_every_exit_code_this_binary_uses` fails if they
+/// ever drift apart.
+pub(crate) const CLI_EXIT_CODES: [i32; 3] = [1, 2, 3];
 
 /// Pull the message out of a failed host CLI's stdout.
 ///
@@ -621,7 +765,7 @@ pub(crate) mod fake {
     use super::Usable;
     use crate::session::HostDef;
 
-    type Runner = Box<dyn Fn(&HostDef, &[String]) -> Result<Value, String>>;
+    type Runner = Box<dyn Fn(&HostDef, &[String]) -> Result<Value, super::RunFailure>>;
 
     thread_local! {
         static USABLE: RefCell<Option<Usable>> = const { RefCell::new(None) };
@@ -653,7 +797,26 @@ pub(crate) mod fake {
         USABLE.with(|u| u.borrow().clone())
     }
 
-    pub(super) fn run_override(host: &HostDef, args: &[&str]) -> Option<Result<Value, String>> {
+    /// A failure that never reached the host, as a test would script it.
+    pub fn unreached(message: &str) -> super::RunFailure {
+        super::RunFailure::new(message.to_string(), super::Reach::Unreached)
+    }
+
+    /// A failure the host itself answered with.
+    pub fn answered(message: &str) -> super::RunFailure {
+        super::RunFailure::new(message.to_string(), super::Reach::Answered)
+    }
+
+    /// A failure whose layer could not be told — the case a caller must never
+    /// quietly round to one of the other two.
+    pub fn undetermined(message: &str) -> super::RunFailure {
+        super::RunFailure::new(message.to_string(), super::Reach::Undetermined)
+    }
+
+    pub(super) fn run_override(
+        host: &HostDef,
+        args: &[&str],
+    ) -> Option<Result<Value, super::RunFailure>> {
         let args: Vec<String> = args.iter().map(|a| a.to_string()).collect();
         RUNNER.with(|r| {
             let runner = r.borrow();
@@ -678,6 +841,53 @@ pub(crate) mod fake {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Which layer failed, decided from the exit status and whether the host
+    /// CLI wrote its own structured answer — never from the message. The two
+    /// wrong answers cost differently and both are silent: a transport failure
+    /// read as a reply leaves an orphaned agent nobody looks for again, and a
+    /// reply read as a transport failure authorises a destructive local
+    /// teardown against a host that was perfectly fine.
+    #[test]
+    fn a_failed_remote_call_is_classified_by_layer_not_by_message() {
+        // ssh's own code, and only ssh's: it passes a remote command's status
+        // through untouched, and thurbox-cli only ever exits 1, 2 or 3.
+        assert_eq!(
+            classify_failure(false, Some(SSH_ERROR_EXIT), false),
+            Reach::Unreached
+        );
+        // Even when the host CLI would have had something to say: nothing ran
+        // there to say it.
+        assert_eq!(
+            classify_failure(false, Some(SSH_ERROR_EXIT), true),
+            Reach::Unreached
+        );
+        // `wsl.exe` has no 255 convention, so the same status proves nothing.
+        assert_eq!(
+            classify_failure(true, Some(SSH_ERROR_EXIT), false),
+            Reach::Undetermined
+        );
+        // The structured `{"error": …}` document is positive proof the CLI ran.
+        assert_eq!(classify_failure(false, Some(1), true), Reach::Answered);
+        // An exit code of the CLI's own still says something thurbox-shaped
+        // refused, even on a build too old to write the structured document.
+        for code in [Some(1), Some(2), Some(3)] {
+            assert_eq!(
+                classify_failure(false, code, false),
+                Reach::Answered,
+                "exit {code:?} is one thurbox-cli gives of its own accord"
+            );
+        }
+        // A shell that could not find the binary (127), a host running
+        // something else, a signal: reached or not, nothing here can tell.
+        for code in [Some(127), Some(126), Some(9), None] {
+            assert_eq!(
+                classify_failure(false, code, false),
+                Reach::Undetermined,
+                "exit {code:?} says nothing about which layer failed"
+            );
+        }
+    }
 
     fn cli(version: &str, schema: Option<u32>) -> CliInfo {
         CliInfo {

--- a/src/session_ops/mod.rs
+++ b/src/session_ops/mod.rs
@@ -23,8 +23,8 @@ pub mod spawn;
 pub use builtin::{builtin_extension, ensure_builtin_extensions, Builtin};
 pub use builtin_hooks::hooks_enabled;
 pub use delete::{
-    delete_session_headless, reap_overdue_soft_deletes, reap_soft_deleted, ForceDeleteReport,
-    UNDO_WINDOW,
+    delete_session_headless, reap_overdue_soft_deletes, reap_soft_deleted,
+    retry_owed_remote_teardowns, ForceDeleteReport, UNDO_WINDOW,
 };
 pub use extensions::{
     activate_extension, deactivate_extension, ensure_extension, extension_health,

--- a/src/session_ops/shared_tests.rs
+++ b/src/session_ops/shared_tests.rs
@@ -80,7 +80,7 @@ fn rig() -> Rig {
         match words.as_slice() {
             ["session", "create", rest @ ..] => {
                 if let Some(refusal) = host.refuse_create.take() {
-                    return Err(refusal);
+                    return Err(fake::answered(&refusal));
                 }
                 let name = rest
                     .windows(2)
@@ -108,7 +108,7 @@ fn rig() -> Rig {
                 if !host.active.iter().any(|s| s.id == id) {
                     // Word for word what the host's own resolver answers for a
                     // row it does not hold — see `cli::session_ref::resolve`.
-                    return Err(format!("Session not found: {id}"));
+                    return Err(fake::answered(&format!("Session not found: {id}")));
                 }
                 host.active.retain(|s| s.id != id);
                 let force = rest.contains(&"--force");
@@ -129,7 +129,10 @@ fn rig() -> Rig {
                 host.active.push(host_session(id, "back"));
                 Ok(json!({ "restored": true, "worktrees_wanted": 1, "worktrees_recovered": 1 }))
             }
-            other => Err(format!("unscripted host command: {}", other.join(" "))),
+            other => Err(fake::answered(&format!(
+                "unscripted host command: {}",
+                other.join(" ")
+            ))),
         }
     }));
     Rig {
@@ -423,7 +426,7 @@ fn any_other_refusal_from_the_host_still_aborts_the_delete() {
     let mut row = host_session(id, "wedged");
     row.backend_type = BACKEND.into();
     rig.db.upsert_session(&row).unwrap();
-    fake::install_runner(Box::new(|_, _| Err("worktree is locked".into())));
+    fake::install_runner(Box::new(|_, _| Err(fake::answered("worktree is locked"))));
 
     let err = super::delete_session_headless(&rig.db, id, true).unwrap_err();
     assert_eq!(err, "worktree is locked");

--- a/src/storage/schema/migrations.rs
+++ b/src/storage/schema/migrations.rs
@@ -915,3 +915,17 @@ pub(super) fn migrate_v44_reports_as(conn: &Connection) -> rusqlite::Result<()> 
 pub(super) fn migrate_v45_host_updated_at(conn: &Connection) -> rusqlite::Result<()> {
     add_column_if_absent(conn, "sessions", "host_updated_at", "INTEGER")
 }
+
+/// See [`super::SCHEMA_VERSION`] v46: a force delete whose remote teardown
+/// never reached its host still owes one. `0` on every existing row — a
+/// database upgraded from v45 cannot say which of its past force deletes left
+/// something running on a host, and inventing an owed teardown for all of them
+/// would send the sweep after windows that are long gone.
+pub(super) fn migrate_v46_teardown_owed(conn: &Connection) -> rusqlite::Result<()> {
+    add_column_if_absent(
+        conn,
+        "sessions",
+        "teardown_owed",
+        "INTEGER NOT NULL DEFAULT 0",
+    )
+}

--- a/src/storage/schema/mod.rs
+++ b/src/storage/schema/mod.rs
@@ -41,8 +41,15 @@ use rusqlite::Connection;
 /// live restore by comparing those two directly conflates two clocks that can
 /// be skewed against each other; comparing the host's new `updated_at`
 /// against this snapshot instead orders two readings of the *same* clock.
+/// v46 adds `teardown_owed` to `sessions`: a force delete whose remote
+/// teardown never reached its host still owes one. The kill and the worktree
+/// removals happen on the host, an unreachable host is an ordinary reason to
+/// force-delete, and a `force_deleted` row is skipped by every reaper — so the
+/// one-shot best-effort attempt was the only one that would ever be made, and
+/// the agent it failed to kill outlived the session forever. The mark is what
+/// lets the sweep come back for it.
 /// Gaps in the step table are fine (there is no v18 step either).
-pub const SCHEMA_VERSION: u32 = 45;
+pub const SCHEMA_VERSION: u32 = 46;
 
 /// A single migration step: applied when the stored version is below `target`.
 type MigrationStep = (u32, fn(&Connection) -> rusqlite::Result<()>);
@@ -116,6 +123,7 @@ pub fn initialize(conn: &Connection) -> rusqlite::Result<()> {
             stopped_at        INTEGER,
             reports_as        TEXT,
             host_updated_at   INTEGER,
+            teardown_owed     INTEGER NOT NULL DEFAULT 0,
             created_at        INTEGER NOT NULL,
             updated_at        INTEGER NOT NULL,
             deleted_at        INTEGER
@@ -358,6 +366,7 @@ fn migrate(conn: &Connection) -> rusqlite::Result<()> {
         (43, migrate_v43_session_events),
         (44, migrate_v44_reports_as),
         (45, migrate_v45_host_updated_at),
+        (46, migrate_v46_teardown_owed),
     ];
 
     for &(target, step) in steps {
@@ -614,6 +623,46 @@ mod tests {
             .exists([])
             .unwrap();
         assert!(has_description, "description column should be added at v26");
+
+        let version: String = conn
+            .query_row(
+                "SELECT value FROM metadata WHERE key = 'schema_version'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(version, SCHEMA_VERSION.to_string());
+    }
+
+    #[test]
+    fn migrate_from_v45_adds_teardown_owed_column() {
+        let conn = Connection::open_in_memory().unwrap();
+        // Minimal v45 state: a sessions table without the teardown_owed column.
+        conn.execute_batch(
+            "CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+             INSERT INTO metadata (key, value) VALUES ('schema_version', '45');
+             CREATE TABLE sessions (
+                id TEXT PRIMARY KEY, name TEXT NOT NULL,
+                created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL,
+                deleted_at INTEGER);
+             INSERT INTO sessions (id, name, created_at, updated_at, deleted_at)
+                VALUES ('a', 'old', 0, 0, 1);",
+        )
+        .unwrap();
+
+        migrate(&conn).unwrap();
+
+        // An upgraded database cannot say which of its past force deletes left
+        // something running on a host, so none of them owe a teardown: the
+        // sweep must not go hunting windows that have long since gone.
+        let owed: i64 = conn
+            .query_row(
+                "SELECT teardown_owed FROM sessions WHERE id = 'a'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(owed, 0, "existing rows owe nothing at v46");
 
         let version: String = conn
             .query_row(

--- a/src/storage/sessions.rs
+++ b/src/storage/sessions.rs
@@ -85,6 +85,12 @@ pub struct DeletedSessionInfo {
     /// rather than created (`created_by_thurbox`, schema v42): the teardown
     /// skipped every one, so nothing was lost and the restore is not refused.
     pub force_deleted: bool,
+    /// Whether this row's teardown never reached the host it was owed on
+    /// (schema v46), so the sweep must come back for it. Only a remote session
+    /// can owe one: the kill and the worktree removals happen on the host, and
+    /// a host that was down at delete time is the whole reason the attempt
+    /// failed. Cleared the moment the host answers.
+    pub teardown_owed: bool,
     pub worktrees: Vec<SharedWorktree>,
 }
 
@@ -286,6 +292,38 @@ impl Database {
         tx.commit()
     }
 
+    /// Record whether a deleted row still owes a teardown on the host it lived
+    /// on (schema v46).
+    ///
+    /// Set when a force delete could not reach that host, cleared when a later
+    /// attempt does. No session event: this is bookkeeping about a delete that
+    /// already happened and was already announced, not a change of what the
+    /// session *is* — a watcher told the session went away twice would have to
+    /// decide which telling was the real one.
+    pub fn set_teardown_owed(&self, id: SessionId, owed: bool) -> rusqlite::Result<()> {
+        self.conn.execute(
+            "UPDATE sessions SET teardown_owed = ?2 WHERE id = ?1",
+            params![id.to_string(), i64::from(owed)],
+        )?;
+        Ok(())
+    }
+
+    /// The force-deleted rows whose teardown never reached their host, oldest
+    /// delete first — the sweep's worklist.
+    ///
+    /// Force-deleted only, and that is the safety property rather than an
+    /// optimisation: a *soft*-deleted row is restorable for its undo window and
+    /// its windows are the reaper's to take at the end of it, so a second sweep
+    /// killing them on its own schedule would turn undo into a lie.
+    pub fn list_owed_teardowns(&self) -> rusqlite::Result<Vec<DeletedSessionInfo>> {
+        let mut rows = self.query_deleted_sessions(
+            "s.deleted_at IS NOT NULL AND s.force_deleted = 1 AND s.teardown_owed = 1",
+            [],
+        )?;
+        rows.reverse();
+        Ok(rows)
+    }
+
     /// Upgrade an **already-deleted** row to force-deleted: its window and
     /// worktrees turned out to be gone after all (a mirror pass learning what
     /// the owning host did). A row that is not deleted, or already marked, is
@@ -321,8 +359,11 @@ impl Database {
 
         // Clear `force_deleted` defensively — the app layer blocks restoring a
         // force-deleted row, so this only matters if a future caller revives one.
+        // `teardown_owed` goes with it: a row that is alive again has no orphan
+        // for the sweep to collect, and its windows are not the sweep's to kill.
         let restored = self.conn.execute(
-            "UPDATE sessions SET deleted_at = NULL, force_deleted = 0, updated_at = ?1 WHERE id = ?2 AND deleted_at IS NOT NULL",
+            "UPDATE sessions SET deleted_at = NULL, force_deleted = 0, teardown_owed = 0, \
+             updated_at = ?1 WHERE id = ?2 AND deleted_at IS NOT NULL",
             params![now, id_str],
         )?;
 
@@ -786,7 +827,7 @@ impl Database {
              s.cwd, s.parent_session_id, s.deleted_at, s.backend_type, \
              s.force_deleted, s.backend_id, s.shell_backend_id, \
              w.repo_path, w.worktree_path, w.branch, w.created_by_thurbox, \
-             s.host_updated_at \
+             s.host_updated_at, s.teardown_owed \
              FROM sessions s \
              LEFT JOIN worktrees w ON s.id = w.session_id \
              WHERE {condition} \
@@ -810,6 +851,7 @@ impl Database {
             let wt_branch: Option<String> = row.get(13)?;
             let wt_mine: Option<bool> = row.get(14)?;
             let host_updated_at: Option<i64> = row.get(15)?;
+            let teardown_owed: i64 = row.get(16)?;
 
             let worktree = worktree_from_cols(wt_repo, wt_path, wt_branch, wt_mine);
 
@@ -827,6 +869,7 @@ impl Database {
                     deleted_at: deleted_at as u64,
                     host_updated_at: host_updated_at.map(|at| at as u64),
                     force_deleted: force_deleted != 0,
+                    teardown_owed: teardown_owed != 0,
                     worktrees: Vec::new(),
                 },
                 worktree,

--- a/tests/shared_sessions.rs
+++ b/tests/shared_sessions.rs
@@ -6,6 +6,7 @@
 //! faked, so the tests stop where a host would be needed.
 
 use std::path::PathBuf;
+use std::process::Command as ProcessCommand;
 
 use serde_json::json;
 use thurbox::cli::sessions::{run, Action};
@@ -16,6 +17,18 @@ use thurbox::storage::Database;
 use thurbox::sync::SharedSession;
 
 const BACKEND: &str = "ssh:devbox";
+
+/// `register` shells out to list windows on this machine's tmux server, so
+/// the refusal it gives only exercises "no live window" where a `tmux`
+/// binary exists to ask; on a runner without one (Windows CI) the call fails
+/// before it gets that far, the same gate other tmux-backed tests use.
+fn have_tmux() -> bool {
+    ProcessCommand::new("tmux")
+        .arg("-V")
+        .output()
+        .map(|out| out.status.success())
+        .unwrap_or(false)
+}
 
 fn row(id: SessionId, name: &str, backend: &str) -> SharedSession {
     SharedSession {
@@ -103,6 +116,10 @@ fn register_records_only_a_window_that_is_running() {
     // No tmux server is reachable from a test, so the one answer `register`
     // can give is the refusal — which is the property: it records, it never
     // launches, and it will not invent a row for a window that is not there.
+    if !have_tmux() {
+        eprintln!("skipping: tmux is not installed");
+        return;
+    }
     let db = Database::open_in_memory().unwrap();
     let id = SessionId::default();
     let body = mirror::session_to_json(&row(id, "elsewhere", "local-tmux"), None, None, None);


### PR DESCRIPTION
## Intent

Captain's words, 2026-09-07:

"Also for thurbox when handling deletion of remote session, I want to ensure that
remote process are properly killed also"

He approves every merge himself - do not merge.

## What Changed

- Reworked remote session delete/teardown so that when a host cannot be reached at delete time, the local database still records the failure and a background sweep (`retry_owed_remote_teardowns`, wired into the automation tick and the `Reap` command) finishes killing the remote tmux windows and removing worktrees once the host answers again.
- Introduced a `Reach` classification (`Unreached` / `Answered` / `Undetermined`) in `session_ops/host_cli.rs` (`run_classified`, `RunFailure`) so the delete path decides "take it from here" vs "abort" based on which layer failed (launcher/ssh/CLI) rather than by pattern-matching error text; `session_ops/delete.rs` now distinguishes `host_unreachable` from `host_unknown` and `remote_teardown_error`/`remote_teardown_owed`.
- Added `TmuxBackend::discover_answered` (and `agent/tmux.rs` helpers `listing_is_absence`/`mux_answered_absent`) so a remote `list-windows` failure is only treated as "no windows" when the multiplexer explicitly answered "nothing here," not when the host was simply unreachable; used by `agent_window` and `kill_remote_windows`.
- Added schema v46 (`teardown_owed` column on `sessions`, migration + `list_owed_teardowns`/`set_teardown_owed` in storage) to persist which force-deleted sessions still owe a remote teardown, surfaced through `thurbox-cli session delete`/`list-deleted` output.
- Updated `thurbox-remote-hosts`, `thurbox-cli`, `thurbox-testing` skills, `docs/ARCHITECTURE.md`/`docs/FEATURES.md`, and `scripts/dev/e2e/linux-container.sh` to document and exercise the new reachability-aware teardown/retry behavior.

## Risk Assessment

✅ Low: The change implements the intent (kill remote processes on session delete, including when the host is unreachable) with a carefully layered reachability classification (Reach::Unreached/Answered/Undetermined, mux_answered_absent), an owed-teardown DB column plus retry sweep, and a matching e2e/unit test suite; all three findings accepted in the prior review round were correctly and precisely addressed (agent_window now uses discover_answered, delegated-delete falls through on Unreached/Undetermined but still aborts on Answered, and the e2e script restores hosts.toml via a RETURN trap on every exit path), with docs updated to match.

## Testing

Baseline `cargo nextest run --all` already passed; on top of that, 6 focused unit tests for this round's fixes pass, and a real container-based e2e run demonstrates the end-user behavior directly — a remote agent process force-deleted while its host is unreachable is actually killed once the host comes back, and restart --if-missing no longer spawns a duplicate agent window when a host is merely unreachable — with only the known, pre-existing, unrelated GLIBC-mismatch failure in the unrelated shared_sessions_probe.

<details>
<summary>Evidence: linux-container.sh test — remote_teardown_probe + restart_if_missing_probe live-process evidence</summary>

```text
==> asserting an owed remote teardown is finished when the host comes back
ok the agent process (290) is running on the container
WARN thurbox::session_ops::delete: could not kill the remote window of 'e2e-teardown' on ssh:podman: ... ssh: connect to host localhost port 59999: Connection refused
ok force-delete still works against a host that is down
ok the delete says the teardown is owed, not merely failed
ok no kill was claimed for a question the host never received
ok the agent is still running, and thurbox knows it has unfinished business
ok the orphaned window was killed once the host answered
ok and the agent process it was running is gone
ok the row no longer owes a teardown
==> asserting --if-missing refuses to relaunch when the host cannot be reached
ok restart --if-missing refuses rather than guessing when the host is unreachable
ok no second agent window was started while the host looked unreachable
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (14m49s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"6d47c76f818db29c2a2ddfeccf00c0b17c7d63e8","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `scripts/dev/e2e/linux-container.sh:216` - The strongest, most direct evidence for the user&#39;s intent (&#34;ensure remote processes are properly killed&#34;) is the new scripts/dev/e2e/linux-container.sh remote_teardown_probe/restart_if_missing_probe: it creates a real remote agent process in a container, force-deletes while unreachable, brings the host back, and asserts via `kill -0` and `tmux list-windows` on the container that the window and process are actually gone. I could not run it because `cmd_up` does `podman rm -f thurbox-remote` unconditionally, and a container named `thurbox-remote` (port 2233) is already running on this machine, created independently of this worktree/gate run — force-removing it to run the probe would destroy state I don&#39;t own and can&#39;t confirm is disposable. All logic-level unit tests covering the same fix (classification, fallback, sweep bookkeeping) pass, but that is not the live-process evidence the user&#39;s intent calls for. Recommend running `scripts/dev/e2e/linux-container.sh up &amp;&amp; scripts/dev/e2e/linux-container.sh test` in an environment where that container name is free (or after confirming the existing one can be discarded) before relying on this as fully verified end-to-end.
- `cargo nextest run --all`
- `cargo nextest run --lib -E 'test(owes_remote_teardown) or test(owed_teardown) or test(teardown_probe) or test(mux_answered_absent) or test(listing_is_absence) or test(host_cli_knows_every_exit_code) or test(force_delete_that_could_not_reach) or test(local_force_delete_owes_nothing) or test(restoring_a_row_clears) or test(owed_worklist_never_includes) or test(host_is_not_configured)' — 7 passed`
- `cargo nextest run --lib -E 'test(the_multiplexers_own_refusal) or test(socket_that_cannot_be_opened) or test(ssh_failing_on_its_own_account) or test(a_delete_taken_while_the_host_was_unusable) or test(any_other_refusal_from_the_host_still_aborts) or test(a_delete_the_host_does_not_know) or test(host_cli_knows_every_exit_code) or test(host_cli::)' — 20 passed`
- `cargo nextest run --lib -E 'test(mux_answered_absent) or test(a_socket_that_cannot_be_opened) or test(ssh_failing_on_its_own_account)' — 2 passed`
- `cargo nextest run --lib -E 'test(only_the_multiplexers_own_refusal)' — 1 passed`
- <code>Manual inspection: confirmed scripts/dev/e2e/linux-container.sh&#39;s remote_teardown_probe/restart_if_missing_probe exist and assert real process/window death via ssh + tmux list-windows/kill -0, but declined to run `up`/`test` because it would force-remove a pre-existing, non-worktree-owned podman container named thurbox-remote</code>

🔧 Fix: verify: e2e teardown/restart probes pass, no code fix needed
✅ Re-checked - no issues remain.
- `cargo nextest run --all`
- `cargo nextest run --lib agent::tmux::tests::only_the_multiplexers_own_refusal_counts_as_an_empty_answer agent::tmux::tests::a_socket_that_cannot_be_opened_is_not_a_server_that_is_not_there agent::tmux::tests::ssh_failing_on_its_own_account_is_never_absence session_ops::delete::tests::a_delegated_delete_falls_back_locally_when_the_host_cannot_be_reached session_ops::delete::tests::a_delegated_delete_falls_back_on_a_failure_it_cannot_classify session_ops::delete::tests::a_delegated_delete_still_aborts_when_the_host_answers_with_an_error`
- `scripts/dev/e2e/linux-container.sh up`
- `scripts/dev/e2e/linux-container.sh test (remote_teardown_probe, restart_if_missing_probe, shared_sessions_probe)`
- `scripts/dev/e2e/linux-container.sh clean`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
