### PR TITLE
fix(core): resolve local spawn commands against thurbox's own PATH, skip non-absolute PATH entries

### DIFF
--- a/.agents/skills/thurbox-testing/SKILL.md
+++ b/.agents/skills/thurbox-testing/SKILL.md
@@ -106,6 +106,14 @@ kernel over the real `ui/`** rather than a harness that imitates either:
   sees "no session" and races `new-session`, and the regression this pins is
   that a loser must not abort its whole respawn over tmux's `duplicate
   session` — it has to notice the winner's session and continue.
+- **`tests/spawn_command_resolution.rs`** (unix) — a local spawn against a *real*
+  tmux on a throwaway socket (skipped when tmux is absent): starts a server
+  whose own `PATH` lacks the agent, then spawns it through `TmuxBackend`'s
+  control-mode path with the agent only on thurbox's `PATH`. Pins the fix in
+  `resolve_local_program` (`docs/CONFIG.md` → How `command` is resolved): a
+  local window command used to be left for the multiplexer to resolve, which
+  sees the *server's* `PATH` (an attached client's is not copied in), not the
+  one thurbox itself was launched with.
 - **`tests/session_state_agreement.rs`** — one row, four independent readers
   (`session get`, `session list`, `watch --initial` via the real binary, and
   `SnapshotStore` in-process): all four must answer the same `SessionState`.

--- a/.agents/skills/thurbox-testing/SKILL.md
+++ b/.agents/skills/thurbox-testing/SKILL.md
@@ -114,6 +114,13 @@ kernel over the real `ui/`** rather than a harness that imitates either:
   local window command used to be left for the multiplexer to resolve, which
   sees the *server's* `PATH` (an attached client's is not copied in), not the
   one thurbox itself was launched with.
+- **`tests/path_resolution_absolute.rs`** (unix) — its own test binary because it
+  moves the process working directory, which a sibling test in the same binary
+  would see. Pins that `resolve_on_path` (`docs/CONFIG.md` → How `command` is
+  resolved) skips an empty `PATH` component rather than joining it as "the
+  current directory": that join used to answer with a bare relative name,
+  reintroducing the multiplexer-resolves-it dependence the function exists to
+  remove.
 - **`tests/session_state_agreement.rs`** — one row, four independent readers
   (`session get`, `session list`, `watch --initial` via the real binary, and
   `SnapshotStore` in-process): all four must answer the same `SessionState`.

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -184,6 +184,12 @@ through verbatim, exactly as before. A **remote** (SSH/WSL) session is not
 resolved either — its `PATH` is the host's; its window command is wrapped in a
 login shell instead.
 
+Only **absolute** `PATH` entries are considered. That excludes the empty entry
+POSIX reads as "the current directory" (`:/usr/bin`, or a stray trailing colon),
+because the resolved path is handed to a process with a working directory of its
+own — honouring it would let a `claude` sitting in the repo you are working on
+shadow the real one, which is the dependence this removes rather than moves.
+
 `hook_schema` is optional. Custom agents are agent-neutral, so the built-in
 **hooks** extension normally wires status hooks only for the built-ins it knows
 by name. Set `hook_schema = "claude"` on a **rebranded** agent (one whose

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -155,6 +155,35 @@ are emitted only when their driving value exists; precedence is
 fork > resume > new-session. See the seeded file's comments and
 the `thurbox-agents` skill for the `resume_latest` semantics.
 
+### How `command` is resolved
+
+For a **local** session, thurbox resolves a bare `command` against **its own
+`PATH`** and hands the multiplexer the absolute path it found. It does that
+because the multiplexer would otherwise resolve the name itself, in an
+environment thurbox neither chose nor can see:
+
+- tmux copies the *client's* `PATH` into a new pane only for an **unattached**
+  client, so a window created over thurbox's (attached) control-mode connection
+  — a restart, a plugin program, the companion shell pane — got the `PATH` of
+  whatever first started the tmux **server**.
+- a window command that reaches tmux as a **single** argument is run by tmux's
+  `default-shell`, not `execvp` — so an agent with no args was launched by a
+  shell thurbox never chose, under that shell's `PATH` and quoting.
+
+Under zsh/bash those `PATH`s agree, because the interactive additions live in
+`~/.zshenv` / `~/.profile`, which any shell that starts a tmux server sources.
+Under **fish** they do not: `fish_add_path` writes `fish_user_paths`, which only
+fish applies — so a server started from anything else never sees the agent, for
+the life of that server, and the spawn fails with a shell's `command not found`
+(exit **127**; an `execvp` failure is exit 1).
+
+Resolution is **best-effort and never a new way to fail**: a `command` that is
+already a path, that nothing on `PATH` matches (a shell function or alias, or a
+binary installed after thurbox started), or that runs on Windows is passed
+through verbatim, exactly as before. A **remote** (SSH/WSL) session is not
+resolved either — its `PATH` is the host's; its window command is wrapped in a
+login shell instead.
+
 `hook_schema` is optional. Custom agents are agent-neutral, so the built-in
 **hooks** extension normally wires status hooks only for the built-ins it knows
 by name. Set `hook_schema = "claude"` on a **rebranded** agent (one whose

--- a/src/agent/control_mode/mod.rs
+++ b/src/agent/control_mode/mod.rs
@@ -744,6 +744,21 @@ impl ControlMode {
             .take()
             .context("Failed to get control mode stdout")?;
 
+        // Consume tmux's implicit response to the `-C attach-session` command
+        // carried on argv — the one `%begin`/`%end` block tmux emits on
+        // connect that is not a reply to anything we send. This must happen
+        // synchronously, before the reader thread exists: `deliver_response`
+        // matches replies to waiters by queue position only, so if the
+        // reader thread instead raced a `send_command` no-op meant to drain
+        // this block — as this used to — whichever finished first decided
+        // whether that no-op's waiter received this block (harmless, since
+        // both are empty) or the *real* reply to the no-op did, silently
+        // shifting every later response one FIFO slot for the rest of the
+        // connection's life. Draining here, before any waiter can exist,
+        // makes that race impossible instead of merely unlikely.
+        let mut reader = BufReader::new(stdout);
+        Self::drain_implicit_attach_response(&mut reader)?;
+
         let stdin = Arc::new(Mutex::new(stdin));
         let pane_senders: PaneSendersMapShared =
             Arc::new(Mutex::new(std::collections::HashMap::new()));
@@ -763,7 +778,7 @@ impl ControlMode {
             .name("tmux-control-reader".into())
             .spawn(move || {
                 Self::reader_thread(
-                    stdout,
+                    reader,
                     reader_stdin,
                     reader_pane_senders,
                     reader_queue,
@@ -782,12 +797,6 @@ impl ControlMode {
             reader_handle: Mutex::new(Some(reader_handle)),
             child: Mutex::new(child),
         };
-
-        // Drain the implicit attach response (%begin/%end) that tmux sends
-        // when a control mode client connects. We send a no-op command and
-        // wait for its response — this synchronizes with the reader thread
-        // and guarantees all prior unsolicited responses have been consumed.
-        control.send_command("refresh-client")?;
 
         // Enable flow control (pause-after=5 seconds of buffered output).
         control.send_command("refresh-client -f pause-after=5")?;
@@ -929,6 +938,34 @@ impl ControlMode {
         Some(String::from_utf8_lossy(line_buf).into_owned())
     }
 
+    /// Synchronously consume tmux's implicit `%begin`/`%end`(`%error`) reply
+    /// to the `-C attach-session` command carried on argv, before the reader
+    /// thread (and thus any `response_queue` waiter) exists — see the call
+    /// site in [`Self::start`] for why that ordering matters. Any notification
+    /// lines ahead of the block (tmux has been observed to send `%output` /
+    /// `%session-changed` first) are harmless to skip here: nothing is
+    /// registered to receive them yet.
+    fn drain_implicit_attach_response(
+        reader: &mut BufReader<std::process::ChildStdout>,
+    ) -> Result<()> {
+        let mut line_buf = Vec::new();
+        while let Some(line) = Self::next_control_line(reader, &mut line_buf) {
+            if !matches!(parse_notification(&line), Notification::Begin) {
+                continue;
+            }
+            while let Some(line) = Self::next_control_line(reader, &mut line_buf) {
+                if matches!(
+                    parse_notification(&line),
+                    Notification::End | Notification::Error
+                ) {
+                    return Ok(());
+                }
+            }
+            bail!("control mode closed mid-way through its implicit attach response");
+        }
+        bail!("control mode closed before sending its implicit attach response");
+    }
+
     /// Background thread that reads and dispatches control mode output.
     ///
     /// Responses arrive in FIFO order matching `send_command()` calls.
@@ -938,13 +975,12 @@ impl ControlMode {
     /// blocks, but no waiter is in the queue for them — those responses are
     /// simply discarded.
     fn reader_thread(
-        stdout: std::process::ChildStdout,
+        mut reader: BufReader<std::process::ChildStdout>,
         stdin: Arc<Mutex<ChildStdin>>,
         pane_senders: PaneSendersMapShared,
         response_queue: Arc<Mutex<VecDeque<SyncSender<CommandResponse>>>>,
         sub_events: Arc<Mutex<VecDeque<(String, String)>>>,
     ) {
-        let mut reader = BufReader::new(stdout);
         // Accumulates response lines for the current in-flight command.
         let mut collecting: Option<Vec<String>> = None;
         let mut line_buf = Vec::new();

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -3360,7 +3360,7 @@ mod tests {
         use std::os::unix::fs::PermissionsExt;
         let p = dir.join(name);
         std::fs::write(&p, b"#!/bin/sh\n").unwrap();
-        std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o700)).unwrap();
         p
     }
 

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -3373,22 +3373,22 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let expected = agent_only_thurbox_can_see(dir.path(), "tbx-spawn-probe");
 
-        let saved = std::env::var_os("PATH");
-        std::env::set_var("PATH", dir.path());
-        let local = TmuxBackend::local().program_for_window("tbx-spawn-probe");
-        let free = resolve_local_program("tbx-spawn-probe");
-        // A remote host's PATH is the host's, so its command is the host's to
-        // resolve — and it is login-wrapped instead.
-        let remote = TmuxBackend::from_host(&crate::session::HostDef {
-            name: "devbox".into(),
-            destination: "me@devbox".into(),
-            ..Default::default()
-        })
-        .program_for_window("tbx-spawn-probe");
-        match saved {
-            Some(v) => std::env::set_var("PATH", v),
-            None => std::env::remove_var("PATH"),
-        }
+        // Through the shared helper: `PATH` is process state, and the unit
+        // tests that set it run concurrently under plain `cargo test`.
+        let (local, free, remote) = crate::paths::with_path(dir.path(), || {
+            (
+                TmuxBackend::local().program_for_window("tbx-spawn-probe"),
+                resolve_local_program("tbx-spawn-probe"),
+                // A remote host's PATH is the host's, so its command is the
+                // host's to resolve — and it is login-wrapped instead.
+                TmuxBackend::from_host(&crate::session::HostDef {
+                    name: "devbox".into(),
+                    destination: "me@devbox".into(),
+                    ..Default::default()
+                })
+                .program_for_window("tbx-spawn-probe"),
+            )
+        });
 
         assert_eq!(local, expected.to_string_lossy());
         assert_eq!(free, expected.to_string_lossy());

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -1181,6 +1181,18 @@ impl TmuxBackend {
         }
     }
 
+    /// The program a **local** window should launch: the agent's command,
+    /// resolved against thurbox's own `PATH` — see [`resolve_local_program`].
+    /// A remote/WSL backend passes through: its `PATH` is the *host's*, and its
+    /// window command is login-wrapped instead
+    /// ([`login_wrap_for_remote`](Self::login_wrap_for_remote)).
+    fn program_for_window(&self, command: &str) -> String {
+        if self.transport.is_remote() {
+            return command.to_string();
+        }
+        resolve_local_program(command)
+    }
+
     /// Build the shell command string to pass to tmux new-window.
     ///
     /// The whole string is interpreted by the multiplexer server's shell, so
@@ -1203,10 +1215,16 @@ impl TmuxBackend {
     /// non-login shell skips those files, so the agent binary isn't found, the
     /// window command exits 1, and the pane dies instantly — the remote session
     /// appears to "not launch". `exec` replaces the wrapper so no extra process
-    /// lingers. Local backends already inherit the user's interactive `PATH`, so
-    /// they pass through unchanged — and so does a **psmux** remote (a Windows
-    /// SSH host), which has no `/bin/sh` to wrap with (psmux windows are built by
+    /// lingers. A **psmux** remote (a Windows SSH host) passes through: it has
+    /// no `/bin/sh` to wrap with (psmux windows are built by
     /// [`psmux_window_command`] instead).
+    ///
+    /// Local backends pass through too, but **not** because they inherit the
+    /// user's interactive `PATH` — that claim used to stand here and was wrong
+    /// (see [`resolve_local_program`], which is what makes them safe now). They
+    /// are not wrapped because thurbox can resolve a local command itself, and
+    /// an absolute path needs no shell's `PATH` at all; a wrap would only add a
+    /// second shell whose own quoting rules could differ.
     ///
     /// Done here — not via tmux `default-command` — because that value round-trips
     /// through the remote transport's per-arg shell-quoting, where a `-l` flag's
@@ -1616,7 +1634,8 @@ impl SessionBackend for TmuxBackend {
         } else if is_remote_shell_pane {
             self.remote_shell_pane_command()
         } else {
-            self.login_wrap_for_remote(&Self::build_shell_command(command, args))
+            let program = self.program_for_window(command);
+            self.login_wrap_for_remote(&Self::build_shell_command(&program, args))
         };
 
         // psmux's tokenizer can't read POSIX `'\''` escapes (see
@@ -2698,6 +2717,50 @@ const SESSION_OPTS: &[(&str, &str)] = &[
     ("window-size", "manual"),
 ];
 
+/// The agent's command as an **absolute path**, resolved against thurbox's own
+/// `PATH`, so the multiplexer never has to resolve it.
+///
+/// thurbox used to hand tmux a bare name (`claude`) and let tmux find it. Which
+/// resolver ran, and with which `PATH`, was not thurbox's to choose:
+///
+/// - tmux copies the *client's* `PATH` into the new pane only for an
+///   **unattached** client (`spawn.c`: "the session one is replaced from the
+///   client … only unattached clients"). thurbox's control-mode client is
+///   attached, so [`TmuxBackend::spawn`] — a restart, a plugin program, the
+///   shell pane — got the `PATH` of whatever first started the tmux **server**.
+/// - tmux runs a window command given as a **single** argument through its
+///   `default-shell` (`spawn.c`: `execl(shell, argv0, "-c", cmd)`), and only a
+///   multi-argument one through `execvp`. So an agent with no args was launched
+///   by a shell thurbox never chose, under that shell's quoting and `PATH`.
+///
+/// Both are why a fish user saw a spawn fail where a zsh user did not. zsh and
+/// bash put their `PATH` additions in `~/.zshenv` / `~/.profile`, which any
+/// shell that starts a tmux server sources, so the server's `PATH` and the
+/// interactive one agree. fish's `fish_add_path` writes `fish_user_paths`, which
+/// **only fish** applies — so a server started from anything else never sees
+/// them, for the life of that server. And the exit status tells you which
+/// resolver spoke: `execvp` failing makes the pane exit **1**, a shell that
+/// cannot find the command exits **127**.
+///
+/// An absolute path is immune to both: `execvp` and every shell take it as-is.
+///
+/// Best-effort by design — the command is returned **unchanged** when it is
+/// already a path, when nothing on `PATH` matches, or on Windows (psmux runs
+/// its own command model, and a bare name there wants `PATHEXT` semantics this
+/// deliberately does not have). A `command` that is a shell function, an alias,
+/// or a binary installed *after* this resolves therefore behaves exactly as it
+/// did before: resolution is an improvement where it succeeds, never a new way
+/// to fail.
+pub(crate) fn resolve_local_program(command: &str) -> String {
+    if cfg!(windows) {
+        return command.to_string();
+    }
+    match crate::paths::resolve_on_path(command) {
+        Some(path) => path.to_string_lossy().into_owned(),
+        None => command.to_string(),
+    }
+}
+
 /// Spawn a new tmux window running `command` with `args` in `cwd`.
 ///
 /// Thin helper for headless callers (CLI, MCP) that don't need PTY I/O
@@ -2748,8 +2811,14 @@ pub fn spawn_window(
             tmux.args(["-e", &format!("{k}={v}")]);
         }
         // Pass the command + args as a single argv list. tmux treats trailing
-        // args as the command to run inside the window.
-        tmux.arg(command);
+        // args as the command to run inside the window. Resolved here for the
+        // same reason the control-mode path resolves it (see
+        // `resolve_local_program`): this path happens to get thurbox's own
+        // `PATH` because its client is unattached, but a session must not
+        // launch differently depending on which of the two created it — a
+        // session created here and later restarted through control mode would
+        // otherwise resolve against two different environments.
+        tmux.arg(resolve_local_program(command));
         for a in args {
             tmux.arg(a);
         }
@@ -3280,6 +3349,65 @@ mod tests {
         let p = resolve_cli_binary();
         let name = p.file_name().unwrap().to_string_lossy();
         assert_eq!(name, format!("thurbox-cli{}", std::env::consts::EXE_SUFFIX));
+    }
+
+    // --- local command resolution ---
+
+    /// An executable on a directory only *this process* has on `PATH` — the
+    /// shape an agent installed by `fish_add_path` is in.
+    #[cfg(unix)]
+    fn agent_only_thurbox_can_see(dir: &std::path::Path, name: &str) -> std::path::PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        let p = dir.join(name);
+        std::fs::write(&p, b"#!/bin/sh\n").unwrap();
+        std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o755)).unwrap();
+        p
+    }
+
+    /// The whole point of the fix: what tmux is handed must not need tmux's own
+    /// `PATH` (nor the `PATH` of the shell tmux runs a single-token command
+    /// with) to be found.
+    #[test]
+    #[cfg(unix)]
+    fn a_local_window_command_is_an_absolute_path() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let expected = agent_only_thurbox_can_see(dir.path(), "tbx-spawn-probe");
+
+        let saved = std::env::var_os("PATH");
+        std::env::set_var("PATH", dir.path());
+        let local = TmuxBackend::local().program_for_window("tbx-spawn-probe");
+        let free = resolve_local_program("tbx-spawn-probe");
+        // A remote host's PATH is the host's, so its command is the host's to
+        // resolve — and it is login-wrapped instead.
+        let remote = TmuxBackend::from_host(&crate::session::HostDef {
+            name: "devbox".into(),
+            destination: "me@devbox".into(),
+            ..Default::default()
+        })
+        .program_for_window("tbx-spawn-probe");
+        match saved {
+            Some(v) => std::env::set_var("PATH", v),
+            None => std::env::remove_var("PATH"),
+        }
+
+        assert_eq!(local, expected.to_string_lossy());
+        assert_eq!(free, expected.to_string_lossy());
+        assert_eq!(remote, "tbx-spawn-probe");
+    }
+
+    /// Best-effort: a name nothing on `PATH` matches is passed through, so a
+    /// shell function, an alias, or a binary installed after this ran keeps
+    /// working exactly as it did before.
+    #[test]
+    fn an_unresolvable_local_command_is_passed_through() {
+        assert_eq!(
+            resolve_local_program("tbx-agent-that-is-not-installed"),
+            "tbx-agent-that-is-not-installed"
+        );
+        assert_eq!(
+            resolve_local_program("/opt/My Agents/codex"),
+            "/opt/My Agents/codex"
+        );
     }
 
     // --- build_shell_command tests ---

--- a/src/paths/mod.rs
+++ b/src/paths/mod.rs
@@ -81,14 +81,50 @@ pub fn which_on_path(exe: &str) -> bool {
 /// directory named `claude` on `PATH` is not the agent, and a mode-644 file is
 /// not something `execvp` will run. Verbatim, with no `.exe`/`PATHEXT` munging
 /// — the same lookup `which_on_path` has always done.
+///
+/// A `PATH` component that is not **absolute** is skipped, which includes the
+/// empty one POSIX reads as "the current directory" (`:/usr/bin`, or a stray
+/// trailing colon — an ordinary accident in a shell config). Whose current
+/// directory is the entire question: the answer here is handed to a consumer
+/// with a working directory of its own, so a relative one would be resolved
+/// there — reintroducing exactly the dependence this exists to remove, and
+/// letting a `claude` sitting in the repo being worked on shadow the real one.
+/// Skipping is also the safe half of that choice: declining leaves the caller
+/// with the command it already had, where honouring it would silently launch a
+/// different binary.
 pub fn resolve_on_path(exe: &str) -> Option<PathBuf> {
     if exe.is_empty() || exe.contains(std::path::MAIN_SEPARATOR) || exe.contains('/') {
         return None;
     }
     let path = std::env::var_os("PATH")?;
     std::env::split_paths(&path)
+        .filter(|dir| dir.is_absolute())
         .map(|dir| dir.join(exe))
         .find(|candidate| is_executable_file(candidate))
+}
+
+/// Run `f` with `PATH` set to `path`, restoring what was there before.
+///
+/// Serialized on a process-wide lock, and the **only** way a test may set
+/// `PATH`: it is process state, and under plain `cargo test` the unit tests
+/// that need it run concurrently in one process, where interleaved writes make
+/// one test observe another's directory or restore a stale value. (`nextest`,
+/// the repo's gate, gives each test its own process — this is what keeps the
+/// other entry point honest.)
+#[cfg(test)]
+pub(crate) fn with_path<T>(path: impl AsRef<OsStr>, f: impl FnOnce() -> T) -> T {
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    // A test that panicked while holding it poisoned the lock; the value is
+    // `()`, so there is nothing to protect against and the next test may run.
+    let _guard = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let saved = std::env::var_os("PATH");
+    std::env::set_var("PATH", path.as_ref());
+    let out = f();
+    match saved {
+        Some(v) => std::env::set_var("PATH", v),
+        None => std::env::remove_var("PATH"),
+    }
+    out
 }
 
 /// Whether `p` is a file this process could `exec`.

--- a/src/paths/mod.rs
+++ b/src/paths/mod.rs
@@ -65,10 +65,49 @@ pub fn home_dir() -> Option<PathBuf> {
 /// `which` crate for a one-off probe (used to detect optional helper binaries
 /// like `wsl.exe` / `powershell.exe`); cheap PATH scan, no process spawn.
 pub fn which_on_path(exe: &str) -> bool {
-    let Ok(path) = std::env::var("PATH") else {
+    resolve_on_path(exe).is_some()
+}
+
+/// Where `exe` resolves on `PATH`, as a path a caller can hand to something
+/// that does *not* share this process's `PATH` — `agent::tmux`'s
+/// `resolve_local_program`, which hands a local window command to the
+/// multiplexer, is why this exists rather than [`which_on_path`] alone.
+///
+/// `None` when nothing matches, and also when `exe` already carries a path
+/// separator: a caller-supplied path is the caller's decision, and re-resolving
+/// it against `PATH` would be wrong (`./agent` is not `bin/./agent`).
+///
+/// The match is the file being **executable** on Unix, not merely present: a
+/// directory named `claude` on `PATH` is not the agent, and a mode-644 file is
+/// not something `execvp` will run. Verbatim, with no `.exe`/`PATHEXT` munging
+/// — the same lookup `which_on_path` has always done.
+pub fn resolve_on_path(exe: &str) -> Option<PathBuf> {
+    if exe.is_empty() || exe.contains(std::path::MAIN_SEPARATOR) || exe.contains('/') {
+        return None;
+    }
+    let path = std::env::var_os("PATH")?;
+    std::env::split_paths(&path)
+        .map(|dir| dir.join(exe))
+        .find(|candidate| is_executable_file(candidate))
+}
+
+/// Whether `p` is a file this process could `exec`.
+fn is_executable_file(p: &Path) -> bool {
+    let Ok(meta) = std::fs::metadata(p) else {
         return false;
     };
-    std::env::split_paths(&path).any(|dir| dir.join(exe).exists())
+    if !meta.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        meta.permissions().mode() & 0o111 != 0
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
 }
 
 /// Base directory for config files. `$XDG_CONFIG_HOME` wins on every platform

--- a/src/paths/tests.rs
+++ b/src/paths/tests.rs
@@ -23,7 +23,7 @@ fn executable_marker(dir: &Path, name: &str) -> PathBuf {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o700)).unwrap();
     }
     p
 }

--- a/src/paths/tests.rs
+++ b/src/paths/tests.rs
@@ -16,25 +16,91 @@ fn display_path_uses_basename() {
     );
 }
 
-#[test]
-fn which_on_path_finds_present_and_rejects_absent() {
-    let dir = tempfile::TempDir::new().unwrap();
-    // `which_on_path` checks for the file verbatim (no `.exe` munging), so a
-    // plain marker filename resolves identically on every platform.
-    let marker = "tbx_which_probe_marker";
-    std::fs::write(dir.path().join(marker), b"").unwrap();
+/// Write an executable marker file, the way a `PATH` lookup expects to find one.
+fn executable_marker(dir: &Path, name: &str) -> PathBuf {
+    let p = dir.join(name);
+    std::fs::write(&p, b"#!/bin/sh\n").unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    p
+}
 
+/// Run `f` with `PATH` set to `dir`, restoring whatever was there before.
+fn with_path<T>(dir: &Path, f: impl FnOnce() -> T) -> T {
     let saved = std::env::var_os("PATH");
-    std::env::set_var("PATH", dir.path());
-    let found = which_on_path(marker);
-    let missing = which_on_path("tbx_which_probe_absent");
+    std::env::set_var("PATH", dir);
+    let out = f();
     match saved {
         Some(v) => std::env::set_var("PATH", v),
         None => std::env::remove_var("PATH"),
     }
+    out
+}
+
+#[test]
+fn which_on_path_finds_present_and_rejects_absent() {
+    let dir = tempfile::TempDir::new().unwrap();
+    // The lookup is verbatim (no `.exe` munging), so a plain marker filename
+    // resolves identically on every platform.
+    let marker = "tbx_which_probe_marker";
+    executable_marker(dir.path(), marker);
+
+    let (found, missing) = with_path(dir.path(), || {
+        (
+            which_on_path(marker),
+            which_on_path("tbx_which_probe_absent"),
+        )
+    });
 
     assert!(found, "marker on PATH should be found");
     assert!(!missing, "a name not on PATH should not be found");
+}
+
+#[test]
+fn resolve_on_path_answers_with_the_absolute_path() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let marker = "tbx_resolve_probe_marker";
+    let expected = executable_marker(dir.path(), marker);
+
+    let found = with_path(dir.path(), || resolve_on_path(marker));
+
+    assert_eq!(found.as_deref(), Some(expected.as_path()));
+}
+
+#[test]
+fn resolve_on_path_declines_a_name_that_is_already_a_path() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let marker = "tbx_resolve_relative_marker";
+    executable_marker(dir.path(), marker);
+
+    // A caller-supplied path is the caller's decision: re-resolving `./x`
+    // against PATH would name a different file.
+    let found = with_path(dir.path(), || resolve_on_path(&format!("./{marker}")));
+
+    assert_eq!(found, None);
+}
+
+/// A directory named like the binary, or a file nobody can execute, is not what
+/// `execvp` would have picked — so neither is what this may answer with.
+#[test]
+#[cfg(unix)]
+fn resolve_on_path_skips_what_cannot_be_executed() {
+    let dir = tempfile::TempDir::new().unwrap();
+    std::fs::create_dir(dir.path().join("tbx_dir_probe")).unwrap();
+    std::fs::write(dir.path().join("tbx_plain_probe"), b"").unwrap();
+
+    let (as_dir, as_plain) = with_path(dir.path(), || {
+        (
+            resolve_on_path("tbx_dir_probe"),
+            resolve_on_path("tbx_plain_probe"),
+        )
+    });
+
+    assert_eq!(as_dir, None, "a directory is not the binary");
+    assert_eq!(as_plain, None, "a non-executable file is not the binary");
 }
 
 #[test]

--- a/src/paths/tests.rs
+++ b/src/paths/tests.rs
@@ -28,18 +28,6 @@ fn executable_marker(dir: &Path, name: &str) -> PathBuf {
     p
 }
 
-/// Run `f` with `PATH` set to `dir`, restoring whatever was there before.
-fn with_path<T>(dir: &Path, f: impl FnOnce() -> T) -> T {
-    let saved = std::env::var_os("PATH");
-    std::env::set_var("PATH", dir);
-    let out = f();
-    match saved {
-        Some(v) => std::env::set_var("PATH", v),
-        None => std::env::remove_var("PATH"),
-    }
-    out
-}
-
 #[test]
 fn which_on_path_finds_present_and_rejects_absent() {
     let dir = tempfile::TempDir::new().unwrap();

--- a/tests/path_resolution_absolute.rs
+++ b/tests/path_resolution_absolute.rs
@@ -1,0 +1,54 @@
+//! `resolve_on_path` must never answer with a **relative** path.
+//!
+//! It exists so a local window command does not depend on the multiplexer's
+//! `PATH` or working directory. An empty `PATH` component — an ordinary
+//! accident, a stray leading or trailing colon in a shell config — is read by
+//! POSIX as "the current directory", so joining it produces a bare name again:
+//! the very thing tmux would then resolve from the *window's* `-c` directory,
+//! which is the bug this function was added to prevent.
+//!
+//! Its own test binary because it changes the process working directory, which
+//! a sibling test in the same binary would see.
+
+#![cfg(unix)]
+
+use std::path::PathBuf;
+
+/// An executable file in `dir`, the way a `PATH` lookup expects to find one.
+fn executable_marker(dir: &std::path::Path, name: &str) -> PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+    let p = dir.join(name);
+    std::fs::write(&p, b"#!/bin/sh\n").unwrap();
+    std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o700)).unwrap();
+    p
+}
+
+#[test]
+fn an_empty_path_component_never_resolves_to_a_relative_program() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let marker = "tbx_empty_component_probe";
+    executable_marker(dir.path(), marker);
+
+    let saved_cwd = std::env::current_dir().expect("cwd");
+    // The current directory *is* the directory holding the marker, so an empty
+    // component would match — and match first.
+    std::env::set_current_dir(dir.path()).expect("chdir");
+    let saved_path = std::env::var_os("PATH");
+    std::env::set_var("PATH", format!(":{}", dir.path().to_string_lossy()));
+
+    let found = thurbox::paths::resolve_on_path(marker);
+
+    match saved_path {
+        Some(v) => std::env::set_var("PATH", v),
+        None => std::env::remove_var("PATH"),
+    }
+    std::env::set_current_dir(&saved_cwd).expect("restore cwd");
+
+    let found = found.expect("the real directory on PATH still resolves it");
+    assert!(
+        found.is_absolute(),
+        "resolved to {found:?}, which the consumer would resolve from its own \
+         working directory rather than thurbox's"
+    );
+    assert_eq!(found.file_name().unwrap(), marker);
+}

--- a/tests/spawn_command_resolution.rs
+++ b/tests/spawn_command_resolution.rs
@@ -66,7 +66,7 @@ fn a_local_spawn_finds_the_agent_the_multiplexer_cannot() {
     .expect("write probe agent");
     {
         use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&agent, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+        std::fs::set_permissions(&agent, std::fs::Permissions::from_mode(0o700)).expect("chmod");
     }
 
     // nextest runs one process per test, so process-wide env is safe here.

--- a/tests/spawn_command_resolution.rs
+++ b/tests/spawn_command_resolution.rs
@@ -1,0 +1,156 @@
+//! A local spawn must launch the agent **thurbox** resolved, not whatever the
+//! multiplexer's own `PATH` happens to resolve.
+//!
+//! thurbox hands tmux a bare command name (`claude`) and lets tmux resolve it.
+//! Which resolver runs, and with which `PATH`, is not thurbox's to choose:
+//! tmux copies the *client's* `PATH` into the new pane only for an **unattached**
+//! client (`spawn.c`: "the session one is replaced from the client ... only
+//! unattached clients"). thurbox's control-mode client is attached, so its
+//! windows get the `PATH` of whatever first started the tmux **server** — and a
+//! single-token command is handed to that server's `default-shell` rather than
+//! `execvp`, so the resolver can be a shell thurbox never chose.
+//!
+//! Under zsh/bash the two `PATH`s agree, because the interactive additions live
+//! in `~/.zshenv` / `~/.profile`, which any shell that starts a server sources.
+//! Under **fish** they do not: `fish_add_path` writes `fish_user_paths`, which
+//! only fish applies — so a server started from anything else never sees them,
+//! for the life of that server.
+//!
+//! Skipped when tmux is absent rather than failing: a missing multiplexer is an
+//! environment fact, not a regression.
+
+#![cfg(unix)]
+
+use std::collections::HashMap;
+use std::process::Command;
+
+use thurbox::agent::backend::SessionBackend;
+use thurbox::agent::tmux::{TmuxBackend, SOCKET_OVERRIDE_ENV, SOCKET_OWNER_ENV};
+
+/// A throwaway socket, so this never touches the real one.
+const SOCKET: &str = "thurbox-spawn-cmd-e2e";
+
+fn have_tmux() -> bool {
+    Command::new("tmux")
+        .arg("-V")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn cleanup() {
+    let _ = Command::new("tmux")
+        .args(["-L", SOCKET, "kill-server"])
+        .output();
+}
+
+#[test]
+fn a_local_spawn_finds_the_agent_the_multiplexer_cannot() {
+    if !have_tmux() {
+        eprintln!("skipping: tmux is not installed");
+        return;
+    }
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let bin = dir.path().join("bin");
+    std::fs::create_dir_all(&bin).expect("bin dir");
+    let marker = dir.path().join("agent-ran");
+    let agent = bin.join("tb-probe-agent");
+    std::fs::write(
+        &agent,
+        format!(
+            "#!/bin/sh\nprintf ok > {}\nsleep 30\n",
+            marker.to_string_lossy()
+        ),
+    )
+    .expect("write probe agent");
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&agent, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+    }
+
+    // nextest runs one process per test, so process-wide env is safe here.
+    std::env::set_var("TMUX_TMPDIR", dir.path());
+    std::env::set_var(SOCKET_OVERRIDE_ENV, SOCKET);
+    // The override is dropped when it was injected for someone else's data dir
+    // (see `socket_for`); this test *is* somebody typing it.
+    std::env::remove_var(SOCKET_OWNER_ENV);
+    thurbox::paths::set_test_dir(dir.path());
+
+    cleanup();
+    // The server starts without the agent's directory on `PATH` — the shape a
+    // fish user's machine is in whenever the server was started by anything
+    // that is not fish.
+    let started = Command::new("tmux")
+        .args([
+            "-L",
+            SOCKET,
+            "new-session",
+            "-d",
+            "-s",
+            "thurbox",
+            "-x",
+            "80",
+            "-y",
+            "24",
+        ])
+        .env("PATH", "/usr/bin:/bin")
+        .env("TMUX_TMPDIR", dir.path())
+        .output()
+        .expect("run tmux");
+    if !started.status.success() {
+        cleanup();
+        eprintln!(
+            "skipping: tmux would not start a server: {}",
+            String::from_utf8_lossy(&started.stderr).trim()
+        );
+        return;
+    }
+
+    // thurbox's own `PATH` *does* have it: this is the user's interactive PATH,
+    // the one the agent was installed onto.
+    let path = format!(
+        "{}:{}",
+        bin.to_string_lossy(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    std::env::set_var("PATH", &path);
+
+    let backend = TmuxBackend::local();
+    if let Err(e) = backend.ensure_ready() {
+        cleanup();
+        eprintln!("skipping: tmux control mode would not start: {e:#}");
+        return;
+    }
+    let spawned = backend.spawn(
+        "tb-probe",
+        "tb-probe-agent",
+        &[],
+        Some(dir.path()),
+        &HashMap::new(),
+        24,
+        80,
+    );
+    let spawned = match spawned {
+        Ok(s) => s,
+        Err(e) => {
+            cleanup();
+            panic!("the spawn itself failed: {e:#}");
+        }
+    };
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    while std::time::Instant::now() < deadline && !marker.exists() {
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    let ran = marker.exists();
+    drop(spawned);
+    cleanup();
+
+    assert!(
+        ran,
+        "the agent thurbox resolved on its own PATH never ran: the window command \
+         was left for the multiplexer to resolve, and the multiplexer's PATH does \
+         not have it"
+    );
+}

--- a/tests/spawn_command_resolution.rs
+++ b/tests/spawn_command_resolution.rs
@@ -1,14 +1,15 @@
 //! A local spawn must launch the agent **thurbox** resolved, not whatever the
 //! multiplexer's own `PATH` happens to resolve.
 //!
-//! thurbox hands tmux a bare command name (`claude`) and lets tmux resolve it.
-//! Which resolver runs, and with which `PATH`, is not thurbox's to choose:
-//! tmux copies the *client's* `PATH` into the new pane only for an **unattached**
-//! client (`spawn.c`: "the session one is replaced from the client ... only
-//! unattached clients"). thurbox's control-mode client is attached, so its
-//! windows get the `PATH` of whatever first started the tmux **server** — and a
-//! single-token command is handed to that server's `default-shell` rather than
-//! `execvp`, so the resolver can be a shell thurbox never chose.
+//! thurbox used to hand tmux a bare command name (`claude`) and let tmux
+//! resolve it. Which resolver ran, and with which `PATH`, was not thurbox's to
+//! choose: tmux copies the *client's* `PATH` into the new pane only for an
+//! **unattached** client (`spawn.c`: "the session one is replaced from the
+//! client ... only unattached clients"). thurbox's control-mode client is
+//! attached, so its windows got the `PATH` of whatever first started the tmux
+//! **server** — and a single-token command is handed to that server's
+//! `default-shell` rather than `execvp`, so the resolver could be a shell
+//! thurbox never chose.
 //!
 //! Under zsh/bash the two `PATH`s agree, because the interactive additions live
 //! in `~/.zshenv` / `~/.profile`, which any shell that starts a server sources.


### PR DESCRIPTION
## Intent

Fix a defect Greptile found in the core of the previous commit on this branch (PR #1100), then re-attest so the PR body names the commit that would merge. Fleet's standing policy requires that, and thurbox was just added to fleet's auto-merge set, so an attestation naming an older commit must not be what merges.

The defect (Greptile P1 on src/paths/mod.rs, confidence 4/5, "not yet safe to merge"): resolve_on_path joined EVERY PATH component with the binary name, including the empty one POSIX reads as "the current directory" (PATH of the form :/usr/bin, or a stray trailing colon). That made it answer with a bare RELATIVE name, which tmux then resolves from the WINDOW's start directory - so the agent is not found, or a same-named file sitting in the repo being worked on is launched instead. That is precisely the cwd/PATH dependence the function was added to remove, reintroduced by the function itself. Confirmed by writing the regression FIRST and watching it fail.

The deliberate decision, which the review asked to have stated: SKIP every non-absolute PATH entry rather than resolving it against thurbox's own working directory. Both readings are defensible. Skipping was chosen because the answer is handed to a process with a working directory of its own, so "the current directory" has no single meaning at this boundary, and because honouring it would let an agent-named file in a worktree shadow the real agent. It is also the safe half of the choice under this change's standing "never a new way to fail" rule: declining leaves the caller with the command it already had, whereas honouring would silently launch a different binary. The rule is spelled as "absolute only", which covers a relative non-empty component too, not just the empty one.

Also fixed from the same review, both P2: every test that sets PATH now goes through one locked paths::with_path helper, because under plain cargo test those unit tests share a process and interleaved writes let one test observe another's temporary directory or restore a stale PATH (nextest, the repo's gate, isolates per process - this keeps the other documented entry point honest). And tests/spawn_command_resolution.rs's module doc no longer describes the pre-fix behaviour in the present tense, per the repo's rule that a stale comment is worse than none.

The regression test lives in its own test binary (tests/path_resolution_absolute.rs) because it moves the process working directory, which a sibling test in the same binary would see. docs/CONFIG.md's "How command is resolved" section gained the absolute-only rule and its rationale.

Context for the rest of the branch, unchanged from the earlier runs: this fixes a report where, on macOS with fish 4.7.1 and tmux 3.6b, creating a local session in thurbox v2.19.5/2.19.6 failed with "tmux new-window exited exit status: 127" while v1.8.7 worked. Mechanism, established from tmux 3.6's source and experiments with real tmux: tmux runs a single-argument window command through its default-shell and a multi-argument one through execvp (verified - a missing command leaves the pane at 127 vs 1), and tmux copies the CLIENT's PATH into a new pane only for an UNATTACHED client, so thurbox's attached control-mode client got the PATH of whatever first started the tmux server. Fish-specific because fish_add_path writes fish_user_paths, which only fish applies, whereas zsh/bash additions live in files any server-starting shell sources. The fix resolves the command against thurbox's own PATH instead of wrapping local spawns in /bin/sh, which the task brief explicitly forbade without proving the wrap was the cause. Remote SSH/WSL backends are deliberately untouched and keep their login wrap; Windows/psmux passes through.

Not reproducible on the reporter's exact machine: the tmux new-window CLIENT could not be made to exit 127 in any failure mode, tmux 3.6's source has no path returning a window command's exit status to the client, and no macOS machine was available.

## What Changed

- Added `paths::resolve_on_path` to resolve a local agent command to an absolute path using thurbox's own `PATH` (checking real executability via file mode, not just existence), and wired it into `TmuxBackend::program_for_window` / `spawn_window` in `src/agent/tmux.rs` so local (non-remote) window commands are handed to tmux as absolute paths instead of bare names — fixing spawn failures (exit 127) where tmux's attached control-mode client inherited the tmux server's launch-time `PATH` rather than the interactive shell's (e.g. fish's `fish_add_path`/`fish_user_paths`, which only fish sources). Remote/WSL/psmux backends are untouched and keep their existing login-wrap/pass-through behavior.
- Fixed `resolve_on_path` to skip every non-absolute `PATH` component (including the empty entry POSIX treats as the current directory, e.g. from `:/usr/bin` or a trailing colon) instead of joining it with the binary name, which previously could yield a bare relative name that tmux would then resolve against the window's start directory.
- Fixed a race in `src/agent/control_mode/mod.rs` where tmux's implicit `%begin`/`%end` attach response was drained via a `refresh-client` no-op racing against the newly spawned reader thread; it's now consumed synchronously via `drain_implicit_attach_response` before the reader thread starts, using an explicit `BufReader` handoff.
- Added `paths::with_path`, a locked test helper serializing `PATH` mutation across unit tests sharing a process under plain `cargo test`, and migrated existing PATH-setting tests in `src/paths/tests.rs` to use it; added `tests/path_resolution_absolute.rs` (isolated binary, since it changes the process working directory) and `tests/spawn_command_resolution.rs` as end-to-end regression coverage, and documented the absolute-only PATH resolution rule and rationale in `docs/CONFIG.md` and the `thurbox-testing` skill.

## Risk Assessment

✅ Low: The fix (filtering PATH components to absolute-only in resolve_on_path) is a small, well-bounded change at the correct shared boundary, exercised by a genuine regression test that fails pre-fix and passes post-fix; the accompanying P2 fixes (locked with_path test helper, stale-comment cleanup, docs) match the stated intent exactly and no required/forbidden acceptance criteria are contradicted.

## Testing

Baseline `cargo nextest run --all` had already passed before this phase. I additionally ran the four tests directly touched by this fix and confirmed they pass on the target commit; to validate the regression test itself is meaningful (not a tautology), I temporarily reverted only src/paths/mod.rs to its pre-fix content and re-ran the new regression test, which failed with exactly the panic message the commit message claims, then restored the fix and re-confirmed a clean pass with a clean worktree. Disk space on /home was critically low (down to 52M free) after building a few test binaries — an environment issue unrelated to the code change — so I ran `cargo clean` afterward to free the ~18.5GB of rebuildable target/ cache my testing accumulated; this is a gitignored, transient artifact and does not affect the change itself.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"9dfe8d7b756b2ca47d143a43012aeaf2d415e0f6","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `cargo nextest run --all`
- `cargo nextest run --test path_resolution_absolute (fails pre-fix with the documented panic message, passes post-fix)`
- `cargo nextest run --lib -E 'test(paths::tests)' (57 tests, including resolve_on_path_* and which_on_path_* via the shared with_path helper)`
- `cargo nextest run --lib -E 'test(a_local_window_command_is_an_absolute_path)' (tmux spawn resolution test using the shared paths::with_path helper)`
- `cargo nextest run --test spawn_command_resolution (e2e agent-only-thurbox-can-see spawn test)`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
