### PR TITLE
docs: add required interface delta section to thurview skill

### DIFF
--- a/.agents/skills/thurview/SKILL.md
+++ b/.agents/skills/thurview/SKILL.md
@@ -53,6 +53,8 @@ conflict.
 `thurview scaffold` lists the ones it found under `guidance`.
 
 Read [Document authoring](references/document-authoring.md) before you write.
+Read [Interface delta](references/interface-delta.md) before you write the
+section that says what the change did to the system's public surfaces.
 Read [Components](references/components.md) before you edit `data.yaml` or add
 a fenced component. Read [Lifecycle](references/lifecycle.md) for statuses,
 storage and thread rules. Read [Software map](references/software-map.md)
@@ -108,14 +110,29 @@ gap is the most valuable finding.
 Read every range you anchor from the pinned commit, not the working tree:
 `git show <head>:<path>` or `git show <base>:<path>`.
 
-### 4. Author the document
+### 4. Derive the interface delta
+
+Sweep the diff once per surface kind — exported symbols, command line,
+routes and message kinds, formats and schemas, configuration, extension
+points, packaging — and collect every named surface that base and head
+disagree about. Keep the ones a consumer outside the changed unit binds to
+by name; drop the rest. Anchor each one at the surface itself: at head for
+an addition or a change, at base for a removal.
+
+That becomes the document's `Interface delta` section, which is required
+and sits above every other section. When no surface moved, the section says
+so — that is a finding, not a gap to fill. Read
+[Interface delta](references/interface-delta.md) for the inclusion test,
+the three groups, and what to write when nothing moved.
+
+### 5. Author the document
 
 Edit `review.md` and `data.yaml` in the review directory following
 [Document authoring](references/document-authoring.md). Keep it short.
 Default to anchor links for evidence; use an inline peek only when the reader
 must see the code to follow the main claim.
 
-### 5. Theme the review after the project
+### 6. Theme the review after the project
 
 Read [Theme](references/theme.md). Decide the look in its order: what the
 user asked for, then the reviewed project's own design system read from its
@@ -123,7 +140,7 @@ files at head, then the default skin. Write `theme.yaml` in the review
 directory when steps 1 or 2 yield tokens; leave it empty otherwise. Say
 which source you used when you hand over the review.
 
-### 6. Author the map
+### 7. Author the map
 
 Dispatch one sub-agent to write `map.yaml` per
 [Software map](references/software-map.md) while you write the document, with
@@ -147,7 +164,7 @@ report the errors you could not fix.
 Without a sub-agent facility, write the map yourself after the document, or
 leave `nodes: []` and say the map is not published.
 
-### 7. Publish
+### 8. Publish
 
 ```sh
 thurview publish --review <id>
@@ -155,7 +172,7 @@ thurview publish --review <id>
 
 Read every row of `diagnostics`. Fix each `error` and publish again. A
 `warning` does not block. `publish` refuses (code `THREADS_OPEN`) when a
-submitted comment thread is still open (see step 9). On success `published`
+submitted comment thread is still open (see step 10). On success `published`
 carries `rev` and `url`; the status becomes `awaiting-review`.
 
 Then open it for the reader:
@@ -166,7 +183,7 @@ thurview open --review <id>            # prints url; --view files|commits|map
 
 Give the user the `url` from the output.
 
-### 8. Wait for the reader
+### 9. Wait for the reader
 
 ```sh
 thurview wait --review <id>
@@ -180,13 +197,13 @@ threads that need you:
   not change the document for a question. Wait again.
 - `awaiting-agent-updates`: the reader submitted with "Request changes".
   `threads` lists what to address and `wait.decision` the summary. Go to
-  step 9.
+  step 10.
 - `accepted`: approved. Report and stop.
 - `review-dismissed` or `review-deleted`: stop.
 - error `TIMEOUT` (exit code 1, after `--timeout` seconds, default 3600):
   wait again, or report that the reader has not responded.
 
-### 9. Address requested changes
+### 10. Address requested changes
 
 For each thread in `thurview threads list --review <id> --open`:
 
@@ -199,7 +216,7 @@ For each thread in `thurview threads list --review <id> --open`:
 - `thurview threads resolve <threadId> --review <id>` once the requested
   change is present. Do not resolve a thread you did not address.
 
-Then publish again (step 7), and wait again (step 8). A republish requires
+Then publish again (step 8), and wait again (step 9). A republish requires
 zero open submitted comment threads; questions do not block.
 
 ## Architecture reviews
@@ -214,6 +231,7 @@ other steps are the same; the Files tab shows any file at head on request.
 Report completion only when all of these hold:
 
 - The reader has the URL of a published revision.
+- The interface delta names every surface that moved, or says none did.
 - Every `error` diagnostic is resolved.
 - The map is published, or you said why it is not.
 - The review is waiting on the reader, accepted, dismissed or deleted.

--- a/.agents/skills/thurview/references/document-authoring.md
+++ b/.agents/skills/thurview/references/document-authoring.md
@@ -36,11 +36,18 @@ Support could not tell whether a locked-out user had tried at all. The
 request was "log every attempt, not only successes".
 ```
 
+Then **Interface delta**, before every other `##`. It names what the change
+did to the system's public surfaces and what capability that adds or
+removes, so the reviewer gets their first question answered without
+reconstructing it from the diff. It is required: when no surface moved, the
+section says that, which is a finding of its own. What earns an entry, how
+added, changed and removed are kept apart, and what to write when nothing
+moved are in [Interface delta](interface-delta.md).
+
 Then fewer than five further sections when practical. Pick those that fit:
 
 - requirements
 - design
-- interface change
 - lifecycle or data flow
 - state or storage
 - testing evidence

--- a/.agents/skills/thurview/references/interface-delta.md
+++ b/.agents/skills/thurview/references/interface-delta.md
@@ -1,0 +1,151 @@
+# Interface delta
+
+Every review answers the reviewer's first question before anything else:
+*what can the system do now that it could not before, and what did it
+cost?*
+
+Interfaces are the honest answer, because an interface is where a
+capability becomes visible to the rest of the system. A change that adds a
+feature almost always moves a public surface. A change that moves none is
+internal work, and saying that plainly is a real finding — it tells the
+reviewer to read the diff for structure or behaviour rather than for
+contract.
+
+The section is called **Interface delta**. It goes immediately after the
+landing section, before every other `##`, and is never `{collapsed}`.
+
+## What counts as an interface
+
+A **surface a consumer outside the changed unit binds to by name**. An
+entry earns its place only when all three hold:
+
+1. **It has a name the consumer writes down.** A symbol they import, a
+   command or flag they type, a route they call, a config key they set, an
+   event kind they match, a field they emit or parse, a column another
+   process reads back.
+2. **Base and head disagree about it.** The name, the shape, or the
+   contract behind it — a signature, a default, the set of permitted
+   values, what is guaranteed on error.
+3. **The consumer is outside the unit that changed.** Another module,
+   another process, another repository, the user. A symbol only its own
+   file calls is not an interface.
+
+The test in one question: *could a consumer's code or command line stop
+working, start working, or need editing because of this?* No means no
+entry.
+
+Not entries: a renamed private helper, a new test, a moved block, a
+reworded comment, a field with a default nobody sets, the inside of a
+function whose signature held.
+
+## Where to look
+
+Sweep the diff once per surface kind. Each leaves its own markers in the
+added and removed lines:
+
+- **Exported code**: `pub`, `export`, `__all__`, public members of a public
+  type. A widened or narrowed visibility is an entry on its own.
+- **Command line**: subcommands, flags, arguments, exit codes, and the
+  shape of what the command prints when a script parses it.
+- **Network and messaging**: routes, methods, status codes, RPC names,
+  event and message kinds.
+- **Persistence and formats**: schemas, migrations, file formats,
+  serialized field names, anything another program reads back.
+- **Configuration**: environment variables, config keys, defaults,
+  permitted values.
+- **Extension points**: hooks, plugin APIs, the traits or interfaces a
+  consumer implements.
+- **Packaging**: binary names, package exports, minimum supported
+  versions.
+
+## How to write it
+
+Three groups, in this order, and only the ones that have entries:
+
+```markdown
+## Interface delta
+
+**Removed**
+
+- `thurview publish --strict` is gone; every publish is strict now, so a
+  script passing it gets a usage error. Nothing replaces it.
+  [flag table](anchor:publish-flags)
+
+**Changed**
+
+- `thurview wait` now returns `question` only once per answered thread; a
+  poller that re-read the same question stops seeing it.
+  [dedupe check](anchor:wait-dedupe)
+
+**Added**
+
+- `thurview publish` gains `--dry-run`: validates and prints diagnostics
+  without sealing a revision. [flag registration](anchor:dry-run-flag)
+```
+
+Removed first. A removal is the most review-worthy thing a change can
+carry and must never read like an addition.
+
+Each entry is one line and carries three things:
+
+1. **The consumer's name for it**, in backticks, spelled the way the
+   consumer spells it. `thurview publish --dry-run`, not
+   `PublishOptions.dryRun`.
+2. **What it means for them** — one clause on what they can now do, must
+   now do, or can no longer do.
+3. **An anchor on the surface itself** — the declaration, the flag
+   registration, the route table, the key in the schema. Added and changed
+   entries anchor at head. A removed surface exists only at base, so its
+   anchor needs `graph: base`.
+
+A **removed** entry also says what replaces it, or that nothing does. That
+is the sentence the reviewer needs to judge whether a contract broke.
+
+## Why the anchor is the rule
+
+The anchor is what keeps this section derived rather than asserted.
+`publish` rejects an anchor whose file and lines do not exist at the pinned
+commit, so an entry that no code backs cannot ship, and one describing a
+surface that moved goes stale loudly instead of quietly.
+
+**If you cannot anchor an entry at the surface it names, it is not an
+interface change — delete it.**
+
+## When nothing moved
+
+Say so. Do not manufacture a feature. Two honest forms:
+
+```markdown
+## Interface delta
+
+No interface moved. `thurview publish` keeps its flags, its exit codes and
+its TOON shape; the change is internal to the anchor validator. Read the
+diff for structure, not for contract.
+```
+
+```markdown
+## Interface delta
+
+No interface moved. [`thurview wait`](anchor:wait-cmd) keeps its flags and
+its output; what changed is what it does when a thread was already
+answered — it no longer reports that question again. Read the diff for
+behaviour, not for contract.
+```
+
+The second form names the unchanged surface whose behaviour changed. A bug
+fix belongs there: the reviewer's question is whether the new behaviour is
+right, not what they must update.
+
+## Making the design legible
+
+With the delta on the page the reviewer can ask the questions the diff
+hides — is this surface coherent, is it minimal, does it leak internals,
+did a removal break a contract. Where the answer is evident from the
+surface itself, add one line under the groups as an observation:
+
+> The three new flags are all forms of "do not write"; one `--dry-run`
+> would cover them.
+
+State it and stop. No grade, no score, no checklist of style rules.
+thurview is a guided explanation, not a pass/fail bug hunt: an observation
+the reviewer can act on is in scope, a rubric is not.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,10 +69,12 @@ by a **relative symlink** from that CLI's own directory (`.claude/skills/<name>`
 `.agents/skills/` and symlinked, never the other way round. opencode
 auto-discovers `.claude/skills/`, so those symlinks serve it too — don't mirror
 anything under `.opencode/skills/`, which would double-register it. `thurview`
-is additionally vendored, not authored here: its body is verbatim from
+is additionally vendored rather than originated here: its body came from
 [Thurbeen/thurview](https://github.com/Thurbeen/thurview) and `skills-lock.json`
-pins the source repo, skill path and content hash so it can be verified and
-refreshed later. Slash
+pins the source repo, skill path and content hash of what was vendored. It has
+since diverged locally, so treat the lock as the record of that origin rather
+than a claim the copy still matches — a refresh from upstream has to merge the
+local edits rather than overwrite them. Slash
 commands are the one kind opencode does **not** auto-discover, so a new one goes
 in both `.claude/commands/` and `.opencode/commands/`, kept in sync by hand.
 A minimal [`opencode.json`](opencode.json) declares the `$schema` for editor


### PR DESCRIPTION
## Intent

A thurview review shows a reader the diff, the files and a map of the structure, but never what the change actually does. The operator asked: 'thurview should show features that our pr tackles, think about interfaces and clean code'. The goal is that a reviewer opening a review can see what the change did to the system's interfaces, and what capability that adds or removes, without reading the diff first.

The lens is deliberate: interfaces are where a capability becomes visible to the rest of the system, so the interface delta is the honest answer to 'what does this let us do now'. It is not a list of changed functions - that is the diff again with extra steps.

Chosen shape and the two rejected: (1) its own tab beside Map and Files was rejected because tabs live in the thurview app, not in this vendored skill, and would need a new sealed artifact and schema - the task forbids changing the publish/validation contract; (2) folding it into the Map was rejected because a parallel task owns the Map's rendering and software-map.md, and a capability node would need map.yaml schema fields the task forbids; (3) chosen: a required section of review.md above the file-level detail, which needs no schema change and no new dependency.

Requirements the section had to satisfy, all deliberate: it states the change in the consumer's terms ('thurview publish gains --dry-run', not 'added a boolean to PublishOptions'); added/changed/removed are visually distinct groups with removed FIRST because a removal is the most review-worthy thing a change can carry; it is honest when nothing moved (a pure refactor must say 'no interface moved' rather than manufacture a feature, and there is a second honest form for a bug fix that names the unchanged surface whose behaviour changed); and it is derived, not asserted - every entry carries an anchor on the surface it names, and publish already rejects an anchor whose file and lines do not exist at the pinned commit, so an entry no code backs cannot ship. A removal must anchor with graph: base, because a removed surface exists only at base. The inclusion test is stated explicitly (three conditions plus a one-question test) the way software-map.md states what makes a node worth including.

'Clean code' was read as making design quality legible, NOT as a lint score: the reference deliberately tells the author to add at most a one-line observation from the surface itself and explicitly forbids adding a rubric, a grade or a style checklist, because thurview is a guided explanation and not a pass/fail bug hunt.

Scope notes for a reviewer: this is skill documentation only - no Rust, no runtime code, no new dependency. The repo has no gate over .agents/ (rumdl excludes it, no tests reference skills), so there is no executable surface to add a test against; just lint was run and is green. The thurview skill is vendored from Thurbeen/thurview and CONTRIBUTING.md claimed its body is verbatim from upstream, which this change makes untrue, so that paragraph was corrected in the same commit to say the lock records the origin rather than a still-matching copy. Deliberately NOT touched: the Map's rendering, references/software-map.md, map.yaml's schema and thurview's publish/validation contract - a parallel task owns the Map and the task forbids the schema changes.

## What Changed

- Added `.agents/skills/thurview/references/interface-delta.md`, a new reference defining the "Interface delta" section: what counts as an interface (a three-condition test plus a one-question check), the surface kinds to sweep (exported code, command line, network/messaging, persistence/formats, configuration, extension points, packaging), the added/changed/removed grouping (removed listed first), how to anchor each entry (`graph: base` for removals, head for additions/changes), and the honest forms for "no surface moved" and for a bug fix that changes behaviour without changing a surface's shape.
- Wired the new section into the authoring flow: `SKILL.md` gains a "Derive the interface delta" step (renumbering the remaining steps from 4-9 to 5-10) and a completion-checklist line requiring the section to name every moved surface or state that none moved; `document-authoring.md` now places "Interface delta" as the required, non-collapsible section immediately after the landing section and removes the old ad hoc "interface change" bullet from the optional-sections list.
- Corrected `CONTRIBUTING.md`'s description of the vendored `thurview` skill: it no longer claims the skill body is verbatim from upstream, and instead explains that `skills-lock.json` records the vendoring origin while the local copy has since diverged, so a future refresh must merge rather than overwrite local edits.

## Risk Assessment

✅ Low: Docs-only change to a vendored skill (no Rust/runtime code, no schema or dependency changes); the new Interface delta section, its placement, ordering rules, anchor/derivation requirements, and the two honest "nothing moved" forms all match the required intent verbatim, and the SKILL.md step renumbering (4→10) and cross-references were verified internally consistent.

## Testing

This is a documentation-only change (a vendored skill's reference docs plus a CONTRIBUTING.md correction) with no Rust or runtime code and no executable surface — the repo's own lint config excludes `.agents/` and no test references skills, matching what the author's intent states. Since no automated test can exercise it, I performed manual consistency verification instead: diffed the exact file set changed, walked every renumbered step and cross-reference in SKILL.md for staleness, confirmed the new interface-delta.md file exists at its linked path with content matching the required structure (Interface delta section ordering, removed-first grouping, anchor requirements, honest 'nothing moved' forms) described in the intent, and confirmed the CONTRIBUTING.md vendoring claim was corrected in the same commit. No inconsistencies found; no findings to report.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"f3ce0279279d6c801e83f582906c3aa2a9834f3c","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `cargo nextest run --all`
- <code>`git diff efa67ca f3ce027 --stat` — confirmed only SKILL.md, references/document-authoring.md, the new references/interface-delta.md, and CONTRIBUTING.md changed; no src/, tests/, or schema files touched</code>
- <code>Manually verified `.rumdl.toml` excludes `.agents` and `grep -rln skills tests/` returns nothing, confirming the intent&#39;s claim that no gate exists over this path</code>
- `Manually walked SKILL.md's renumbered steps 1-10 and all internal cross-references ('see step 10', 'step 8', 'step 9') to confirm they were updated consistently and none were left stale`
- <code>Confirmed `references/interface-delta.md` exists at the path linked from both SKILL.md and document-authoring.md, and that the old &#39;interface change&#39; bullet was removed from document-authoring.md&#39;s section list without leaving a dangling reference</code>
- `Confirmed the vendoring paragraph in CONTRIBUTING.md was corrected in the same commit (no longer claims the thurview skill body is verbatim from upstream), matching the stated intent`
- <code>Confirmed the `.claude/skills/thurview` symlink still resolves correctly to `../../.agents/skills/thurview`</code>
- <code>`git status --porcelain` — worktree left clean, no transient artifacts</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
