### PR TITLE
fix(core): never register the WSL distro thurbox runs in as a host

### DIFF
--- a/.agents/skills/thurbox-remote-hosts/SKILL.md
+++ b/.agents/skills/thurbox-remote-hosts/SKILL.md
@@ -23,10 +23,13 @@ interop, from inside a distro as well. What discovery never offers is the
 distro thurbox is running in: a **loopback** (`HostDef::is_wsl_loopback`, keyed
 on `$WSL_DISTRO_NAME`) is this machine, so sessions on it are local. It is
 dropped from both halves of the registry — discovered and configured (the
-configured one with a warning) — and schema v47 restores the rows a released
-build already relabelled `wsl:<us>`: being shareable by default, the loopback
-was mirrored, and its "host" database was this database, so the pass rewrote
-our own local rows as remote. Siblings stay ordinary hosts. The seeded file
+configured one with a warning) — as is a configured host that reaches a sibling
+but is *named* after the current distro (`shadows_current_wsl_distro`): it would
+register as `wsl:<us>` and be indistinguishable from a loopback row, so it is
+dropped with a warning telling you to rename it. Schema v47 restores the rows a
+released build already relabelled `wsl:<us>`: being shareable by default, the
+loopback was mirrored, and its "host" database was this database, so the pass
+rewrote our own local rows as remote. Siblings stay ordinary hosts. The seeded file
 documents every field inline; the schema:
 
 ```toml
@@ -108,7 +111,8 @@ session), never on the loop, ADR-P12).
   it); backend-name helpers `is_ssh_backend`/`is_wsl_backend`/
   `is_remote_backend`. **Loading**: `agent::host_config::load_all{,_with_warnings}`
   = configured hosts + `discover_wsl_hosts()` (deduped; a configured entry
-  wins), minus any loopback (`drop_wsl_loopback` / `wsl_hosts_from`).
+  wins), minus any loopback or backend-name shadow of it (`drop_wsl_loopback`
+  / `wsl_hosts_from`).
 - **Selection**: `SessionConfig.backend` (`ssh:<host>` / `wsl:<distro>` or `None`
   = local). The TUI new-session flow shows a **host picker** first (skipped when
   none configured/discovered); the chosen host runs git worktree creation +

--- a/.agents/skills/thurbox-remote-hosts/SKILL.md
+++ b/.agents/skills/thurbox-remote-hosts/SKILL.md
@@ -29,7 +29,10 @@ configured one with a warning). A configured host that reaches a sibling but is
 **exactly as written** — it works — and what it costs instead is the repair, for
 that one name: the rows under it are the bug's local rows *and* the host's own
 sibling rows at once, so both rewrites are wrong for half of them and neither is
-attempted (a warning says so). Rows a released build already
+attempted (a warning says so). That is one case of a general rule — the repair
+never rewrites a spelling a host it still serves registers under, including a
+dropped loopback's own free-label `name`, which auto-discovery may hand
+straight to a real sibling. Rows a released build already
 relabelled `wsl:<us>` (being shareable by default, the loopback was mirrored,
 and its "host" database was this database, so the pass rewrote our own local
 rows as remote) are put back by a one-time repair rather than by the migration:
@@ -119,23 +122,29 @@ session), never on the loop, ADR-P12).
   = configured hosts + `discover_wsl_hosts()` (deduped; a configured entry
   wins), with every entry claiming the current distro settled first
   (`settle_wsl_self_hosts` / `wsl_hosts_from`): a loopback dropped, a
-  backend-name shadow kept as written with its spelling withheld from the
-  repair.
+  backend-name shadow kept as written. `augment_with` is the pure dedup both
+  the load path and the repair path go through, so they cannot disagree about
+  which host ends up serving a name.
 - **The one-time repair**: `session_ops::repair_wsl_loopback_rows`, guarded by
   the `wsl_loopback_repair_owed` mark schema v47 writes and it clears. Run from
   **both** startups that open the database (`coordinator::boot` and
   `bin/thurbox-cli`), because the mark is written by whichever gets there first.
-  What it rewrites is a `session::WslRepairPlan` decided by the registry, not by
-  a spelling, and by the same pass that settles it
-  (`agent::host_config::wsl_repair_plan`) so the two cannot disagree:
-  - `to_local` = `wsl:$WSL_DISTRO_NAME` **plus** each dropped loopback's own
+  What it rewrites is a `session::WslRepairPlan` decided by the registry as
+  callers *see* it — `agent::host_config::wsl_repair_plan` settles then
+  augments with discovery, the loader's own two steps in order:
+  - Candidates = `wsl:$WSL_DISTRO_NAME` **plus** each dropped loopback's own
     `backend_name()` (a hand-written `name = "self", distro = "<us>"` wrote
     `wsl:self`, and dropping the entry without healing those rows strands
-    them), **minus** every spelling a shadow entry claims — keyed on the entry
-    existing, since that alone is what makes the name unreadable.
-  - An unparseable `hosts.toml` is `Err`, not an empty registry: the pass leaves
-    the mark set and returns, rather than reading silence as "no entry claims
-    `wsl:<us>`" and relabelling a sibling's live sessions local.
+    them).
+  - `to_local` = the candidates no served host registers under; `withheld` =
+    the rest, matched on the whole backend name (an `ssh:` host named after a
+    distro serves none of its rows, so it withholds nothing).
+  - Only an **answer** clears the owed mark. An unparseable `hosts.toml` is
+    `Err`, distros that cannot be enumerated are `Err`, and a `withheld` name is
+    unfinished business: each leaves the mark set so a later start settles it
+    once the claim is gone. Silence must never read as "no host claims this" —
+    though a machine with no `wsl.exe` at all is a definite "no distros", since
+    interop puts `wsl.exe` on `PATH` inside a distro.
 
   `Database::apply_wsl_repair_plan` owns the SQL. `(host, repo_path)` is the
   bookmark key, so colliding readings of one path are resolved on recency —

--- a/.agents/skills/thurbox-remote-hosts/SKILL.md
+++ b/.agents/skills/thurbox-remote-hosts/SKILL.md
@@ -18,7 +18,15 @@ everything downstream of the launcher (control-mode protocol, POSIX quoting,
 worktree layout) is identical to the SSH path — no `wslpath` translation. Hosts
 are declared as data in `~/.config/thurbox/hosts.toml` (seeded commented-out;
 fresh install = zero SSH hosts, behaves as before), **plus WSL distros are
-auto-discovered on Windows** (`wsl.exe -l -q`) with no config. The seeded file
+auto-discovered** (`wsl.exe -l -q`) with no config — on Windows and, via
+interop, from inside a distro as well. What discovery never offers is the
+distro thurbox is running in: a **loopback** (`HostDef::is_wsl_loopback`, keyed
+on `$WSL_DISTRO_NAME`) is this machine, so sessions on it are local. It is
+dropped from both halves of the registry — discovered and configured (the
+configured one with a warning) — and schema v47 restores the rows a released
+build already relabelled `wsl:<us>`: being shareable by default, the loopback
+was mirrored, and its "host" database was this database, so the pass rewrote
+our own local rows as remote. Siblings stay ordinary hosts. The seeded file
 documents every field inline; the schema:
 
 ```toml
@@ -99,7 +107,8 @@ session), never on the loop, ADR-P12).
   `HostRegistry` (pure data, in `session/` so both `agent` and `git` can use
   it); backend-name helpers `is_ssh_backend`/`is_wsl_backend`/
   `is_remote_backend`. **Loading**: `agent::host_config::load_all{,_with_warnings}`
-  = configured hosts + `discover_wsl_hosts()` (deduped; a configured entry wins).
+  = configured hosts + `discover_wsl_hosts()` (deduped; a configured entry
+  wins), minus any loopback (`drop_wsl_loopback` / `wsl_hosts_from`).
 - **Selection**: `SessionConfig.backend` (`ssh:<host>` / `wsl:<distro>` or `None`
   = local). The TUI new-session flow shows a **host picker** first (skipped when
   none configured/discovered); the chosen host runs git worktree creation +

--- a/.agents/skills/thurbox-remote-hosts/SKILL.md
+++ b/.agents/skills/thurbox-remote-hosts/SKILL.md
@@ -139,12 +139,19 @@ session), never on the loop, ADR-P12).
   - `to_local` = the candidates no served host registers under; `withheld` =
     the rest, matched on the whole backend name (an `ssh:` host named after a
     distro serves none of its rows, so it withholds nothing).
-  - Only an **answer** clears the owed mark. An unparseable `hosts.toml` is
-    `Err`, distros that cannot be enumerated are `Err`, and a `withheld` name is
-    unfinished business: each leaves the mark set so a later start settles it
-    once the claim is gone. Silence must never read as "no host claims this" —
-    though a machine with no `wsl.exe` at all is a definite "no distros", since
-    interop puts `wsl.exe` on `PATH` inside a distro.
+  - Only a question that could not be **asked** keeps the owed mark: an
+    unparseable `hosts.toml` and distros that could not be enumerated are both
+    `Err`, so nothing is touched and a later start retries. A `withheld` name
+    is an **answer** and clears it — those rows never become classifiable, so
+    waiting for the claim to disappear would just rewrite them once the
+    evidence was gone, relabelling a live sibling's sessions local. Silence
+    must never read as "no host claims this", though a machine with no
+    `wsl.exe` at all is a definite "no distros", since interop puts `wsl.exe`
+    on `PATH` inside a distro.
+  - Discovery is consulted **only** for a candidate it could decide — never for
+    `wsl:$WSL_DISTRO_NAME`, the spelling `wsl_hosts_from` filters out — so the
+    ordinary repair spawns no `wsl.exe`, and its outcome does not depend on the
+    machine having a working one. `with_discovered_wsl` pins the list in tests.
 
   `Database::apply_wsl_repair_plan` owns the SQL. `(host, repo_path)` is the
   bookmark key, so colliding readings of one path are resolved on recency —

--- a/.agents/skills/thurbox-remote-hosts/SKILL.md
+++ b/.agents/skills/thurbox-remote-hosts/SKILL.md
@@ -23,15 +23,18 @@ interop, from inside a distro as well. What discovery never offers is the
 distro thurbox is running in: a **loopback** (`HostDef::is_wsl_loopback`, keyed
 on `$WSL_DISTRO_NAME`) is this machine, so sessions on it are local. It is
 dropped from both halves of the registry — discovered and configured (the
-configured one with a warning) — as is a configured host that reaches a sibling
-but is *named* after the current distro (`shadows_current_wsl_distro`): it would
-register as `wsl:<us>` and be indistinguishable from a loopback row, so it is
-dropped with a warning telling you to rename it. Rows a released build already
+configured one with a warning). A configured host that reaches a sibling but is
+*named* after the current distro (`shadows_current_wsl_distro`) would register
+as `wsl:<us>` and be indistinguishable from a loopback row, so it is
+**re-registered** under the distro it reaches (with a warning saying which name
+`--host` now takes) and the rows it already wrote move with it; if another entry
+already describes that distro, it defers to it. Rows a released build already
 relabelled `wsl:<us>` (being shareable by default, the loopback was mirrored,
 and its "host" database was this database, so the pass rewrote our own local
 rows as remote) are put back by a one-time repair rather than by the migration:
 schema v47 only marks it **owed**, and `session_ops::repair_wsl_loopback_rows`
-runs it once at startup. Siblings stay ordinary hosts. The seeded file
+runs it from every startup that opens the database — the TUI boot *and* the
+`thurbox-cli` entrypoint. Siblings stay ordinary hosts. The seeded file
 documents every field inline; the schema:
 
 ```toml
@@ -113,20 +116,33 @@ session), never on the loop, ADR-P12).
   it); backend-name helpers `is_ssh_backend`/`is_wsl_backend`/
   `is_remote_backend`. **Loading**: `agent::host_config::load_all{,_with_warnings}`
   = configured hosts + `discover_wsl_hosts()` (deduped; a configured entry
-  wins), minus any loopback or backend-name shadow of it (`drop_wsl_loopback`
-  / `wsl_hosts_from`).
-- **The loopback repair**: `session_ops::repair_wsl_loopback_rows`, guarded by
-  the `wsl_loopback_repair_owed` mark schema v47 writes and clears when it runs.
-  The set it relabels local comes from the registry, not from a spelling
-  (`agent::host_config::wsl_loopback_backend_names`): `wsl:$WSL_DISTRO_NAME`,
-  **plus** each refused loopback's own `backend_name()` (a hand-written
-  `name = "self", distro = "<us>"` wrote `wsl:self`, and dropping the entry
-  without healing those rows strands them), **minus** each refused shadow's
-  (while that entry exists the spelling reaches a sibling and is genuinely
-  remote). `Database::relabel_wsl_loopback_rows` owns the SQL; `(host,
-  repo_path)` is the bookmark key, so colliding readings of one path are
-  resolved on recency — ties keep the local row — before the survivor is
-  relabelled.
+  wins), with every entry claiming the current distro settled first
+  (`settle_wsl_self_hosts` / `wsl_hosts_from`): a loopback dropped, a
+  backend-name shadow re-registered under the distro it reaches.
+- **The one-time repair**: `session_ops::repair_wsl_loopback_rows`, guarded by
+  the `wsl_loopback_repair_owed` mark schema v47 writes and it clears. Run from
+  **both** startups that open the database (`coordinator::boot` and
+  `bin/thurbox-cli`), because the mark is written by whichever gets there first.
+  What it rewrites is a `session::WslRepairPlan` decided by the registry, not by
+  a spelling, and from *one* load (`agent::host_config::wsl_repair_plan`) so the
+  arms cannot disagree:
+  - `to_local` = `wsl:$WSL_DISTRO_NAME` **plus** each dropped loopback's own
+    `backend_name()` (a hand-written `name = "self", distro = "<us>"` wrote
+    `wsl:self`, and dropping the entry without healing those rows strands
+    them), **minus** anything in `renames`.
+  - `renames` = each re-registered shadow's `(old backend name, new one)`, so
+    its sessions follow the host instead of being read as local.
+  - `to_local` is applied **first**, and that order is load-bearing: a name it
+    heals is one the registry refuses from now on, while a rename's destination
+    is one the registry serves.
+  - An unparseable `hosts.toml` is `Err`, not an empty registry: the pass leaves
+    the mark set and returns, rather than reading silence as "no entry claims
+    `wsl:<us>`" and relabelling a sibling's live sessions local.
+
+  `Database::apply_wsl_repair_plan` owns the SQL. `(host, repo_path)` is the
+  bookmark key, so colliding readings of one path are resolved on recency —
+  ties keep the row already at the destination — before the survivor is
+  rewritten.
 - **Selection**: `SessionConfig.backend` (`ssh:<host>` / `wsl:<distro>` or `None`
   = local). The TUI new-session flow shows a **host picker** first (skipped when
   none configured/discovered); the chosen host runs git worktree creation +

--- a/.agents/skills/thurbox-remote-hosts/SKILL.md
+++ b/.agents/skills/thurbox-remote-hosts/SKILL.md
@@ -26,10 +26,12 @@ dropped from both halves of the registry — discovered and configured (the
 configured one with a warning) — as is a configured host that reaches a sibling
 but is *named* after the current distro (`shadows_current_wsl_distro`): it would
 register as `wsl:<us>` and be indistinguishable from a loopback row, so it is
-dropped with a warning telling you to rename it. Schema v47 restores the rows a
-released build already relabelled `wsl:<us>`: being shareable by default, the
-loopback was mirrored, and its "host" database was this database, so the pass
-rewrote our own local rows as remote. Siblings stay ordinary hosts. The seeded file
+dropped with a warning telling you to rename it. Rows a released build already
+relabelled `wsl:<us>` (being shareable by default, the loopback was mirrored,
+and its "host" database was this database, so the pass rewrote our own local
+rows as remote) are put back by a one-time repair rather than by the migration:
+schema v47 only marks it **owed**, and `session_ops::repair_wsl_loopback_rows`
+runs it once at startup. Siblings stay ordinary hosts. The seeded file
 documents every field inline; the schema:
 
 ```toml
@@ -113,6 +115,18 @@ session), never on the loop, ADR-P12).
   = configured hosts + `discover_wsl_hosts()` (deduped; a configured entry
   wins), minus any loopback or backend-name shadow of it (`drop_wsl_loopback`
   / `wsl_hosts_from`).
+- **The loopback repair**: `session_ops::repair_wsl_loopback_rows`, guarded by
+  the `wsl_loopback_repair_owed` mark schema v47 writes and clears when it runs.
+  The set it relabels local comes from the registry, not from a spelling
+  (`agent::host_config::wsl_loopback_backend_names`): `wsl:$WSL_DISTRO_NAME`,
+  **plus** each refused loopback's own `backend_name()` (a hand-written
+  `name = "self", distro = "<us>"` wrote `wsl:self`, and dropping the entry
+  without healing those rows strands them), **minus** each refused shadow's
+  (while that entry exists the spelling reaches a sibling and is genuinely
+  remote). `Database::relabel_wsl_loopback_rows` owns the SQL; `(host,
+  repo_path)` is the bookmark key, so colliding readings of one path are
+  resolved on recency — ties keep the local row — before the survivor is
+  relabelled.
 - **Selection**: `SessionConfig.backend` (`ssh:<host>` / `wsl:<distro>` or `None`
   = local). The TUI new-session flow shows a **host picker** first (skipped when
   none configured/discovered); the chosen host runs git worktree creation +

--- a/.agents/skills/thurbox-remote-hosts/SKILL.md
+++ b/.agents/skills/thurbox-remote-hosts/SKILL.md
@@ -28,7 +28,10 @@ configured one with a warning). A configured host that reaches a sibling but is
 as `wsl:<us>` and be indistinguishable from a loopback row, so it is
 **re-registered** under the distro it reaches (with a warning saying which name
 `--host` now takes) and the rows it already wrote move with it; if another entry
-already describes that distro, it defers to it. Rows a released build already
+already *reaches* that distro, it defers to that entry's backend name. Matching
+is on the distro, never the name: an unrelated host holding the sibling's name,
+or a second shadow sharing the one spelling, is dropped with no rename so the
+rows wait rather than being routed somewhere wrong. Rows a released build already
 relabelled `wsl:<us>` (being shareable by default, the loopback was mirrored,
 and its "host" database was this database, so the pass rewrote our own local
 rows as remote) are put back by a one-time repair rather than by the migration:

--- a/.agents/skills/thurbox-remote-hosts/SKILL.md
+++ b/.agents/skills/thurbox-remote-hosts/SKILL.md
@@ -24,14 +24,12 @@ distro thurbox is running in: a **loopback** (`HostDef::is_wsl_loopback`, keyed
 on `$WSL_DISTRO_NAME`) is this machine, so sessions on it are local. It is
 dropped from both halves of the registry — discovered and configured (the
 configured one with a warning). A configured host that reaches a sibling but is
-*named* after the current distro (`shadows_current_wsl_distro`) would register
-as `wsl:<us>` and be indistinguishable from a loopback row, so it is
-**re-registered** under the distro it reaches (with a warning saying which name
-`--host` now takes) and the rows it already wrote move with it; if another entry
-already *reaches* that distro, it defers to that entry's backend name. Matching
-is on the distro, never the name: an unrelated host holding the sibling's name,
-or a second shadow sharing the one spelling, is dropped with no rename so the
-rows wait rather than being routed somewhere wrong. Rows a released build already
+*named* after the current distro (`shadows_current_wsl_distro`) registers as
+`wsl:<us>` and is therefore indistinguishable from a loopback row. It is kept
+**exactly as written** — it works — and what it costs instead is the repair, for
+that one name: the rows under it are the bug's local rows *and* the host's own
+sibling rows at once, so both rewrites are wrong for half of them and neither is
+attempted (a warning says so). Rows a released build already
 relabelled `wsl:<us>` (being shareable by default, the loopback was mirrored,
 and its "host" database was this database, so the pass rewrote our own local
 rows as remote) are put back by a one-time repair rather than by the migration:
@@ -121,31 +119,29 @@ session), never on the loop, ADR-P12).
   = configured hosts + `discover_wsl_hosts()` (deduped; a configured entry
   wins), with every entry claiming the current distro settled first
   (`settle_wsl_self_hosts` / `wsl_hosts_from`): a loopback dropped, a
-  backend-name shadow re-registered under the distro it reaches.
+  backend-name shadow kept as written with its spelling withheld from the
+  repair.
 - **The one-time repair**: `session_ops::repair_wsl_loopback_rows`, guarded by
   the `wsl_loopback_repair_owed` mark schema v47 writes and it clears. Run from
   **both** startups that open the database (`coordinator::boot` and
   `bin/thurbox-cli`), because the mark is written by whichever gets there first.
   What it rewrites is a `session::WslRepairPlan` decided by the registry, not by
-  a spelling, and from *one* load (`agent::host_config::wsl_repair_plan`) so the
-  arms cannot disagree:
+  a spelling, and by the same pass that settles it
+  (`agent::host_config::wsl_repair_plan`) so the two cannot disagree:
   - `to_local` = `wsl:$WSL_DISTRO_NAME` **plus** each dropped loopback's own
     `backend_name()` (a hand-written `name = "self", distro = "<us>"` wrote
     `wsl:self`, and dropping the entry without healing those rows strands
-    them), **minus** anything in `renames`.
-  - `renames` = each re-registered shadow's `(old backend name, new one)`, so
-    its sessions follow the host instead of being read as local.
-  - `to_local` is applied **first**, and that order is load-bearing: a name it
-    heals is one the registry refuses from now on, while a rename's destination
-    is one the registry serves.
+    them), **minus** every spelling a shadow entry claims — keyed on the entry
+    existing, since that alone is what makes the name unreadable.
   - An unparseable `hosts.toml` is `Err`, not an empty registry: the pass leaves
     the mark set and returns, rather than reading silence as "no entry claims
     `wsl:<us>`" and relabelling a sibling's live sessions local.
 
   `Database::apply_wsl_repair_plan` owns the SQL. `(host, repo_path)` is the
   bookmark key, so colliding readings of one path are resolved on recency —
-  ties keep the row already at the destination — before the survivor is
-  rewritten.
+  ties keep the row that is already local — before the survivor is rewritten,
+  and the survivor inherits the group's `is_parent`/`parent_path` so a healed
+  parent keeps the mark its children hang off.
 - **Selection**: `SessionConfig.backend` (`ssh:<host>` / `wsl:<distro>` or `None`
   = local). The TUI new-session flow shows a **host picker** first (skipped when
   none configured/discovered); the chosen host runs git worktree creation +

--- a/.agents/skills/thurbox-remote-hosts/SKILL.md
+++ b/.agents/skills/thurbox-remote-hosts/SKILL.md
@@ -139,10 +139,13 @@ session), never on the loop, ADR-P12).
   - `to_local` = the candidates no served host registers under; `withheld` =
     the rest, matched on the whole backend name (an `ssh:` host named after a
     distro serves none of its rows, so it withholds nothing).
-  - Only a question that could not be **asked** keeps the owed mark: an
-    unparseable `hosts.toml` and distros that could not be enumerated are both
-    `Err`, so nothing is touched and a later start retries. A `withheld` name
-    is an **answer** and clears it — those rows never become classifiable, so
+  - Only a question that could not be **asked** keeps the owed mark, and only
+    where the answer depended on it: an unparseable `hosts.toml` and distros
+    that could not be enumerated are both `Err`, so nothing is touched and a
+    later start retries — but `$WSL_DISTRO_NAME` is checked before the file is
+    read, so off WSL the plan is empty however `hosts.toml` reads, and an
+    unrelated typo cannot defer a repair that has nothing to do. A `withheld`
+    name is an **answer** and clears it — those rows never become classifiable, so
     waiting for the claim to disappear would just rewrite them once the
     evidence was gone, relabelling a live sibling's sessions local. Silence
     must never read as "no host claims this", though a machine with no

--- a/.agents/skills/thurbox-remote-hosts/SKILL.md
+++ b/.agents/skills/thurbox-remote-hosts/SKILL.md
@@ -29,10 +29,11 @@ configured one with a warning). A configured host that reaches a sibling but is
 **exactly as written** — it works — and what it costs instead is the repair, for
 that one name: the rows under it are the bug's local rows *and* the host's own
 sibling rows at once, so both rewrites are wrong for half of them and neither is
-attempted (a warning says so). That is one case of a general rule — the repair
-never rewrites a spelling a host it still serves registers under, including a
-dropped loopback's own free-label `name`, which auto-discovery may hand
-straight to a real sibling. Rows a released build already
+attempted (a notice says so, counted with `rows_recorded_on` and skipped when
+the claimed spelling holds no row). That is one case of a general rule — the
+repair never rewrites a spelling a host it still serves registers under,
+including a dropped loopback's own free-label `name`, which auto-discovery may
+hand straight to a real sibling. Rows a released build already
 relabelled `wsl:<us>` (being shareable by default, the loopback was mirrored,
 and its "host" database was this database, so the pass rewrote our own local
 rows as remote) are put back by a one-time repair rather than by the migration:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -593,8 +593,18 @@ WSL needs no credentials at all.
   (ADR-24) and that database was this one: the mirror pass read our own
   rows back and rewrote each `backend_type` to `wsl:<us>`, after which
   every attach, diff and delete went out through `wsl.exe` at the machine
-  it started on. Schema v47 restores rows a released build had already
-  relabelled.
+  it started on. Rows a released build already relabelled are put back by
+  a **one-time repair**, not by the migration: schema v47 only marks it
+  owed, and `session_ops::repair_wsl_loopback_rows` runs it once at
+  startup, from the one layer that sees both the registry and the
+  database. Which spellings it heals is decided by the registry rather
+  than guessed from the name
+  (`agent::host_config::wsl_loopback_backend_names`): `wsl:<us>`, plus
+  every refused loopback's own backend name (a hand-written
+  `name = "self"` wrote `wsl:self`), minus every refused shadow's (while
+  such an entry exists that spelling is genuinely remote). `storage`
+  may reference `session` but not `agent`, which is why the migration
+  cannot make that call itself.
 - **Selection**: `SessionConfig.backend` (`ssh:<host>` / `wsl:<distro>`
   or `None`); `is_remote_backend` covers both. The TUI shows a host
   picker as the first new-session step (skipped when none configured/

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -585,7 +585,10 @@ WSL needs no credentials at all.
   (interop exports `wsl.exe`), so a thurbox in one distro reaches its
   siblings — but **never itself**: the distro named by `$WSL_DISTRO_NAME`
   is a *loopback* (`HostDef::is_wsl_loopback`) and is dropped from both
-  halves of the registry. Registering it made every local session remote,
+  halves of the registry, as is a configured host that merely *registers*
+  under `wsl:<us>` while pointing elsewhere
+  (`HostDef::shadows_current_wsl_distro`) — its rows would be spelled like
+  the bug's. Registering a loopback made every local session remote,
   because a shareable host's own database is the record of its sessions
   (ADR-24) and that database was this one: the mirror pass read our own
   rows back and rewrote each `backend_type` to `wsl:<us>`, after which

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -602,11 +602,14 @@ WSL needs no credentials at all.
   rows written after, and nothing in the database tells them apart.
   Relabelling them all local sends the sibling's sessions at this
   machine; moving them all onto the sibling sends this machine's at the
-  sibling. So the repair skips the name entirely and warns. The same
-  rule covers a *dropped loopback's own* backend name, which is a free
-  label and can be a live sibling's: dropping the entry hands the name
-  back to auto-discovery, so the real distro re-registers under exactly
-  that spelling. The residue is the pre-existing corruption left
+  sibling. So the repair skips the name entirely, and says so when it
+  actually left rows behind — `rows_recorded_on` counts them, because a
+  host that claims the spelling but never wrote a row has nothing to be
+  told about, and this notice is the only one its owner would ever see.
+  The same rule covers a *dropped loopback's own* backend name, which is
+  a free label and can be a live sibling's: dropping the entry hands the
+  name back to auto-discovery, so the real distro re-registers under
+  exactly that spelling. The residue is the pre-existing corruption left
   unhealed, not damage the change does, and it is the only outcome that
   never operates on the wrong machine.
 - **The one-time repair**: rows a released build already relabelled are

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -591,9 +591,10 @@ WSL needs no credentials at all.
   our own rows back and rewrote each `backend_type` to `wsl:<us>`, after
   which every attach, diff and delete went out through `wsl.exe` at the
   machine it started on.
-- **The name `wsl:<us>` can be claimed, and then it is unreadable.** A
-  configured host that merely *registers* under it while pointing
-  elsewhere (`HostDef::shadows_current_wsl_distro`) is left **exactly as
+- **A spelling another host claims is unreadable, and is left alone.**
+  The clearest case is a configured host that merely *registers* under
+  `wsl:<us>` while pointing elsewhere
+  (`HostDef::shadows_current_wsl_distro`): it is left **exactly as
   written** — it works, and renaming or dropping it would strand or
   misroute its sessions. What it costs is the one-time repair, for that
   one name: the rows under it are two populations at once, local rows
@@ -601,10 +602,13 @@ WSL needs no credentials at all.
   rows written after, and nothing in the database tells them apart.
   Relabelling them all local sends the sibling's sessions at this
   machine; moving them all onto the sibling sends this machine's at the
-  sibling. So the repair skips the name entirely and warns. The residue
-  is the pre-existing corruption left unhealed, not damage the change
-  does, and it is the only outcome that never operates on the wrong
-  machine.
+  sibling. So the repair skips the name entirely and warns. The same
+  rule covers a *dropped loopback's own* backend name, which is a free
+  label and can be a live sibling's: dropping the entry hands the name
+  back to auto-discovery, so the real distro re-registers under exactly
+  that spelling. The residue is the pre-existing corruption left
+  unhealed, not damage the change does, and it is the only outcome that
+  never operates on the wrong machine.
 - **The one-time repair**: rows a released build already relabelled are
   put back by `session_ops::repair_wsl_loopback_rows`, not by the
   migration — schema v47 only marks it **owed**, and every startup that
@@ -613,17 +617,26 @@ WSL needs no credentials at all.
   database first and a headless install need never launch the
   interface). `storage` may reference `session` but not `agent`, so the
   migration cannot decide what to rewrite: that is
-  `agent::host_config::wsl_repair_plan`, from the same pass that settles
-  the registry, so the two cannot disagree about who owns `wsl:<us>`.
-  `to_local` = `wsl:<us>` plus every dropped loopback's own backend name
-  (a hand-written `name = "self"` wrote `wsl:self`), minus every
-  spelling a shadow entry claims. A `hosts.toml` that cannot be parsed
-  is not an answer, so the pass leaves the mark set and comes back
-  rather than reading the silence as "nothing claims `wsl:<us>`". The
-  bookmark half resolves colliding readings of one path on recency
-  (`(host, repo_path)` is the key, so only one can survive) and the
-  survivor inherits the group's `is_parent`/`parent_path`, so a healed
-  parent keeps the mark its children hang off.
+  `agent::host_config::wsl_repair_plan`, which settles the registry and
+  augments it with discovery in the same order the loader does, so what
+  it rewrites and what a session resolves against cannot disagree about
+  who owns a spelling. Candidates = `wsl:<us>` plus every dropped
+  loopback's own backend name (a hand-written `name = "self"` wrote
+  `wsl:self`); each one a served host registers under goes to
+  `withheld` instead of `to_local`, matched on the whole backend name
+  since that is what a row resolves through.
+- **Only an answer retires the repair.** A `hosts.toml` that cannot be
+  parsed, WSL distros that cannot be enumerated, and a name still
+  claimed are all "could not say", not "nothing to do": the pass leaves
+  the owed mark set and settles those names on a later start once the
+  claim is gone. Enumeration failing reads as *claimed* — silence must
+  never read as "nothing claims it" — while a machine with no `wsl.exe`
+  at all is a definite "no distros" (interop puts `wsl.exe` on `PATH`
+  inside a distro, so the two cases do not overlap). The bookmark half
+  resolves colliding readings of one path on recency (`(host,
+  repo_path)` is the key, so only one can survive) and the survivor
+  inherits the group's `is_parent`/`parent_path`, so a healed parent
+  keeps the mark its children hang off.
 - **Selection**: `SessionConfig.backend` (`ssh:<host>` / `wsl:<distro>`
   or `None`); `is_remote_backend` covers both. The TUI shows a host
   picker as the first new-session step (skipped when none configured/

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -600,8 +600,13 @@ WSL needs no credentials at all.
   resolving, and one spelling keeps one meaning. It is not dropped:
   dropping it would strand every session it had created, and telling the
   user to rename it by hand would not move the rows. A shadow whose
-  distro another entry already describes defers to that entry, so one
-  distro keeps one backend.
+  distro another entry already **reaches** defers to that entry, so one
+  distro keeps one backend — the test is the distro, never the name,
+  since `name` is a free label and an unrelated host holding the
+  sibling's name would route the rows at the wrong distro. That
+  collision, and a second shadow sharing the one spelling, are dropped
+  with no rename instead: unresolved rows are recoverable by hand, a
+  silent misroute is not.
 - **The one-time repair**: rows a released build already relabelled are
   put back by `session_ops::repair_wsl_loopback_rows`, not by the
   migration — schema v47 only marks it **owed**, and every startup that

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -591,22 +591,20 @@ WSL needs no credentials at all.
   our own rows back and rewrote each `backend_type` to `wsl:<us>`, after
   which every attach, diff and delete went out through `wsl.exe` at the
   machine it started on.
-- **The name `wsl:<us>` is kept unambiguous**, because the repair below
-  has to be able to trust it. A configured host that merely *registers*
-  under it while pointing elsewhere
-  (`HostDef::shadows_current_wsl_distro`) is **re-registered** under the
-  distro it actually reaches, and the rows it already wrote are moved
-  onto that name with it — the host keeps working, its sessions keep
-  resolving, and one spelling keeps one meaning. It is not dropped:
-  dropping it would strand every session it had created, and telling the
-  user to rename it by hand would not move the rows. A shadow whose
-  distro another entry already **reaches** defers to that entry, so one
-  distro keeps one backend — the test is the distro, never the name,
-  since `name` is a free label and an unrelated host holding the
-  sibling's name would route the rows at the wrong distro. That
-  collision, and a second shadow sharing the one spelling, are dropped
-  with no rename instead: unresolved rows are recoverable by hand, a
-  silent misroute is not.
+- **The name `wsl:<us>` can be claimed, and then it is unreadable.** A
+  configured host that merely *registers* under it while pointing
+  elsewhere (`HostDef::shadows_current_wsl_distro`) is left **exactly as
+  written** — it works, and renaming or dropping it would strand or
+  misroute its sessions. What it costs is the one-time repair, for that
+  one name: the rows under it are two populations at once, local rows
+  the bug relabelled before the entry existed and the host's own sibling
+  rows written after, and nothing in the database tells them apart.
+  Relabelling them all local sends the sibling's sessions at this
+  machine; moving them all onto the sibling sends this machine's at the
+  sibling. So the repair skips the name entirely and warns. The residue
+  is the pre-existing corruption left unhealed, not damage the change
+  does, and it is the only outcome that never operates on the wrong
+  machine.
 - **The one-time repair**: rows a released build already relabelled are
   put back by `session_ops::repair_wsl_loopback_rows`, not by the
   migration — schema v47 only marks it **owed**, and every startup that
@@ -615,17 +613,17 @@ WSL needs no credentials at all.
   database first and a headless install need never launch the
   interface). `storage` may reference `session` but not `agent`, so the
   migration cannot decide what to rewrite: that is
-  `agent::host_config::wsl_repair_plan`, from one registry load, so its
-  two arms cannot disagree about who owns `wsl:<us>`. `to_local` =
-  `wsl:<us>` plus every dropped loopback's own backend name (a
-  hand-written `name = "self"` wrote `wsl:self`), minus anything being
-  renamed; `renames` = each re-registered shadow's old name → its new
-  one. `to_local` is applied first, and the order is load-bearing: a
-  name it heals is one the registry refuses from now on, while a
-  rename's destination is one the registry serves. A `hosts.toml` that
-  cannot be parsed is not an answer, so the pass leaves the mark set and
-  comes back rather than reading the silence as "nothing claims
-  `wsl:<us>`".
+  `agent::host_config::wsl_repair_plan`, from the same pass that settles
+  the registry, so the two cannot disagree about who owns `wsl:<us>`.
+  `to_local` = `wsl:<us>` plus every dropped loopback's own backend name
+  (a hand-written `name = "self"` wrote `wsl:self`), minus every
+  spelling a shadow entry claims. A `hosts.toml` that cannot be parsed
+  is not an answer, so the pass leaves the mark set and comes back
+  rather than reading the silence as "nothing claims `wsl:<us>`". The
+  bookmark half resolves colliding readings of one path on recency
+  (`(host, repo_path)` is the key, so only one can survive) and the
+  survivor inherits the group's `is_parent`/`parent_path`, so a healed
+  parent keeps the mark its children hang off.
 - **Selection**: `SessionConfig.backend` (`ssh:<host>` / `wsl:<distro>`
   or `None`); `is_remote_backend` covers both. The TUI shows a host
   picker as the first new-session step (skipped when none configured/

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -634,13 +634,13 @@ WSL needs no credentials at all.
   those rows exactly where they are, under a name no host registers.
   Only a question that could not be **asked** keeps the mark: a
   `hosts.toml` that would not parse, distros that could not be
-  enumerated, a failed write. Enumeration failing reads as *claimed* —
-  silence must never read as "nothing claims it" — while a machine with
-  no `wsl.exe` at all is a definite "no distros" (interop puts `wsl.exe`
-  on `PATH` inside a distro, so the two cases do not overlap). And it is
-  asked at all only for a candidate discovery could decide: never for
-  `wsl:<us>`, the one spelling discovery filters out, so the ordinary
-  repair spawns no subprocess. The bookmark half resolves colliding
+  enumerated, a failed write. Silence must never read as "nothing claims
+  it", while a machine with no `wsl.exe` at all is a definite "no
+  distros" (interop puts `wsl.exe` on `PATH` inside a distro, so the two
+  cases do not overlap). Enumeration is asked at all only for a
+  candidate discovery could decide — never for `wsl:<us>`, the one
+  spelling discovery filters out — so the ordinary repair spawns no
+  subprocess. The bookmark half resolves colliding
   readings of one path on recency (`(host, repo_path)` is the key, so
   only one can survive) and the survivor inherits the group's
   `is_parent`/`parent_path`, so a healed parent keeps the mark its
@@ -676,6 +676,19 @@ stalls. Worth the most manual testing.
 - *Embedded SSH library (russh, etc.)* — reimplements `~/.ssh/config`,
   agent forwarding, and multiplexing that the system `ssh` already
   provides.
+- *Re-registering a `wsl:<us>` shadow under the distro it reaches, and
+  moving its rows onto that name* — built and withdrawn, not merely
+  considered. It cannot be made correct: the shadow's backend name *is*
+  `wsl:$WSL_DISTRO_NAME`, so the rows under it are two populations at
+  once — local rows an older release mislabelled before the entry
+  existed, and the host's own remote rows written through it after — and
+  nothing in the database separates them. Renaming them all onto the
+  sibling misassigns the local ones; relabelling them all local
+  misassigns the sibling's. Narrowing *which* host the rename targets
+  does not help, because the ambiguity is in the rows, not the target.
+  Leaving every such row alone is the only outcome that never operates
+  on the wrong machine, so the entry stays exactly as written and the
+  repair withholds that one spelling. Do not reintroduce the rename.
 
 ### psmux divergences from tmux
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -585,26 +585,42 @@ WSL needs no credentials at all.
   (interop exports `wsl.exe`), so a thurbox in one distro reaches its
   siblings — but **never itself**: the distro named by `$WSL_DISTRO_NAME`
   is a *loopback* (`HostDef::is_wsl_loopback`) and is dropped from both
-  halves of the registry, as is a configured host that merely *registers*
-  under `wsl:<us>` while pointing elsewhere
-  (`HostDef::shadows_current_wsl_distro`) — its rows would be spelled like
-  the bug's. Registering a loopback made every local session remote,
-  because a shareable host's own database is the record of its sessions
-  (ADR-24) and that database was this one: the mirror pass read our own
-  rows back and rewrote each `backend_type` to `wsl:<us>`, after which
-  every attach, diff and delete went out through `wsl.exe` at the machine
-  it started on. Rows a released build already relabelled are put back by
-  a **one-time repair**, not by the migration: schema v47 only marks it
-  owed, and `session_ops::repair_wsl_loopback_rows` runs it once at
-  startup, from the one layer that sees both the registry and the
-  database. Which spellings it heals is decided by the registry rather
-  than guessed from the name
-  (`agent::host_config::wsl_loopback_backend_names`): `wsl:<us>`, plus
-  every refused loopback's own backend name (a hand-written
-  `name = "self"` wrote `wsl:self`), minus every refused shadow's (while
-  such an entry exists that spelling is genuinely remote). `storage`
-  may reference `session` but not `agent`, which is why the migration
-  cannot make that call itself.
+  halves of the registry. Registering one made every local session
+  remote, because a shareable host's own database is the record of its
+  sessions (ADR-24) and that database was this one: the mirror pass read
+  our own rows back and rewrote each `backend_type` to `wsl:<us>`, after
+  which every attach, diff and delete went out through `wsl.exe` at the
+  machine it started on.
+- **The name `wsl:<us>` is kept unambiguous**, because the repair below
+  has to be able to trust it. A configured host that merely *registers*
+  under it while pointing elsewhere
+  (`HostDef::shadows_current_wsl_distro`) is **re-registered** under the
+  distro it actually reaches, and the rows it already wrote are moved
+  onto that name with it — the host keeps working, its sessions keep
+  resolving, and one spelling keeps one meaning. It is not dropped:
+  dropping it would strand every session it had created, and telling the
+  user to rename it by hand would not move the rows. A shadow whose
+  distro another entry already describes defers to that entry, so one
+  distro keeps one backend.
+- **The one-time repair**: rows a released build already relabelled are
+  put back by `session_ops::repair_wsl_loopback_rows`, not by the
+  migration — schema v47 only marks it **owed**, and every startup that
+  opens the database runs it (the TUI boot and the `thurbox-cli`
+  entrypoint, since the mark is written by whichever binary opens the
+  database first and a headless install need never launch the
+  interface). `storage` may reference `session` but not `agent`, so the
+  migration cannot decide what to rewrite: that is
+  `agent::host_config::wsl_repair_plan`, from one registry load, so its
+  two arms cannot disagree about who owns `wsl:<us>`. `to_local` =
+  `wsl:<us>` plus every dropped loopback's own backend name (a
+  hand-written `name = "self"` wrote `wsl:self`), minus anything being
+  renamed; `renames` = each re-registered shadow's old name → its new
+  one. `to_local` is applied first, and the order is load-bearing: a
+  name it heals is one the registry refuses from now on, while a
+  rename's destination is one the registry serves. A `hosts.toml` that
+  cannot be parsed is not an answer, so the pass leaves the mark set and
+  comes back rather than reading the silence as "nothing claims
+  `wsl:<us>`".
 - **Selection**: `SessionConfig.backend` (`ssh:<host>` / `wsl:<distro>`
   or `None`); `is_remote_backend` covers both. The TUI shows a host
   picker as the first new-session step (skipped when none configured/

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -632,15 +632,18 @@ WSL needs no credentials at all.
   the *evidence* was gone and relabel a live sibling's sessions local.
   The mark is therefore cleared, and dropping the entry afterwards leaves
   those rows exactly where they are, under a name no host registers.
-  Only a question that could not be **asked** keeps the mark: a
-  `hosts.toml` that would not parse, distros that could not be
-  enumerated, a failed write. Silence must never read as "nothing claims
-  it", while a machine with no `wsl.exe` at all is a definite "no
-  distros" (interop puts `wsl.exe` on `PATH` inside a distro, so the two
-  cases do not overlap). Enumeration is asked at all only for a
-  candidate discovery could decide — never for `wsl:<us>`, the one
-  spelling discovery filters out — so the ordinary repair spawns no
-  subprocess. The bookmark half resolves colliding
+  Only a question that could not be **asked** keeps the mark, and only
+  when the answer depended on it: a `hosts.toml` that would not parse,
+  distros that could not be enumerated, a failed write. Each is asked
+  solely where it can matter — `$WSL_DISTRO_NAME` is read first, so off
+  WSL nothing is owed whatever `hosts.toml` says (only a loopback wrote
+  these rows, and only a thurbox inside a distro can have one), and
+  enumeration is consulted only for a candidate discovery could
+  decide, never for `wsl:<us>`, the one spelling it filters out. So the
+  ordinary repair parses one file, spawns no subprocess, and retires.
+  Silence must never read as "nothing claims it", while a machine with
+  no `wsl.exe` at all is a definite "no distros" (interop puts `wsl.exe`
+  on `PATH` inside a distro, so the two cases do not overlap). The bookmark half resolves colliding
   readings of one path on recency (`(host, repo_path)` is the key, so
   only one can survive) and the survivor inherits the group's
   `is_parent`/`parent_path`, so a healed parent keeps the mark its

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -625,18 +625,26 @@ WSL needs no credentials at all.
   `wsl:self`); each one a served host registers under goes to
   `withheld` instead of `to_local`, matched on the whole backend name
   since that is what a row resolves through.
-- **Only an answer retires the repair.** A `hosts.toml` that cannot be
-  parsed, WSL distros that cannot be enumerated, and a name still
-  claimed are all "could not say", not "nothing to do": the pass leaves
-  the owed mark set and settles those names on a later start once the
-  claim is gone. Enumeration failing reads as *claimed* — silence must
-  never read as "nothing claims it" — while a machine with no `wsl.exe`
-  at all is a definite "no distros" (interop puts `wsl.exe` on `PATH`
-  inside a distro, so the two cases do not overlap). The bookmark half
-  resolves colliding readings of one path on recency (`(host,
-  repo_path)` is the key, so only one can survive) and the survivor
-  inherits the group's `is_parent`/`parent_path`, so a healed parent
-  keeps the mark its children hang off.
+- **A withheld name is an answer, and the repair retires on it.** Those
+  rows never become classifiable — the claiming host's own remote rows and
+  the ones the bug mislabelled are the same spelling — so waiting for the
+  claim to disappear would not settle them, it would rewrite them once
+  the *evidence* was gone and relabel a live sibling's sessions local.
+  The mark is therefore cleared, and dropping the entry afterwards leaves
+  those rows exactly where they are, under a name no host registers.
+  Only a question that could not be **asked** keeps the mark: a
+  `hosts.toml` that would not parse, distros that could not be
+  enumerated, a failed write. Enumeration failing reads as *claimed* —
+  silence must never read as "nothing claims it" — while a machine with
+  no `wsl.exe` at all is a definite "no distros" (interop puts `wsl.exe`
+  on `PATH` inside a distro, so the two cases do not overlap). And it is
+  asked at all only for a candidate discovery could decide: never for
+  `wsl:<us>`, the one spelling discovery filters out, so the ordinary
+  repair spawns no subprocess. The bookmark half resolves colliding
+  readings of one path on recency (`(host, repo_path)` is the key, so
+  only one can survive) and the survivor inherits the group's
+  `is_parent`/`parent_path`, so a healed parent keeps the mark its
+  children hang off.
 - **Selection**: `SessionConfig.backend` (`ssh:<host>` / `wsl:<distro>`
   or `None`); `is_remote_backend` covers both. The TUI shows a host
   picker as the first new-session step (skipped when none configured/

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -549,7 +549,7 @@ differs.
 
 Hosts are declared as data in `~/.config/thurbox/hosts.toml`
 (`session::HostDef { kind: HostKind {Ssh, Wsl}, … }`/`HostRegistry`),
-and WSL distros are additionally **auto-discovered** on Windows
+and WSL distros are additionally **auto-discovered**
 (`agent::host_config::discover_wsl_hosts` via `wsl.exe -l -q`). The
 combined set is loaded by `agent::host_config::load_all`, each
 registered as a backend named `ssh:<host>` / `wsl:<distro>` via
@@ -581,7 +581,17 @@ WSL needs no credentials at all.
 - **Auto-discovery**: WSL distros appear with zero config; an explicit
   `kind = "wsl"` entry of the same name wins (for overrides like
   `worktrees_dir`). `discover_wsl_hosts` decodes `wsl.exe`'s UTF-16LE
-  output and is a no-op off Windows / without `wsl.exe`.
+  output and is a no-op without `wsl.exe`. It runs inside a distro too
+  (interop exports `wsl.exe`), so a thurbox in one distro reaches its
+  siblings — but **never itself**: the distro named by `$WSL_DISTRO_NAME`
+  is a *loopback* (`HostDef::is_wsl_loopback`) and is dropped from both
+  halves of the registry. Registering it made every local session remote,
+  because a shareable host's own database is the record of its sessions
+  (ADR-24) and that database was this one: the mirror pass read our own
+  rows back and rewrote each `backend_type` to `wsl:<us>`, after which
+  every attach, diff and delete went out through `wsl.exe` at the machine
+  it started on. Schema v47 restores rows a released build had already
+  relabelled.
 - **Selection**: `SessionConfig.backend` (`ssh:<host>` / `wsl:<distro>`
   or `None`); `is_remote_backend` covers both. The TUI shows a host
   picker as the first new-session step (skipped when none configured/

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -240,12 +240,13 @@ a default (e.g. `worktrees_dir`). Discovery also works from *inside* a
 distro (interop puts `wsl.exe` on `PATH` there), and excludes the distro
 thurbox is itself running in: that one is this machine, sessions on it
 are ordinary **local** sessions created with no `--host`. An entry whose
-`distro` is that one is ignored with a startup warning; an entry merely
-*named* after it — reaching a sibling — is re-registered under the
-distro it reaches, and its existing sessions move with it (a warning
-says which name `--host` now takes), unless another host already holds
-that name while reaching somewhere else, in which case it is ignored
-too and its sessions wait rather than being pointed at the wrong distro.
+`distro` is that one is ignored with a startup warning. An entry merely
+*named* after it — reaching a sibling — works as written and keeps its
+sessions, but it records them under the very name an older thurbox
+mislabelled *local* sessions with; the two are indistinguishable, so
+thurbox warns and leaves every row under that name alone (any local
+session still recorded there stays recorded there). Name such an entry
+after the distro it reaches and there is nothing to warn about.
 For both kinds, tmux, git, the agent,
 and worktrees all run **on the host / inside the distro** at native
 paths (a WSL distro's worktrees live in its own Linux filesystem, not on

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -892,6 +892,7 @@ User-set (read by thurbox):
 | `RUST_LOG` | log filter for `thurbox.log` |
 | `THURBOX_PERF_LOG` | opt-in performance logging: a one-shot `startup` phase breakdown at first paint, per-session `restore_adopt`/`adopt_split` lines, steady-state `perf_window` lines (~10 s cadence), and wall-clock frame/tick timing collection. Any value enables it. See `docs/PERFORMANCE.md`. |
 | `THURBOX_SOCKET` | overrides the **local** multiplexer socket name, winning over the data-dir derivation below. For test/sandbox tooling: Unix scoping uses `TMUX_TMPDIR`, but psmux (Windows) resolves every `-L <name>` machine-wide, so this is the only way to fully scope an instance there. Remote hosts are unaffected (socket from `hosts.toml`). Empty = unset. |
+| `WSL_DISTRO_NAME` | set by WSL itself, not by you: it is how thurbox knows which distro it is running inside. That distro is *this machine*, so it is never offered as a host and a `hosts.toml` entry pointing at it is ignored — see [hosts.toml](#hoststoml) |
 
 Set **by** thurbox into every spawned agent process (not user-set;
 `session_ops::inject_thurbox_env` / `App::build_spawn_inputs`). An

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -243,7 +243,10 @@ are ordinary **local** sessions created with no `--host`. An entry whose
 `distro` is that one is ignored with a startup warning; an entry merely
 *named* after it — reaching a sibling — is re-registered under the
 distro it reaches, and its existing sessions move with it (a warning
-says which name `--host` now takes). For both kinds, tmux, git, the agent,
+says which name `--host` now takes), unless another host already holds
+that name while reaching somewhere else, in which case it is ignored
+too and its sessions wait rather than being pointed at the wrong distro.
+For both kinds, tmux, git, the agent,
 and worktrees all run **on the host / inside the distro** at native
 paths (a WSL distro's worktrees live in its own Linux filesystem, not on
 `/mnt/c`); the distro needs `tmux` >= 3.2 and `git`. Host changes

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -233,10 +233,14 @@ configured hosts, error shown.
 
 **SSH** auth comes entirely from your `~/.ssh/config`; thurbox never
 handles credentials. **WSL** distros are reached with
-`wsl.exe -d <distro>` and need no config entry at all — on Windows they
-are **auto-discovered** (`wsl.exe -l -q`) and appear in the host picker
+`wsl.exe -d <distro>` and need no config entry at all — they are
+**auto-discovered** (`wsl.exe -l -q`) and appear in the host picker
 and `--host` automatically; add a `kind = "wsl"` entry only to override
-a default (e.g. `worktrees_dir`). For both kinds, tmux, git, the agent,
+a default (e.g. `worktrees_dir`). Discovery also works from *inside* a
+distro (interop puts `wsl.exe` on `PATH` there), and excludes the distro
+thurbox is itself running in: that one is this machine, sessions on it
+are ordinary **local** sessions created with no `--host`, and a
+`hosts.toml` entry naming it is ignored with a startup warning. For both kinds, tmux, git, the agent,
 and worktrees all run **on the host / inside the distro** at native
 paths (a WSL distro's worktrees live in its own Linux filesystem, not on
 `/mnt/c`); the distro needs `tmux` >= 3.2 and `git`. Host changes

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -239,8 +239,11 @@ and `--host` automatically; add a `kind = "wsl"` entry only to override
 a default (e.g. `worktrees_dir`). Discovery also works from *inside* a
 distro (interop puts `wsl.exe` on `PATH` there), and excludes the distro
 thurbox is itself running in: that one is this machine, sessions on it
-are ordinary **local** sessions created with no `--host`, and a
-`hosts.toml` entry naming it is ignored with a startup warning. For both kinds, tmux, git, the agent,
+are ordinary **local** sessions created with no `--host`. An entry whose
+`distro` is that one is ignored with a startup warning; an entry merely
+*named* after it — reaching a sibling — is re-registered under the
+distro it reaches, and its existing sessions move with it (a warning
+says which name `--host` now takes). For both kinds, tmux, git, the agent,
 and worktrees all run **on the host / inside the distro** at native
 paths (a WSL distro's worktrees live in its own Linux filesystem, not on
 `/mnt/c`); the distro needs `tmux` >= 3.2 and `git`. Host changes

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -245,8 +245,10 @@ are ordinary **local** sessions created with no `--host`. An entry whose
 sessions, but it records them under the very name an older thurbox
 mislabelled *local* sessions with; the two are indistinguishable, so
 thurbox warns and leaves every row under that name alone (any local
-session still recorded there stays recorded there). Name such an entry
-after the distro it reaches and there is nothing to warn about.
+session still recorded there stays recorded there). Name a **new** entry
+after the distro it reaches and there is nothing to warn about; renaming
+an **existing** one moves no row, and leaves its recorded sessions
+behind under a name no host registers.
 For both kinds, tmux, git, the agent,
 and worktrees all run **on the host / inside the distro** at native
 paths (a WSL distro's worktrees live in its own Linux filesystem, not on

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -480,8 +480,10 @@ remote machine over SSH, or inside a local **WSL distro**, while the
 TUI stays local. Hosts are declared in
 `~/.config/thurbox/hosts.toml` (seeded commented-out, so a fresh
 install has none and behaves exactly as before) — **and WSL distros
-are auto-discovered on Windows** (`wsl.exe -l -q`), so they need no
-entry at all:
+are auto-discovered** (`wsl.exe -l -q`), so they need no entry at all.
+Running thurbox *inside* a distro discovers its siblings but not the
+distro itself: that one is this machine, and its sessions are plain
+local ones.
 
 ```toml
 [[hosts]]

--- a/src/agent/host_config.rs
+++ b/src/agent/host_config.rs
@@ -221,7 +221,9 @@ pub fn load_or_seed_with_warnings() -> (HostRegistry, Vec<String>) {
 /// **loopback** ([`HostDef::is_wsl_loopback`] — this machine, and not a host at
 /// all) and not as a **shadow** of its backend name
 /// ([`HostDef::shadows_current_wsl_distro`]). This is the one chokepoint every
-/// caller shares, so dropping both here is what keeps a local session local.
+/// caller shares, so dropping both here is what keeps a local session local —
+/// and the same split decides which already-written rows the one-time repair
+/// puts back ([`wsl_loopback_backend_names`]).
 pub fn load_all_with_warnings() -> (HostRegistry, Vec<String>) {
     let (mut reg, mut warnings) = load_or_seed_with_warnings();
     warnings.extend(drop_wsl_loopback(&mut reg));
@@ -259,46 +261,113 @@ pub fn cached_registry() -> &'static (HostRegistry, Vec<String>) {
     CACHE.get_or_init(load_all_with_warnings)
 }
 
-/// Drop the two kinds of configured host that may not claim the current WSL
-/// distro, returning one warning per entry removed.
+/// The configured hosts that may not claim the current WSL distro, split by
+/// the rule that refused each.
+///
+/// Kept rather than discarded because the one-time repair of the rows they
+/// already wrote is decided by exactly this split — see
+/// [`wsl_loopback_backend_names`].
+#[derive(Debug, Default)]
+struct RefusedWslHosts {
+    /// Entries that point `wsl.exe` back at us. Their backend name is a
+    /// spelling this machine's own *local* rows may be recorded under.
+    loopbacks: Vec<HostDef>,
+    /// Entries that reach another distro while registering as `wsl:<us>`.
+    /// Their backend name is a *genuinely remote* one, whatever it looks like.
+    shadows: Vec<HostDef>,
+}
+
+/// Remove the two kinds of configured host that may not claim the current WSL
+/// distro, returning them classified.
 ///
 /// A [loopback](HostDef::is_wsl_loopback) points `wsl.exe` back at us and
 /// cannot work: it describes this very machine as somewhere else.
 /// A [shadow](HostDef::shadows_current_wsl_distro) reaches a real sibling but
-/// *registers* as `wsl:<us>`, so its rows are indistinguishable from the ones
-/// the loopback bug wrote and the schema v47 heal would relabel them local;
-/// renaming it costs nothing and keeps that backend name unambiguous.
+/// *registers* as `wsl:<us>`, so its rows are spelled like the ones the
+/// loopback bug wrote; renaming it costs nothing and keeps that backend name
+/// unambiguous.
 ///
 /// Auto-discovery can produce neither — it names a host after the distro it
 /// points at, and [`discover_wsl_hosts`] filters the loopback — so both come
-/// only from a hand-written entry, and a warning naming it is better than
-/// either honouring it or removing it in silence.
-fn drop_wsl_loopback(reg: &mut HostRegistry) -> Vec<String> {
-    let mut warnings = Vec::new();
+/// only from a hand-written entry.
+fn refuse_wsl_self_hosts(reg: &mut HostRegistry) -> RefusedWslHosts {
+    let mut refused = RefusedWslHosts::default();
     reg.hosts.retain(|h| {
         if h.is_wsl_loopback() {
-            warnings.push(format!(
-                "hosts.toml: ignoring host '{}' — it names the WSL distro thurbox \
-                 is running in ('{}'), so sessions on it are local, not remote. \
-                 Create them with no --host.",
-                h.name,
-                h.distro_name()
-            ));
+            refused.loopbacks.push(h.clone());
             return false;
         }
         if h.shadows_current_wsl_distro() {
-            warnings.push(format!(
-                "hosts.toml: ignoring host '{}' — it reaches distro '{}' but is \
-                 named after the one thurbox runs in, so its sessions would be \
-                 recorded as local. Rename the entry to keep it.",
-                h.name,
-                h.distro_name()
-            ));
+            refused.shadows.push(h.clone());
             return false;
         }
         true
     });
-    warnings
+    refused
+}
+
+/// [`refuse_wsl_self_hosts`], reported: one warning per entry removed, because
+/// naming it is better than either honouring it or dropping it in silence.
+fn drop_wsl_loopback(reg: &mut HostRegistry) -> Vec<String> {
+    let refused = refuse_wsl_self_hosts(reg);
+    let loopbacks = refused.loopbacks.iter().map(|h| {
+        format!(
+            "hosts.toml: ignoring host '{}' — it names the WSL distro thurbox \
+             is running in ('{}'), so sessions on it are local, not remote. \
+             Create them with no --host.",
+            h.name,
+            h.distro_name()
+        )
+    });
+    let shadows = refused.shadows.iter().map(|h| {
+        format!(
+            "hosts.toml: ignoring host '{}' — it reaches distro '{}' but is \
+             named after the one thurbox runs in, so its sessions would be \
+             recorded as local. Rename the entry to keep it.",
+            h.name,
+            h.distro_name()
+        )
+    });
+    loopbacks.chain(shadows).collect()
+}
+
+/// The `sessions.backend_type` / `repo_bookmarks.host` spellings on this
+/// machine that the WSL loopback bug can have written — the set
+/// `session_ops::repair_wsl_loopback_rows` relabels local, and the reason that
+/// repair does not live in the migration that records it as owed.
+///
+/// Decided by the registry, not by a spelling. A host is registered — and
+/// persisted — under its `name`, so the two do not coincide in either
+/// direction:
+///
+/// - `wsl:$WSL_DISTRO_NAME` is the base case: what auto-discovery offered
+///   before [`HostDef::is_wsl_loopback`] filtered it.
+/// - **plus** every refused loopback's own backend name: a hand-written
+///   `name = "self", distro = "<us>"` wrote `wsl:self`, and dropping the entry
+///   without healing those rows would strand them on a host `hosts.toml` no
+///   longer describes.
+/// - **minus** every refused shadow's backend name: when such an entry exists,
+///   that spelling reaches a *sibling* and its rows are genuinely remote, so
+///   relabelling them local would act on the wrong machine.
+///
+/// Subtraction is case-insensitive and wins, so an ambiguous pair of entries
+/// leaves the rows alone rather than guessing. Empty off WSL, where there is
+/// no loopback to have written anything.
+pub fn wsl_loopback_backend_names() -> Vec<String> {
+    let mut reg = load_or_seed_with_warnings().0;
+    let refused = refuse_wsl_self_hosts(&mut reg);
+    let discovered = crate::session::current_wsl_distro()
+        .map(|d| format!("{}{d}", crate::session::WSL_BACKEND_PREFIX));
+    let shadowed: Vec<String> = refused.shadows.iter().map(HostDef::backend_name).collect();
+
+    let mut names: Vec<String> = discovered
+        .into_iter()
+        .chain(refused.loopbacks.iter().map(HostDef::backend_name))
+        .filter(|n| !shadowed.iter().any(|s| s.eq_ignore_ascii_case(n)))
+        .collect();
+    names.sort_by_key(|n| n.to_ascii_lowercase());
+    names.dedup_by(|a, b| a.eq_ignore_ascii_case(b));
+    names
 }
 
 /// Append auto-discovered WSL distros to `reg`, skipping any whose name already

--- a/src/agent/host_config.rs
+++ b/src/agent/host_config.rs
@@ -29,11 +29,15 @@ pub const SEED_HOSTS_TOML: &str = r#"# Thurbox hosts  —  ~/.config/thurbox/hos
 # keys, and connection details all come from your ~/.ssh/config — thurbox never
 # handles credentials itself. The remote host needs `tmux` >= 3.2 and `git`.
 #
-# WSL distros are AUTO-DISCOVERED on Windows (via `wsl.exe -l -q`) and appear in
-# the host picker with NO config here — only add a [[hosts]] entry with
-# kind = "wsl" when you want to override defaults (e.g. worktrees_dir). The
-# distro needs `tmux` >= 3.2 and `git` installed inside it; worktrees live in
-# the distro's own Linux filesystem (fast), not on /mnt/c.
+# WSL distros are AUTO-DISCOVERED (via `wsl.exe -l -q`) and appear in the host
+# picker with NO config here — only add a [[hosts]] entry with kind = "wsl"
+# when you want to override defaults (e.g. worktrees_dir). The distro needs
+# `tmux` >= 3.2 and `git` installed inside it; worktrees live in the distro's
+# own Linux filesystem (fast), not on /mnt/c.
+#
+# Running thurbox INSIDE a distro discovers its siblings, but never the distro
+# itself: that one is this machine, and a session on it is a plain local
+# session (no --host). An entry naming it is ignored with a warning.
 #
 # This file starts empty (every entry below is commented out): a fresh install
 # registers zero SSH hosts (WSL distros still auto-discover) and otherwise
@@ -212,8 +216,14 @@ pub fn load_or_seed_with_warnings() -> (HostRegistry, Vec<String>) {
 /// headless `--host` resolver use so WSL distros are selectable with zero
 /// config; the discovered set never overrides an explicitly configured host of
 /// the same name.
+///
+/// Neither half may register a **loopback** — the WSL distro thurbox is running
+/// inside, which is this machine and not a host at all
+/// ([`HostDef::is_wsl_loopback`]). This is the one chokepoint every caller
+/// shares, so dropping it here is what keeps a local session local.
 pub fn load_all_with_warnings() -> (HostRegistry, Vec<String>) {
-    let (mut reg, warnings) = load_or_seed_with_warnings();
+    let (mut reg, mut warnings) = load_or_seed_with_warnings();
+    warnings.extend(drop_wsl_loopback(&mut reg));
     augment_with_wsl(&mut reg);
     (reg, warnings)
 }
@@ -251,6 +261,32 @@ pub fn cached_registry() -> &'static (HostRegistry, Vec<String>) {
 /// Append auto-discovered WSL distros to `reg`, skipping any whose name already
 /// matches a configured host (so a hand-written `hosts.toml` entry for a distro
 /// — e.g. with a custom `worktrees_dir` — wins over the bare discovered one).
+/// Drop a configured host that names the WSL distro thurbox is running inside,
+/// returning one warning per entry removed.
+///
+/// Such an entry is a loopback ([`HostDef::is_wsl_loopback`]) and cannot work:
+/// it describes this very machine as somewhere else. Auto-discovery never
+/// offers one — [`discover_wsl_hosts`] filters it — so the only way to get one
+/// is by hand, and a warning naming it is better than either honouring it or
+/// removing it in silence.
+fn drop_wsl_loopback(reg: &mut HostRegistry) -> Vec<String> {
+    let mut warnings = Vec::new();
+    reg.hosts.retain(|h| {
+        if !h.is_wsl_loopback() {
+            return true;
+        }
+        warnings.push(format!(
+            "hosts.toml: ignoring host '{}' — it names the WSL distro thurbox \
+             is running in ('{}'), so sessions on it are local, not remote. \
+             Create them with no --host.",
+            h.name,
+            h.distro_name()
+        ));
+        false
+    });
+    warnings
+}
+
 fn augment_with_wsl(reg: &mut HostRegistry) {
     let configured: HashSet<&str> = reg.hosts.iter().map(|h| h.name.as_str()).collect();
     let discovered: Vec<HostDef> = discover_wsl_hosts()
@@ -270,6 +306,11 @@ const WSL_INFRA_DISTROS: &[&str] = &["docker-desktop", "docker-desktop-data"];
 /// Runs `wsl.exe -l -q` and parses its output. Returns empty when `wsl.exe`
 /// isn't available (any non-Windows host, or Windows without WSL) or the
 /// command fails — discovery is strictly best-effort and never blocks startup.
+///
+/// The distro thurbox is itself running inside is **not** among them: `wsl.exe`
+/// lists it like any other, but it is this machine
+/// ([`HostDef::is_wsl_loopback`] argues what registering it cost). Its siblings
+/// are still discovered, so a thurbox inside one distro reaches the rest.
 pub(crate) fn discover_wsl_hosts() -> Vec<HostDef> {
     if !wsl_exe_available() {
         return Vec::new();
@@ -288,9 +329,17 @@ pub(crate) fn discover_wsl_hosts() -> Vec<HostDef> {
             return Vec::new();
         }
     };
-    parse_wsl_distros(&output.stdout)
+    wsl_hosts_from(parse_wsl_distros(&output.stdout))
+}
+
+/// The discoverable hosts among `distros`: one [`HostDef::wsl`] each, minus the
+/// loopback. Split out from [`discover_wsl_hosts`] so the exclusion is testable
+/// without a live `wsl.exe`.
+fn wsl_hosts_from(distros: Vec<String>) -> Vec<HostDef> {
+    distros
         .into_iter()
         .map(HostDef::wsl)
+        .filter(|h| !h.is_wsl_loopback())
         .collect()
 }
 
@@ -397,6 +446,57 @@ mod tests {
             Some("/custom/wt")
         );
         assert!(reg.hosts.len() >= before);
+    }
+
+    #[test]
+    fn discovery_offers_every_distro_but_the_one_we_are_in() {
+        crate::session::host_def::with_wsl_distro(Some("MagicDebian"), || {
+            let hosts = wsl_hosts_from(vec![
+                "Ubuntu".to_string(),
+                "MagicDebian".to_string(),
+                "MagicDebianPerso".to_string(),
+            ]);
+            assert_eq!(
+                hosts.iter().map(|h| h.name.as_str()).collect::<Vec<_>>(),
+                ["Ubuntu", "MagicDebianPerso"],
+                "the current distro is this machine; a sibling is a real host"
+            );
+        });
+        // Off WSL there is nothing to exclude.
+        crate::session::host_def::with_wsl_distro(None, || {
+            assert_eq!(wsl_hosts_from(vec!["Ubuntu".to_string()]).len(), 1);
+        });
+    }
+
+    #[test]
+    fn a_configured_loopback_is_dropped_with_a_warning() {
+        crate::session::host_def::with_wsl_distro(Some("MagicDebian"), || {
+            let mut reg = HostRegistry {
+                config_version: None,
+                hosts: vec![
+                    HostDef {
+                        name: "self".into(),
+                        kind: crate::session::HostKind::Wsl,
+                        distro: Some("MagicDebian".into()),
+                        ..Default::default()
+                    },
+                    HostDef::wsl("Ubuntu"),
+                    HostDef {
+                        name: "devbox".into(),
+                        destination: "me@devbox".into(),
+                        ..Default::default()
+                    },
+                ],
+            };
+            let warnings = drop_wsl_loopback(&mut reg);
+            assert_eq!(reg.names(), ["Ubuntu", "devbox"]);
+            assert_eq!(warnings.len(), 1);
+            assert!(
+                warnings[0].contains("'self'") && warnings[0].contains("MagicDebian"),
+                "the warning must name the entry and the distro: {}",
+                warnings[0]
+            );
+        });
     }
 
     #[test]

--- a/src/agent/host_config.rs
+++ b/src/agent/host_config.rs
@@ -7,7 +7,7 @@
 //! and behaves exactly as before. If the file exists but cannot be read or
 //! parsed, we fall back to an empty registry rather than failing to start.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -38,8 +38,11 @@ pub const SEED_HOSTS_TOML: &str = r#"# Thurbox hosts  —  ~/.config/thurbox/hos
 # Running thurbox INSIDE a distro discovers its siblings, but never the distro
 # itself: that one is this machine, and a session on it is a plain local
 # session (no --host). An entry whose `distro` is that one is ignored with a
-# startup warning; an entry merely *named* after it is re-registered under the
-# distro it reaches, and its existing sessions move with it.
+# startup warning. An entry merely *named* after it works as written, but it
+# records its sessions under the very name an older thurbox mislabelled local
+# sessions with, so thurbox warns and leaves every row under that name alone —
+# name such an entry after the distro it reaches and there is nothing to warn
+# about.
 #
 # This file starts empty (every entry below is commented out): a fresh install
 # registers zero SSH hosts (WSL distros still auto-discover) and otherwise
@@ -214,14 +217,13 @@ fn load_or_seed_result() -> Result<(HostRegistry, Vec<String>), String> {
 /// config; the discovered set never overrides an explicitly configured host of
 /// the same name.
 ///
-/// Neither half may claim the WSL distro thurbox is running inside: a
-/// **loopback** ([`HostDef::is_wsl_loopback`]) is this machine and is dropped,
-/// and a **shadow** of its backend name
-/// ([`HostDef::shadows_current_wsl_distro`]) is re-registered under the distro
-/// it reaches. This is the one chokepoint every caller shares, so settling
-/// both here (`settle_wsl_self_hosts`) is what keeps a local session local —
-/// and the same pass decides what the one-time repair owes the rows they
-/// already wrote ([`wsl_repair_plan`]).
+/// Neither half may claim the WSL distro thurbox is running inside as a
+/// **loopback** ([`HostDef::is_wsl_loopback`]): that one is this machine, so
+/// it is dropped. This is the one chokepoint every caller shares, so settling
+/// it here (`settle_wsl_self_hosts`) is what keeps a local session local — and
+/// the same pass decides what the one-time repair owes the rows it already
+/// wrote ([`wsl_repair_plan`]), including which spelling a **shadow**
+/// ([`HostDef::shadows_current_wsl_distro`]) puts out of the repair's reach.
 pub fn load_all_with_warnings() -> (HostRegistry, Vec<String>) {
     let (mut reg, mut warnings) = load_or_seed_with_warnings();
     warnings.extend(settle_wsl_self_hosts(&mut reg).0);
@@ -263,36 +265,25 @@ pub fn cached_registry() -> &'static (HostRegistry, Vec<String>) {
 /// inside, in place, and report both the warnings it owes the user and the row
 /// rewrites it owes the database.
 ///
-/// Two rules, and they differ because only one of the entries can work:
+/// Two rules, and only one of them rewrites a row:
 ///
 /// - A [loopback](HostDef::is_wsl_loopback) points `wsl.exe` back at us. It
 ///   describes this machine as somewhere else, so it is **dropped** — and the
 ///   rows it wrote are this machine's own local rows, so they go to
 ///   [`WslRepairPlan::to_local`].
 /// - A [shadow](HostDef::shadows_current_wsl_distro) reaches a real sibling
-///   but *registers* as `wsl:<us>`, the one spelling that has to keep meaning
-///   "this machine". The host itself is fine, so it is **re-registered** under
-///   the distro it reaches and its rows are moved onto that name with it
-///   ([`WslRepairPlan::renames`]). Dropping it instead would strand every
-///   session it had already created, and telling the user to rename it by hand
-///   would not move the rows.
+///   while *registering* as `wsl:<us>`. It is **kept exactly as written**, and
+///   the spelling it claims is subtracted from `to_local` instead: under that
+///   name the bug's local rows and this host's own sibling rows are the same
+///   spelling, so the repair leaves all of them alone. Any mislabelled local
+///   row there stays mislabelled — the pre-existing corruption, left unhealed
+///   for the one name that cannot be read either way, which is the only
+///   outcome that never operates on the wrong machine.
 ///
-/// A re-registered shadow **defers** to an entry that already *reaches* the
-/// same distro: the rows move onto that entry's own backend name and the
-/// duplicate backend is never created. The test is the distro, never the name
-/// — `name` is a free label, so an unrelated host can hold the sibling's name
-/// while launching something else entirely, and renaming the rows onto it
-/// would route live sessions at the wrong distro (or, for an SSH entry, over
-/// ssh). That case is **dropped with no rename**: the rows keep their spelling
-/// and stay unresolvable until the collision is settled by hand, which is
-/// recoverable, where a silent misroute is not. Two shadows at once are
-/// refused the same way — they share one spelling, so nothing can say whose
-/// rows are whose. Auto-discovery needs no such handling
-/// ([`augment_with_wsl`] already skips a name that is configured).
-///
-/// Neither case can come from discovery ([`discover_wsl_hosts`] filters the
-/// loopback and names a host after the distro it points at), so both are
-/// hand-written entries and each gets a warning naming what happened.
+/// Auto-discovery needs no such handling: [`discover_wsl_hosts`] filters the
+/// loopback and names each host after the distro it points at, and
+/// [`augment_with_wsl`] skips a name that is configured. So both cases are
+/// hand-written entries, and each gets a warning saying what happened.
 fn settle_wsl_self_hosts(reg: &mut HostRegistry) -> (Vec<String>, WslRepairPlan) {
     let mut warnings = Vec::new();
     let mut plan = WslRepairPlan::default();
@@ -304,42 +295,13 @@ fn settle_wsl_self_hosts(reg: &mut HostRegistry) -> (Vec<String>, WslRepairPlan)
             .push(format!("{}{distro}", crate::session::WSL_BACKEND_PREFIX));
     }
 
-    // What will still be in force after this pass, so a shadow can tell
-    // "already described" from "described by an entry about to go". Names and
-    // distros are both matched the way `wsl.exe -d` matches one, so they are
-    // held folded.
-    let survives =
-        |h: &HostDef| -> bool { !h.is_wsl_loopback() && !h.shadows_current_wsl_distro() };
-    let mut taken: HashSet<String> = reg
-        .hosts
-        .iter()
-        .filter(|h| survives(h))
-        .map(|h| h.name.to_ascii_lowercase())
-        .collect();
-    // The distro an entry reaches -> the backend name it reaches it under.
-    // This, not `taken`, is what a shadow may defer to.
-    let mut reaching: HashMap<String, String> = reg
-        .hosts
-        .iter()
-        .filter(|h| h.is_wsl() && survives(h))
-        .map(|h| (h.distro_name().to_ascii_lowercase(), h.backend_name()))
-        .collect();
-
-    // Every spelling a shadow claims, whatever becomes of the entry. The
-    // subtraction below keys on this rather than on the renames, so a shadow
-    // that is dropped still keeps its genuinely remote rows off `to_local`.
+    // Every spelling a shadow claims. Keyed on the entry merely existing:
+    // nothing is done to it, and its presence alone is what makes the name
+    // unreadable.
     let mut shadowed: Vec<String> = Vec::new();
-    // One spelling cannot rename two ways, so a second shadow makes both
-    // ambiguous rather than making the first one wrong.
-    let ambiguous = reg
-        .hosts
-        .iter()
-        .filter(|h| h.shadows_current_wsl_distro())
-        .count()
-        > 1;
 
     let mut settled = Vec::with_capacity(reg.hosts.len());
-    for mut host in std::mem::take(&mut reg.hosts) {
+    for host in std::mem::take(&mut reg.hosts) {
         if host.is_wsl_loopback() {
             warnings.push(format!(
                 "hosts.toml: ignoring host '{}' — it names the WSL distro thurbox \
@@ -352,70 +314,22 @@ fn settle_wsl_self_hosts(reg: &mut HostRegistry) -> (Vec<String>, WslRepairPlan)
             continue;
         }
         if host.shadows_current_wsl_distro() {
-            let sibling = host.distro_name();
             let from = host.backend_name();
-            shadowed.push(from.clone());
-
-            if ambiguous {
-                warnings.push(format!(
-                    "hosts.toml: ignoring host '{}' — more than one entry is named after \
-                     the WSL distro thurbox runs in, so they share one backend name and \
-                     nothing can say which sessions belong to which. Rename all but one \
-                     to keep them; their sessions are left as they are.",
-                    host.name
-                ));
-                continue;
-            }
-            if let Some(target) = reaching.get(&sibling.to_ascii_lowercase()) {
-                warnings.push(format!(
-                    "hosts.toml: ignoring host '{}' — it is named after the WSL distro \
-                     thurbox runs in, which has to keep meaning this machine, and \
-                     '{target}' already reaches the distro it points at ('{sibling}'). \
-                     Its sessions have moved to that host.",
-                    host.name
-                ));
-                if !target.eq_ignore_ascii_case(&from) {
-                    plan.renames.push((from, target.clone()));
-                }
-                continue;
-            }
-            if taken.contains(&sibling.to_ascii_lowercase()) {
-                // The name is held by a host that reaches somewhere else.
-                // Moving the rows onto it would point live sessions at the
-                // wrong distro, so they keep their spelling and wait.
-                warnings.push(format!(
-                    "hosts.toml: ignoring host '{}' — it is named after the WSL distro \
-                     thurbox runs in, which has to keep meaning this machine, and it \
-                     cannot re-register as '{sibling}' because another host already has \
-                     that name and reaches somewhere else. Rename one of the two; until \
-                     then its sessions stay recorded on '{from}' and will not resolve.",
-                    host.name
-                ));
-                continue;
-            }
-
-            let to = format!("{}{sibling}", crate::session::WSL_BACKEND_PREFIX);
             warnings.push(format!(
                 "hosts.toml: host '{}' is named after the WSL distro thurbox runs in, \
-                 which has to keep meaning this machine, so it now registers as the \
-                 distro it reaches. Its sessions have moved with it: use --host \
-                 {sibling}.",
+                 so it records its sessions on '{from}' — the same name an older \
+                 thurbox wrote onto local sessions by mistake. The host works as \
+                 written and keeps its own sessions; but thurbox cannot tell a \
+                 mislabelled local session under that name from one of this host's, \
+                 so it has left every row recorded there exactly as it found it.",
                 host.name
             ));
-            plan.renames.push((from, to.clone()));
-            taken.insert(sibling.to_ascii_lowercase());
-            reaching.insert(sibling.to_ascii_lowercase(), to);
-            host.name = sibling;
-            settled.push(host);
-            continue;
+            shadowed.push(from);
         }
         settled.push(host);
     }
     reg.hosts = settled;
 
-    // A spelling any shadow claims is not this machine's: while such an entry
-    // exists that spelling reaches a sibling, and its rows either follow the
-    // rename or stay put — never become local.
     plan.to_local
         .retain(|n| !shadowed.iter().any(|s| s.eq_ignore_ascii_case(n)));
     plan.to_local.sort_by_key(|n| n.to_ascii_lowercase());
@@ -432,8 +346,9 @@ fn settle_wsl_self_hosts(reg: &mut HostRegistry) -> (Vec<String>, WslRepairPlan)
 /// answer at all, and `session_ops::repair_wsl_loopback_rows` leaves the owed
 /// mark in place and comes back once the file parses.
 ///
-/// Both arms come from the **same** load (`settle_wsl_self_hosts`), so they
-/// cannot disagree about who owns `wsl:<us>`.
+/// Decided by the **same** pass that settles the registry
+/// (`settle_wsl_self_hosts`), so what the repair rewrites and what the
+/// registry serves cannot disagree about who owns `wsl:<us>`.
 pub fn wsl_repair_plan() -> Result<WslRepairPlan, String> {
     let (mut reg, _) = load_or_seed_result()?;
     Ok(settle_wsl_self_hosts(&mut reg).1)
@@ -664,16 +579,15 @@ mod tests {
             // Its own backend name as well as the discovered one: the rows it
             // wrote are spelled `wsl:self`.
             assert_eq!(plan.to_local, ["wsl:MagicDebian", "wsl:self"]);
-            assert!(plan.renames.is_empty());
         });
     }
 
-    /// A host named after the current distro reaches a real sibling, so it is
-    /// re-registered under that sibling rather than dropped — dropping it
-    /// would strand every session it had already created, and a hand rename
-    /// would leave those rows spelled after a host that no longer exists.
+    /// A host named after the current distro reaches a real sibling, so the
+    /// entry itself is right and is left exactly as written. What it costs is
+    /// the repair: its rows and the rows the loopback bug mislabelled share
+    /// one spelling, so none of them is rewritten.
     #[test]
-    fn a_configured_shadow_is_re_registered_under_the_distro_it_reaches() {
+    fn a_configured_shadow_is_kept_as_written_and_its_rows_are_left_alone() {
         crate::session::host_def::with_wsl_distro(Some("MagicDebian"), || {
             let mut reg = registry(vec![
                 HostDef {
@@ -685,137 +599,64 @@ mod tests {
 
             let (warnings, plan) = settle_wsl_self_hosts(&mut reg);
 
-            assert_eq!(reg.names(), ["MagicDebianPerso", "Ubuntu"]);
+            assert_eq!(reg.names(), ["MagicDebian", "Ubuntu"]);
             assert_eq!(
-                reg.get("MagicDebianPerso")
-                    .unwrap()
-                    .worktrees_dir
-                    .as_deref(),
+                reg.get("MagicDebian").unwrap().worktrees_dir.as_deref(),
                 Some("/srv/wt"),
-                "the entry keeps working, overrides and all — only its name changed"
+                "the entry is untouched, overrides and all"
             );
-            assert_eq!(
-                plan.renames,
-                [(
-                    "wsl:MagicDebian".to_string(),
-                    "wsl:MagicDebianPerso".to_string()
-                )]
-            );
-            // The subtraction arm: while that entry claims the spelling, it is
-            // a sibling's, so its rows must not be relabelled local.
+            // The subtraction arm, and the whole of it: while that entry
+            // claims the spelling nothing under it can be classified, so the
+            // repair is given nothing to do.
             assert!(plan.to_local.is_empty());
             assert_eq!(warnings.len(), 1);
             assert!(
-                warnings[0].contains("--host MagicDebianPerso"),
-                "the warning must say which name --host now takes: {}",
+                warnings[0].contains("'wsl:MagicDebian'")
+                    && warnings[0].contains("left every row recorded there"),
+                "the warning must name the spelling and say the rows were left alone: {}",
                 warnings[0]
             );
         });
     }
 
-    /// One distro has one backend name, so a shadow whose sibling another
-    /// entry already reaches defers to that entry instead of duplicating it —
-    /// and its rows still move, because the host they now name reaches them.
-    /// The target is that entry's own backend name, which need not be spelled
-    /// like the distro at all.
+    /// Nothing about a shadow is decided by what else is in the file: a second
+    /// one, or another host holding the sibling's name, changes neither the
+    /// registry nor the plan. Every entry the user wrote keeps working, and the
+    /// one unreadable spelling is still the only thing withheld from the
+    /// repair.
     #[test]
-    fn a_re_registered_shadow_defers_to_the_entry_that_reaches_its_distro() {
-        crate::session::host_def::with_wsl_distro(Some("MagicDebian"), || {
-            let mut reg = registry(vec![
-                wsl("MagicDebian", "MagicDebianPerso"),
-                wsl("perso", "MagicDebianPerso"),
-            ]);
-
-            let (warnings, plan) = settle_wsl_self_hosts(&mut reg);
-
-            assert_eq!(reg.names(), ["perso"]);
-            assert_eq!(
-                plan.renames,
-                [("wsl:MagicDebian".to_string(), "wsl:perso".to_string())],
-                "the rows move onto the backend name that actually reaches the distro"
-            );
-            assert!(plan.to_local.is_empty());
-            assert!(
-                warnings[0].contains("already reaches") && warnings[0].contains("'wsl:perso'"),
-                "the warning must say it deferred and to which host: {}",
-                warnings[0]
-            );
-        });
-    }
-
-    /// `name` is a free label, so a host can hold the sibling's name while
-    /// launching something else entirely. Deferring on the name alone would
-    /// rewrite live sessions onto a host that runs a different distro — or,
-    /// for an SSH entry, over ssh. The shadow is dropped with no rename
-    /// instead: rows that do not resolve are recoverable by hand, a silent
-    /// misroute is not.
-    #[test]
-    fn a_shadow_does_not_defer_to_an_unrelated_host_holding_the_name() {
-        for other in [
-            wsl("MagicDebianPerso", "Debian-12"),
-            HostDef {
-                name: "MagicDebianPerso".into(),
-                destination: "me@elsewhere".into(),
-                ..Default::default()
-            },
-        ] {
-            crate::session::host_def::with_wsl_distro(Some("MagicDebian"), || {
-                let mut reg = registry(vec![wsl("MagicDebian", "MagicDebianPerso"), other.clone()]);
-
-                let (warnings, plan) = settle_wsl_self_hosts(&mut reg);
-
-                assert_eq!(reg.names(), ["MagicDebianPerso"]);
-                assert!(
-                    plan.renames.is_empty(),
-                    "no rename may point rows at a host reaching somewhere else"
-                );
-                assert!(
-                    plan.to_local.is_empty(),
-                    "and they are not this machine's either — they wait"
-                );
-                assert_eq!(warnings.len(), 1);
-                assert!(
-                    warnings[0].contains("another host already has that name")
-                        && warnings[0].contains("'wsl:MagicDebian'"),
-                    "the warning must name the collision and the stranded spelling: {}",
-                    warnings[0]
-                );
-            });
-        }
-    }
-
-    /// Two shadows share the one spelling `wsl:<us>`, so nothing can say whose
-    /// rows are whose. Both are refused and neither set of rows is touched.
-    #[test]
-    fn two_shadows_are_ambiguous_and_neither_moves_any_row() {
+    fn other_entries_do_not_change_what_a_shadow_settles_to() {
         crate::session::host_def::with_wsl_distro(Some("MagicDebian"), || {
             let mut reg = registry(vec![
                 wsl("MagicDebian", "MagicDebianPerso"),
                 wsl("MagicDebian", "Debian-12"),
+                wsl("MagicDebianPerso", "Debian-12"),
+                HostDef {
+                    name: "devbox".into(),
+                    destination: "me@devbox".into(),
+                    ..Default::default()
+                },
             ]);
 
             let (warnings, plan) = settle_wsl_self_hosts(&mut reg);
 
-            assert!(reg.is_empty());
-            assert!(plan.renames.is_empty());
-            assert!(plan.to_local.is_empty());
-            assert_eq!(warnings.len(), 2);
-            assert!(
-                warnings.iter().all(|w| w.contains("more than one entry")),
-                "each warning must say why neither could be settled: {warnings:?}"
+            assert_eq!(
+                reg.names(),
+                ["MagicDebian", "MagicDebian", "MagicDebianPerso", "devbox"],
+                "no entry is dropped or renamed"
             );
+            assert!(plan.to_local.is_empty());
+            assert_eq!(warnings.len(), 2, "one per shadow: {warnings:?}");
         });
     }
 
     /// The two entries at their most confusing: one is a loopback *named*
-    /// after the sibling, the other a shadow reaching it. Each arm still
-    /// resolves on its own rule — the loopback's rows are this machine's, the
-    /// shadow's are the sibling's — and because the shadow frees the name the
-    /// loopback was squatting on, it re-registers there. `to_local` running
-    /// first is what keeps the arms from meeting: the loopback's rows go local
-    /// before the shadow's are carried onto the same spelling.
+    /// after the sibling, the other a shadow reaching it. Each is settled on
+    /// its own rule and neither reaches into the other's spelling — the
+    /// loopback's rows are this machine's and are healed, the shadow's name is
+    /// withheld.
     #[test]
-    fn a_loopback_and_a_shadow_together_keep_their_arms_apart() {
+    fn a_loopback_is_still_healed_alongside_a_shadow() {
         crate::session::host_def::with_wsl_distro(Some("MagicDebian"), || {
             let mut reg = registry(vec![
                 wsl("MagicDebianPerso", "MagicDebian"),
@@ -824,20 +665,8 @@ mod tests {
 
             let (_, plan) = settle_wsl_self_hosts(&mut reg);
 
-            assert_eq!(reg.names(), ["MagicDebianPerso"]);
-            assert_eq!(
-                reg.get("MagicDebianPerso").unwrap().distro_name(),
-                "MagicDebianPerso",
-                "the name is held by the entry that actually reaches that distro"
-            );
+            assert_eq!(reg.names(), ["MagicDebian"], "only the loopback is dropped");
             assert_eq!(plan.to_local, ["wsl:MagicDebianPerso"]);
-            assert_eq!(
-                plan.renames,
-                [(
-                    "wsl:MagicDebian".to_string(),
-                    "wsl:MagicDebianPerso".to_string()
-                )]
-            );
         });
     }
 

--- a/src/agent/host_config.rs
+++ b/src/agent/host_config.rs
@@ -336,7 +336,7 @@ fn settle_wsl_self_hosts(reg: &mut HostRegistry) -> (Vec<String>, Vec<String>) {
 /// part of it is [`withheld`](WslRepairPlan::withheld).
 ///
 /// Built from the registry as callers will *see* it — `settle_wsl_self_hosts`
-/// then [`augment_with`], the same two steps in the same order as
+/// then `augment_with`, the same two steps in the same order as
 /// [`load_all_with_warnings`] — so what the repair rewrites and what a session
 /// resolves against cannot disagree about who owns a spelling.
 pub fn wsl_repair_plan() -> Result<WslRepairPlan, String> {

--- a/src/agent/host_config.rs
+++ b/src/agent/host_config.rs
@@ -11,7 +11,7 @@ use std::collections::HashSet;
 use std::path::PathBuf;
 use std::process::Command;
 
-use crate::session::{HostDef, HostRegistry};
+use crate::session::{HostDef, HostRegistry, WslRepairPlan};
 
 /// Seed contents for `hosts.toml` on first run: full field documentation plus a
 /// commented-out example, but no active hosts.
@@ -162,53 +162,48 @@ pub fn load_or_seed() -> HostRegistry {
 /// [`load_or_seed`], also returning user-facing warnings for anything that
 /// silently degraded (parse error → no remote hosts, seed failure, …).
 pub fn load_or_seed_with_warnings() -> (HostRegistry, Vec<String>) {
+    match load_or_seed_result() {
+        Ok(loaded) => loaded,
+        Err(failure) => (HostRegistry::default(), vec![failure]),
+    }
+}
+
+/// [`load_or_seed_with_warnings`] before the degradation: `Err` is a
+/// `hosts.toml` whose contents could **not be established** — an unresolvable
+/// path, a seed that could not be written, an unreadable file, a parse error.
+/// The `Ok` warnings are the benign ones (an unknown key), where the registry
+/// still is what the file says.
+///
+/// Only one caller needs the distinction, and it needs it badly:
+/// [`wsl_repair_plan`] rewrites persisted rows according to what the file
+/// says, so reading "could not parse" as "describes no hosts" would relabel a
+/// genuinely remote session — silently, once, and unrecoverably. Everything
+/// else wants the degraded registry and a warning.
+fn load_or_seed_result() -> Result<(HostRegistry, Vec<String>), String> {
     let Some(path) = hosts_config_path() else {
-        return (
-            HostRegistry::default(),
-            vec!["Could not resolve hosts.toml path; no remote hosts".into()],
-        );
+        return Err("Could not resolve hosts.toml path; no remote hosts".into());
     };
 
     if !path.exists() {
         if let Some(parent) = path.parent() {
-            if let Err(e) = std::fs::create_dir_all(parent) {
-                return (
-                    HostRegistry::default(),
-                    vec![format!("Failed to create config dir for hosts.toml: {e}")],
-                );
-            }
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("Failed to create config dir for hosts.toml: {e}"))?;
         }
-        if let Err(e) = std::fs::write(&path, SEED_HOSTS_TOML) {
-            return (
-                HostRegistry::default(),
-                vec![format!("Failed to seed hosts.toml: {e}")],
-            );
-        }
+        std::fs::write(&path, SEED_HOSTS_TOML)
+            .map_err(|e| format!("Failed to seed hosts.toml: {e}"))?;
         tracing::info!(path = %path.display(), "Seeded hosts.toml (no active hosts)");
-        return (HostRegistry::default(), Vec::new());
+        return Ok((HostRegistry::default(), Vec::new()));
     }
 
-    match std::fs::read_to_string(&path) {
-        Ok(contents) => {
-            match super::agent_config::parse_toml_reporting_unknown::<HostRegistry>(
-                &contents,
-                "hosts.toml",
-            ) {
-                Ok((reg, warnings)) => (reg, warnings),
-                Err(e) => (
-                    HostRegistry::default(),
-                    vec![format!(
-                        "hosts.toml: {}; no remote hosts",
-                        super::agent_config::compact_toml_error(&e.to_string())
-                    )],
-                ),
-            }
-        }
-        Err(e) => (
-            HostRegistry::default(),
-            vec![format!("Failed to read hosts.toml: {e}")],
-        ),
-    }
+    let contents =
+        std::fs::read_to_string(&path).map_err(|e| format!("Failed to read hosts.toml: {e}"))?;
+    super::agent_config::parse_toml_reporting_unknown::<HostRegistry>(&contents, "hosts.toml")
+        .map_err(|e| {
+            format!(
+                "hosts.toml: {}; no remote hosts",
+                super::agent_config::compact_toml_error(&e.to_string())
+            )
+        })
 }
 
 /// Load configured hosts (`hosts.toml`) and append auto-discovered local WSL
@@ -217,16 +212,17 @@ pub fn load_or_seed_with_warnings() -> (HostRegistry, Vec<String>) {
 /// config; the discovered set never overrides an explicitly configured host of
 /// the same name.
 ///
-/// Neither half may claim the WSL distro thurbox is running inside: not as a
-/// **loopback** ([`HostDef::is_wsl_loopback`] — this machine, and not a host at
-/// all) and not as a **shadow** of its backend name
-/// ([`HostDef::shadows_current_wsl_distro`]). This is the one chokepoint every
-/// caller shares, so dropping both here is what keeps a local session local —
-/// and the same split decides which already-written rows the one-time repair
-/// puts back ([`wsl_loopback_backend_names`]).
+/// Neither half may claim the WSL distro thurbox is running inside: a
+/// **loopback** ([`HostDef::is_wsl_loopback`]) is this machine and is dropped,
+/// and a **shadow** of its backend name
+/// ([`HostDef::shadows_current_wsl_distro`]) is re-registered under the distro
+/// it reaches. This is the one chokepoint every caller shares, so settling
+/// both here (`settle_wsl_self_hosts`) is what keeps a local session local —
+/// and the same pass decides what the one-time repair owes the rows they
+/// already wrote ([`wsl_repair_plan`]).
 pub fn load_all_with_warnings() -> (HostRegistry, Vec<String>) {
     let (mut reg, mut warnings) = load_or_seed_with_warnings();
-    warnings.extend(drop_wsl_loopback(&mut reg));
+    warnings.extend(settle_wsl_self_hosts(&mut reg).0);
     augment_with_wsl(&mut reg);
     (reg, warnings)
 }
@@ -261,113 +257,123 @@ pub fn cached_registry() -> &'static (HostRegistry, Vec<String>) {
     CACHE.get_or_init(load_all_with_warnings)
 }
 
-/// The configured hosts that may not claim the current WSL distro, split by
-/// the rule that refused each.
+/// Settle every configured entry that claims the WSL distro thurbox runs
+/// inside, in place, and report both the warnings it owes the user and the row
+/// rewrites it owes the database.
 ///
-/// Kept rather than discarded because the one-time repair of the rows they
-/// already wrote is decided by exactly this split — see
-/// [`wsl_loopback_backend_names`].
-#[derive(Debug, Default)]
-struct RefusedWslHosts {
-    /// Entries that point `wsl.exe` back at us. Their backend name is a
-    /// spelling this machine's own *local* rows may be recorded under.
-    loopbacks: Vec<HostDef>,
-    /// Entries that reach another distro while registering as `wsl:<us>`.
-    /// Their backend name is a *genuinely remote* one, whatever it looks like.
-    shadows: Vec<HostDef>,
-}
+/// Two rules, and they differ because only one of the entries can work:
+///
+/// - A [loopback](HostDef::is_wsl_loopback) points `wsl.exe` back at us. It
+///   describes this machine as somewhere else, so it is **dropped** — and the
+///   rows it wrote are this machine's own local rows, so they go to
+///   [`WslRepairPlan::to_local`].
+/// - A [shadow](HostDef::shadows_current_wsl_distro) reaches a real sibling
+///   but *registers* as `wsl:<us>`, the one spelling that has to keep meaning
+///   "this machine". The host itself is fine, so it is **re-registered** under
+///   the distro it reaches and its rows are moved onto that name with it
+///   ([`WslRepairPlan::renames`]). Dropping it instead would strand every
+///   session it had already created, and telling the user to rename it by hand
+///   would not move the rows.
+///
+/// A re-registered shadow **defers** to an entry that already carries the
+/// sibling's name: that is the same distro, so the rows still move onto it and
+/// the duplicate backend is never created. Auto-discovery needs no such
+/// handling — [`augment_with_wsl`] already skips a name that is configured.
+///
+/// Neither case can come from discovery ([`discover_wsl_hosts`] filters the
+/// loopback and names a host after the distro it points at), so both are
+/// hand-written entries and each gets a warning naming what happened.
+fn settle_wsl_self_hosts(reg: &mut HostRegistry) -> (Vec<String>, WslRepairPlan) {
+    let mut warnings = Vec::new();
+    let mut plan = WslRepairPlan::default();
 
-/// Remove the two kinds of configured host that may not claim the current WSL
-/// distro, returning them classified.
-///
-/// A [loopback](HostDef::is_wsl_loopback) points `wsl.exe` back at us and
-/// cannot work: it describes this very machine as somewhere else.
-/// A [shadow](HostDef::shadows_current_wsl_distro) reaches a real sibling but
-/// *registers* as `wsl:<us>`, so its rows are spelled like the ones the
-/// loopback bug wrote; renaming it costs nothing and keeps that backend name
-/// unambiguous.
-///
-/// Auto-discovery can produce neither — it names a host after the distro it
-/// points at, and [`discover_wsl_hosts`] filters the loopback — so both come
-/// only from a hand-written entry.
-fn refuse_wsl_self_hosts(reg: &mut HostRegistry) -> RefusedWslHosts {
-    let mut refused = RefusedWslHosts::default();
-    reg.hosts.retain(|h| {
-        if h.is_wsl_loopback() {
-            refused.loopbacks.push(h.clone());
-            return false;
-        }
-        if h.shadows_current_wsl_distro() {
-            refused.shadows.push(h.clone());
-            return false;
-        }
-        true
-    });
-    refused
-}
+    // The base case, owed before any entry is read: the backend name
+    // auto-discovery offered for the current distro until it was filtered.
+    if let Some(distro) = crate::session::current_wsl_distro() {
+        plan.to_local
+            .push(format!("{}{distro}", crate::session::WSL_BACKEND_PREFIX));
+    }
 
-/// [`refuse_wsl_self_hosts`], reported: one warning per entry removed, because
-/// naming it is better than either honouring it or dropping it in silence.
-fn drop_wsl_loopback(reg: &mut HostRegistry) -> Vec<String> {
-    let refused = refuse_wsl_self_hosts(reg);
-    let loopbacks = refused.loopbacks.iter().map(|h| {
-        format!(
-            "hosts.toml: ignoring host '{}' — it names the WSL distro thurbox \
-             is running in ('{}'), so sessions on it are local, not remote. \
-             Create them with no --host.",
-            h.name,
-            h.distro_name()
-        )
-    });
-    let shadows = refused.shadows.iter().map(|h| {
-        format!(
-            "hosts.toml: ignoring host '{}' — it reaches distro '{}' but is \
-             named after the one thurbox runs in, so its sessions would be \
-             recorded as local. Rename the entry to keep it.",
-            h.name,
-            h.distro_name()
-        )
-    });
-    loopbacks.chain(shadows).collect()
-}
-
-/// The `sessions.backend_type` / `repo_bookmarks.host` spellings on this
-/// machine that the WSL loopback bug can have written — the set
-/// `session_ops::repair_wsl_loopback_rows` relabels local, and the reason that
-/// repair does not live in the migration that records it as owed.
-///
-/// Decided by the registry, not by a spelling. A host is registered — and
-/// persisted — under its `name`, so the two do not coincide in either
-/// direction:
-///
-/// - `wsl:$WSL_DISTRO_NAME` is the base case: what auto-discovery offered
-///   before [`HostDef::is_wsl_loopback`] filtered it.
-/// - **plus** every refused loopback's own backend name: a hand-written
-///   `name = "self", distro = "<us>"` wrote `wsl:self`, and dropping the entry
-///   without healing those rows would strand them on a host `hosts.toml` no
-///   longer describes.
-/// - **minus** every refused shadow's backend name: when such an entry exists,
-///   that spelling reaches a *sibling* and its rows are genuinely remote, so
-///   relabelling them local would act on the wrong machine.
-///
-/// Subtraction is case-insensitive and wins, so an ambiguous pair of entries
-/// leaves the rows alone rather than guessing. Empty off WSL, where there is
-/// no loopback to have written anything.
-pub fn wsl_loopback_backend_names() -> Vec<String> {
-    let mut reg = load_or_seed_with_warnings().0;
-    let refused = refuse_wsl_self_hosts(&mut reg);
-    let discovered = crate::session::current_wsl_distro()
-        .map(|d| format!("{}{d}", crate::session::WSL_BACKEND_PREFIX));
-    let shadowed: Vec<String> = refused.shadows.iter().map(HostDef::backend_name).collect();
-
-    let mut names: Vec<String> = discovered
-        .into_iter()
-        .chain(refused.loopbacks.iter().map(HostDef::backend_name))
-        .filter(|n| !shadowed.iter().any(|s| s.eq_ignore_ascii_case(n)))
+    // The names that will still be in force after this pass, so a shadow can
+    // tell "already described" from "described by an entry about to go".
+    let mut taken: HashSet<String> = reg
+        .hosts
+        .iter()
+        .filter(|h| !h.is_wsl_loopback() && !h.shadows_current_wsl_distro())
+        .map(|h| h.name.clone())
         .collect();
-    names.sort_by_key(|n| n.to_ascii_lowercase());
-    names.dedup_by(|a, b| a.eq_ignore_ascii_case(b));
-    names
+
+    let mut settled = Vec::with_capacity(reg.hosts.len());
+    for mut host in std::mem::take(&mut reg.hosts) {
+        if host.is_wsl_loopback() {
+            warnings.push(format!(
+                "hosts.toml: ignoring host '{}' — it names the WSL distro thurbox \
+                 is running in ('{}'), so sessions on it are local, not remote. \
+                 Create them with no --host.",
+                host.name,
+                host.distro_name()
+            ));
+            plan.to_local.push(host.backend_name());
+            continue;
+        }
+        if host.shadows_current_wsl_distro() {
+            let sibling = host.distro_name();
+            let from = host.backend_name();
+            let to = format!("{}{sibling}", crate::session::WSL_BACKEND_PREFIX);
+            plan.renames.push((from, to));
+            if taken.contains(&sibling) {
+                warnings.push(format!(
+                    "hosts.toml: ignoring host '{}' — it is named after the WSL distro \
+                     thurbox runs in, which has to keep meaning this machine, and host \
+                     '{sibling}' already describes the distro it reaches. Its sessions \
+                     have moved to that host: use --host {sibling}.",
+                    host.name
+                ));
+                continue;
+            }
+            warnings.push(format!(
+                "hosts.toml: host '{}' is named after the WSL distro thurbox runs in, \
+                 which has to keep meaning this machine, so it now registers as the \
+                 distro it reaches. Its sessions have moved with it: use --host \
+                 {sibling}.",
+                host.name
+            ));
+            taken.insert(sibling.clone());
+            host.name = sibling;
+            settled.push(host);
+            continue;
+        }
+        settled.push(host);
+    }
+    reg.hosts = settled;
+
+    // A name being renamed is not this machine's: while such an entry exists
+    // that spelling reaches a sibling, and its rows follow the rename instead.
+    plan.to_local.retain(|n| {
+        !plan
+            .renames
+            .iter()
+            .any(|(from, _)| from.eq_ignore_ascii_case(n))
+    });
+    plan.to_local.sort_by_key(|n| n.to_ascii_lowercase());
+    plan.to_local.dedup_by(|a, b| a.eq_ignore_ascii_case(b));
+
+    (warnings, plan)
+}
+
+/// The row rewrites the one-time WSL repair owes, or the reason `hosts.toml`
+/// could not be read.
+///
+/// `Err` is what keeps the repair honest: it is decided by what the file says,
+/// so a file that cannot be parsed is not "no hosts configured" — it is not an
+/// answer at all, and `session_ops::repair_wsl_loopback_rows` leaves the owed
+/// mark in place and comes back once the file parses.
+///
+/// Both arms come from the **same** load (`settle_wsl_self_hosts`), so they
+/// cannot disagree about who owns `wsl:<us>`.
+pub fn wsl_repair_plan() -> Result<WslRepairPlan, String> {
+    let (mut reg, _) = load_or_seed_result()?;
+    Ok(settle_wsl_self_hosts(&mut reg).1)
 }
 
 /// Append auto-discovered WSL distros to `reg`, skipping any whose name already
@@ -390,8 +396,8 @@ const WSL_INFRA_DISTROS: &[&str] = &["docker-desktop", "docker-desktop-data"];
 /// [`HostKind::Wsl`](crate::session::HostKind::Wsl)).
 ///
 /// Runs `wsl.exe -l -q` and parses its output. Returns empty when `wsl.exe`
-/// isn't available (any non-Windows host, or Windows without WSL) or the
-/// command fails — discovery is strictly best-effort and never blocks startup.
+/// isn't available (no `wsl.exe` on `PATH`, and not Windows) or the command
+/// fails — discovery is strictly best-effort and never blocks startup.
 ///
 /// The distro thurbox is itself running inside is **not** among them: `wsl.exe`
 /// lists it like any other, but it is this machine
@@ -554,27 +560,37 @@ mod tests {
         });
     }
 
+    fn wsl(name: &str, distro: &str) -> HostDef {
+        HostDef {
+            name: name.into(),
+            kind: crate::session::HostKind::Wsl,
+            distro: Some(distro.into()),
+            ..Default::default()
+        }
+    }
+
+    fn registry(hosts: Vec<HostDef>) -> HostRegistry {
+        HostRegistry {
+            config_version: None,
+            hosts,
+        }
+    }
+
     #[test]
-    fn a_configured_loopback_is_dropped_with_a_warning() {
+    fn a_configured_loopback_is_dropped_and_its_rows_owed_to_local() {
         crate::session::host_def::with_wsl_distro(Some("MagicDebian"), || {
-            let mut reg = HostRegistry {
-                config_version: None,
-                hosts: vec![
-                    HostDef {
-                        name: "self".into(),
-                        kind: crate::session::HostKind::Wsl,
-                        distro: Some("MagicDebian".into()),
-                        ..Default::default()
-                    },
-                    HostDef::wsl("Ubuntu"),
-                    HostDef {
-                        name: "devbox".into(),
-                        destination: "me@devbox".into(),
-                        ..Default::default()
-                    },
-                ],
-            };
-            let warnings = drop_wsl_loopback(&mut reg);
+            let mut reg = registry(vec![
+                wsl("self", "MagicDebian"),
+                HostDef::wsl("Ubuntu"),
+                HostDef {
+                    name: "devbox".into(),
+                    destination: "me@devbox".into(),
+                    ..Default::default()
+                },
+            ]);
+
+            let (warnings, plan) = settle_wsl_self_hosts(&mut reg);
+
             assert_eq!(reg.names(), ["Ubuntu", "devbox"]);
             assert_eq!(warnings.len(), 1);
             assert!(
@@ -582,34 +598,154 @@ mod tests {
                 "the warning must name the entry and the distro: {}",
                 warnings[0]
             );
+            // Its own backend name as well as the discovered one: the rows it
+            // wrote are spelled `wsl:self`.
+            assert_eq!(plan.to_local, ["wsl:MagicDebian", "wsl:self"]);
+            assert!(plan.renames.is_empty());
+        });
+    }
+
+    /// A host named after the current distro reaches a real sibling, so it is
+    /// re-registered under that sibling rather than dropped — dropping it
+    /// would strand every session it had already created, and a hand rename
+    /// would leave those rows spelled after a host that no longer exists.
+    #[test]
+    fn a_configured_shadow_is_re_registered_under_the_distro_it_reaches() {
+        crate::session::host_def::with_wsl_distro(Some("MagicDebian"), || {
+            let mut reg = registry(vec![
+                HostDef {
+                    worktrees_dir: Some("/srv/wt".into()),
+                    ..wsl("MagicDebian", "MagicDebianPerso")
+                },
+                HostDef::wsl("Ubuntu"),
+            ]);
+
+            let (warnings, plan) = settle_wsl_self_hosts(&mut reg);
+
+            assert_eq!(reg.names(), ["MagicDebianPerso", "Ubuntu"]);
+            assert_eq!(
+                reg.get("MagicDebianPerso")
+                    .unwrap()
+                    .worktrees_dir
+                    .as_deref(),
+                Some("/srv/wt"),
+                "the entry keeps working, overrides and all — only its name changed"
+            );
+            assert_eq!(
+                plan.renames,
+                [(
+                    "wsl:MagicDebian".to_string(),
+                    "wsl:MagicDebianPerso".to_string()
+                )]
+            );
+            // The subtraction arm: while that entry claims the spelling, it is
+            // a sibling's, so its rows must not be relabelled local.
+            assert!(plan.to_local.is_empty());
+            assert_eq!(warnings.len(), 1);
+            assert!(
+                warnings[0].contains("--host MagicDebianPerso"),
+                "the warning must say which name --host now takes: {}",
+                warnings[0]
+            );
+        });
+    }
+
+    /// One distro has one backend name, so a shadow whose sibling is already
+    /// described defers to that entry instead of duplicating it — and its rows
+    /// still move, because the host they now name reaches them.
+    #[test]
+    fn a_re_registered_shadow_defers_to_an_entry_that_already_holds_the_name() {
+        crate::session::host_def::with_wsl_distro(Some("MagicDebian"), || {
+            let mut reg = registry(vec![
+                wsl("MagicDebian", "MagicDebianPerso"),
+                HostDef::wsl("MagicDebianPerso"),
+            ]);
+
+            let (warnings, plan) = settle_wsl_self_hosts(&mut reg);
+
+            assert_eq!(reg.names(), ["MagicDebianPerso"]);
+            assert_eq!(
+                plan.renames,
+                [(
+                    "wsl:MagicDebian".to_string(),
+                    "wsl:MagicDebianPerso".to_string()
+                )]
+            );
+            assert!(
+                warnings[0].contains("already describes")
+                    && warnings[0].contains("--host MagicDebianPerso"),
+                "the warning must say it deferred and to which name: {}",
+                warnings[0]
+            );
+        });
+    }
+
+    /// The two entries at their most confusing: one is a loopback *named*
+    /// after the sibling, the other a shadow reaching it. Each arm still
+    /// resolves on its own rule — the loopback's rows are this machine's, the
+    /// shadow's are the sibling's — and because the shadow frees the name the
+    /// loopback was squatting on, it re-registers there. `to_local` running
+    /// first is what keeps the arms from meeting: the loopback's rows go local
+    /// before the shadow's are carried onto the same spelling.
+    #[test]
+    fn a_loopback_and_a_shadow_together_keep_their_arms_apart() {
+        crate::session::host_def::with_wsl_distro(Some("MagicDebian"), || {
+            let mut reg = registry(vec![
+                wsl("MagicDebianPerso", "MagicDebian"),
+                wsl("MagicDebian", "MagicDebianPerso"),
+            ]);
+
+            let (_, plan) = settle_wsl_self_hosts(&mut reg);
+
+            assert_eq!(reg.names(), ["MagicDebianPerso"]);
+            assert_eq!(
+                reg.get("MagicDebianPerso").unwrap().distro_name(),
+                "MagicDebianPerso",
+                "the name is held by the entry that actually reaches that distro"
+            );
+            assert_eq!(plan.to_local, ["wsl:MagicDebianPerso"]);
+            assert_eq!(
+                plan.renames,
+                [(
+                    "wsl:MagicDebian".to_string(),
+                    "wsl:MagicDebianPerso".to_string()
+                )]
+            );
         });
     }
 
     #[test]
-    fn a_configured_shadow_of_our_distro_is_dropped_with_its_own_warning() {
+    fn off_wsl_nothing_is_settled_and_nothing_is_owed() {
+        crate::session::host_def::with_wsl_distro(None, || {
+            let mut reg = registry(vec![HostDef::wsl("Ubuntu"), wsl("work", "Debian")]);
+
+            let (warnings, plan) = settle_wsl_self_hosts(&mut reg);
+
+            assert_eq!(reg.names(), ["Ubuntu", "work"]);
+            assert!(warnings.is_empty());
+            assert!(plan.is_empty());
+        });
+    }
+
+    /// The plan is decided by what `hosts.toml` says, so a file that cannot be
+    /// parsed is not an answer — it must not read as "no entry claims
+    /// `wsl:<us>`", which would relabel a shadow host's sibling sessions local.
+    #[test]
+    fn an_unparseable_hosts_toml_yields_no_plan_at_all() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let path = hosts_config_path().unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "[[hosts]\nname = \"MagicDebian\"\n").unwrap();
+
         crate::session::host_def::with_wsl_distro(Some("MagicDebian"), || {
-            let mut reg = HostRegistry {
-                config_version: None,
-                hosts: vec![
-                    // Reaches a genuine sibling, but registers as
-                    // `wsl:MagicDebian` — indistinguishable from a loopback row.
-                    HostDef {
-                        name: "MagicDebian".into(),
-                        kind: crate::session::HostKind::Wsl,
-                        distro: Some("MagicDebianPerso".into()),
-                        ..Default::default()
-                    },
-                    HostDef::wsl("Ubuntu"),
-                ],
-            };
-            let warnings = drop_wsl_loopback(&mut reg);
-            assert_eq!(reg.names(), ["Ubuntu"]);
-            assert_eq!(warnings.len(), 1);
             assert!(
-                warnings[0].contains("MagicDebianPerso") && warnings[0].contains("Rename"),
-                "the warning must name the distro it reaches and say to rename: {}",
-                warnings[0]
+                wsl_repair_plan().is_err(),
+                "an unreadable file is a failure, not an empty registry"
             );
+            // The degrading loader still answers, for every other caller.
+            let (reg, warnings) = load_or_seed_with_warnings();
+            assert!(reg.is_empty() && !warnings.is_empty());
         });
     }
 

--- a/src/agent/host_config.rs
+++ b/src/agent/host_config.rs
@@ -325,13 +325,15 @@ fn settle_wsl_self_hosts(reg: &mut HostRegistry) -> (Vec<String>, Vec<String>) {
     (warnings, candidates)
 }
 
-/// The row rewrites the one-time WSL repair owes, or the reason `hosts.toml`
-/// could not be read.
+/// The row rewrites the one-time WSL repair owes, or the reason nothing can be
+/// said yet.
 ///
-/// `Err` is what keeps the repair honest: it is decided by what the file says,
-/// so a file that cannot be parsed is not "no hosts configured" — it is not an
-/// answer at all, and `session_ops::repair_wsl_loopback_rows` leaves the owed
-/// mark in place and comes back once the file parses.
+/// `Err` is what keeps the repair honest, and it means one thing: a **question
+/// that could not be asked** — `hosts.toml` did not parse, the WSL distros
+/// could not be enumerated. Neither is "no hosts configured", so
+/// `session_ops::repair_wsl_loopback_rows` touches nothing, leaves the owed
+/// mark in place, and comes back. A plan, by contrast, is an answer, even when
+/// part of it is [`withheld`](WslRepairPlan::withheld).
 ///
 /// Built from the registry as callers will *see* it — `settle_wsl_self_hosts`
 /// then [`augment_with`], the same two steps in the same order as
@@ -345,26 +347,32 @@ pub fn wsl_repair_plan() -> Result<WslRepairPlan, String> {
     if candidates.is_empty() {
         return Ok(WslRepairPlan::default());
     }
-    let serving = match try_discover_wsl_hosts() {
-        Ok(discovered) => {
-            augment_with(&mut reg, discovered);
-            Some(&reg)
-        }
-        Err(e) => {
-            tracing::warn!(
-                "WSL distros could not be enumerated ({e}); the one-time row repair \
-                 withholds every candidate rather than risk relabelling a live \
-                 sibling's sessions as local"
-            );
-            None
-        }
-    };
-    Ok(wsl_repair_plan_for(candidates, serving))
+    if any_candidate_a_sibling_could_claim(&candidates) {
+        augment_with(&mut reg, discover_wsl_hosts()?);
+    }
+    Ok(wsl_repair_plan_for(candidates, &reg))
+}
+
+/// Whether enumerating the distros could change any candidate's verdict.
+///
+/// Discovery only ever *adds* hosts ([`augment_with`]), so it can only add
+/// claims — and never one for `wsl:<us>`, the spelling it filters out
+/// ([`wsl_hosts_from`]). So the only candidate it can decide is one spelled
+/// after a *different* distro, which is a hand-written loopback under a `name`
+/// that is not this distro's. Nothing hand-written, or an entry named after
+/// the distro it points at, means the repair asks `wsl.exe` nothing: no
+/// subprocess on the startup path, and no outcome that depends on whether this
+/// machine has a working one.
+fn any_candidate_a_sibling_could_claim(candidates: &[String]) -> bool {
+    let ours = crate::session::current_wsl_distro()
+        .map(|d| format!("{}{d}", crate::session::WSL_BACKEND_PREFIX));
+    candidates
+        .iter()
+        .any(|c| !ours.as_deref().is_some_and(|o| o.eq_ignore_ascii_case(c)))
 }
 
 /// Split `candidates` into what the repair may rewrite and what it must leave
-/// alone, given the registry that will `serve` them — `None` when the WSL
-/// distros could not be enumerated.
+/// alone, given the registry that will `serve` them.
 ///
 /// A candidate is withheld when a host the registry serves registers under
 /// exactly that backend name: rows there may be that host's own, and a live
@@ -373,16 +381,11 @@ pub fn wsl_repair_plan() -> Result<WslRepairPlan, String> {
 /// resolves through — an `ssh:` host named after a distro serves none of its
 /// rows.
 ///
-/// An enumeration that failed reads as "claimed", never as "nothing claims
-/// it": every candidate is withheld and the repair comes back, because rows
-/// that stay put are recoverable by hand and a silent misroute is not.
-fn wsl_repair_plan_for(candidates: Vec<String>, serving: Option<&HostRegistry>) -> WslRepairPlan {
-    let Some(serving) = serving else {
-        return WslRepairPlan {
-            to_local: Vec::new(),
-            withheld: candidates,
-        };
-    };
+/// Withholding is the **answer** for that name, not a deferral of one: the
+/// rows under a claimed spelling are permanently indistinguishable, so no
+/// later start can classify them any better. See
+/// `session_ops::repair_wsl_loopback_rows`, which retires the repair on this.
+fn wsl_repair_plan_for(candidates: Vec<String>, serving: &HostRegistry) -> WslRepairPlan {
     let claimed: HashSet<String> = serving
         .hosts
         .iter()
@@ -400,7 +403,7 @@ fn wsl_repair_plan_for(candidates: Vec<String>, serving: Option<&HostRegistry>) 
 /// be enumerated is one the host picker does not offer, which is the same
 /// outcome as not having it.
 fn augment_with_wsl(reg: &mut HostRegistry) {
-    match try_discover_wsl_hosts() {
+    match discover_wsl_hosts() {
         Ok(discovered) => augment_with(reg, discovered),
         Err(e) => tracing::debug!(error = %e, "no WSL distros auto-discovered"),
     }
@@ -425,25 +428,48 @@ fn augment_with(reg: &mut HostRegistry, discovered: Vec<HostDef>) {
 /// shells — filtered out of auto-discovery (matched case-insensitively).
 const WSL_INFRA_DISTROS: &[&str] = &["docker-desktop", "docker-desktop-data"];
 
-/// Auto-discover installed WSL distros as [`HostDef`]s (kind
-/// [`HostKind::Wsl`](crate::session::HostKind::Wsl)).
+/// What [`discover_wsl_hosts`] should answer instead of running `wsl.exe`.
 ///
-/// Returns empty rather than erroring on a machine that has no `wsl.exe` at
-/// all, and never blocks startup. See [`try_discover_wsl_hosts`] for the
-/// distinction between that and a failed enumeration.
+/// `wsl_exe_available()` is unconditionally true on Windows, and the CI gate
+/// runs the suite there, so without this the repair's outcome is decided by
+/// whether the runner happens to have a distro installed. Tests pin the list.
+#[cfg(test)]
+static DISCOVERY_STUB: std::sync::Mutex<Option<Result<Vec<HostDef>, String>>> =
+    std::sync::Mutex::new(None);
+
+/// Run `f` with WSL discovery answering `stub` instead of consulting the
+/// machine's own `wsl.exe`, restoring what was there before.
 ///
-/// The distro thurbox is itself running inside is **not** among them: `wsl.exe`
-/// lists it like any other, but it is this machine
-/// ([`HostDef::is_wsl_loopback`] argues what registering it cost). Its siblings
-/// are still discovered, so a thurbox inside one distro reaches the rest.
-pub(crate) fn discover_wsl_hosts() -> Vec<HostDef> {
-    try_discover_wsl_hosts().unwrap_or_else(|e| {
-        tracing::debug!(error = %e, "no WSL distros auto-discovered");
-        Vec::new()
-    })
+/// Serialized on a process-wide lock, and the **only** way a test may set it,
+/// for the reason `session::host_def::with_wsl_distro` gives: under plain
+/// `cargo test` these tests share one process. Nest it *inside*
+/// `with_wsl_distro` when a test needs both, so the two locks are always taken
+/// in one order.
+#[cfg(test)]
+pub(crate) fn with_discovered_wsl<T>(
+    stub: Result<Vec<HostDef>, String>,
+    f: impl FnOnce() -> T,
+) -> T {
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    let _guard = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let saved = DISCOVERY_STUB
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .replace(stub);
+    let out = f();
+    *DISCOVERY_STUB.lock().unwrap_or_else(|e| e.into_inner()) = saved;
+    out
 }
 
-/// [`discover_wsl_hosts`], separating "there are none" from "could not say".
+/// Auto-discover installed WSL distros as [`HostDef`]s (kind
+/// [`HostKind::Wsl`](crate::session::HostKind::Wsl)), separating "there are
+/// none" from "could not say".
+///
+/// The distro thurbox is itself running inside is **not** among them:
+/// `wsl.exe` lists it like any other, but it is this machine
+/// ([`HostDef::is_wsl_loopback`] argues what registering it cost). Its
+/// siblings are still discovered, so a thurbox inside one distro reaches the
+/// rest.
 ///
 /// No `wsl.exe` at all (not Windows, nothing on `PATH`) is an **answer**:
 /// there is no WSL here, so there are no distros — and interop puts `wsl.exe`
@@ -453,7 +479,15 @@ pub(crate) fn discover_wsl_hosts() -> Vec<HostDef> {
 /// `wsl.exe` failing when it *is* there is not an answer: distros may exist
 /// and be unlisted. That is `Err`, which is what lets `wsl_repair_plan`
 /// withhold instead of reading the silence as "no host claims this name".
-fn try_discover_wsl_hosts() -> Result<Vec<HostDef>, String> {
+pub(crate) fn discover_wsl_hosts() -> Result<Vec<HostDef>, String> {
+    #[cfg(test)]
+    if let Some(stub) = DISCOVERY_STUB
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .clone()
+    {
+        return stub;
+    }
     if !wsl_exe_available() {
         return Ok(Vec::new());
     }
@@ -619,23 +653,17 @@ mod tests {
         }
     }
 
-    /// The two steps `wsl_repair_plan` runs, with `discovered` standing in for
-    /// what `wsl.exe -l -q` reports — `None` = it could not be asked. Only the
-    /// subprocess is swapped; settling, augmenting and withholding are the
-    /// same code the real path takes.
+    /// The three steps `wsl_repair_plan` runs, with `discovered` standing in
+    /// for what `wsl.exe -l -q` reports. Only the subprocess is swapped;
+    /// settling, augmenting and withholding are the same code the real path
+    /// takes.
     fn settle_and_plan(
         reg: &mut HostRegistry,
-        discovered: Option<Vec<HostDef>>,
+        discovered: Vec<HostDef>,
     ) -> (Vec<String>, WslRepairPlan) {
         let (warnings, candidates) = settle_wsl_self_hosts(reg);
-        let plan = match discovered {
-            Some(hosts) => {
-                augment_with(reg, hosts);
-                wsl_repair_plan_for(candidates, Some(reg))
-            }
-            None => wsl_repair_plan_for(candidates, None),
-        };
-        (warnings, plan)
+        augment_with(reg, discovered);
+        (warnings, wsl_repair_plan_for(candidates, reg))
     }
 
     #[test]
@@ -651,7 +679,7 @@ mod tests {
                 },
             ]);
 
-            let (warnings, plan) = settle_and_plan(&mut reg, Some(Vec::new()));
+            let (warnings, plan) = settle_and_plan(&mut reg, Vec::new());
 
             assert_eq!(reg.names(), ["Ubuntu", "devbox"]);
             assert_eq!(warnings.len(), 1);
@@ -678,7 +706,7 @@ mod tests {
         crate::session::host_def::with_wsl_distro(Some("Ubuntu"), || {
             let mut reg = registry(vec![wsl("Debian", "Ubuntu")]);
 
-            let (_, plan) = settle_and_plan(&mut reg, Some(vec![HostDef::wsl("Debian")]));
+            let (_, plan) = settle_and_plan(&mut reg, vec![HostDef::wsl("Debian")]);
 
             assert_eq!(
                 reg.names(),
@@ -698,7 +726,7 @@ mod tests {
         crate::session::host_def::with_wsl_distro(Some("Ubuntu"), || {
             let mut reg = registry(vec![wsl("dev", "Ubuntu"), wsl("dev", "Debian")]);
 
-            let (_, plan) = settle_and_plan(&mut reg, Some(Vec::new()));
+            let (_, plan) = settle_and_plan(&mut reg, Vec::new());
 
             assert_eq!(reg.names(), ["dev"]);
             assert_eq!(plan.to_local, ["wsl:Ubuntu"]);
@@ -722,24 +750,49 @@ mod tests {
                 },
             ]);
 
-            let (_, plan) = settle_and_plan(&mut reg, Some(Vec::new()));
+            let (_, plan) = settle_and_plan(&mut reg, Vec::new());
 
             assert_eq!(plan.to_local, ["wsl:Debian", "wsl:Ubuntu"]);
             assert!(plan.withheld.is_empty());
         });
     }
 
-    /// Distros that could not be enumerated are not "no distros": a sibling
-    /// may hold a candidate's name and be unlisted. Every candidate waits.
+    /// Distros that could not be enumerated are a question that could not be
+    /// asked, so the plan is `Err` and the repair stays owed — never a plan
+    /// that reads the silence as "nothing claims this name".
     #[test]
-    fn an_unenumerable_wsl_withholds_every_candidate() {
+    fn an_unenumerable_wsl_yields_no_plan_at_all() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let path = hosts_config_path().unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            "[[hosts]]\nname = \"self\"\nkind = \"wsl\"\ndistro = \"MagicDebian\"\n",
+        )
+        .unwrap();
+
         crate::session::host_def::with_wsl_distro(Some("MagicDebian"), || {
-            let mut reg = registry(vec![wsl("self", "MagicDebian")]);
-
-            let (_, plan) = settle_and_plan(&mut reg, None);
-
-            assert!(plan.to_local.is_empty(), "nothing is rewritten on a guess");
-            assert_eq!(plan.withheld, ["wsl:MagicDebian", "wsl:self"]);
+            with_discovered_wsl(Err("wsl.exe -l -q failed".to_string()), || {
+                assert!(
+                    wsl_repair_plan().is_err(),
+                    "a candidate named after no distro we know needs the list"
+                );
+            });
+            // The base spelling is one discovery can never claim, so a list it
+            // could not produce decides nothing: no subprocess, and the same
+            // answer on a machine with a broken `wsl.exe`.
+            std::fs::write(&path, "").unwrap();
+            with_discovered_wsl(
+                Err("wsl.exe must not be consulted here".to_string()),
+                || {
+                    assert_eq!(
+                        wsl_repair_plan().unwrap().to_local,
+                        ["wsl:MagicDebian"],
+                        "the base case is answered without asking"
+                    );
+                },
+            );
         });
     }
 
@@ -758,7 +811,7 @@ mod tests {
                 HostDef::wsl("Ubuntu"),
             ]);
 
-            let (warnings, plan) = settle_and_plan(&mut reg, Some(Vec::new()));
+            let (warnings, plan) = settle_and_plan(&mut reg, Vec::new());
 
             assert_eq!(reg.names(), ["MagicDebian", "Ubuntu"]);
             assert_eq!(
@@ -796,7 +849,7 @@ mod tests {
                 },
             ]);
 
-            let (warnings, plan) = settle_and_plan(&mut reg, Some(Vec::new()));
+            let (warnings, plan) = settle_and_plan(&mut reg, Vec::new());
 
             assert_eq!(
                 reg.names(),
@@ -822,7 +875,7 @@ mod tests {
                 wsl("MagicDebian", "MagicDebianPerso"),
             ]);
 
-            let (_, plan) = settle_and_plan(&mut reg, Some(Vec::new()));
+            let (_, plan) = settle_and_plan(&mut reg, Vec::new());
 
             assert_eq!(reg.names(), ["MagicDebian"], "only the loopback is dropped");
             assert_eq!(plan.to_local, ["wsl:MagicDebianPerso"]);
@@ -835,7 +888,7 @@ mod tests {
         crate::session::host_def::with_wsl_distro(None, || {
             let mut reg = registry(vec![HostDef::wsl("Ubuntu"), wsl("work", "Debian")]);
 
-            let (warnings, plan) = settle_and_plan(&mut reg, Some(Vec::new()));
+            let (warnings, plan) = settle_and_plan(&mut reg, Vec::new());
 
             assert_eq!(reg.names(), ["Ubuntu", "work"]);
             assert!(warnings.is_empty());

--- a/src/agent/host_config.rs
+++ b/src/agent/host_config.rs
@@ -217,10 +217,11 @@ pub fn load_or_seed_with_warnings() -> (HostRegistry, Vec<String>) {
 /// config; the discovered set never overrides an explicitly configured host of
 /// the same name.
 ///
-/// Neither half may register a **loopback** — the WSL distro thurbox is running
-/// inside, which is this machine and not a host at all
-/// ([`HostDef::is_wsl_loopback`]). This is the one chokepoint every caller
-/// shares, so dropping it here is what keeps a local session local.
+/// Neither half may claim the WSL distro thurbox is running inside: not as a
+/// **loopback** ([`HostDef::is_wsl_loopback`] — this machine, and not a host at
+/// all) and not as a **shadow** of its backend name
+/// ([`HostDef::shadows_current_wsl_distro`]). This is the one chokepoint every
+/// caller shares, so dropping both here is what keeps a local session local.
 pub fn load_all_with_warnings() -> (HostRegistry, Vec<String>) {
     let (mut reg, mut warnings) = load_or_seed_with_warnings();
     warnings.extend(drop_wsl_loopback(&mut reg));
@@ -258,35 +259,51 @@ pub fn cached_registry() -> &'static (HostRegistry, Vec<String>) {
     CACHE.get_or_init(load_all_with_warnings)
 }
 
-/// Append auto-discovered WSL distros to `reg`, skipping any whose name already
-/// matches a configured host (so a hand-written `hosts.toml` entry for a distro
-/// — e.g. with a custom `worktrees_dir` — wins over the bare discovered one).
-/// Drop a configured host that names the WSL distro thurbox is running inside,
-/// returning one warning per entry removed.
+/// Drop the two kinds of configured host that may not claim the current WSL
+/// distro, returning one warning per entry removed.
 ///
-/// Such an entry is a loopback ([`HostDef::is_wsl_loopback`]) and cannot work:
-/// it describes this very machine as somewhere else. Auto-discovery never
-/// offers one — [`discover_wsl_hosts`] filters it — so the only way to get one
-/// is by hand, and a warning naming it is better than either honouring it or
-/// removing it in silence.
+/// A [loopback](HostDef::is_wsl_loopback) points `wsl.exe` back at us and
+/// cannot work: it describes this very machine as somewhere else.
+/// A [shadow](HostDef::shadows_current_wsl_distro) reaches a real sibling but
+/// *registers* as `wsl:<us>`, so its rows are indistinguishable from the ones
+/// the loopback bug wrote and the schema v47 heal would relabel them local;
+/// renaming it costs nothing and keeps that backend name unambiguous.
+///
+/// Auto-discovery can produce neither — it names a host after the distro it
+/// points at, and [`discover_wsl_hosts`] filters the loopback — so both come
+/// only from a hand-written entry, and a warning naming it is better than
+/// either honouring it or removing it in silence.
 fn drop_wsl_loopback(reg: &mut HostRegistry) -> Vec<String> {
     let mut warnings = Vec::new();
     reg.hosts.retain(|h| {
-        if !h.is_wsl_loopback() {
-            return true;
+        if h.is_wsl_loopback() {
+            warnings.push(format!(
+                "hosts.toml: ignoring host '{}' — it names the WSL distro thurbox \
+                 is running in ('{}'), so sessions on it are local, not remote. \
+                 Create them with no --host.",
+                h.name,
+                h.distro_name()
+            ));
+            return false;
         }
-        warnings.push(format!(
-            "hosts.toml: ignoring host '{}' — it names the WSL distro thurbox \
-             is running in ('{}'), so sessions on it are local, not remote. \
-             Create them with no --host.",
-            h.name,
-            h.distro_name()
-        ));
-        false
+        if h.shadows_current_wsl_distro() {
+            warnings.push(format!(
+                "hosts.toml: ignoring host '{}' — it reaches distro '{}' but is \
+                 named after the one thurbox runs in, so its sessions would be \
+                 recorded as local. Rename the entry to keep it.",
+                h.name,
+                h.distro_name()
+            ));
+            return false;
+        }
+        true
     });
     warnings
 }
 
+/// Append auto-discovered WSL distros to `reg`, skipping any whose name already
+/// matches a configured host (so a hand-written `hosts.toml` entry for a distro
+/// — e.g. with a custom `worktrees_dir` — wins over the bare discovered one).
 fn augment_with_wsl(reg: &mut HostRegistry) {
     let configured: HashSet<&str> = reg.hosts.iter().map(|h| h.name.as_str()).collect();
     let discovered: Vec<HostDef> = discover_wsl_hosts()
@@ -494,6 +511,34 @@ mod tests {
             assert!(
                 warnings[0].contains("'self'") && warnings[0].contains("MagicDebian"),
                 "the warning must name the entry and the distro: {}",
+                warnings[0]
+            );
+        });
+    }
+
+    #[test]
+    fn a_configured_shadow_of_our_distro_is_dropped_with_its_own_warning() {
+        crate::session::host_def::with_wsl_distro(Some("MagicDebian"), || {
+            let mut reg = HostRegistry {
+                config_version: None,
+                hosts: vec![
+                    // Reaches a genuine sibling, but registers as
+                    // `wsl:MagicDebian` — indistinguishable from a loopback row.
+                    HostDef {
+                        name: "MagicDebian".into(),
+                        kind: crate::session::HostKind::Wsl,
+                        distro: Some("MagicDebianPerso".into()),
+                        ..Default::default()
+                    },
+                    HostDef::wsl("Ubuntu"),
+                ],
+            };
+            let warnings = drop_wsl_loopback(&mut reg);
+            assert_eq!(reg.names(), ["Ubuntu"]);
+            assert_eq!(warnings.len(), 1);
+            assert!(
+                warnings[0].contains("MagicDebianPerso") && warnings[0].contains("Rename"),
+                "the warning must name the distro it reaches and say to rename: {}",
                 warnings[0]
             );
         });

--- a/src/agent/host_config.rs
+++ b/src/agent/host_config.rs
@@ -245,7 +245,8 @@ pub fn load_all() -> HostRegistry {
 /// [`load_all_with_warnings`], resolved once and held for the process lifetime.
 ///
 /// Loading is not just a file read: WSL discovery walks `$PATH` for `wsl.exe`
-/// and, on Windows, runs `wsl.exe -l -q` — and the callers on the TUI's hot
+/// and runs `wsl.exe -l -q` wherever it finds one — on Windows, and inside a
+/// distro, where interop puts it on `PATH` — and the callers on the TUI's hot
 /// paths (the snapshot rebuild, `session_ops::resolve_host` per diff request,
 /// the metrics/usage sampler, the command drain) were each paying that per
 /// call. The same reasoning as `git::remote::remote_home_cache`: `hosts.toml`

--- a/src/agent/host_config.rs
+++ b/src/agent/host_config.rs
@@ -7,7 +7,7 @@
 //! and behaves exactly as before. If the file exists but cannot be read or
 //! parsed, we fall back to an empty registry rather than failing to start.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -37,7 +37,9 @@ pub const SEED_HOSTS_TOML: &str = r#"# Thurbox hosts  —  ~/.config/thurbox/hos
 #
 # Running thurbox INSIDE a distro discovers its siblings, but never the distro
 # itself: that one is this machine, and a session on it is a plain local
-# session (no --host). An entry naming it is ignored with a warning.
+# session (no --host). An entry whose `distro` is that one is ignored with a
+# startup warning; an entry merely *named* after it is re-registered under the
+# distro it reaches, and its existing sessions move with it.
 #
 # This file starts empty (every entry below is commented out): a fresh install
 # registers zero SSH hosts (WSL distros still auto-discover) and otherwise
@@ -275,10 +277,18 @@ pub fn cached_registry() -> &'static (HostRegistry, Vec<String>) {
 ///   session it had already created, and telling the user to rename it by hand
 ///   would not move the rows.
 ///
-/// A re-registered shadow **defers** to an entry that already carries the
-/// sibling's name: that is the same distro, so the rows still move onto it and
-/// the duplicate backend is never created. Auto-discovery needs no such
-/// handling — [`augment_with_wsl`] already skips a name that is configured.
+/// A re-registered shadow **defers** to an entry that already *reaches* the
+/// same distro: the rows move onto that entry's own backend name and the
+/// duplicate backend is never created. The test is the distro, never the name
+/// — `name` is a free label, so an unrelated host can hold the sibling's name
+/// while launching something else entirely, and renaming the rows onto it
+/// would route live sessions at the wrong distro (or, for an SSH entry, over
+/// ssh). That case is **dropped with no rename**: the rows keep their spelling
+/// and stay unresolvable until the collision is settled by hand, which is
+/// recoverable, where a silent misroute is not. Two shadows at once are
+/// refused the same way — they share one spelling, so nothing can say whose
+/// rows are whose. Auto-discovery needs no such handling
+/// ([`augment_with_wsl`] already skips a name that is configured).
 ///
 /// Neither case can come from discovery ([`discover_wsl_hosts`] filters the
 /// loopback and names a host after the distro it points at), so both are
@@ -294,14 +304,39 @@ fn settle_wsl_self_hosts(reg: &mut HostRegistry) -> (Vec<String>, WslRepairPlan)
             .push(format!("{}{distro}", crate::session::WSL_BACKEND_PREFIX));
     }
 
-    // The names that will still be in force after this pass, so a shadow can
-    // tell "already described" from "described by an entry about to go".
+    // What will still be in force after this pass, so a shadow can tell
+    // "already described" from "described by an entry about to go". Names and
+    // distros are both matched the way `wsl.exe -d` matches one, so they are
+    // held folded.
+    let survives =
+        |h: &HostDef| -> bool { !h.is_wsl_loopback() && !h.shadows_current_wsl_distro() };
     let mut taken: HashSet<String> = reg
         .hosts
         .iter()
-        .filter(|h| !h.is_wsl_loopback() && !h.shadows_current_wsl_distro())
-        .map(|h| h.name.clone())
+        .filter(|h| survives(h))
+        .map(|h| h.name.to_ascii_lowercase())
         .collect();
+    // The distro an entry reaches -> the backend name it reaches it under.
+    // This, not `taken`, is what a shadow may defer to.
+    let mut reaching: HashMap<String, String> = reg
+        .hosts
+        .iter()
+        .filter(|h| h.is_wsl() && survives(h))
+        .map(|h| (h.distro_name().to_ascii_lowercase(), h.backend_name()))
+        .collect();
+
+    // Every spelling a shadow claims, whatever becomes of the entry. The
+    // subtraction below keys on this rather than on the renames, so a shadow
+    // that is dropped still keeps its genuinely remote rows off `to_local`.
+    let mut shadowed: Vec<String> = Vec::new();
+    // One spelling cannot rename two ways, so a second shadow makes both
+    // ambiguous rather than making the first one wrong.
+    let ambiguous = reg
+        .hosts
+        .iter()
+        .filter(|h| h.shadows_current_wsl_distro())
+        .count()
+        > 1;
 
     let mut settled = Vec::with_capacity(reg.hosts.len());
     for mut host in std::mem::take(&mut reg.hosts) {
@@ -319,18 +354,47 @@ fn settle_wsl_self_hosts(reg: &mut HostRegistry) -> (Vec<String>, WslRepairPlan)
         if host.shadows_current_wsl_distro() {
             let sibling = host.distro_name();
             let from = host.backend_name();
-            let to = format!("{}{sibling}", crate::session::WSL_BACKEND_PREFIX);
-            plan.renames.push((from, to));
-            if taken.contains(&sibling) {
+            shadowed.push(from.clone());
+
+            if ambiguous {
                 warnings.push(format!(
-                    "hosts.toml: ignoring host '{}' — it is named after the WSL distro \
-                     thurbox runs in, which has to keep meaning this machine, and host \
-                     '{sibling}' already describes the distro it reaches. Its sessions \
-                     have moved to that host: use --host {sibling}.",
+                    "hosts.toml: ignoring host '{}' — more than one entry is named after \
+                     the WSL distro thurbox runs in, so they share one backend name and \
+                     nothing can say which sessions belong to which. Rename all but one \
+                     to keep them; their sessions are left as they are.",
                     host.name
                 ));
                 continue;
             }
+            if let Some(target) = reaching.get(&sibling.to_ascii_lowercase()) {
+                warnings.push(format!(
+                    "hosts.toml: ignoring host '{}' — it is named after the WSL distro \
+                     thurbox runs in, which has to keep meaning this machine, and \
+                     '{target}' already reaches the distro it points at ('{sibling}'). \
+                     Its sessions have moved to that host.",
+                    host.name
+                ));
+                if !target.eq_ignore_ascii_case(&from) {
+                    plan.renames.push((from, target.clone()));
+                }
+                continue;
+            }
+            if taken.contains(&sibling.to_ascii_lowercase()) {
+                // The name is held by a host that reaches somewhere else.
+                // Moving the rows onto it would point live sessions at the
+                // wrong distro, so they keep their spelling and wait.
+                warnings.push(format!(
+                    "hosts.toml: ignoring host '{}' — it is named after the WSL distro \
+                     thurbox runs in, which has to keep meaning this machine, and it \
+                     cannot re-register as '{sibling}' because another host already has \
+                     that name and reaches somewhere else. Rename one of the two; until \
+                     then its sessions stay recorded on '{from}' and will not resolve.",
+                    host.name
+                ));
+                continue;
+            }
+
+            let to = format!("{}{sibling}", crate::session::WSL_BACKEND_PREFIX);
             warnings.push(format!(
                 "hosts.toml: host '{}' is named after the WSL distro thurbox runs in, \
                  which has to keep meaning this machine, so it now registers as the \
@@ -338,7 +402,9 @@ fn settle_wsl_self_hosts(reg: &mut HostRegistry) -> (Vec<String>, WslRepairPlan)
                  {sibling}.",
                 host.name
             ));
-            taken.insert(sibling.clone());
+            plan.renames.push((from, to.clone()));
+            taken.insert(sibling.to_ascii_lowercase());
+            reaching.insert(sibling.to_ascii_lowercase(), to);
             host.name = sibling;
             settled.push(host);
             continue;
@@ -347,14 +413,11 @@ fn settle_wsl_self_hosts(reg: &mut HostRegistry) -> (Vec<String>, WslRepairPlan)
     }
     reg.hosts = settled;
 
-    // A name being renamed is not this machine's: while such an entry exists
-    // that spelling reaches a sibling, and its rows follow the rename instead.
-    plan.to_local.retain(|n| {
-        !plan
-            .renames
-            .iter()
-            .any(|(from, _)| from.eq_ignore_ascii_case(n))
-    });
+    // A spelling any shadow claims is not this machine's: while such an entry
+    // exists that spelling reaches a sibling, and its rows either follow the
+    // rename or stay put — never become local.
+    plan.to_local
+        .retain(|n| !shadowed.iter().any(|s| s.eq_ignore_ascii_case(n)));
     plan.to_local.sort_by_key(|n| n.to_ascii_lowercase());
     plan.to_local.dedup_by(|a, b| a.eq_ignore_ascii_case(b));
 
@@ -650,32 +713,96 @@ mod tests {
         });
     }
 
-    /// One distro has one backend name, so a shadow whose sibling is already
-    /// described defers to that entry instead of duplicating it — and its rows
-    /// still move, because the host they now name reaches them.
+    /// One distro has one backend name, so a shadow whose sibling another
+    /// entry already reaches defers to that entry instead of duplicating it —
+    /// and its rows still move, because the host they now name reaches them.
+    /// The target is that entry's own backend name, which need not be spelled
+    /// like the distro at all.
     #[test]
-    fn a_re_registered_shadow_defers_to_an_entry_that_already_holds_the_name() {
+    fn a_re_registered_shadow_defers_to_the_entry_that_reaches_its_distro() {
         crate::session::host_def::with_wsl_distro(Some("MagicDebian"), || {
             let mut reg = registry(vec![
                 wsl("MagicDebian", "MagicDebianPerso"),
-                HostDef::wsl("MagicDebianPerso"),
+                wsl("perso", "MagicDebianPerso"),
             ]);
 
             let (warnings, plan) = settle_wsl_self_hosts(&mut reg);
 
-            assert_eq!(reg.names(), ["MagicDebianPerso"]);
+            assert_eq!(reg.names(), ["perso"]);
             assert_eq!(
                 plan.renames,
-                [(
-                    "wsl:MagicDebian".to_string(),
-                    "wsl:MagicDebianPerso".to_string()
-                )]
+                [("wsl:MagicDebian".to_string(), "wsl:perso".to_string())],
+                "the rows move onto the backend name that actually reaches the distro"
             );
+            assert!(plan.to_local.is_empty());
             assert!(
-                warnings[0].contains("already describes")
-                    && warnings[0].contains("--host MagicDebianPerso"),
-                "the warning must say it deferred and to which name: {}",
+                warnings[0].contains("already reaches") && warnings[0].contains("'wsl:perso'"),
+                "the warning must say it deferred and to which host: {}",
                 warnings[0]
+            );
+        });
+    }
+
+    /// `name` is a free label, so a host can hold the sibling's name while
+    /// launching something else entirely. Deferring on the name alone would
+    /// rewrite live sessions onto a host that runs a different distro — or,
+    /// for an SSH entry, over ssh. The shadow is dropped with no rename
+    /// instead: rows that do not resolve are recoverable by hand, a silent
+    /// misroute is not.
+    #[test]
+    fn a_shadow_does_not_defer_to_an_unrelated_host_holding_the_name() {
+        for other in [
+            wsl("MagicDebianPerso", "Debian-12"),
+            HostDef {
+                name: "MagicDebianPerso".into(),
+                destination: "me@elsewhere".into(),
+                ..Default::default()
+            },
+        ] {
+            crate::session::host_def::with_wsl_distro(Some("MagicDebian"), || {
+                let mut reg = registry(vec![wsl("MagicDebian", "MagicDebianPerso"), other.clone()]);
+
+                let (warnings, plan) = settle_wsl_self_hosts(&mut reg);
+
+                assert_eq!(reg.names(), ["MagicDebianPerso"]);
+                assert!(
+                    plan.renames.is_empty(),
+                    "no rename may point rows at a host reaching somewhere else"
+                );
+                assert!(
+                    plan.to_local.is_empty(),
+                    "and they are not this machine's either — they wait"
+                );
+                assert_eq!(warnings.len(), 1);
+                assert!(
+                    warnings[0].contains("another host already has that name")
+                        && warnings[0].contains("'wsl:MagicDebian'"),
+                    "the warning must name the collision and the stranded spelling: {}",
+                    warnings[0]
+                );
+            });
+        }
+    }
+
+    /// Two shadows share the one spelling `wsl:<us>`, so nothing can say whose
+    /// rows are whose. Both are refused and neither set of rows is touched.
+    #[test]
+    fn two_shadows_are_ambiguous_and_neither_moves_any_row() {
+        crate::session::host_def::with_wsl_distro(Some("MagicDebian"), || {
+            let mut reg = registry(vec![
+                wsl("MagicDebian", "MagicDebianPerso"),
+                wsl("MagicDebian", "Debian-12"),
+            ]);
+
+            let (warnings, plan) = settle_wsl_self_hosts(&mut reg);
+
+            assert!(reg.is_empty());
+            assert!(plan.renames.is_empty());
+            assert!(plan.to_local.is_empty());
+            assert_eq!(warnings.len(), 2);
+            assert!(
+                warnings.iter().all(|w| w.contains("more than one entry")),
+                "each warning must say why neither could be settled: {warnings:?}"
             );
         });
     }

--- a/src/agent/host_config.rs
+++ b/src/agent/host_config.rs
@@ -40,9 +40,10 @@ pub const SEED_HOSTS_TOML: &str = r#"# Thurbox hosts  —  ~/.config/thurbox/hos
 # session (no --host). An entry whose `distro` is that one is ignored with a
 # startup warning. An entry merely *named* after it works as written, but it
 # records its sessions under the very name an older thurbox mislabelled local
-# sessions with, so thurbox warns and leaves every row under that name alone —
-# name such an entry after the distro it reaches and there is nothing to warn
-# about.
+# sessions with, so thurbox warns and leaves every row under that name alone.
+# Name a NEW entry after the distro it reaches and there is nothing to warn
+# about; renaming an EXISTING one moves no row, and leaves its recorded
+# sessions behind under a name no host registers.
 #
 # This file starts empty (every entry below is commented out): a fresh install
 # registers zero SSH hosts (WSL distros still auto-discover) and otherwise
@@ -221,9 +222,9 @@ fn load_or_seed_result() -> Result<(HostRegistry, Vec<String>), String> {
 /// **loopback** ([`HostDef::is_wsl_loopback`]): that one is this machine, so
 /// it is dropped. This is the one chokepoint every caller shares, so settling
 /// it here (`settle_wsl_self_hosts`) is what keeps a local session local — and
-/// the same pass decides what the one-time repair owes the rows it already
-/// wrote ([`wsl_repair_plan`]), including which spelling a **shadow**
-/// ([`HostDef::shadows_current_wsl_distro`]) puts out of the repair's reach.
+/// the spellings that pass names the rows the one-time repair owes
+/// ([`wsl_repair_plan`], which reads the *served* registry these two steps
+/// build so it can tell a stale spelling from a live host's own).
 pub fn load_all_with_warnings() -> (HostRegistry, Vec<String>) {
     let (mut reg, mut warnings) = load_or_seed_with_warnings();
     warnings.extend(settle_wsl_self_hosts(&mut reg).0);
@@ -262,43 +263,32 @@ pub fn cached_registry() -> &'static (HostRegistry, Vec<String>) {
 }
 
 /// Settle every configured entry that claims the WSL distro thurbox runs
-/// inside, in place, and report both the warnings it owes the user and the row
-/// rewrites it owes the database.
+/// inside, in place, returning the warnings it owes the user and the backend
+/// names the loopback bug can have written.
 ///
-/// Two rules, and only one of them rewrites a row:
+/// Two rules, and only one of them concerns a row:
 ///
 /// - A [loopback](HostDef::is_wsl_loopback) points `wsl.exe` back at us. It
 ///   describes this machine as somewhere else, so it is **dropped** — and the
-///   rows it wrote are this machine's own local rows, so they go to
-///   [`WslRepairPlan::to_local`].
+///   rows it wrote are candidates for [`WslRepairPlan::to_local`], under its
+///   own backend name as well as the discovered one.
 /// - A [shadow](HostDef::shadows_current_wsl_distro) reaches a real sibling
-///   while *registering* as `wsl:<us>`. It is **kept exactly as written**, and
-///   the spelling it claims is subtracted from `to_local` instead: under that
-///   name the bug's local rows and this host's own sibling rows are the same
-///   spelling, so the repair leaves all of them alone. Any mislabelled local
-///   row there stays mislabelled — the pre-existing corruption, left unhealed
-///   for the one name that cannot be read either way, which is the only
-///   outcome that never operates on the wrong machine.
+///   while *registering* as `wsl:<us>`. It is **kept exactly as written** and
+///   warned about: under that name the bug's local rows and this host's own
+///   sibling rows are the same spelling, so nothing there can be classified.
 ///
-/// Auto-discovery needs no such handling: [`discover_wsl_hosts`] filters the
-/// loopback and names each host after the distro it points at, and
-/// [`augment_with_wsl`] skips a name that is configured. So both cases are
-/// hand-written entries, and each gets a warning saying what happened.
-fn settle_wsl_self_hosts(reg: &mut HostRegistry) -> (Vec<String>, WslRepairPlan) {
+/// A candidate is only a candidate: it is [`wsl_repair_plan`] that decides
+/// which are safe to rewrite, because that needs the registry as it ends up —
+/// including auto-discovery, which this pass runs before.
+fn settle_wsl_self_hosts(reg: &mut HostRegistry) -> (Vec<String>, Vec<String>) {
     let mut warnings = Vec::new();
-    let mut plan = WslRepairPlan::default();
+    let mut candidates = Vec::new();
 
     // The base case, owed before any entry is read: the backend name
     // auto-discovery offered for the current distro until it was filtered.
     if let Some(distro) = crate::session::current_wsl_distro() {
-        plan.to_local
-            .push(format!("{}{distro}", crate::session::WSL_BACKEND_PREFIX));
+        candidates.push(format!("{}{distro}", crate::session::WSL_BACKEND_PREFIX));
     }
-
-    // Every spelling a shadow claims. Keyed on the entry merely existing:
-    // nothing is done to it, and its presence alone is what makes the name
-    // unreadable.
-    let mut shadowed: Vec<String> = Vec::new();
 
     let mut settled = Vec::with_capacity(reg.hosts.len());
     for host in std::mem::take(&mut reg.hosts) {
@@ -310,32 +300,29 @@ fn settle_wsl_self_hosts(reg: &mut HostRegistry) -> (Vec<String>, WslRepairPlan)
                 host.name,
                 host.distro_name()
             ));
-            plan.to_local.push(host.backend_name());
+            candidates.push(host.backend_name());
             continue;
         }
         if host.shadows_current_wsl_distro() {
-            let from = host.backend_name();
             warnings.push(format!(
                 "hosts.toml: host '{}' is named after the WSL distro thurbox runs in, \
-                 so it records its sessions on '{from}' — the same name an older \
+                 so it records its sessions on '{}' — the same name an older \
                  thurbox wrote onto local sessions by mistake. The host works as \
                  written and keeps its own sessions; but thurbox cannot tell a \
                  mislabelled local session under that name from one of this host's, \
                  so it has left every row recorded there exactly as it found it.",
-                host.name
+                host.name,
+                host.backend_name()
             ));
-            shadowed.push(from);
         }
         settled.push(host);
     }
     reg.hosts = settled;
 
-    plan.to_local
-        .retain(|n| !shadowed.iter().any(|s| s.eq_ignore_ascii_case(n)));
-    plan.to_local.sort_by_key(|n| n.to_ascii_lowercase());
-    plan.to_local.dedup_by(|a, b| a.eq_ignore_ascii_case(b));
+    candidates.sort_by_key(|n| n.to_ascii_lowercase());
+    candidates.dedup_by(|a, b| a.eq_ignore_ascii_case(b));
 
-    (warnings, plan)
+    (warnings, candidates)
 }
 
 /// The row rewrites the one-time WSL repair owes, or the reason `hosts.toml`
@@ -346,24 +333,92 @@ fn settle_wsl_self_hosts(reg: &mut HostRegistry) -> (Vec<String>, WslRepairPlan)
 /// answer at all, and `session_ops::repair_wsl_loopback_rows` leaves the owed
 /// mark in place and comes back once the file parses.
 ///
-/// Decided by the **same** pass that settles the registry
-/// (`settle_wsl_self_hosts`), so what the repair rewrites and what the
-/// registry serves cannot disagree about who owns `wsl:<us>`.
+/// Built from the registry as callers will *see* it — `settle_wsl_self_hosts`
+/// then [`augment_with`], the same two steps in the same order as
+/// [`load_all_with_warnings`] — so what the repair rewrites and what a session
+/// resolves against cannot disagree about who owns a spelling.
 pub fn wsl_repair_plan() -> Result<WslRepairPlan, String> {
     let (mut reg, _) = load_or_seed_result()?;
-    Ok(settle_wsl_self_hosts(&mut reg).1)
+    let candidates = settle_wsl_self_hosts(&mut reg).1;
+    // Nothing to place, so nothing to ask `wsl.exe` about — which is every
+    // machine that is not inside a distro.
+    if candidates.is_empty() {
+        return Ok(WslRepairPlan::default());
+    }
+    let serving = match try_discover_wsl_hosts() {
+        Ok(discovered) => {
+            augment_with(&mut reg, discovered);
+            Some(&reg)
+        }
+        Err(e) => {
+            tracing::warn!(
+                "WSL distros could not be enumerated ({e}); the one-time row repair \
+                 withholds every candidate rather than risk relabelling a live \
+                 sibling's sessions as local"
+            );
+            None
+        }
+    };
+    Ok(wsl_repair_plan_for(candidates, serving))
 }
 
-/// Append auto-discovered WSL distros to `reg`, skipping any whose name already
-/// matches a configured host (so a hand-written `hosts.toml` entry for a distro
-/// — e.g. with a custom `worktrees_dir` — wins over the bare discovered one).
+/// Split `candidates` into what the repair may rewrite and what it must leave
+/// alone, given the registry that will `serve` them — `None` when the WSL
+/// distros could not be enumerated.
+///
+/// A candidate is withheld when a host the registry serves registers under
+/// exactly that backend name: rows there may be that host's own, and a live
+/// host's sessions relabelled local look for their windows on the wrong tmux
+/// server. Full backend names, not bare host names, because that is what a row
+/// resolves through — an `ssh:` host named after a distro serves none of its
+/// rows.
+///
+/// An enumeration that failed reads as "claimed", never as "nothing claims
+/// it": every candidate is withheld and the repair comes back, because rows
+/// that stay put are recoverable by hand and a silent misroute is not.
+fn wsl_repair_plan_for(candidates: Vec<String>, serving: Option<&HostRegistry>) -> WslRepairPlan {
+    let Some(serving) = serving else {
+        return WslRepairPlan {
+            to_local: Vec::new(),
+            withheld: candidates,
+        };
+    };
+    let claimed: HashSet<String> = serving
+        .hosts
+        .iter()
+        .map(|h| h.backend_name().to_ascii_lowercase())
+        .collect();
+    let (withheld, to_local) = candidates
+        .into_iter()
+        .partition(|n| claimed.contains(&n.to_ascii_lowercase()));
+    WslRepairPlan { to_local, withheld }
+}
+
+/// Append auto-discovered WSL distros to `reg`.
+///
+/// Best-effort, as every caller but the repair wants: a distro that could not
+/// be enumerated is one the host picker does not offer, which is the same
+/// outcome as not having it.
 fn augment_with_wsl(reg: &mut HostRegistry) {
+    match try_discover_wsl_hosts() {
+        Ok(discovered) => augment_with(reg, discovered),
+        Err(e) => tracing::debug!(error = %e, "no WSL distros auto-discovered"),
+    }
+}
+
+/// Append `discovered` to `reg`, skipping any whose name already matches a
+/// configured host (so a hand-written `hosts.toml` entry for a distro — e.g.
+/// with a custom `worktrees_dir` — wins over the bare discovered one).
+///
+/// Pure, so the load path and the repair path cannot disagree about which host
+/// ends up serving a name.
+fn augment_with(reg: &mut HostRegistry, discovered: Vec<HostDef>) {
     let configured: HashSet<&str> = reg.hosts.iter().map(|h| h.name.as_str()).collect();
-    let discovered: Vec<HostDef> = discover_wsl_hosts()
+    let fresh: Vec<HostDef> = discovered
         .into_iter()
         .filter(|h| !configured.contains(h.name.as_str()))
         .collect();
-    reg.hosts.extend(discovered);
+    reg.hosts.extend(fresh);
 }
 
 /// Infrastructure distros `wsl.exe -l -q` reports that aren't interactive
@@ -373,33 +428,41 @@ const WSL_INFRA_DISTROS: &[&str] = &["docker-desktop", "docker-desktop-data"];
 /// Auto-discover installed WSL distros as [`HostDef`]s (kind
 /// [`HostKind::Wsl`](crate::session::HostKind::Wsl)).
 ///
-/// Runs `wsl.exe -l -q` and parses its output. Returns empty when `wsl.exe`
-/// isn't available (no `wsl.exe` on `PATH`, and not Windows) or the command
-/// fails — discovery is strictly best-effort and never blocks startup.
+/// Returns empty rather than erroring on a machine that has no `wsl.exe` at
+/// all, and never blocks startup. See [`try_discover_wsl_hosts`] for the
+/// distinction between that and a failed enumeration.
 ///
 /// The distro thurbox is itself running inside is **not** among them: `wsl.exe`
 /// lists it like any other, but it is this machine
 /// ([`HostDef::is_wsl_loopback`] argues what registering it cost). Its siblings
 /// are still discovered, so a thurbox inside one distro reaches the rest.
 pub(crate) fn discover_wsl_hosts() -> Vec<HostDef> {
+    try_discover_wsl_hosts().unwrap_or_else(|e| {
+        tracing::debug!(error = %e, "no WSL distros auto-discovered");
+        Vec::new()
+    })
+}
+
+/// [`discover_wsl_hosts`], separating "there are none" from "could not say".
+///
+/// No `wsl.exe` at all (not Windows, nothing on `PATH`) is an **answer**:
+/// there is no WSL here, so there are no distros — and interop puts `wsl.exe`
+/// on `PATH` inside a distro, so that case does not overlap with running in
+/// one. `Ok(empty)` accordingly.
+///
+/// `wsl.exe` failing when it *is* there is not an answer: distros may exist
+/// and be unlisted. That is `Err`, which is what lets `wsl_repair_plan`
+/// withhold instead of reading the silence as "no host claims this name".
+fn try_discover_wsl_hosts() -> Result<Vec<HostDef>, String> {
     if !wsl_exe_available() {
-        return Vec::new();
+        return Ok(Vec::new());
     }
     let output = match Command::new("wsl.exe").arg("-l").arg("-q").output() {
         Ok(o) if o.status.success() => o,
-        Ok(o) => {
-            tracing::debug!(
-                status = ?o.status,
-                "wsl.exe -l -q failed; no WSL distros auto-discovered"
-            );
-            return Vec::new();
-        }
-        Err(e) => {
-            tracing::debug!(error = %e, "could not run wsl.exe; no WSL distros auto-discovered");
-            return Vec::new();
-        }
+        Ok(o) => return Err(format!("wsl.exe -l -q failed: {}", o.status)),
+        Err(e) => return Err(format!("could not run wsl.exe: {e}")),
     };
-    wsl_hosts_from(parse_wsl_distros(&output.stdout))
+    Ok(wsl_hosts_from(parse_wsl_distros(&output.stdout)))
 }
 
 /// The discoverable hosts among `distros`: one [`HostDef::wsl`] each, minus the
@@ -493,11 +556,10 @@ mod tests {
         assert!(parse_wsl_distros(&utf16le("\r\n  \r\n")).is_empty());
     }
 
+    /// A configured entry for a distro wins over the discovered one, so its
+    /// overrides survive; every other discovered distro is added.
     #[test]
-    fn augment_with_wsl_keeps_configured_entries() {
-        // A configured host named "Ubuntu" must not be duplicated by discovery.
-        // (discover_wsl_hosts() returns empty off-Windows here, but the dedup
-        // logic is exercised directly.)
+    fn augment_with_keeps_configured_entries() {
         let mut reg = HostRegistry {
             config_version: None,
             hosts: vec![HostDef {
@@ -507,15 +569,18 @@ mod tests {
                 ..Default::default()
             }],
         };
-        let before = reg.hosts.len();
-        augment_with_wsl(&mut reg);
-        // The configured Ubuntu survives untouched; on a non-WSL host nothing
-        // else is added.
+
+        augment_with(
+            &mut reg,
+            vec![HostDef::wsl("Ubuntu"), HostDef::wsl("Debian")],
+        );
+
+        assert_eq!(reg.names(), ["Ubuntu", "Debian"]);
         assert_eq!(
             reg.get("Ubuntu").unwrap().worktrees_dir.as_deref(),
-            Some("/custom/wt")
+            Some("/custom/wt"),
+            "the configured entry is the one that survives"
         );
-        assert!(reg.hosts.len() >= before);
     }
 
     #[test]
@@ -554,8 +619,27 @@ mod tests {
         }
     }
 
+    /// The two steps `wsl_repair_plan` runs, with `discovered` standing in for
+    /// what `wsl.exe -l -q` reports — `None` = it could not be asked. Only the
+    /// subprocess is swapped; settling, augmenting and withholding are the
+    /// same code the real path takes.
+    fn settle_and_plan(
+        reg: &mut HostRegistry,
+        discovered: Option<Vec<HostDef>>,
+    ) -> (Vec<String>, WslRepairPlan) {
+        let (warnings, candidates) = settle_wsl_self_hosts(reg);
+        let plan = match discovered {
+            Some(hosts) => {
+                augment_with(reg, hosts);
+                wsl_repair_plan_for(candidates, Some(reg))
+            }
+            None => wsl_repair_plan_for(candidates, None),
+        };
+        (warnings, plan)
+    }
+
     #[test]
-    fn a_configured_loopback_is_dropped_and_its_rows_owed_to_local() {
+    fn a_configured_loopback_is_dropped_and_its_rows_healed() {
         crate::session::host_def::with_wsl_distro(Some("MagicDebian"), || {
             let mut reg = registry(vec![
                 wsl("self", "MagicDebian"),
@@ -567,7 +651,7 @@ mod tests {
                 },
             ]);
 
-            let (warnings, plan) = settle_wsl_self_hosts(&mut reg);
+            let (warnings, plan) = settle_and_plan(&mut reg, Some(Vec::new()));
 
             assert_eq!(reg.names(), ["Ubuntu", "devbox"]);
             assert_eq!(warnings.len(), 1);
@@ -579,13 +663,90 @@ mod tests {
             // Its own backend name as well as the discovered one: the rows it
             // wrote are spelled `wsl:self`.
             assert_eq!(plan.to_local, ["wsl:MagicDebian", "wsl:self"]);
+            assert!(plan.withheld.is_empty());
+        });
+    }
+
+    /// A loopback's own backend name is only a *candidate*. `name` is a free
+    /// label, so the name a mistaken entry squats on can be a live sibling's —
+    /// and dropping the entry hands that name straight back to discovery, so
+    /// the real distro re-registers under exactly the spelling the repair was
+    /// about to relabel local. Its sessions run in that distro; healing them
+    /// would send every attach, diff and delete to the local tmux server.
+    #[test]
+    fn a_loopbacks_own_name_is_withheld_when_a_discovered_sibling_claims_it() {
+        crate::session::host_def::with_wsl_distro(Some("Ubuntu"), || {
+            let mut reg = registry(vec![wsl("Debian", "Ubuntu")]);
+
+            let (_, plan) = settle_and_plan(&mut reg, Some(vec![HostDef::wsl("Debian")]));
+
+            assert_eq!(
+                reg.names(),
+                ["Debian"],
+                "the entry is dropped and discovery re-registers the real distro"
+            );
+            assert_eq!(plan.to_local, ["wsl:Ubuntu"], "the base case still heals");
+            assert_eq!(plan.withheld, ["wsl:Debian"]);
+        });
+    }
+
+    /// The same collision without discovery: two configured entries share a
+    /// `name`, and only one of them is the loopback. The survivor serves that
+    /// spelling, so the repair must not claim its rows are this machine's.
+    #[test]
+    fn a_loopbacks_own_name_is_withheld_when_a_configured_host_survives_on_it() {
+        crate::session::host_def::with_wsl_distro(Some("Ubuntu"), || {
+            let mut reg = registry(vec![wsl("dev", "Ubuntu"), wsl("dev", "Debian")]);
+
+            let (_, plan) = settle_and_plan(&mut reg, Some(Vec::new()));
+
+            assert_eq!(reg.names(), ["dev"]);
+            assert_eq!(plan.to_local, ["wsl:Ubuntu"]);
+            assert_eq!(plan.withheld, ["wsl:dev"]);
+        });
+    }
+
+    /// An `ssh:` host named after a distro claims nothing: a row spelled
+    /// `wsl:<name>` resolves through the backend name, which that host does
+    /// not serve, so withholding on the bare name would strand rows for no
+    /// reason.
+    #[test]
+    fn a_bare_name_held_by_an_ssh_host_does_not_withhold_the_wsl_spelling() {
+        crate::session::host_def::with_wsl_distro(Some("Ubuntu"), || {
+            let mut reg = registry(vec![
+                wsl("Debian", "Ubuntu"),
+                HostDef {
+                    name: "Debian".into(),
+                    destination: "me@elsewhere".into(),
+                    ..Default::default()
+                },
+            ]);
+
+            let (_, plan) = settle_and_plan(&mut reg, Some(Vec::new()));
+
+            assert_eq!(plan.to_local, ["wsl:Debian", "wsl:Ubuntu"]);
+            assert!(plan.withheld.is_empty());
+        });
+    }
+
+    /// Distros that could not be enumerated are not "no distros": a sibling
+    /// may hold a candidate's name and be unlisted. Every candidate waits.
+    #[test]
+    fn an_unenumerable_wsl_withholds_every_candidate() {
+        crate::session::host_def::with_wsl_distro(Some("MagicDebian"), || {
+            let mut reg = registry(vec![wsl("self", "MagicDebian")]);
+
+            let (_, plan) = settle_and_plan(&mut reg, None);
+
+            assert!(plan.to_local.is_empty(), "nothing is rewritten on a guess");
+            assert_eq!(plan.withheld, ["wsl:MagicDebian", "wsl:self"]);
         });
     }
 
     /// A host named after the current distro reaches a real sibling, so the
     /// entry itself is right and is left exactly as written. What it costs is
-    /// the repair: its rows and the rows the loopback bug mislabelled share
-    /// one spelling, so none of them is rewritten.
+    /// the repair: it serves `wsl:<us>`, so the rows there are its own and the
+    /// bug's at once and none of them is rewritten.
     #[test]
     fn a_configured_shadow_is_kept_as_written_and_its_rows_are_left_alone() {
         crate::session::host_def::with_wsl_distro(Some("MagicDebian"), || {
@@ -597,7 +758,7 @@ mod tests {
                 HostDef::wsl("Ubuntu"),
             ]);
 
-            let (warnings, plan) = settle_wsl_self_hosts(&mut reg);
+            let (warnings, plan) = settle_and_plan(&mut reg, Some(Vec::new()));
 
             assert_eq!(reg.names(), ["MagicDebian", "Ubuntu"]);
             assert_eq!(
@@ -605,10 +766,8 @@ mod tests {
                 Some("/srv/wt"),
                 "the entry is untouched, overrides and all"
             );
-            // The subtraction arm, and the whole of it: while that entry
-            // claims the spelling nothing under it can be classified, so the
-            // repair is given nothing to do.
             assert!(plan.to_local.is_empty());
+            assert_eq!(plan.withheld, ["wsl:MagicDebian"]);
             assert_eq!(warnings.len(), 1);
             assert!(
                 warnings[0].contains("'wsl:MagicDebian'")
@@ -622,8 +781,7 @@ mod tests {
     /// Nothing about a shadow is decided by what else is in the file: a second
     /// one, or another host holding the sibling's name, changes neither the
     /// registry nor the plan. Every entry the user wrote keeps working, and the
-    /// one unreadable spelling is still the only thing withheld from the
-    /// repair.
+    /// one unreadable spelling is still the only thing withheld.
     #[test]
     fn other_entries_do_not_change_what_a_shadow_settles_to() {
         crate::session::host_def::with_wsl_distro(Some("MagicDebian"), || {
@@ -638,7 +796,7 @@ mod tests {
                 },
             ]);
 
-            let (warnings, plan) = settle_wsl_self_hosts(&mut reg);
+            let (warnings, plan) = settle_and_plan(&mut reg, Some(Vec::new()));
 
             assert_eq!(
                 reg.names(),
@@ -646,6 +804,7 @@ mod tests {
                 "no entry is dropped or renamed"
             );
             assert!(plan.to_local.is_empty());
+            assert_eq!(plan.withheld, ["wsl:MagicDebian"]);
             assert_eq!(warnings.len(), 2, "one per shadow: {warnings:?}");
         });
     }
@@ -663,10 +822,11 @@ mod tests {
                 wsl("MagicDebian", "MagicDebianPerso"),
             ]);
 
-            let (_, plan) = settle_wsl_self_hosts(&mut reg);
+            let (_, plan) = settle_and_plan(&mut reg, Some(Vec::new()));
 
             assert_eq!(reg.names(), ["MagicDebian"], "only the loopback is dropped");
             assert_eq!(plan.to_local, ["wsl:MagicDebianPerso"]);
+            assert_eq!(plan.withheld, ["wsl:MagicDebian"]);
         });
     }
 
@@ -675,11 +835,11 @@ mod tests {
         crate::session::host_def::with_wsl_distro(None, || {
             let mut reg = registry(vec![HostDef::wsl("Ubuntu"), wsl("work", "Debian")]);
 
-            let (warnings, plan) = settle_wsl_self_hosts(&mut reg);
+            let (warnings, plan) = settle_and_plan(&mut reg, Some(Vec::new()));
 
             assert_eq!(reg.names(), ["Ubuntu", "work"]);
             assert!(warnings.is_empty());
-            assert!(plan.is_empty());
+            assert!(plan.is_empty() && plan.withheld.is_empty());
         });
     }
 

--- a/src/agent/host_config.rs
+++ b/src/agent/host_config.rs
@@ -340,13 +340,17 @@ fn settle_wsl_self_hosts(reg: &mut HostRegistry) -> (Vec<String>, Vec<String>) {
 /// [`load_all_with_warnings`] — so what the repair rewrites and what a session
 /// resolves against cannot disagree about who owns a spelling.
 pub fn wsl_repair_plan() -> Result<WslRepairPlan, String> {
-    let (mut reg, _) = load_or_seed_result()?;
-    let candidates = settle_wsl_self_hosts(&mut reg).1;
-    // Nothing to place, so nothing to ask `wsl.exe` about — which is every
-    // machine that is not inside a distro.
-    if candidates.is_empty() {
+    // Asked first, because it decides the answer on its own: only a loopback
+    // can have written one of these rows, and only a thurbox running *inside*
+    // a distro can have a loopback. So off WSL there is nothing to repair
+    // whatever `hosts.toml` says — and a failure only defers when the answer
+    // depends on what failed, or an unrelated typo in that file would defer
+    // this forever and re-parse it on every invocation.
+    if crate::session::current_wsl_distro().is_none() {
         return Ok(WslRepairPlan::default());
     }
+    let (mut reg, _) = load_or_seed_result()?;
+    let candidates = settle_wsl_self_hosts(&mut reg).1;
     if any_candidate_a_sibling_could_claim(&candidates) {
         augment_with(&mut reg, discover_wsl_hosts()?);
     }

--- a/src/bin/thurbox-cli.rs
+++ b/src/bin/thurbox-cli.rs
@@ -80,8 +80,12 @@ fn main() {
     // the reap sweep refuses to kill windows it believes are elsewhere and
     // leaks them. Costs one indexed lookup when nothing is owed, which is every
     // invocation after the first.
+    // `warn!`, not `info!`: the logger installed above filters to WARN with no
+    // `RUST_LOG` set, and this is the one record that a one-time rewrite of
+    // persisted rows happened — the owed mark is gone afterwards, so the TUI
+    // cannot report it later.
     for notice in thurbox::session_ops::repair_wsl_loopback_rows(&db) {
-        tracing::info!("{notice}");
+        tracing::warn!("{notice}");
     }
 
     match cli::run(cli, &db) {

--- a/src/bin/thurbox-cli.rs
+++ b/src/bin/thurbox-cli.rs
@@ -73,6 +73,17 @@ fn main() {
         ),
     };
 
+    // The one-time WSL row repair schema v47 marks as owed. Driven from here as
+    // well as from the TUI boot: the mark is written by whichever binary opens
+    // the database first, and a headless-driven install need never launch the
+    // interface — until the repair runs, a mislabelled row reads as remote, so
+    // the reap sweep refuses to kill windows it believes are elsewhere and
+    // leaks them. Costs one indexed lookup when nothing is owed, which is every
+    // invocation after the first.
+    for notice in thurbox::session_ops::repair_wsl_loopback_rows(&db) {
+        tracing::info!("{notice}");
+    }
+
     match cli::run(cli, &db) {
         Ok(cli::Outcome::Ok) => {}
         // The report is already on stdout and is the answer; only the verdict

--- a/src/coordinator/boot.rs
+++ b/src/coordinator/boot.rs
@@ -104,9 +104,11 @@ pub(crate) async fn run() -> Result<(), Box<dyn Error>> {
         startup_notices.extend(thurbox::session_ops::heal_active_extensions(&db));
         startup_notices.extend(thurbox::session_ops::ensure_builtin_extensions(&db));
         // The one-time repair schema v47 marked as owed: rows a loopback WSL
-        // host recorded as remote, put back as local. Here because it needs
+        // host recorded as remote, and rows a host named after the current
+        // distro recorded under the loopback's own name. Here because it needs
         // both the host registry and the database, and the migration that
-        // marked it has only the second.
+        // marked it has only the second; `thurbox-cli` runs it too, since the
+        // mark is written by whichever binary opens the database first.
         startup_notices.extend(thurbox::session_ops::repair_wsl_loopback_rows(&db));
         for notice in &startup_notices {
             tracing::info!("{notice}");

--- a/src/coordinator/boot.rs
+++ b/src/coordinator/boot.rs
@@ -104,11 +104,10 @@ pub(crate) async fn run() -> Result<(), Box<dyn Error>> {
         startup_notices.extend(thurbox::session_ops::heal_active_extensions(&db));
         startup_notices.extend(thurbox::session_ops::ensure_builtin_extensions(&db));
         // The one-time repair schema v47 marked as owed: rows a loopback WSL
-        // host recorded as remote, and rows a host named after the current
-        // distro recorded under the loopback's own name. Here because it needs
-        // both the host registry and the database, and the migration that
-        // marked it has only the second; `thurbox-cli` runs it too, since the
-        // mark is written by whichever binary opens the database first.
+        // host recorded as remote. Here because it needs both the host
+        // registry and the database, and the migration that marked it has only
+        // the second; `thurbox-cli` runs it too, since the mark is written by
+        // whichever binary opens the database first.
         startup_notices.extend(thurbox::session_ops::repair_wsl_loopback_rows(&db));
         for notice in &startup_notices {
             tracing::info!("{notice}");

--- a/src/coordinator/boot.rs
+++ b/src/coordinator/boot.rs
@@ -103,6 +103,11 @@ pub(crate) async fn run() -> Result<(), Box<dyn Error>> {
     if let Some(db) = snapshots_db() {
         startup_notices.extend(thurbox::session_ops::heal_active_extensions(&db));
         startup_notices.extend(thurbox::session_ops::ensure_builtin_extensions(&db));
+        // The one-time repair schema v47 marked as owed: rows a loopback WSL
+        // host recorded as remote, put back as local. Here because it needs
+        // both the host registry and the database, and the migration that
+        // marked it has only the second.
+        startup_notices.extend(thurbox::session_ops::repair_wsl_loopback_rows(&db));
         for notice in &startup_notices {
             tracing::info!("{notice}");
         }

--- a/src/session/host_def.rs
+++ b/src/session/host_def.rs
@@ -71,6 +71,37 @@ fn is_current_wsl_distro(distro: &str) -> bool {
     current_wsl_distro().is_some_and(|d| d.eq_ignore_ascii_case(distro))
 }
 
+/// The row rewrites the one-time WSL repair owes, decided from **one**
+/// registry load so its two arms cannot disagree about who owns `wsl:<us>`.
+///
+/// Pure data, and here rather than in `storage` or `agent` because both need
+/// to name it: `agent::host_config::wsl_repair_plan` decides it from
+/// `hosts.toml`, and `storage` applies it — and `storage` may reference
+/// `session` but not `agent`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct WslRepairPlan {
+    /// Backend names whose rows are this machine's own local rows, recorded as
+    /// remote by a loopback host.
+    ///
+    /// Applied **before** [`renames`](Self::renames), and the order is
+    /// load-bearing: a name here is one the registry refuses from now on, so
+    /// nothing may be moved *onto* it, while a rename's destination is a name
+    /// the registry does serve. Reversing the two would send a renamed row
+    /// straight on to local.
+    pub to_local: Vec<String>,
+    /// `(from, to)`: backend names that move to another host's, because the
+    /// `hosts.toml` entry that wrote them was named after the current distro
+    /// and now registers under the distro it reaches.
+    pub renames: Vec<(String, String)>,
+}
+
+impl WslRepairPlan {
+    /// Whether there is nothing to rewrite.
+    pub fn is_empty(&self) -> bool {
+        self.to_local.is_empty() && self.renames.is_empty()
+    }
+}
+
 /// How thurbox reaches a host: over SSH, or into a local WSL distro.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
@@ -213,13 +244,14 @@ impl HostDef {
     /// `name = "<us>"` with `distro = "<a sibling>"` is a working remote host
     /// that writes rows spelled exactly like the ones the loopback bug wrote.
     /// One spelling cannot mean both, and it is the *name* that is free to
-    /// change: dropping the entry — with a warning that says to rename it —
-    /// keeps `wsl:<us>` unambiguous, and the sibling stays reachable under any
-    /// other name, so nothing is lost but the collision.
+    /// change — so the registry changes it: such an entry is re-registered
+    /// under the distro it actually reaches, and the rows it already wrote are
+    /// moved onto that name with it ([`WslRepairPlan::renames`]). The host
+    /// keeps working, its sessions keep resolving, and `wsl:<us>` stays
+    /// unambiguous.
     ///
-    /// While such an entry does exist, that spelling is remote, so
-    /// `agent::host_config::wsl_loopback_backend_names` subtracts it from the
-    /// set the one-time loopback repair relabels local.
+    /// Renaming the entry by hand does *not* do this: the rows keep the old
+    /// spelling, and nothing in `hosts.toml` describes it any more.
     pub fn shadows_current_wsl_distro(&self) -> bool {
         self.is_wsl() && !self.is_wsl_loopback() && is_current_wsl_distro(&self.name)
     }

--- a/src/session/host_def.rs
+++ b/src/session/host_def.rs
@@ -205,6 +205,23 @@ impl HostDef {
         self.is_wsl() && is_current_wsl_distro(&self.distro_name())
     }
 
+    /// Whether this host would **register under the loopback's backend name**
+    /// (`wsl:<us>`) while pointing `wsl.exe` at some other distro.
+    ///
+    /// A host is registered — and persisted in `sessions.backend_type` — under
+    /// its [`name`](Self::name), not its [`distro`](Self::distro). So
+    /// `name = "<us>"` with `distro = "<a sibling>"` is a working remote host
+    /// that writes rows spelled exactly like the ones the loopback bug wrote,
+    /// and the schema v47 heal keys on that spelling: it cannot tell the two
+    /// apart, and would relabel a genuinely remote session local.
+    ///
+    /// Dropping the entry — with a warning that says to rename it — is what
+    /// keeps `wsl:<us>` unambiguous. The sibling stays reachable under any
+    /// other name, so nothing is lost but the collision.
+    pub fn shadows_current_wsl_distro(&self) -> bool {
+        self.is_wsl() && !self.is_wsl_loopback() && is_current_wsl_distro(&self.name)
+    }
+
     /// The backend name this host registers under: `ssh:<name>` or
     /// `wsl:<name>`.
     pub fn backend_name(&self) -> String {
@@ -589,10 +606,48 @@ worktrees_dir = "/home/me/wt"
     }
 
     #[test]
+    fn a_host_named_after_our_distro_shadows_its_backend_name() {
+        with_wsl_distro(Some("Ubuntu"), || {
+            // Reaches a real sibling, but would register as `wsl:Ubuntu` —
+            // the very spelling the v47 heal reads as "this machine".
+            let shadow = HostDef {
+                name: "Ubuntu".into(),
+                kind: HostKind::Wsl,
+                distro: Some("Debian".into()),
+                ..Default::default()
+            };
+            assert!(shadow.shadows_current_wsl_distro());
+            assert!(!shadow.is_wsl_loopback());
+            assert_eq!(shadow.backend_name(), "wsl:Ubuntu");
+
+            // A true loopback is not also a shadow: the two are reported
+            // separately so each gets the warning that fits it.
+            assert!(!HostDef::wsl("Ubuntu").shadows_current_wsl_distro());
+            // Renaming the entry is all it takes.
+            assert!(!HostDef {
+                name: "work".into(),
+                kind: HostKind::Wsl,
+                distro: Some("Debian".into()),
+                ..Default::default()
+            }
+            .shadows_current_wsl_distro());
+            // An SSH host named after the distro collides with nothing: it
+            // registers as `ssh:Ubuntu`.
+            assert!(!HostDef {
+                name: "Ubuntu".into(),
+                destination: "me@ubuntu".into(),
+                ..Default::default()
+            }
+            .shadows_current_wsl_distro());
+        });
+    }
+
+    #[test]
     fn off_wsl_nothing_is_a_loopback() {
         with_wsl_distro(None, || {
             assert_eq!(current_wsl_distro(), None);
             assert!(!HostDef::wsl("Ubuntu").is_wsl_loopback());
+            assert!(!HostDef::wsl("Ubuntu").shadows_current_wsl_distro());
         });
         // A distro that set the variable empty is no distro at all.
         with_wsl_distro(Some("  "), || {

--- a/src/session/host_def.rs
+++ b/src/session/host_def.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 /// tmux server, no launch prefix. Re-exported as
 /// `session_ops::spawn::LOCAL_TMUX_BACKEND_TYPE`, which is the spelling most
 /// call sites use; it lives here so `storage` (which may reference `session`
-/// and not `session_ops`) can name the value a migration writes.
+/// and not `session_ops`) can name the value the loopback repair writes.
 pub const LOCAL_BACKEND_TYPE: &str = "local-tmux";
 
 /// The backend-name prefix for SSH hosts. A host named `devbox` is registered
@@ -67,7 +67,7 @@ pub fn current_wsl_distro() -> Option<String> {
 
 /// Whether `distro` is the one [`current_wsl_distro`] reports, compared the way
 /// `wsl.exe -d` matches a distro name — case-insensitively.
-pub fn is_current_wsl_distro(distro: &str) -> bool {
+fn is_current_wsl_distro(distro: &str) -> bool {
     current_wsl_distro().is_some_and(|d| d.eq_ignore_ascii_case(distro))
 }
 
@@ -211,13 +211,15 @@ impl HostDef {
     /// A host is registered — and persisted in `sessions.backend_type` — under
     /// its [`name`](Self::name), not its [`distro`](Self::distro). So
     /// `name = "<us>"` with `distro = "<a sibling>"` is a working remote host
-    /// that writes rows spelled exactly like the ones the loopback bug wrote,
-    /// and the schema v47 heal keys on that spelling: it cannot tell the two
-    /// apart, and would relabel a genuinely remote session local.
-    ///
-    /// Dropping the entry — with a warning that says to rename it — is what
-    /// keeps `wsl:<us>` unambiguous. The sibling stays reachable under any
+    /// that writes rows spelled exactly like the ones the loopback bug wrote.
+    /// One spelling cannot mean both, and it is the *name* that is free to
+    /// change: dropping the entry — with a warning that says to rename it —
+    /// keeps `wsl:<us>` unambiguous, and the sibling stays reachable under any
     /// other name, so nothing is lost but the collision.
+    ///
+    /// While such an entry does exist, that spelling is remote, so
+    /// `agent::host_config::wsl_loopback_backend_names` subtracts it from the
+    /// set the one-time loopback repair relabels local.
     pub fn shadows_current_wsl_distro(&self) -> bool {
         self.is_wsl() && !self.is_wsl_loopback() && is_current_wsl_distro(&self.name)
     }
@@ -609,7 +611,7 @@ worktrees_dir = "/home/me/wt"
     fn a_host_named_after_our_distro_shadows_its_backend_name() {
         with_wsl_distro(Some("Ubuntu"), || {
             // Reaches a real sibling, but would register as `wsl:Ubuntu` —
-            // the very spelling the v47 heal reads as "this machine".
+            // the very spelling the loopback repair reads as "this machine".
             let shadow = HostDef {
                 name: "Ubuntu".into(),
                 kind: HostKind::Wsl,

--- a/src/session/host_def.rs
+++ b/src/session/host_def.rs
@@ -16,6 +16,13 @@
 
 use serde::{Deserialize, Serialize};
 
+/// The backend name a local session is registered under — this machine's own
+/// tmux server, no launch prefix. Re-exported as
+/// `session_ops::spawn::LOCAL_TMUX_BACKEND_TYPE`, which is the spelling most
+/// call sites use; it lives here so `storage` (which may reference `session`
+/// and not `session_ops`) can name the value a migration writes.
+pub const LOCAL_BACKEND_TYPE: &str = "local-tmux";
+
 /// The backend-name prefix for SSH hosts. A host named `devbox` is registered
 /// (and persisted in `backend_type`) as `ssh:devbox`.
 pub const SSH_BACKEND_PREFIX: &str = "ssh:";
@@ -39,6 +46,29 @@ pub fn is_wsl_backend(backend_name: &str) -> bool {
 /// local filesystem. Local backends (`""`, `tmux`, `local-tmux`) are not.
 pub fn is_remote_backend(backend_name: &str) -> bool {
     is_ssh_backend(backend_name) || is_wsl_backend(backend_name)
+}
+
+/// The environment variable every WSL2 distro's init sets to that distro's own
+/// name. Present only *inside* a distro — not on Windows, not on a plain Linux
+/// or macOS host.
+pub const WSL_DISTRO_NAME_VAR: &str = "WSL_DISTRO_NAME";
+
+/// The WSL distro thurbox is itself running inside, if any.
+///
+/// Read from the environment rather than probed for: `wsl.exe` is on `PATH`
+/// inside a distro (interop), so its presence says a distro is *reachable* and
+/// never which one we are already in.
+pub fn current_wsl_distro() -> Option<String> {
+    std::env::var(WSL_DISTRO_NAME_VAR)
+        .ok()
+        .map(|d| d.trim().to_string())
+        .filter(|d| !d.is_empty())
+}
+
+/// Whether `distro` is the one [`current_wsl_distro`] reports, compared the way
+/// `wsl.exe -d` matches a distro name — case-insensitively.
+pub fn is_current_wsl_distro(distro: &str) -> bool {
+    current_wsl_distro().is_some_and(|d| d.eq_ignore_ascii_case(distro))
 }
 
 /// How thurbox reaches a host: over SSH, or into a local WSL distro.
@@ -155,6 +185,26 @@ impl HostDef {
         self.distro.clone().unwrap_or_else(|| self.name.clone())
     }
 
+    /// Whether this host is a **loopback**: the WSL distro thurbox is itself
+    /// running inside.
+    ///
+    /// `wsl.exe -d <us>` from inside `<us>` lands back on this same machine —
+    /// the same tmux server, the same worktrees, the same thurbox database — so
+    /// such a host is not off-local at all, and registering one made every
+    /// LOCAL session on this machine remote. A shareable host's own database is
+    /// the record of the sessions on it (ADR-24), and here that database *is*
+    /// ours: the mirror pass read our own rows back and rewrote each one's
+    /// `backend_type` to `wsl:<us>`, after which every attach, diff and delete
+    /// went out through `wsl.exe` and failed against the machine it started on.
+    ///
+    /// So a loopback is dropped at the registry — the one chokepoint every
+    /// caller shares — rather than guarded for at each use. A *sibling* distro
+    /// stays an ordinary host: reaching one from inside another is supported
+    /// (see `shell::wsl_command`), and only self-reference is the bug.
+    pub fn is_wsl_loopback(&self) -> bool {
+        self.is_wsl() && is_current_wsl_distro(&self.distro_name())
+    }
+
     /// The backend name this host registers under: `ssh:<name>` or
     /// `wsl:<name>`.
     pub fn backend_name(&self) -> String {
@@ -257,6 +307,32 @@ impl HostRegistry {
     pub fn is_empty(&self) -> bool {
         self.hosts.is_empty()
     }
+}
+
+/// Run `f` with [`WSL_DISTRO_NAME_VAR`] set to `distro` (or unset, for
+/// `None`), restoring what was there before.
+///
+/// Serialized on a process-wide lock, and the **only** way a test may set it:
+/// it is process state, and under plain `cargo test` the unit tests that need
+/// it run concurrently in one process, where interleaved writes make one test
+/// observe another's distro. (`nextest`, the repo's gate, gives each test its
+/// own process — this is what keeps the other entry point honest.) Mirrors
+/// `paths::with_path`, which `session` may not reach.
+#[cfg(test)]
+pub(crate) fn with_wsl_distro<T>(distro: Option<&str>, f: impl FnOnce() -> T) -> T {
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    let _guard = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let saved = std::env::var_os(WSL_DISTRO_NAME_VAR);
+    match distro {
+        Some(d) => std::env::set_var(WSL_DISTRO_NAME_VAR, d),
+        None => std::env::remove_var(WSL_DISTRO_NAME_VAR),
+    }
+    let out = f();
+    match saved {
+        Some(v) => std::env::set_var(WSL_DISTRO_NAME_VAR, v),
+        None => std::env::remove_var(WSL_DISTRO_NAME_VAR),
+    }
+    out
 }
 
 #[cfg(test)]
@@ -482,5 +558,52 @@ worktrees_dir = "/home/me/wt"
         assert_eq!(full.socket.as_deref(), Some("tb2"));
         assert_eq!(full.ssh_opts, ["-o", "ControlMaster=auto"]);
         assert_eq!(full.worktrees_dir.as_deref(), Some("/home/me/wt"));
+    }
+
+    #[test]
+    fn the_distro_we_run_in_is_a_loopback_and_its_siblings_are_not() {
+        with_wsl_distro(Some("Ubuntu"), || {
+            assert!(HostDef::wsl("Ubuntu").is_wsl_loopback());
+            // wsl.exe matches a distro name case-insensitively; so does this.
+            assert!(HostDef::wsl("ubuntu").is_wsl_loopback());
+            assert!(!HostDef::wsl("Debian").is_wsl_loopback());
+            // A prefix is a different distro, not us.
+            assert!(!HostDef::wsl("Ubuntu-22.04").is_wsl_loopback());
+            // The `distro` field is what wsl.exe is handed, so it — not the
+            // host's own name — decides.
+            assert!(HostDef {
+                name: "work".into(),
+                kind: HostKind::Wsl,
+                distro: Some("Ubuntu".into()),
+                ..Default::default()
+            }
+            .is_wsl_loopback());
+            // An SSH host is never one, whatever it is called.
+            assert!(!HostDef {
+                name: "Ubuntu".into(),
+                destination: "me@ubuntu".into(),
+                ..Default::default()
+            }
+            .is_wsl_loopback());
+        });
+    }
+
+    #[test]
+    fn off_wsl_nothing_is_a_loopback() {
+        with_wsl_distro(None, || {
+            assert_eq!(current_wsl_distro(), None);
+            assert!(!HostDef::wsl("Ubuntu").is_wsl_loopback());
+        });
+        // A distro that set the variable empty is no distro at all.
+        with_wsl_distro(Some("  "), || {
+            assert_eq!(current_wsl_distro(), None);
+            assert!(!HostDef::wsl("Ubuntu").is_wsl_loopback());
+        });
+    }
+
+    #[test]
+    fn local_backend_type_is_the_one_spawn_publishes() {
+        assert_eq!(LOCAL_BACKEND_TYPE, "local-tmux");
+        assert!(!is_remote_backend(LOCAL_BACKEND_TYPE));
     }
 }

--- a/src/session/host_def.rs
+++ b/src/session/host_def.rs
@@ -86,16 +86,17 @@ pub struct WslRepairPlan {
     /// serves registers under one of them, so the rows there cannot be told
     /// apart from that host's own.
     ///
-    /// Distinct from an empty [`to_local`](Self::to_local): "nothing to do" is
-    /// an answer and retires the repair, "could not say" is not, so while this
-    /// is non-empty `session_ops::repair_wsl_loopback_rows` keeps the owed mark
-    /// and settles those names on a later start once nothing claims them.
+    /// A **final** verdict, reported only so the user can be told which rows
+    /// were left: those rows never become classifiable, so
+    /// `session_ops::repair_wsl_loopback_rows` retires the repair rather than
+    /// waiting for the claim to disappear — which would rewrite them on no
+    /// better evidence than this pass had.
     pub withheld: Vec<String>,
 }
 
 impl WslRepairPlan {
-    /// Whether there are no rows to rewrite. Says nothing about
-    /// [`withheld`](Self::withheld) — a plan can be empty *and* unfinished.
+    /// Whether there are no rows to rewrite — which a plan that
+    /// [withheld](Self::withheld) every candidate also satisfies.
     pub fn is_empty(&self) -> bool {
         self.to_local.is_empty()
     }

--- a/src/session/host_def.rs
+++ b/src/session/host_def.rs
@@ -71,8 +71,7 @@ fn is_current_wsl_distro(distro: &str) -> bool {
     current_wsl_distro().is_some_and(|d| d.eq_ignore_ascii_case(distro))
 }
 
-/// The row rewrites the one-time WSL repair owes, decided from **one**
-/// registry load so its two arms cannot disagree about who owns `wsl:<us>`.
+/// The row rewrites the one-time WSL repair owes, decided by the registry.
 ///
 /// Pure data, and here rather than in `storage` or `agent` because both need
 /// to name it: `agent::host_config::wsl_repair_plan` decides it from
@@ -83,22 +82,17 @@ pub struct WslRepairPlan {
     /// Backend names whose rows are this machine's own local rows, recorded as
     /// remote by a loopback host.
     ///
-    /// Applied **before** [`renames`](Self::renames), and the order is
-    /// load-bearing: a name here is one the registry refuses from now on, so
-    /// nothing may be moved *onto* it, while a rename's destination is a name
-    /// the registry does serve. Reversing the two would send a renamed row
-    /// straight on to local.
+    /// A spelling a configured [shadow](HostDef::shadows_current_wsl_distro)
+    /// claims is **not** among them: under such a name the bug's local rows
+    /// and that host's own sibling rows are indistinguishable, so the repair
+    /// leaves every one of them where it found it.
     pub to_local: Vec<String>,
-    /// `(from, to)`: backend names that move to another host's, because the
-    /// `hosts.toml` entry that wrote them was named after the current distro
-    /// and now registers under the distro it reaches.
-    pub renames: Vec<(String, String)>,
 }
 
 impl WslRepairPlan {
     /// Whether there is nothing to rewrite.
     pub fn is_empty(&self) -> bool {
-        self.to_local.is_empty() && self.renames.is_empty()
+        self.to_local.is_empty()
     }
 }
 
@@ -243,15 +237,19 @@ impl HostDef {
     /// its [`name`](Self::name), not its [`distro`](Self::distro). So
     /// `name = "<us>"` with `distro = "<a sibling>"` is a working remote host
     /// that writes rows spelled exactly like the ones the loopback bug wrote.
-    /// One spelling cannot mean both, and it is the *name* that is free to
-    /// change — so the registry changes it: such an entry is re-registered
-    /// under the distro it actually reaches, and the rows it already wrote are
-    /// moved onto that name with it ([`WslRepairPlan::renames`]). The host
-    /// keeps working, its sessions keep resolving, and `wsl:<us>` stays
-    /// unambiguous.
+    /// It is left **exactly as written** — nothing about it is wrong, and it is
+    /// the only outcome that never acts on the wrong machine.
     ///
-    /// Renaming the entry by hand does *not* do this: the rows keep the old
-    /// spelling, and nothing in `hosts.toml` describes it any more.
+    /// What that costs is the one-time repair, and only for that spelling: the
+    /// rows under it are two populations at once — local rows the bug
+    /// relabelled before the entry existed, and this host's own sibling rows
+    /// written after — and nothing in the database tells them apart.
+    /// Relabelling them all local would send the sibling's sessions at this
+    /// machine; moving them all onto the sibling would send this machine's at
+    /// the sibling. So the repair skips the name entirely
+    /// ([`WslRepairPlan::to_local`] subtracts it) and any mislabelled local
+    /// row under it stays mislabelled. That residue is the pre-existing
+    /// corruption left unhealed, not damage the repair does.
     pub fn shadows_current_wsl_distro(&self) -> bool {
         self.is_wsl() && !self.is_wsl_loopback() && is_current_wsl_distro(&self.name)
     }
@@ -657,7 +655,7 @@ worktrees_dir = "/home/me/wt"
             // A true loopback is not also a shadow: the two are reported
             // separately so each gets the warning that fits it.
             assert!(!HostDef::wsl("Ubuntu").shadows_current_wsl_distro());
-            // Renaming the entry is all it takes.
+            // Any other name, and the predicate does not hold.
             assert!(!HostDef {
                 name: "work".into(),
                 kind: HostKind::Wsl,

--- a/src/session/host_def.rs
+++ b/src/session/host_def.rs
@@ -80,17 +80,22 @@ fn is_current_wsl_distro(distro: &str) -> bool {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct WslRepairPlan {
     /// Backend names whose rows are this machine's own local rows, recorded as
-    /// remote by a loopback host.
-    ///
-    /// A spelling a configured [shadow](HostDef::shadows_current_wsl_distro)
-    /// claims is **not** among them: under such a name the bug's local rows
-    /// and that host's own sibling rows are indistinguishable, so the repair
-    /// leaves every one of them where it found it.
+    /// remote by a loopback host, and which no host the registry serves claims.
     pub to_local: Vec<String>,
+    /// Candidate backend names left alone because a host the registry still
+    /// serves registers under one of them, so the rows there cannot be told
+    /// apart from that host's own.
+    ///
+    /// Distinct from an empty [`to_local`](Self::to_local): "nothing to do" is
+    /// an answer and retires the repair, "could not say" is not, so while this
+    /// is non-empty `session_ops::repair_wsl_loopback_rows` keeps the owed mark
+    /// and settles those names on a later start once nothing claims them.
+    pub withheld: Vec<String>,
 }
 
 impl WslRepairPlan {
-    /// Whether there is nothing to rewrite.
+    /// Whether there are no rows to rewrite. Says nothing about
+    /// [`withheld`](Self::withheld) — a plan can be empty *and* unfinished.
     pub fn is_empty(&self) -> bool {
         self.to_local.is_empty()
     }
@@ -246,10 +251,14 @@ impl HostDef {
     /// written after — and nothing in the database tells them apart.
     /// Relabelling them all local would send the sibling's sessions at this
     /// machine; moving them all onto the sibling would send this machine's at
-    /// the sibling. So the repair skips the name entirely
-    /// ([`WslRepairPlan::to_local`] subtracts it) and any mislabelled local
-    /// row under it stays mislabelled. That residue is the pre-existing
+    /// the sibling. So the repair skips the name entirely and any mislabelled
+    /// local row under it stays mislabelled. That residue is the pre-existing
     /// corruption left unhealed, not damage the repair does.
+    ///
+    /// This predicate is only the *warning*: what withholds the name is the
+    /// general rule that a candidate claimed by a host the registry serves
+    /// goes to [`WslRepairPlan::withheld`], and such an entry claims
+    /// `wsl:<us>` like any other host claims its own backend name.
     pub fn shadows_current_wsl_distro(&self) -> bool {
         self.is_wsl() && !self.is_wsl_loopback() && is_current_wsl_distro(&self.name)
     }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -31,8 +31,9 @@ pub use hook_status::{
     WORKING_QUIET_MS,
 };
 pub use host_def::{
-    is_remote_backend, is_ssh_backend, is_wsl_backend, HostDef, HostKind, HostRegistry,
-    SSH_BACKEND_PREFIX, WSL_BACKEND_PREFIX,
+    current_wsl_distro, is_current_wsl_distro, is_remote_backend, is_ssh_backend, is_wsl_backend,
+    HostDef, HostKind, HostRegistry, LOCAL_BACKEND_TYPE, SSH_BACKEND_PREFIX, WSL_BACKEND_PREFIX,
+    WSL_DISTRO_NAME_VAR,
 };
 pub use hyperlink::{HyperlinkRun, HyperlinkTable, VisibleRun};
 pub use message::SessionMessage;

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -32,7 +32,7 @@ pub use hook_status::{
 };
 pub use host_def::{
     current_wsl_distro, is_remote_backend, is_ssh_backend, is_wsl_backend, HostDef, HostKind,
-    HostRegistry, LOCAL_BACKEND_TYPE, SSH_BACKEND_PREFIX, WSL_BACKEND_PREFIX,
+    HostRegistry, WslRepairPlan, LOCAL_BACKEND_TYPE, SSH_BACKEND_PREFIX, WSL_BACKEND_PREFIX,
 };
 pub use hyperlink::{HyperlinkRun, HyperlinkTable, VisibleRun};
 pub use message::SessionMessage;

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -31,9 +31,8 @@ pub use hook_status::{
     WORKING_QUIET_MS,
 };
 pub use host_def::{
-    current_wsl_distro, is_current_wsl_distro, is_remote_backend, is_ssh_backend, is_wsl_backend,
-    HostDef, HostKind, HostRegistry, LOCAL_BACKEND_TYPE, SSH_BACKEND_PREFIX, WSL_BACKEND_PREFIX,
-    WSL_DISTRO_NAME_VAR,
+    current_wsl_distro, is_remote_backend, is_ssh_backend, is_wsl_backend, HostDef, HostKind,
+    HostRegistry, LOCAL_BACKEND_TYPE, SSH_BACKEND_PREFIX, WSL_BACKEND_PREFIX,
 };
 pub use hyperlink::{HyperlinkRun, HyperlinkTable, VisibleRun};
 pub use message::SessionMessage;

--- a/src/session_ops/mod.rs
+++ b/src/session_ops/mod.rs
@@ -19,6 +19,7 @@ pub mod restore;
 #[cfg(test)]
 mod shared_tests;
 pub mod spawn;
+pub mod wsl_loopback;
 
 pub use builtin::{builtin_extension, ensure_builtin_extensions, Builtin};
 pub use builtin_hooks::hooks_enabled;
@@ -36,6 +37,7 @@ pub use lifecycle_hooks::{fire_post, fire_pre};
 pub use restart::{restart_session_headless, RestartReport};
 pub use restore::{restore_refusal, restore_session_headless, RestoreReport};
 pub use spawn::{spawn_session_headless, SpawnRequest, SpawnResult};
+pub use wsl_loopback::repair_wsl_loopback_rows;
 
 use std::collections::{BTreeMap, HashMap};
 

--- a/src/session_ops/spawn.rs
+++ b/src/session_ops/spawn.rs
@@ -12,7 +12,7 @@ use crate::sync::{SharedSession, SharedWorktree};
 const DEFAULT_BASE_BRANCH: &str = "main";
 
 /// Backend identifier for the local-tmux backend (matches `LocalTmuxBackend`).
-pub const LOCAL_TMUX_BACKEND_TYPE: &str = "local-tmux";
+pub const LOCAL_TMUX_BACKEND_TYPE: &str = crate::session::LOCAL_BACKEND_TYPE;
 
 /// Request to create a new headless session.
 ///

--- a/src/session_ops/wsl_loopback.rs
+++ b/src/session_ops/wsl_loopback.rs
@@ -1,9 +1,10 @@
-//! The one-time repair of rows a WSL loopback or shadow host recorded wrong.
+//! The one-time repair of rows a WSL loopback host recorded as remote.
 //!
 //! Schema v47 only marks the repair as owed. It has to: what to rewrite is
-//! decided by the *registry* — which host claims `wsl:<us>`, and which distro
-//! it really reaches — and `storage` may not read `hosts.toml`. This is the
-//! layer that sees both, so this is where the two halves meet: the plan from
+//! decided by the *registry* — which names a loopback entry can have written,
+//! and which one spelling a host merely named after the current distro puts
+//! out of reach — and `storage` may not read `hosts.toml`. This is the layer
+//! that sees both, so this is where the two halves meet: the plan from
 //! [`crate::agent::host_config::wsl_repair_plan`], the SQL from
 //! [`crate::storage::Database::apply_wsl_repair_plan`].
 //!
@@ -33,9 +34,9 @@ pub fn repair_wsl_loopback_rows(db: &Database) -> Vec<String> {
         }
     }
 
-    // A `hosts.toml` that cannot be read is not "no hosts configured": the
-    // plan's rename arm is the only thing that keeps a shadow host's rows
-    // remote, and losing it would relabel a live sibling session as local.
+    // A `hosts.toml` that cannot be read is not "no hosts configured": what
+    // keeps a shadow host's rows out of the heal is that entry being *seen*,
+    // and losing it would relabel a live sibling session as local.
     let plan = match crate::agent::host_config::wsl_repair_plan() {
         Ok(plan) => plan,
         Err(e) => {
@@ -64,17 +65,6 @@ pub fn repair_wsl_loopback_rows(db: &Database) -> Vec<String> {
             "{} session(s) and {} repo bookmark(s) were recorded on the WSL distro \
              thurbox runs in, which is this machine; restored them as local",
             report.sessions_local, report.bookmarks_local
-        ));
-    }
-    if report.sessions_moved > 0 || report.bookmarks_moved > 0 {
-        let onto: Vec<&str> = plan.renames.iter().map(|(_, to)| to.as_str()).collect();
-        notices.push(format!(
-            "{} session(s) and {} repo bookmark(s) moved onto {}: the hosts.toml entry \
-             that recorded them was named after the WSL distro thurbox runs in, and now \
-             registers as the distro it reaches",
-            report.sessions_moved,
-            report.bookmarks_moved,
-            onto.join(", ")
         ));
     }
     if report.bookmarks_superseded > 0 {
@@ -194,12 +184,13 @@ mod tests {
         });
     }
 
-    /// A shadow entry reaches a real sibling: its sessions are genuinely
-    /// remote, so they must not be relabelled local — they move onto the
-    /// distro the entry reaches, under which the host now registers, and stay
-    /// resolvable there.
+    /// A shadow entry records its sessions under the same name the loopback
+    /// bug wrote, and nothing tells the two apart — so the repair leaves every
+    /// row under that name exactly as it found it, in both directions: no
+    /// sibling session is relabelled local, and no local one is moved onto the
+    /// sibling.
     #[test]
-    fn a_shadow_configs_rows_move_onto_the_distro_it_reaches() {
+    fn a_shadow_configs_rows_are_left_exactly_as_they_are() {
         with_wsl_distro(Some("MagicDebian"), || {
             let rig = rig("[[hosts]]\nname = \"MagicDebian\"\nkind = \"wsl\"\n\
                  distro = \"MagicDebianPerso\"\n");
@@ -215,35 +206,30 @@ mod tests {
 
             let notices = repair_wsl_loopback_rows(&rig.db);
 
-            assert_eq!(backend(&rig.db, "a"), "wsl:MagicDebianPerso");
-            assert_eq!(bookmark_hosts(&rig.db), ["wsl:MagicDebianPerso"]);
-            assert!(
-                notices
-                    .iter()
-                    .any(|n| n.contains("moved onto wsl:MagicDebianPerso")),
-                "the repair names where the rows went: {notices:?}"
-            );
+            assert_eq!(backend(&rig.db, "a"), "wsl:MagicDebian");
+            assert_eq!(bookmark_hosts(&rig.db), ["wsl:MagicDebian"]);
+            assert!(notices.is_empty(), "nothing was rewritten: {notices:?}");
+            // Still a one-shot: there is nothing further a later start could
+            // learn about those rows.
             assert!(!rig.db.wsl_loopback_repair_owed().unwrap());
         });
     }
 
-    /// The same shadow, but the distro it reaches is already described by
-    /// another entry. The rows still move onto it — one distro has one backend
-    /// name whichever entry ends up serving it (which one that is, and that no
-    /// duplicate is created, is settled in `agent::host_config`).
+    /// The shadow withholds its own spelling and nothing else: a loopback
+    /// alongside it is still healed under its own distinct name.
     #[test]
-    fn a_shadow_whose_distro_is_already_configured_moves_its_rows_there_too() {
+    fn a_loopback_is_still_healed_alongside_a_shadow() {
         with_wsl_distro(Some("MagicDebian"), || {
             let rig = rig("[[hosts]]\nname = \"MagicDebian\"\nkind = \"wsl\"\n\
                  distro = \"MagicDebianPerso\"\n\n\
-                 [[hosts]]\nname = \"MagicDebianPerso\"\nkind = \"wsl\"\n");
+                 [[hosts]]\nname = \"self\"\nkind = \"wsl\"\ndistro = \"MagicDebian\"\n");
             session(&rig.db, "a", "wsl:MagicDebian");
-            session(&rig.db, "b", "wsl:MagicDebianPerso");
+            session(&rig.db, "b", "wsl:self");
 
             repair_wsl_loopback_rows(&rig.db);
 
-            assert_eq!(backend(&rig.db, "a"), "wsl:MagicDebianPerso");
-            assert_eq!(backend(&rig.db, "b"), "wsl:MagicDebianPerso");
+            assert_eq!(backend(&rig.db, "a"), "wsl:MagicDebian");
+            assert_eq!(backend(&rig.db, "b"), "local-tmux");
         });
     }
 

--- a/src/session_ops/wsl_loopback.rs
+++ b/src/session_ops/wsl_loopback.rs
@@ -1,58 +1,87 @@
-//! The one-time repair of rows a WSL loopback host recorded as remote.
+//! The one-time repair of rows a WSL loopback or shadow host recorded wrong.
 //!
-//! Schema v47 only marks the repair as owed. It has to: the rows to put back
-//! are the ones written under a backend name the *registry* refuses, and
-//! `storage` may not read `hosts.toml`. This is the layer that sees both, so
-//! this is where the two halves meet — the set from
-//! [`crate::agent::host_config::wsl_loopback_backend_names`], the SQL from
-//! [`crate::storage::Database::relabel_wsl_loopback_rows`].
+//! Schema v47 only marks the repair as owed. It has to: what to rewrite is
+//! decided by the *registry* — which host claims `wsl:<us>`, and which distro
+//! it really reaches — and `storage` may not read `hosts.toml`. This is the
+//! layer that sees both, so this is where the two halves meet: the plan from
+//! [`crate::agent::host_config::wsl_repair_plan`], the SQL from
+//! [`crate::storage::Database::apply_wsl_repair_plan`].
+//!
+//! Driven from **every** startup that opens the database — the TUI boot and
+//! the `thurbox-cli` entrypoint — because the mark is written by any binary
+//! that opens it, and a headless-driven install need never launch the
+//! interface. Until it runs, a mislabelled row reads as remote: a reap sweep
+//! refuses to kill windows it believes are on another machine, and leaks them.
 
 use crate::storage::Database;
 
-/// Perform the loopback repair if it is owed, returning startup notices.
+/// Perform the repair if it is owed, returning startup notices.
 ///
-/// Runs at most once per database: the mark is cleared on success and left in
-/// place on failure, so a transient error is retried on the next start rather
-/// than losing the repair. Best-effort throughout — a database that cannot be
-/// repaired must still open.
+/// Runs at most once per database, and the mark is what guarantees it: read
+/// first so an invocation with nothing to do pays a single query, and cleared
+/// only once a pass has completed. Anything that leaves the outcome unknown —
+/// an unreadable `hosts.toml`, a failed write — keeps the mark instead, so the
+/// repair comes back rather than being lost. Best-effort throughout: a
+/// database that cannot be repaired must still open.
 pub fn repair_wsl_loopback_rows(db: &Database) -> Vec<String> {
     match db.wsl_loopback_repair_owed() {
         Ok(false) => return Vec::new(),
         Ok(true) => {}
         Err(e) => {
-            tracing::warn!("could not read the WSL loopback repair mark: {e}");
+            tracing::warn!("could not read the WSL repair mark: {e}");
             return Vec::new();
         }
     }
 
-    let heal = crate::agent::host_config::wsl_loopback_backend_names();
-    let report = match db.relabel_wsl_loopback_rows(&heal) {
+    // A `hosts.toml` that cannot be read is not "no hosts configured": the
+    // plan's rename arm is the only thing that keeps a shadow host's rows
+    // remote, and losing it would relabel a live sibling session as local.
+    let plan = match crate::agent::host_config::wsl_repair_plan() {
+        Ok(plan) => plan,
+        Err(e) => {
+            tracing::warn!(
+                "WSL row repair deferred — hosts.toml could not be read ({e}); \
+                 it stays owed and runs once the file parses"
+            );
+            return Vec::new();
+        }
+    };
+
+    let report = match db.apply_wsl_repair_plan(&plan) {
         Ok(report) => report,
         Err(e) => {
-            tracing::warn!("WSL loopback repair failed, will retry on next start: {e}");
+            tracing::warn!("WSL row repair failed, will retry on next start: {e}");
             return Vec::new();
         }
     };
     if let Err(e) = db.clear_wsl_loopback_repair_owed() {
-        tracing::warn!("WSL loopback repair ran but its mark could not be cleared: {e}");
+        tracing::warn!("WSL row repair ran but its mark could not be cleared: {e}");
     }
 
-    if report.is_empty() {
-        return Vec::new();
-    }
     let mut notices = Vec::new();
-    if report.sessions > 0 {
+    if report.sessions_local > 0 || report.bookmarks_local > 0 {
         notices.push(format!(
-            "{} session(s) were recorded on the WSL distro thurbox runs in, which is \
-             this machine; restored them as local",
-            report.sessions
+            "{} session(s) and {} repo bookmark(s) were recorded on the WSL distro \
+             thurbox runs in, which is this machine; restored them as local",
+            report.sessions_local, report.bookmarks_local
         ));
     }
-    if report.bookmarks > 0 || report.bookmarks_superseded > 0 {
+    if report.sessions_moved > 0 || report.bookmarks_moved > 0 {
+        let onto: Vec<&str> = plan.renames.iter().map(|(_, to)| to.as_str()).collect();
         notices.push(format!(
-            "{} repo bookmark(s) restored as local ({} superseded by a more recent \
-             reading of the same path)",
-            report.bookmarks, report.bookmarks_superseded
+            "{} session(s) and {} repo bookmark(s) moved onto {}: the hosts.toml entry \
+             that recorded them was named after the WSL distro thurbox runs in, and now \
+             registers as the distro it reaches",
+            report.sessions_moved,
+            report.bookmarks_moved,
+            onto.join(", ")
+        ));
+    }
+    if report.bookmarks_superseded > 0 {
+        notices.push(format!(
+            "{} repo bookmark(s) dropped as a staler reading of a path another row \
+             already records",
+            report.bookmarks_superseded
         ));
     }
     notices
@@ -146,9 +175,9 @@ mod tests {
         });
     }
 
-    /// The union arm. A hand-written loopback registers under its own `name`,
-    /// so its rows are spelled `wsl:self` and the base `wsl:<us>` would miss
-    /// them — stranding them on a host `hosts.toml` no longer describes.
+    /// A hand-written loopback registers under its own `name`, so its rows are
+    /// spelled `wsl:self` and the base `wsl:<us>` would miss them — stranding
+    /// them on a host `hosts.toml` no longer describes.
     #[test]
     fn a_differently_named_loopbacks_rows_are_healed_too() {
         with_wsl_distro(Some("MagicDebian"), || {
@@ -165,22 +194,56 @@ mod tests {
         });
     }
 
-    /// The subtraction arm. While a shadow entry exists, `wsl:<us>` reaches a
-    /// *sibling*: those sessions really are remote, and relabelling them local
-    /// would run every attach, diff and delete on the wrong machine.
+    /// A shadow entry reaches a real sibling: its sessions are genuinely
+    /// remote, so they must not be relabelled local — they move onto the
+    /// distro the entry reaches, under which the host now registers, and stay
+    /// resolvable there.
     #[test]
-    fn a_shadow_configs_remote_rows_are_left_alone() {
+    fn a_shadow_configs_rows_move_onto_the_distro_it_reaches() {
         with_wsl_distro(Some("MagicDebian"), || {
             let rig = rig("[[hosts]]\nname = \"MagicDebian\"\nkind = \"wsl\"\n\
                  distro = \"MagicDebianPerso\"\n");
             session(&rig.db, "a", "wsl:MagicDebian");
+            rig.db
+                .conn_ref()
+                .execute(
+                    "INSERT INTO repo_bookmarks (host, repo_path, last_used_at) \
+                     VALUES ('wsl:MagicDebian', '/repo', 1)",
+                    [],
+                )
+                .unwrap();
 
             let notices = repair_wsl_loopback_rows(&rig.db);
 
-            assert_eq!(backend(&rig.db, "a"), "wsl:MagicDebian");
-            assert!(notices.is_empty(), "nothing was owed: {notices:?}");
-            // The mark still clears, so the no-op is not retried forever.
+            assert_eq!(backend(&rig.db, "a"), "wsl:MagicDebianPerso");
+            assert_eq!(bookmark_hosts(&rig.db), ["wsl:MagicDebianPerso"]);
+            assert!(
+                notices
+                    .iter()
+                    .any(|n| n.contains("moved onto wsl:MagicDebianPerso")),
+                "the repair names where the rows went: {notices:?}"
+            );
             assert!(!rig.db.wsl_loopback_repair_owed().unwrap());
+        });
+    }
+
+    /// The same shadow, but the distro it reaches is already described by
+    /// another entry. The rows still move onto it — one distro has one backend
+    /// name whichever entry ends up serving it (which one that is, and that no
+    /// duplicate is created, is settled in `agent::host_config`).
+    #[test]
+    fn a_shadow_whose_distro_is_already_configured_moves_its_rows_there_too() {
+        with_wsl_distro(Some("MagicDebian"), || {
+            let rig = rig("[[hosts]]\nname = \"MagicDebian\"\nkind = \"wsl\"\n\
+                 distro = \"MagicDebianPerso\"\n\n\
+                 [[hosts]]\nname = \"MagicDebianPerso\"\nkind = \"wsl\"\n");
+            session(&rig.db, "a", "wsl:MagicDebian");
+            session(&rig.db, "b", "wsl:MagicDebianPerso");
+
+            repair_wsl_loopback_rows(&rig.db);
+
+            assert_eq!(backend(&rig.db, "a"), "wsl:MagicDebianPerso");
+            assert_eq!(backend(&rig.db, "b"), "wsl:MagicDebianPerso");
         });
     }
 
@@ -208,7 +271,7 @@ mod tests {
     }
 
     /// Two case-variant spellings of the loopback bookmarking one repo both
-    /// relabel to `host = ''`, which is one BINARY primary key for two rows.
+    /// rewrite to `host = ''`, which is one BINARY primary key for two rows.
     /// A SQLITE_CONSTRAINT here would repeat on every start.
     #[test]
     fn two_case_variant_loopbacks_bookmarking_one_repo_do_not_fail() {
@@ -232,6 +295,33 @@ mod tests {
                 .query_row("SELECT label FROM repo_bookmarks", [], |r| r.get(0))
                 .unwrap();
             assert_eq!(label, "newer", "resolved on recency");
+            assert!(!rig.db.wsl_loopback_repair_owed().unwrap());
+        });
+    }
+
+    /// A `hosts.toml` that does not parse says nothing about who owns
+    /// `wsl:<us>`, and acting on that silence would relabel a shadow host's
+    /// live sibling sessions as local. So the pass changes nothing and stays
+    /// owed, and the next start — once the file parses — does the work.
+    #[test]
+    fn an_unparseable_hosts_toml_defers_the_repair_and_changes_nothing() {
+        with_wsl_distro(Some("MagicDebian"), || {
+            let rig = rig("[[hosts]\nname = \"MagicDebian\"\n");
+            session(&rig.db, "a", "wsl:MagicDebian");
+
+            assert!(repair_wsl_loopback_rows(&rig.db).is_empty());
+
+            assert_eq!(backend(&rig.db, "a"), "wsl:MagicDebian");
+            assert!(
+                rig.db.wsl_loopback_repair_owed().unwrap(),
+                "the mark survives, so the repair is not lost"
+            );
+
+            // Once the file parses, the same call does the work.
+            let path = crate::agent::host_config::hosts_config_path().unwrap();
+            std::fs::write(&path, "").unwrap();
+            repair_wsl_loopback_rows(&rig.db);
+            assert_eq!(backend(&rig.db, "a"), "local-tmux");
             assert!(!rig.db.wsl_loopback_repair_owed().unwrap());
         });
     }

--- a/src/session_ops/wsl_loopback.rs
+++ b/src/session_ops/wsl_loopback.rs
@@ -2,8 +2,8 @@
 //!
 //! Schema v47 only marks the repair as owed. It has to: what to rewrite is
 //! decided by the *registry* — which names a loopback entry can have written,
-//! and which one spelling a host merely named after the current distro puts
-//! out of reach — and `storage` may not read `hosts.toml`. This is the layer
+//! and which of those a host thurbox still serves claims — and `storage` may
+//! not read `hosts.toml` or run `wsl.exe`. This is the layer
 //! that sees both, so this is where the two halves meet: the plan from
 //! [`crate::agent::host_config::wsl_repair_plan`], the SQL from
 //! [`crate::storage::Database::apply_wsl_repair_plan`].
@@ -20,10 +20,11 @@ use crate::storage::Database;
 ///
 /// Runs at most once per database, and the mark is what guarantees it: read
 /// first so an invocation with nothing to do pays a single query, and cleared
-/// only once a pass has completed. Anything that leaves the outcome unknown —
-/// an unreadable `hosts.toml`, a failed write — keeps the mark instead, so the
-/// repair comes back rather than being lost. Best-effort throughout: a
-/// database that cannot be repaired must still open.
+/// only once a pass has answered for **every** candidate spelling. Anything
+/// that leaves an outcome unknown — an unreadable `hosts.toml`, distros that
+/// could not be enumerated, a name a live host still claims, a failed write —
+/// keeps the mark instead, so the repair comes back rather than being lost.
+/// Best-effort throughout: a database that cannot be repaired must still open.
 pub fn repair_wsl_loopback_rows(db: &Database) -> Vec<String> {
     match db.wsl_loopback_repair_owed() {
         Ok(false) => return Vec::new(),
@@ -35,8 +36,8 @@ pub fn repair_wsl_loopback_rows(db: &Database) -> Vec<String> {
     }
 
     // A `hosts.toml` that cannot be read is not "no hosts configured": what
-    // keeps a shadow host's rows out of the heal is that entry being *seen*,
-    // and losing it would relabel a live sibling session as local.
+    // keeps a live host's rows out of the heal is that entry being *seen*, and
+    // losing it would relabel a sibling's live sessions as local.
     let plan = match crate::agent::host_config::wsl_repair_plan() {
         Ok(plan) => plan,
         Err(e) => {
@@ -55,11 +56,22 @@ pub fn repair_wsl_loopback_rows(db: &Database) -> Vec<String> {
             return Vec::new();
         }
     };
-    if let Err(e) = db.clear_wsl_loopback_repair_owed() {
-        tracing::warn!("WSL row repair ran but its mark could not be cleared: {e}");
+    if plan.withheld.is_empty() {
+        if let Err(e) = db.clear_wsl_loopback_repair_owed() {
+            tracing::warn!("WSL row repair ran but its mark could not be cleared: {e}");
+        }
     }
 
     let mut notices = Vec::new();
+    if !plan.withheld.is_empty() {
+        notices.push(format!(
+            "sessions recorded on {} were left as they are: a host thurbox still \
+             serves registers under that name, so a mislabelled local session there \
+             cannot be told from one of its own. Thurbox will settle them if nothing \
+             claims the name any more",
+            plan.withheld.join(", ")
+        ));
+    }
     if report.sessions_local > 0 || report.bookmarks_local > 0 {
         notices.push(format!(
             "{} session(s) and {} repo bookmark(s) were recorded on the WSL distro \
@@ -188,7 +200,8 @@ mod tests {
     /// bug wrote, and nothing tells the two apart — so the repair leaves every
     /// row under that name exactly as it found it, in both directions: no
     /// sibling session is relabelled local, and no local one is moved onto the
-    /// sibling.
+    /// sibling. Withheld, not answered: the mark stays so a later start can
+    /// settle those rows once no host claims the name.
     #[test]
     fn a_shadow_configs_rows_are_left_exactly_as_they_are() {
         with_wsl_distro(Some("MagicDebian"), || {
@@ -208,9 +221,38 @@ mod tests {
 
             assert_eq!(backend(&rig.db, "a"), "wsl:MagicDebian");
             assert_eq!(bookmark_hosts(&rig.db), ["wsl:MagicDebian"]);
-            assert!(notices.is_empty(), "nothing was rewritten: {notices:?}");
-            // Still a one-shot: there is nothing further a later start could
-            // learn about those rows.
+            assert!(
+                notices
+                    .iter()
+                    .any(|n| n.contains("wsl:MagicDebian") && n.contains("left as they are")),
+                "the deferral names the spelling it did not touch: {notices:?}"
+            );
+            assert!(
+                rig.db.wsl_loopback_repair_owed().unwrap(),
+                "withheld is not answered: the mark survives for a later start"
+            );
+        });
+    }
+
+    /// The claim is what withholds, so removing it settles the rows — the
+    /// recovery the deferral promises. Nothing else can do it: the entry is
+    /// gone by then, so only the surviving mark carries the work forward.
+    #[test]
+    fn removing_the_claiming_entry_lets_a_later_start_heal_the_rows() {
+        with_wsl_distro(Some("MagicDebian"), || {
+            let rig = rig("[[hosts]]\nname = \"MagicDebian\"\nkind = \"wsl\"\n\
+                 distro = \"MagicDebianPerso\"\n");
+            session(&rig.db, "a", "wsl:MagicDebian");
+
+            repair_wsl_loopback_rows(&rig.db);
+            assert_eq!(backend(&rig.db, "a"), "wsl:MagicDebian");
+
+            let path = crate::agent::host_config::hosts_config_path().unwrap();
+            std::fs::write(&path, "").unwrap();
+
+            repair_wsl_loopback_rows(&rig.db);
+
+            assert_eq!(backend(&rig.db, "a"), "local-tmux");
             assert!(!rig.db.wsl_loopback_repair_owed().unwrap());
         });
     }

--- a/src/session_ops/wsl_loopback.rs
+++ b/src/session_ops/wsl_loopback.rs
@@ -1,0 +1,238 @@
+//! The one-time repair of rows a WSL loopback host recorded as remote.
+//!
+//! Schema v47 only marks the repair as owed. It has to: the rows to put back
+//! are the ones written under a backend name the *registry* refuses, and
+//! `storage` may not read `hosts.toml`. This is the layer that sees both, so
+//! this is where the two halves meet — the set from
+//! [`crate::agent::host_config::wsl_loopback_backend_names`], the SQL from
+//! [`crate::storage::Database::relabel_wsl_loopback_rows`].
+
+use crate::storage::Database;
+
+/// Perform the loopback repair if it is owed, returning startup notices.
+///
+/// Runs at most once per database: the mark is cleared on success and left in
+/// place on failure, so a transient error is retried on the next start rather
+/// than losing the repair. Best-effort throughout — a database that cannot be
+/// repaired must still open.
+pub fn repair_wsl_loopback_rows(db: &Database) -> Vec<String> {
+    match db.wsl_loopback_repair_owed() {
+        Ok(false) => return Vec::new(),
+        Ok(true) => {}
+        Err(e) => {
+            tracing::warn!("could not read the WSL loopback repair mark: {e}");
+            return Vec::new();
+        }
+    }
+
+    let heal = crate::agent::host_config::wsl_loopback_backend_names();
+    let report = match db.relabel_wsl_loopback_rows(&heal) {
+        Ok(report) => report,
+        Err(e) => {
+            tracing::warn!("WSL loopback repair failed, will retry on next start: {e}");
+            return Vec::new();
+        }
+    };
+    if let Err(e) = db.clear_wsl_loopback_repair_owed() {
+        tracing::warn!("WSL loopback repair ran but its mark could not be cleared: {e}");
+    }
+
+    if report.is_empty() {
+        return Vec::new();
+    }
+    let mut notices = Vec::new();
+    if report.sessions > 0 {
+        notices.push(format!(
+            "{} session(s) were recorded on the WSL distro thurbox runs in, which is \
+             this machine; restored them as local",
+            report.sessions
+        ));
+    }
+    if report.bookmarks > 0 || report.bookmarks_superseded > 0 {
+        notices.push(format!(
+            "{} repo bookmark(s) restored as local ({} superseded by a more recent \
+             reading of the same path)",
+            report.bookmarks, report.bookmarks_superseded
+        ));
+    }
+    notices
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::host_def::with_wsl_distro;
+
+    struct Rig {
+        _temp: tempfile::TempDir,
+        _guard: crate::paths::TestPathGuard,
+        db: Database,
+    }
+
+    /// A database owing the repair, with `hosts_toml` as the profile's
+    /// `hosts.toml`.
+    fn rig(hosts_toml: &str) -> Rig {
+        let temp = tempfile::TempDir::new().unwrap();
+        let guard = crate::paths::TestPathGuard::new(temp.path());
+        let path = crate::agent::host_config::hosts_config_path().unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, hosts_toml).unwrap();
+
+        let db = Database::open_in_memory().unwrap();
+        db.conn_ref()
+            .execute(
+                "INSERT INTO metadata (key, value) VALUES ('wsl_loopback_repair_owed', '1') \
+                 ON CONFLICT(key) DO UPDATE SET value = '1'",
+                [],
+            )
+            .unwrap();
+        Rig {
+            _temp: temp,
+            _guard: guard,
+            db,
+        }
+    }
+
+    fn session(db: &Database, id: &str, backend_type: &str) {
+        db.conn_ref()
+            .execute(
+                "INSERT INTO sessions (id, name, agent, backend_type, backend_id, \
+                 created_at, updated_at) VALUES (?1, ?1, 'claude', ?2, '%1', 0, 0)",
+                rusqlite::params![id, backend_type],
+            )
+            .unwrap();
+    }
+
+    fn backend(db: &Database, id: &str) -> String {
+        db.conn_ref()
+            .query_row(
+                "SELECT backend_type FROM sessions WHERE id = ?1",
+                [id],
+                |r| r.get(0),
+            )
+            .unwrap()
+    }
+
+    fn bookmark_hosts(db: &Database) -> Vec<String> {
+        db.conn_ref()
+            .prepare("SELECT host FROM repo_bookmarks ORDER BY host, repo_path")
+            .unwrap()
+            .query_map([], |r| r.get(0))
+            .unwrap()
+            .map(Result::unwrap)
+            .collect()
+    }
+
+    #[test]
+    fn the_discovered_loopbacks_rows_are_healed_and_a_siblings_are_not() {
+        with_wsl_distro(Some("MagicDebian"), || {
+            let rig = rig("");
+            session(&rig.db, "a", "wsl:MagicDebian");
+            session(&rig.db, "b", "wsl:MagicDebianPerso");
+            session(&rig.db, "c", "ssh:devbox");
+
+            let notices = repair_wsl_loopback_rows(&rig.db);
+
+            assert_eq!(backend(&rig.db, "a"), "local-tmux");
+            assert_eq!(backend(&rig.db, "b"), "wsl:MagicDebianPerso");
+            assert_eq!(backend(&rig.db, "c"), "ssh:devbox");
+            assert!(
+                notices.iter().any(|n| n.contains("restored them as local")),
+                "the repair reports what it moved: {notices:?}"
+            );
+            assert!(!rig.db.wsl_loopback_repair_owed().unwrap());
+            // Owed once: a second pass finds nothing to do and says nothing.
+            assert!(repair_wsl_loopback_rows(&rig.db).is_empty());
+        });
+    }
+
+    /// The union arm. A hand-written loopback registers under its own `name`,
+    /// so its rows are spelled `wsl:self` and the base `wsl:<us>` would miss
+    /// them — stranding them on a host `hosts.toml` no longer describes.
+    #[test]
+    fn a_differently_named_loopbacks_rows_are_healed_too() {
+        with_wsl_distro(Some("MagicDebian"), || {
+            let rig = rig("[[hosts]]\nname = \"self\"\nkind = \"wsl\"\ndistro = \"MagicDebian\"\n");
+            session(&rig.db, "a", "wsl:self");
+            session(&rig.db, "b", "wsl:MagicDebian");
+            session(&rig.db, "c", "wsl:MagicDebianPerso");
+
+            repair_wsl_loopback_rows(&rig.db);
+
+            assert_eq!(backend(&rig.db, "a"), "local-tmux");
+            assert_eq!(backend(&rig.db, "b"), "local-tmux");
+            assert_eq!(backend(&rig.db, "c"), "wsl:MagicDebianPerso");
+        });
+    }
+
+    /// The subtraction arm. While a shadow entry exists, `wsl:<us>` reaches a
+    /// *sibling*: those sessions really are remote, and relabelling them local
+    /// would run every attach, diff and delete on the wrong machine.
+    #[test]
+    fn a_shadow_configs_remote_rows_are_left_alone() {
+        with_wsl_distro(Some("MagicDebian"), || {
+            let rig = rig("[[hosts]]\nname = \"MagicDebian\"\nkind = \"wsl\"\n\
+                 distro = \"MagicDebianPerso\"\n");
+            session(&rig.db, "a", "wsl:MagicDebian");
+
+            let notices = repair_wsl_loopback_rows(&rig.db);
+
+            assert_eq!(backend(&rig.db, "a"), "wsl:MagicDebian");
+            assert!(notices.is_empty(), "nothing was owed: {notices:?}");
+            // The mark still clears, so the no-op is not retried forever.
+            assert!(!rig.db.wsl_loopback_repair_owed().unwrap());
+        });
+    }
+
+    #[test]
+    fn off_wsl_the_repair_touches_nothing() {
+        with_wsl_distro(None, || {
+            let rig = rig("");
+            session(&rig.db, "a", "wsl:MagicDebian");
+            rig.db
+                .conn_ref()
+                .execute(
+                    "INSERT INTO repo_bookmarks (host, repo_path, last_used_at) \
+                     VALUES ('wsl:MagicDebian', '/repo', 1)",
+                    [],
+                )
+                .unwrap();
+
+            assert!(repair_wsl_loopback_rows(&rig.db).is_empty());
+
+            // A Windows (or plain Linux) thurbox driving that distro is the
+            // case the repair must not touch.
+            assert_eq!(backend(&rig.db, "a"), "wsl:MagicDebian");
+            assert_eq!(bookmark_hosts(&rig.db), ["wsl:MagicDebian"]);
+        });
+    }
+
+    /// Two case-variant spellings of the loopback bookmarking one repo both
+    /// relabel to `host = ''`, which is one BINARY primary key for two rows.
+    /// A SQLITE_CONSTRAINT here would repeat on every start.
+    #[test]
+    fn two_case_variant_loopbacks_bookmarking_one_repo_do_not_fail() {
+        with_wsl_distro(Some("Ubuntu"), || {
+            let rig = rig("[[hosts]]\nname = \"ubuntu\"\nkind = \"wsl\"\ndistro = \"Ubuntu\"\n");
+            rig.db
+                .conn_ref()
+                .execute_batch(
+                    "INSERT INTO repo_bookmarks (host, repo_path, label, last_used_at) VALUES
+                        ('wsl:Ubuntu', '/repo', 'older', 100),
+                        ('wsl:ubuntu', '/repo', 'newer', 200);",
+                )
+                .unwrap();
+
+            repair_wsl_loopback_rows(&rig.db);
+
+            assert_eq!(bookmark_hosts(&rig.db), [""], "one local row survives");
+            let label: String = rig
+                .db
+                .conn_ref()
+                .query_row("SELECT label FROM repo_bookmarks", [], |r| r.get(0))
+                .unwrap();
+            assert_eq!(label, "newer", "resolved on recency");
+            assert!(!rig.db.wsl_loopback_repair_owed().unwrap());
+        });
+    }
+}

--- a/src/session_ops/wsl_loopback.rs
+++ b/src/session_ops/wsl_loopback.rs
@@ -20,11 +20,22 @@ use crate::storage::Database;
 ///
 /// Runs at most once per database, and the mark is what guarantees it: read
 /// first so an invocation with nothing to do pays a single query, and cleared
-/// only once a pass has answered for **every** candidate spelling. Anything
-/// that leaves an outcome unknown — an unreadable `hosts.toml`, distros that
-/// could not be enumerated, a name a live host still claims, a failed write —
-/// keeps the mark instead, so the repair comes back rather than being lost.
-/// Best-effort throughout: a database that cannot be repaired must still open.
+/// once a pass has an **answer**.
+///
+/// A withheld spelling is an answer, and the distinction matters because the
+/// opposite reading looks reasonable. Rows under a name a live host claims are
+/// permanently indistinguishable — that host's own remote rows and the local
+/// rows an older release mislabelled look identical — so no later start can
+/// classify them better than this one. Keeping the mark until the claim
+/// disappears would not settle them; it would rewrite them once the evidence
+/// was merely *gone*, relabelling a live sibling's sessions local, which is
+/// the misassignment the withholding exists to prevent. So the pass applies
+/// what it can and retires.
+///
+/// Only a question that could not be *asked* keeps the mark: an unreadable
+/// `hosts.toml`, distros that could not be enumerated, a failed write. Those
+/// are transient, and the answer is still out there. Best-effort throughout: a
+/// database that cannot be repaired must still open.
 pub fn repair_wsl_loopback_rows(db: &Database) -> Vec<String> {
     match db.wsl_loopback_repair_owed() {
         Ok(false) => return Vec::new(),
@@ -35,15 +46,15 @@ pub fn repair_wsl_loopback_rows(db: &Database) -> Vec<String> {
         }
     }
 
-    // A `hosts.toml` that cannot be read is not "no hosts configured": what
+    // A registry that could not be read is not "no hosts configured": what
     // keeps a live host's rows out of the heal is that entry being *seen*, and
     // losing it would relabel a sibling's live sessions as local.
     let plan = match crate::agent::host_config::wsl_repair_plan() {
         Ok(plan) => plan,
         Err(e) => {
             tracing::warn!(
-                "WSL row repair deferred — hosts.toml could not be read ({e}); \
-                 it stays owed and runs once the file parses"
+                "WSL row repair deferred — the host registry could not be settled \
+                 ({e}); it stays owed and runs once that is answerable"
             );
             return Vec::new();
         }
@@ -56,19 +67,17 @@ pub fn repair_wsl_loopback_rows(db: &Database) -> Vec<String> {
             return Vec::new();
         }
     };
-    if plan.withheld.is_empty() {
-        if let Err(e) = db.clear_wsl_loopback_repair_owed() {
-            tracing::warn!("WSL row repair ran but its mark could not be cleared: {e}");
-        }
+    if let Err(e) = db.clear_wsl_loopback_repair_owed() {
+        tracing::warn!("WSL row repair ran but its mark could not be cleared: {e}");
     }
 
     let mut notices = Vec::new();
     if !plan.withheld.is_empty() {
         notices.push(format!(
-            "sessions recorded on {} were left as they are: a host thurbox still \
-             serves registers under that name, so a mislabelled local session there \
-             cannot be told from one of its own. Thurbox will settle them if nothing \
-             claims the name any more",
+            "sessions recorded on {} were left as they are, for good: a host thurbox \
+             serves registers under that name, so a local session an older release \
+             mislabelled there cannot be told from one of that host's own, and \
+             guessing either way would operate on the wrong machine",
             plan.withheld.join(", ")
         ));
     }
@@ -92,7 +101,17 @@ pub fn repair_wsl_loopback_rows(db: &Database) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::agent::host_config::with_discovered_wsl;
     use crate::session::host_def::with_wsl_distro;
+    use crate::session::HostDef;
+
+    /// A discovery stub that fails if it is consulted at all: the repair must
+    /// reach its answer without `wsl.exe` whenever no candidate is spelled
+    /// after another distro, and a stubbed failure is a transient one, so any
+    /// test using this would heal nothing if the narrowing regressed.
+    fn discovery_is_not_consulted() -> Result<Vec<HostDef>, String> {
+        Err("wsl.exe must not be consulted here".to_string())
+    }
 
     struct Rig {
         _temp: tempfile::TempDir,
@@ -157,23 +176,25 @@ mod tests {
     #[test]
     fn the_discovered_loopbacks_rows_are_healed_and_a_siblings_are_not() {
         with_wsl_distro(Some("MagicDebian"), || {
-            let rig = rig("");
-            session(&rig.db, "a", "wsl:MagicDebian");
-            session(&rig.db, "b", "wsl:MagicDebianPerso");
-            session(&rig.db, "c", "ssh:devbox");
+            with_discovered_wsl(discovery_is_not_consulted(), || {
+                let rig = rig("");
+                session(&rig.db, "a", "wsl:MagicDebian");
+                session(&rig.db, "b", "wsl:MagicDebianPerso");
+                session(&rig.db, "c", "ssh:devbox");
 
-            let notices = repair_wsl_loopback_rows(&rig.db);
+                let notices = repair_wsl_loopback_rows(&rig.db);
 
-            assert_eq!(backend(&rig.db, "a"), "local-tmux");
-            assert_eq!(backend(&rig.db, "b"), "wsl:MagicDebianPerso");
-            assert_eq!(backend(&rig.db, "c"), "ssh:devbox");
-            assert!(
-                notices.iter().any(|n| n.contains("restored them as local")),
-                "the repair reports what it moved: {notices:?}"
-            );
-            assert!(!rig.db.wsl_loopback_repair_owed().unwrap());
-            // Owed once: a second pass finds nothing to do and says nothing.
-            assert!(repair_wsl_loopback_rows(&rig.db).is_empty());
+                assert_eq!(backend(&rig.db, "a"), "local-tmux");
+                assert_eq!(backend(&rig.db, "b"), "wsl:MagicDebianPerso");
+                assert_eq!(backend(&rig.db, "c"), "ssh:devbox");
+                assert!(
+                    notices.iter().any(|n| n.contains("restored them as local")),
+                    "the repair reports what it moved: {notices:?}"
+                );
+                assert!(!rig.db.wsl_loopback_repair_owed().unwrap());
+                // Owed once: a second pass finds nothing to do and says nothing.
+                assert!(repair_wsl_loopback_rows(&rig.db).is_empty());
+            });
         });
     }
 
@@ -183,16 +204,21 @@ mod tests {
     #[test]
     fn a_differently_named_loopbacks_rows_are_healed_too() {
         with_wsl_distro(Some("MagicDebian"), || {
-            let rig = rig("[[hosts]]\nname = \"self\"\nkind = \"wsl\"\ndistro = \"MagicDebian\"\n");
-            session(&rig.db, "a", "wsl:self");
-            session(&rig.db, "b", "wsl:MagicDebian");
-            session(&rig.db, "c", "wsl:MagicDebianPerso");
+            // `wsl:self` is spelled after no distro this machine has, so the
+            // list is what says nothing claims it.
+            with_discovered_wsl(Ok(vec![HostDef::wsl("MagicDebianPerso")]), || {
+                let rig =
+                    rig("[[hosts]]\nname = \"self\"\nkind = \"wsl\"\ndistro = \"MagicDebian\"\n");
+                session(&rig.db, "a", "wsl:self");
+                session(&rig.db, "b", "wsl:MagicDebian");
+                session(&rig.db, "c", "wsl:MagicDebianPerso");
 
-            repair_wsl_loopback_rows(&rig.db);
+                repair_wsl_loopback_rows(&rig.db);
 
-            assert_eq!(backend(&rig.db, "a"), "local-tmux");
-            assert_eq!(backend(&rig.db, "b"), "local-tmux");
-            assert_eq!(backend(&rig.db, "c"), "wsl:MagicDebianPerso");
+                assert_eq!(backend(&rig.db, "a"), "local-tmux");
+                assert_eq!(backend(&rig.db, "b"), "local-tmux");
+                assert_eq!(backend(&rig.db, "c"), "wsl:MagicDebianPerso");
+            });
         });
     }
 
@@ -200,60 +226,100 @@ mod tests {
     /// bug wrote, and nothing tells the two apart — so the repair leaves every
     /// row under that name exactly as it found it, in both directions: no
     /// sibling session is relabelled local, and no local one is moved onto the
-    /// sibling. Withheld, not answered: the mark stays so a later start can
-    /// settle those rows once no host claims the name.
+    /// sibling. That is the answer for those rows, so the repair retires.
     #[test]
     fn a_shadow_configs_rows_are_left_exactly_as_they_are() {
         with_wsl_distro(Some("MagicDebian"), || {
-            let rig = rig("[[hosts]]\nname = \"MagicDebian\"\nkind = \"wsl\"\n\
-                 distro = \"MagicDebianPerso\"\n");
-            session(&rig.db, "a", "wsl:MagicDebian");
-            rig.db
-                .conn_ref()
-                .execute(
-                    "INSERT INTO repo_bookmarks (host, repo_path, last_used_at) \
-                     VALUES ('wsl:MagicDebian', '/repo', 1)",
-                    [],
-                )
-                .unwrap();
+            with_discovered_wsl(discovery_is_not_consulted(), || {
+                let rig = rig("[[hosts]]\nname = \"MagicDebian\"\nkind = \"wsl\"\n\
+                     distro = \"MagicDebianPerso\"\n");
+                session(&rig.db, "a", "wsl:MagicDebian");
+                rig.db
+                    .conn_ref()
+                    .execute(
+                        "INSERT INTO repo_bookmarks (host, repo_path, last_used_at) \
+                         VALUES ('wsl:MagicDebian', '/repo', 1)",
+                        [],
+                    )
+                    .unwrap();
 
-            let notices = repair_wsl_loopback_rows(&rig.db);
+                let notices = repair_wsl_loopback_rows(&rig.db);
 
-            assert_eq!(backend(&rig.db, "a"), "wsl:MagicDebian");
-            assert_eq!(bookmark_hosts(&rig.db), ["wsl:MagicDebian"]);
-            assert!(
-                notices
-                    .iter()
-                    .any(|n| n.contains("wsl:MagicDebian") && n.contains("left as they are")),
-                "the deferral names the spelling it did not touch: {notices:?}"
-            );
-            assert!(
-                rig.db.wsl_loopback_repair_owed().unwrap(),
-                "withheld is not answered: the mark survives for a later start"
-            );
+                assert_eq!(backend(&rig.db, "a"), "wsl:MagicDebian");
+                assert_eq!(bookmark_hosts(&rig.db), ["wsl:MagicDebian"]);
+                assert!(
+                    notices
+                        .iter()
+                        .any(|n| n.contains("wsl:MagicDebian") && n.contains("for good")),
+                    "the notice names the spelling and says it is final: {notices:?}"
+                );
+                assert!(
+                    !rig.db.wsl_loopback_repair_owed().unwrap(),
+                    "a withheld spelling is an answer, so the repair does not stay owed"
+                );
+            });
         });
     }
 
-    /// The claim is what withholds, so removing it settles the rows — the
-    /// recovery the deferral promises. Nothing else can do it: the entry is
-    /// gone by then, so only the surviving mark carries the work forward.
+    /// The regression the withheld-mark policy caused: a shadow's rows are
+    /// *genuinely remote*, and the claim disappearing does not make them
+    /// readable — it only removes the evidence. A repair still owed at that
+    /// point would relabel live sibling sessions local, so it must already be
+    /// retired.
     #[test]
-    fn removing_the_claiming_entry_lets_a_later_start_heal_the_rows() {
+    fn removing_the_claiming_entry_does_not_relabel_its_rows_later() {
         with_wsl_distro(Some("MagicDebian"), || {
-            let rig = rig("[[hosts]]\nname = \"MagicDebian\"\nkind = \"wsl\"\n\
-                 distro = \"MagicDebianPerso\"\n");
-            session(&rig.db, "a", "wsl:MagicDebian");
+            with_discovered_wsl(discovery_is_not_consulted(), || {
+                let rig = rig("[[hosts]]\nname = \"MagicDebian\"\nkind = \"wsl\"\n\
+                     distro = \"MagicDebianPerso\"\n");
+                session(&rig.db, "a", "wsl:MagicDebian");
 
-            repair_wsl_loopback_rows(&rig.db);
-            assert_eq!(backend(&rig.db, "a"), "wsl:MagicDebian");
+                repair_wsl_loopback_rows(&rig.db);
+                assert_eq!(backend(&rig.db, "a"), "wsl:MagicDebian");
 
-            let path = crate::agent::host_config::hosts_config_path().unwrap();
-            std::fs::write(&path, "").unwrap();
+                // The user acts on the warning and drops the entry.
+                let path = crate::agent::host_config::hosts_config_path().unwrap();
+                std::fs::write(&path, "").unwrap();
 
-            repair_wsl_loopback_rows(&rig.db);
+                assert!(repair_wsl_loopback_rows(&rig.db).is_empty());
 
-            assert_eq!(backend(&rig.db, "a"), "local-tmux");
-            assert!(!rig.db.wsl_loopback_repair_owed().unwrap());
+                assert_eq!(
+                    backend(&rig.db, "a"),
+                    "wsl:MagicDebian",
+                    "its windows are in the sibling distro; local-tmux would be the \
+                     wrong machine"
+                );
+            });
+        });
+    }
+
+    /// Distros that could not be enumerated are a question that could not be
+    /// asked, not an answer: nothing is touched, the mark survives, and the
+    /// work completes once `wsl.exe` answers.
+    #[test]
+    fn an_unenumerable_wsl_keeps_the_mark_and_completes_later() {
+        with_wsl_distro(Some("MagicDebian"), || {
+            let toml = "[[hosts]]\nname = \"self\"\nkind = \"wsl\"\ndistro = \"MagicDebian\"\n";
+            let rig = with_discovered_wsl(Err("wsl.exe -l -q failed".to_string()), || {
+                let rig = rig(toml);
+                session(&rig.db, "a", "wsl:self");
+
+                assert!(repair_wsl_loopback_rows(&rig.db).is_empty());
+
+                assert_eq!(backend(&rig.db, "a"), "wsl:self");
+                assert!(
+                    rig.db.wsl_loopback_repair_owed().unwrap(),
+                    "the mark survives, so the repair is not lost"
+                );
+                rig
+            });
+
+            with_discovered_wsl(Ok(Vec::new()), || {
+                repair_wsl_loopback_rows(&rig.db);
+
+                assert_eq!(backend(&rig.db, "a"), "local-tmux");
+                assert!(!rig.db.wsl_loopback_repair_owed().unwrap());
+            });
         });
     }
 
@@ -262,16 +328,18 @@ mod tests {
     #[test]
     fn a_loopback_is_still_healed_alongside_a_shadow() {
         with_wsl_distro(Some("MagicDebian"), || {
-            let rig = rig("[[hosts]]\nname = \"MagicDebian\"\nkind = \"wsl\"\n\
-                 distro = \"MagicDebianPerso\"\n\n\
-                 [[hosts]]\nname = \"self\"\nkind = \"wsl\"\ndistro = \"MagicDebian\"\n");
-            session(&rig.db, "a", "wsl:MagicDebian");
-            session(&rig.db, "b", "wsl:self");
+            with_discovered_wsl(Ok(vec![HostDef::wsl("MagicDebianPerso")]), || {
+                let rig = rig("[[hosts]]\nname = \"MagicDebian\"\nkind = \"wsl\"\n\
+                     distro = \"MagicDebianPerso\"\n\n\
+                     [[hosts]]\nname = \"self\"\nkind = \"wsl\"\ndistro = \"MagicDebian\"\n");
+                session(&rig.db, "a", "wsl:MagicDebian");
+                session(&rig.db, "b", "wsl:self");
 
-            repair_wsl_loopback_rows(&rig.db);
+                repair_wsl_loopback_rows(&rig.db);
 
-            assert_eq!(backend(&rig.db, "a"), "wsl:MagicDebian");
-            assert_eq!(backend(&rig.db, "b"), "local-tmux");
+                assert_eq!(backend(&rig.db, "a"), "wsl:MagicDebian");
+                assert_eq!(backend(&rig.db, "b"), "local-tmux");
+            });
         });
     }
 
@@ -304,26 +372,29 @@ mod tests {
     #[test]
     fn two_case_variant_loopbacks_bookmarking_one_repo_do_not_fail() {
         with_wsl_distro(Some("Ubuntu"), || {
-            let rig = rig("[[hosts]]\nname = \"ubuntu\"\nkind = \"wsl\"\ndistro = \"Ubuntu\"\n");
-            rig.db
-                .conn_ref()
-                .execute_batch(
-                    "INSERT INTO repo_bookmarks (host, repo_path, label, last_used_at) VALUES
+            with_discovered_wsl(discovery_is_not_consulted(), || {
+                let rig =
+                    rig("[[hosts]]\nname = \"ubuntu\"\nkind = \"wsl\"\ndistro = \"Ubuntu\"\n");
+                rig.db
+                    .conn_ref()
+                    .execute_batch(
+                        "INSERT INTO repo_bookmarks (host, repo_path, label, last_used_at) VALUES
                         ('wsl:Ubuntu', '/repo', 'older', 100),
                         ('wsl:ubuntu', '/repo', 'newer', 200);",
-                )
-                .unwrap();
+                    )
+                    .unwrap();
 
-            repair_wsl_loopback_rows(&rig.db);
+                repair_wsl_loopback_rows(&rig.db);
 
-            assert_eq!(bookmark_hosts(&rig.db), [""], "one local row survives");
-            let label: String = rig
-                .db
-                .conn_ref()
-                .query_row("SELECT label FROM repo_bookmarks", [], |r| r.get(0))
-                .unwrap();
-            assert_eq!(label, "newer", "resolved on recency");
-            assert!(!rig.db.wsl_loopback_repair_owed().unwrap());
+                assert_eq!(bookmark_hosts(&rig.db), [""], "one local row survives");
+                let label: String = rig
+                    .db
+                    .conn_ref()
+                    .query_row("SELECT label FROM repo_bookmarks", [], |r| r.get(0))
+                    .unwrap();
+                assert_eq!(label, "newer", "resolved on recency");
+                assert!(!rig.db.wsl_loopback_repair_owed().unwrap());
+            });
         });
     }
 
@@ -334,23 +405,25 @@ mod tests {
     #[test]
     fn an_unparseable_hosts_toml_defers_the_repair_and_changes_nothing() {
         with_wsl_distro(Some("MagicDebian"), || {
-            let rig = rig("[[hosts]\nname = \"MagicDebian\"\n");
-            session(&rig.db, "a", "wsl:MagicDebian");
+            with_discovered_wsl(discovery_is_not_consulted(), || {
+                let rig = rig("[[hosts]\nname = \"MagicDebian\"\n");
+                session(&rig.db, "a", "wsl:MagicDebian");
 
-            assert!(repair_wsl_loopback_rows(&rig.db).is_empty());
+                assert!(repair_wsl_loopback_rows(&rig.db).is_empty());
 
-            assert_eq!(backend(&rig.db, "a"), "wsl:MagicDebian");
-            assert!(
-                rig.db.wsl_loopback_repair_owed().unwrap(),
-                "the mark survives, so the repair is not lost"
-            );
+                assert_eq!(backend(&rig.db, "a"), "wsl:MagicDebian");
+                assert!(
+                    rig.db.wsl_loopback_repair_owed().unwrap(),
+                    "the mark survives, so the repair is not lost"
+                );
 
-            // Once the file parses, the same call does the work.
-            let path = crate::agent::host_config::hosts_config_path().unwrap();
-            std::fs::write(&path, "").unwrap();
-            repair_wsl_loopback_rows(&rig.db);
-            assert_eq!(backend(&rig.db, "a"), "local-tmux");
-            assert!(!rig.db.wsl_loopback_repair_owed().unwrap());
+                // Once the file parses, the same call does the work.
+                let path = crate::agent::host_config::hosts_config_path().unwrap();
+                std::fs::write(&path, "").unwrap();
+                repair_wsl_loopback_rows(&rig.db);
+                assert_eq!(backend(&rig.db, "a"), "local-tmux");
+                assert!(!rig.db.wsl_loopback_repair_owed().unwrap());
+            });
         });
     }
 }

--- a/src/session_ops/wsl_loopback.rs
+++ b/src/session_ops/wsl_loopback.rs
@@ -72,14 +72,20 @@ pub fn repair_wsl_loopback_rows(db: &Database) -> Vec<String> {
     }
 
     let mut notices = Vec::new();
-    if !plan.withheld.is_empty() {
-        notices.push(format!(
-            "sessions recorded on {} were left as they are, for good: a host thurbox \
-             serves registers under that name, so a local session an older release \
-             mislabelled there cannot be told from one of that host's own, and \
-             guessing either way would operate on the wrong machine",
+    match db.rows_recorded_on(&plan.withheld) {
+        // Nothing was left alone, so there is nothing to report: an entry that
+        // claims the spelling but never wrote a row is ordinary, and this is
+        // the one notice its owner would ever see.
+        Ok((0, 0)) => {}
+        Ok((sessions, bookmarks)) => notices.push(format!(
+            "{sessions} session(s) and {bookmarks} repo bookmark(s) recorded on {} were \
+             left as they are, for good: a host thurbox serves registers under that \
+             name, so a local session an older release mislabelled there cannot be told \
+             from one of that host's own, and guessing either way would operate on the \
+             wrong machine",
             plan.withheld.join(", ")
-        ));
+        )),
+        Err(e) => tracing::warn!("could not count the rows the WSL repair withheld: {e}"),
     }
     if report.sessions_local > 0 || report.bookmarks_local > 0 {
         notices.push(format!(
@@ -101,7 +107,6 @@ pub fn repair_wsl_loopback_rows(db: &Database) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::agent::host_config::with_discovered_wsl;
     use crate::session::host_def::with_wsl_distro;
     use crate::session::HostDef;
 
@@ -176,7 +181,7 @@ mod tests {
     #[test]
     fn the_discovered_loopbacks_rows_are_healed_and_a_siblings_are_not() {
         with_wsl_distro(Some("MagicDebian"), || {
-            with_discovered_wsl(discovery_is_not_consulted(), || {
+            crate::agent::host_config::with_discovered_wsl(discovery_is_not_consulted(), || {
                 let rig = rig("");
                 session(&rig.db, "a", "wsl:MagicDebian");
                 session(&rig.db, "b", "wsl:MagicDebianPerso");
@@ -206,19 +211,23 @@ mod tests {
         with_wsl_distro(Some("MagicDebian"), || {
             // `wsl:self` is spelled after no distro this machine has, so the
             // list is what says nothing claims it.
-            with_discovered_wsl(Ok(vec![HostDef::wsl("MagicDebianPerso")]), || {
-                let rig =
-                    rig("[[hosts]]\nname = \"self\"\nkind = \"wsl\"\ndistro = \"MagicDebian\"\n");
-                session(&rig.db, "a", "wsl:self");
-                session(&rig.db, "b", "wsl:MagicDebian");
-                session(&rig.db, "c", "wsl:MagicDebianPerso");
+            crate::agent::host_config::with_discovered_wsl(
+                Ok(vec![HostDef::wsl("MagicDebianPerso")]),
+                || {
+                    let rig = rig(
+                        "[[hosts]]\nname = \"self\"\nkind = \"wsl\"\ndistro = \"MagicDebian\"\n",
+                    );
+                    session(&rig.db, "a", "wsl:self");
+                    session(&rig.db, "b", "wsl:MagicDebian");
+                    session(&rig.db, "c", "wsl:MagicDebianPerso");
 
-                repair_wsl_loopback_rows(&rig.db);
+                    repair_wsl_loopback_rows(&rig.db);
 
-                assert_eq!(backend(&rig.db, "a"), "local-tmux");
-                assert_eq!(backend(&rig.db, "b"), "local-tmux");
-                assert_eq!(backend(&rig.db, "c"), "wsl:MagicDebianPerso");
-            });
+                    assert_eq!(backend(&rig.db, "a"), "local-tmux");
+                    assert_eq!(backend(&rig.db, "b"), "local-tmux");
+                    assert_eq!(backend(&rig.db, "c"), "wsl:MagicDebianPerso");
+                },
+            );
         });
     }
 
@@ -230,7 +239,7 @@ mod tests {
     #[test]
     fn a_shadow_configs_rows_are_left_exactly_as_they_are() {
         with_wsl_distro(Some("MagicDebian"), || {
-            with_discovered_wsl(discovery_is_not_consulted(), || {
+            crate::agent::host_config::with_discovered_wsl(discovery_is_not_consulted(), || {
                 let rig = rig("[[hosts]]\nname = \"MagicDebian\"\nkind = \"wsl\"\n\
                      distro = \"MagicDebianPerso\"\n");
                 session(&rig.db, "a", "wsl:MagicDebian");
@@ -261,6 +270,30 @@ mod tests {
         });
     }
 
+    /// An entry that claims the spelling but never wrote a row is an ordinary
+    /// config, and this notice is the only one its owner would ever see — so
+    /// telling them sessions were left alone, when there are none, is worse
+    /// than saying nothing.
+    #[test]
+    fn a_claimed_spelling_with_no_rows_is_not_reported() {
+        with_wsl_distro(Some("MagicDebian"), || {
+            crate::agent::host_config::with_discovered_wsl(discovery_is_not_consulted(), || {
+                let rig = rig("[[hosts]]\nname = \"MagicDebian\"\nkind = \"wsl\"\n\
+                     distro = \"MagicDebianPerso\"\n");
+                session(&rig.db, "a", "wsl:MagicDebianPerso");
+
+                let notices = repair_wsl_loopback_rows(&rig.db);
+
+                assert!(
+                    notices.is_empty(),
+                    "nothing was withheld in practice: {notices:?}"
+                );
+                assert_eq!(backend(&rig.db, "a"), "wsl:MagicDebianPerso");
+                assert!(!rig.db.wsl_loopback_repair_owed().unwrap());
+            });
+        });
+    }
+
     /// The regression the withheld-mark policy caused: a shadow's rows are
     /// *genuinely remote*, and the claim disappearing does not make them
     /// readable — it only removes the evidence. A repair still owed at that
@@ -269,7 +302,7 @@ mod tests {
     #[test]
     fn removing_the_claiming_entry_does_not_relabel_its_rows_later() {
         with_wsl_distro(Some("MagicDebian"), || {
-            with_discovered_wsl(discovery_is_not_consulted(), || {
+            crate::agent::host_config::with_discovered_wsl(discovery_is_not_consulted(), || {
                 let rig = rig("[[hosts]]\nname = \"MagicDebian\"\nkind = \"wsl\"\n\
                      distro = \"MagicDebianPerso\"\n");
                 session(&rig.db, "a", "wsl:MagicDebian");
@@ -300,21 +333,24 @@ mod tests {
     fn an_unenumerable_wsl_keeps_the_mark_and_completes_later() {
         with_wsl_distro(Some("MagicDebian"), || {
             let toml = "[[hosts]]\nname = \"self\"\nkind = \"wsl\"\ndistro = \"MagicDebian\"\n";
-            let rig = with_discovered_wsl(Err("wsl.exe -l -q failed".to_string()), || {
-                let rig = rig(toml);
-                session(&rig.db, "a", "wsl:self");
+            let rig = crate::agent::host_config::with_discovered_wsl(
+                Err("wsl.exe -l -q failed".to_string()),
+                || {
+                    let rig = rig(toml);
+                    session(&rig.db, "a", "wsl:self");
 
-                assert!(repair_wsl_loopback_rows(&rig.db).is_empty());
+                    assert!(repair_wsl_loopback_rows(&rig.db).is_empty());
 
-                assert_eq!(backend(&rig.db, "a"), "wsl:self");
-                assert!(
-                    rig.db.wsl_loopback_repair_owed().unwrap(),
-                    "the mark survives, so the repair is not lost"
-                );
-                rig
-            });
+                    assert_eq!(backend(&rig.db, "a"), "wsl:self");
+                    assert!(
+                        rig.db.wsl_loopback_repair_owed().unwrap(),
+                        "the mark survives, so the repair is not lost"
+                    );
+                    rig
+                },
+            );
 
-            with_discovered_wsl(Ok(Vec::new()), || {
+            crate::agent::host_config::with_discovered_wsl(Ok(Vec::new()), || {
                 repair_wsl_loopback_rows(&rig.db);
 
                 assert_eq!(backend(&rig.db, "a"), "local-tmux");
@@ -328,18 +364,21 @@ mod tests {
     #[test]
     fn a_loopback_is_still_healed_alongside_a_shadow() {
         with_wsl_distro(Some("MagicDebian"), || {
-            with_discovered_wsl(Ok(vec![HostDef::wsl("MagicDebianPerso")]), || {
-                let rig = rig("[[hosts]]\nname = \"MagicDebian\"\nkind = \"wsl\"\n\
+            crate::agent::host_config::with_discovered_wsl(
+                Ok(vec![HostDef::wsl("MagicDebianPerso")]),
+                || {
+                    let rig = rig("[[hosts]]\nname = \"MagicDebian\"\nkind = \"wsl\"\n\
                      distro = \"MagicDebianPerso\"\n\n\
                      [[hosts]]\nname = \"self\"\nkind = \"wsl\"\ndistro = \"MagicDebian\"\n");
-                session(&rig.db, "a", "wsl:MagicDebian");
-                session(&rig.db, "b", "wsl:self");
+                    session(&rig.db, "a", "wsl:MagicDebian");
+                    session(&rig.db, "b", "wsl:self");
 
-                repair_wsl_loopback_rows(&rig.db);
+                    repair_wsl_loopback_rows(&rig.db);
 
-                assert_eq!(backend(&rig.db, "a"), "wsl:MagicDebian");
-                assert_eq!(backend(&rig.db, "b"), "local-tmux");
-            });
+                    assert_eq!(backend(&rig.db, "a"), "wsl:MagicDebian");
+                    assert_eq!(backend(&rig.db, "b"), "local-tmux");
+                },
+            );
         });
     }
 
@@ -372,7 +411,7 @@ mod tests {
     #[test]
     fn two_case_variant_loopbacks_bookmarking_one_repo_do_not_fail() {
         with_wsl_distro(Some("Ubuntu"), || {
-            with_discovered_wsl(discovery_is_not_consulted(), || {
+            crate::agent::host_config::with_discovered_wsl(discovery_is_not_consulted(), || {
                 let rig =
                     rig("[[hosts]]\nname = \"ubuntu\"\nkind = \"wsl\"\ndistro = \"Ubuntu\"\n");
                 rig.db
@@ -405,7 +444,7 @@ mod tests {
     #[test]
     fn an_unparseable_hosts_toml_defers_the_repair_and_changes_nothing() {
         with_wsl_distro(Some("MagicDebian"), || {
-            with_discovered_wsl(discovery_is_not_consulted(), || {
+            crate::agent::host_config::with_discovered_wsl(discovery_is_not_consulted(), || {
                 let rig = rig("[[hosts]\nname = \"MagicDebian\"\n");
                 session(&rig.db, "a", "wsl:MagicDebian");
 

--- a/src/session_ops/wsl_loopback.rs
+++ b/src/session_ops/wsl_loopback.rs
@@ -402,6 +402,28 @@ mod tests {
             // case the repair must not touch.
             assert_eq!(backend(&rig.db, "a"), "wsl:MagicDebian");
             assert_eq!(bookmark_hosts(&rig.db), ["wsl:MagicDebian"]);
+            assert!(!rig.db.wsl_loopback_repair_owed().unwrap());
+        });
+    }
+
+    /// Off WSL the answer does not depend on `hosts.toml`: no loopback can
+    /// exist, so nothing is owed however the file reads. A typo in it while
+    /// adding an SSH host must therefore not defer the repair — which would
+    /// keep the mark set and re-parse the file on every hook-frequency
+    /// invocation, forever, on a machine the repair can never apply to.
+    #[test]
+    fn off_wsl_an_unparseable_hosts_toml_still_retires_the_repair() {
+        with_wsl_distro(None, || {
+            let rig = rig("[[hosts]\nname = \"devbox\"\n");
+            session(&rig.db, "a", "wsl:MagicDebian");
+
+            assert!(repair_wsl_loopback_rows(&rig.db).is_empty());
+
+            assert_eq!(backend(&rig.db, "a"), "wsl:MagicDebian");
+            assert!(
+                !rig.db.wsl_loopback_repair_owed().unwrap(),
+                "an answer that never depended on the file retires the repair"
+            );
         });
     }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -27,6 +27,8 @@ pub use sessions::{DeletedSessionInfo, HookRow, SessionFacts};
 pub mod sync;
 pub mod tasks;
 mod worktrees;
+mod wsl_repair;
+pub use wsl_repair::WslLoopbackRepair;
 
 use std::path::{Path, PathBuf};
 

--- a/src/storage/schema/migrations.rs
+++ b/src/storage/schema/migrations.rs
@@ -929,3 +929,53 @@ pub(super) fn migrate_v46_teardown_owed(conn: &Connection) -> rusqlite::Result<(
         "INTEGER NOT NULL DEFAULT 0",
     )
 }
+
+/// See [`super::SCHEMA_VERSION`] v47: a row stamped with the WSL distro thurbox
+/// is running inside is a **local** row that a loopback host relabelled, and
+/// this puts it back.
+///
+/// Auto-discovery used to offer the current distro as a host like any other.
+/// Being shareable by default (ADR-24), it was then mirrored — and its database
+/// is *this* database, so the pass read our own local rows back and rewrote
+/// each one's `backend_type` to `wsl:<us>`. Every attach, diff and delete
+/// afterwards went out through `wsl.exe` at the machine it started on.
+/// [`crate::session::HostDef::is_wsl_loopback`] stops that host being
+/// registered; the rows it already wrote need saying so.
+///
+/// Scoped to `wsl:$WSL_DISTRO_NAME` — the name auto-discovery used, which is
+/// the only way one of these was ever created. A hand-written `hosts.toml`
+/// entry may give a distro some other `name`, but `storage` cannot read that
+/// file (it may reference `session` and not `agent`), and such an entry is
+/// dropped with a warning rather than acted on. Nothing to do off WSL, and
+/// nothing to do to a **sibling** distro's rows: reaching one from inside
+/// another is an ordinary remote session.
+pub(super) fn migrate_v47_wsl_loopback_is_local(conn: &Connection) -> rusqlite::Result<()> {
+    let Some(distro) = crate::session::current_wsl_distro() else {
+        return Ok(());
+    };
+    let loopback = format!("{}{distro}", crate::session::WSL_BACKEND_PREFIX);
+    // Guarded per column, not per table: a `sessions` table without
+    // `backend_type` is only ever a hand-built test fixture, but a migration
+    // that assumes its shape aborts the whole upgrade before the version bump.
+    if column_exists(conn, "sessions", "backend_type")? {
+        let healed = conn.execute(
+            "UPDATE sessions SET backend_type = ?1 WHERE backend_type = ?2 COLLATE NOCASE",
+            [crate::session::LOCAL_BACKEND_TYPE, &loopback],
+        )?;
+        if healed > 0 {
+            tracing::info!(
+                "schema v47: {healed} session(s) were recorded on '{loopback}', the WSL distro \
+                 thurbox runs in; restored them as local"
+            );
+        }
+    }
+    if column_exists(conn, "repo_bookmarks", "host")? {
+        // `OR REPLACE`: the same path may already be bookmarked locally, and
+        // `(host, repo_path)` is the key — the local row is the one to keep.
+        conn.execute(
+            "UPDATE OR REPLACE repo_bookmarks SET host = '' WHERE host = ?1 COLLATE NOCASE",
+            [&loopback],
+        )?;
+    }
+    Ok(())
+}

--- a/src/storage/schema/migrations.rs
+++ b/src/storage/schema/migrations.rs
@@ -930,74 +930,35 @@ pub(super) fn migrate_v46_teardown_owed(conn: &Connection) -> rusqlite::Result<(
     )
 }
 
-/// See [`super::SCHEMA_VERSION`] v47: a row stamped with the WSL distro thurbox
-/// is running inside is a **local** row that a loopback host relabelled, and
-/// this puts it back.
+/// See [`super::SCHEMA_VERSION`] v47: record that the WSL-loopback repair is
+/// **owed**, without performing it.
 ///
-/// Auto-discovery used to offer the current distro as a host like any other.
-/// Being shareable by default (ADR-24), it was then mirrored — and its database
-/// is *this* database, so the pass read our own local rows back and rewrote
-/// each one's `backend_type` to `wsl:<us>`. Every attach, diff and delete
-/// afterwards went out through `wsl.exe` at the machine it started on.
-/// [`crate::session::HostDef::is_wsl_loopback`] stops that host being
-/// registered; the rows it already wrote need saying so.
+/// Auto-discovery used to offer the WSL distro thurbox runs *inside* as a host
+/// like any other. Being shareable by default (ADR-24) it was then mirrored —
+/// and its database is *this* database, so the pass read our own local rows
+/// back and rewrote each one's `backend_type` to `wsl:<us>`. Every attach, diff
+/// and delete afterwards went out through `wsl.exe` at the machine it started
+/// on. [`crate::session::HostDef::is_wsl_loopback`] stops that host being
+/// registered; the rows it already wrote still say otherwise.
 ///
-/// Scoped to `wsl:$WSL_DISTRO_NAME`, which `storage` can derive on its own
-/// (it may reference `session`, not `agent`, so `hosts.toml` is out of reach).
-/// That name is unambiguous because the registry keeps it so: auto-discovery
-/// never offers the loopback, and a hand-written entry that would *register*
-/// under it — whichever distro it actually points at — is dropped with a
-/// warning ([`crate::session::HostDef::shadows_current_wsl_distro`]). So a row
-/// spelled this way can only be one the bug wrote. Nothing to do off WSL, and
-/// nothing to do to a **sibling** distro's rows: reaching one from inside
-/// another is an ordinary remote session.
-pub(super) fn migrate_v47_wsl_loopback_is_local(conn: &Connection) -> rusqlite::Result<()> {
-    let Some(distro) = crate::session::current_wsl_distro() else {
-        return Ok(());
-    };
-    let loopback = format!("{}{distro}", crate::session::WSL_BACKEND_PREFIX);
-    // Guarded per column, not per table: a `sessions` table without
-    // `backend_type` is only ever a hand-built test fixture, but a migration
-    // that assumes its shape aborts the whole upgrade before the version bump.
-    if column_exists(conn, "sessions", "backend_type")? {
-        let healed = conn.execute(
-            "UPDATE sessions SET backend_type = ?1 WHERE backend_type = ?2 COLLATE NOCASE",
-            [crate::session::LOCAL_BACKEND_TYPE, &loopback],
-        )?;
-        if healed > 0 {
-            tracing::info!(
-                "schema v47: {healed} session(s) were recorded on '{loopback}', the WSL distro \
-                 thurbox runs in; restored them as local"
-            );
-        }
-    }
-    if column_exists(conn, "repo_bookmarks", "host")? {
-        // `(host, repo_path)` is the key, so a path bookmarked both before the
-        // bug and during it has two rows that the relabel would collide. Both
-        // record real local use, so the pair is resolved on recency and the
-        // staler row deleted first; `UPDATE OR REPLACE` would instead have
-        // silently dropped whichever row already existed, which is the local
-        // one — the opposite of what a heal should keep.
-        conn.execute(
-            "DELETE FROM repo_bookmarks AS local
-              WHERE local.host = ''
-                AND EXISTS (SELECT 1 FROM repo_bookmarks lb
-                             WHERE lb.host = ?1 COLLATE NOCASE
-                               AND lb.repo_path = local.repo_path
-                               AND lb.last_used_at > local.last_used_at)",
-            [&loopback],
-        )?;
-        conn.execute(
-            "DELETE FROM repo_bookmarks AS lb
-              WHERE lb.host = ?1 COLLATE NOCASE
-                AND EXISTS (SELECT 1 FROM repo_bookmarks local
-                             WHERE local.host = '' AND local.repo_path = lb.repo_path)",
-            [&loopback],
-        )?;
-        conn.execute(
-            "UPDATE repo_bookmarks SET host = '' WHERE host = ?1 COLLATE NOCASE",
-            [&loopback],
-        )?;
-    }
+/// Putting them right is not a schema change and cannot be done from here:
+/// *which* backend names the bug can have written is decided by the host
+/// registry — a hand-written loopback registers under its own `name`, and a
+/// host merely *named* after the current distro reaches a sibling and must
+/// stay remote — and `storage` may reference `session` but not `agent`, so
+/// `hosts.toml` is out of reach. Guessing from the spelling `wsl:$WSL_DISTRO_NAME`
+/// is wrong in both directions. So this step only leaves a mark, and
+/// `session_ops::repair_wsl_loopback_rows` does the work once from a layer
+/// that sees both the registry and the database, clearing the mark when it has.
+///
+/// The mark is recorded unconditionally, including off WSL: whether anything is
+/// owed is exactly the question this layer cannot answer, and the repair
+/// resolves an empty set to a no-op.
+pub(super) fn migrate_v47_wsl_loopback_repair_owed(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute(
+        "INSERT INTO metadata (key, value) VALUES (?1, '1') \
+         ON CONFLICT(key) DO UPDATE SET value = '1'",
+        [crate::storage::wsl_repair::WSL_LOOPBACK_REPAIR_OWED_KEY],
+    )?;
     Ok(())
 }

--- a/src/storage/schema/migrations.rs
+++ b/src/storage/schema/migrations.rs
@@ -942,11 +942,13 @@ pub(super) fn migrate_v46_teardown_owed(conn: &Connection) -> rusqlite::Result<(
 /// [`crate::session::HostDef::is_wsl_loopback`] stops that host being
 /// registered; the rows it already wrote need saying so.
 ///
-/// Scoped to `wsl:$WSL_DISTRO_NAME` — the name auto-discovery used, which is
-/// the only way one of these was ever created. A hand-written `hosts.toml`
-/// entry may give a distro some other `name`, but `storage` cannot read that
-/// file (it may reference `session` and not `agent`), and such an entry is
-/// dropped with a warning rather than acted on. Nothing to do off WSL, and
+/// Scoped to `wsl:$WSL_DISTRO_NAME`, which `storage` can derive on its own
+/// (it may reference `session`, not `agent`, so `hosts.toml` is out of reach).
+/// That name is unambiguous because the registry keeps it so: auto-discovery
+/// never offers the loopback, and a hand-written entry that would *register*
+/// under it — whichever distro it actually points at — is dropped with a
+/// warning ([`crate::session::HostDef::shadows_current_wsl_distro`]). So a row
+/// spelled this way can only be one the bug wrote. Nothing to do off WSL, and
 /// nothing to do to a **sibling** distro's rows: reaching one from inside
 /// another is an ordinary remote session.
 pub(super) fn migrate_v47_wsl_loopback_is_local(conn: &Connection) -> rusqlite::Result<()> {
@@ -970,10 +972,30 @@ pub(super) fn migrate_v47_wsl_loopback_is_local(conn: &Connection) -> rusqlite::
         }
     }
     if column_exists(conn, "repo_bookmarks", "host")? {
-        // `OR REPLACE`: the same path may already be bookmarked locally, and
-        // `(host, repo_path)` is the key — the local row is the one to keep.
+        // `(host, repo_path)` is the key, so a path bookmarked both before the
+        // bug and during it has two rows that the relabel would collide. Both
+        // record real local use, so the pair is resolved on recency and the
+        // staler row deleted first; `UPDATE OR REPLACE` would instead have
+        // silently dropped whichever row already existed, which is the local
+        // one — the opposite of what a heal should keep.
         conn.execute(
-            "UPDATE OR REPLACE repo_bookmarks SET host = '' WHERE host = ?1 COLLATE NOCASE",
+            "DELETE FROM repo_bookmarks AS local
+              WHERE local.host = ''
+                AND EXISTS (SELECT 1 FROM repo_bookmarks lb
+                             WHERE lb.host = ?1 COLLATE NOCASE
+                               AND lb.repo_path = local.repo_path
+                               AND lb.last_used_at > local.last_used_at)",
+            [&loopback],
+        )?;
+        conn.execute(
+            "DELETE FROM repo_bookmarks AS lb
+              WHERE lb.host = ?1 COLLATE NOCASE
+                AND EXISTS (SELECT 1 FROM repo_bookmarks local
+                             WHERE local.host = '' AND local.repo_path = lb.repo_path)",
+            [&loopback],
+        )?;
+        conn.execute(
+            "UPDATE repo_bookmarks SET host = '' WHERE host = ?1 COLLATE NOCASE",
             [&loopback],
         )?;
     }

--- a/src/storage/schema/mod.rs
+++ b/src/storage/schema/mod.rs
@@ -48,13 +48,16 @@ use rusqlite::Connection;
 /// one-shot best-effort attempt was the only one that would ever be made, and
 /// the agent it failed to kill outlived the session forever. The mark is what
 /// lets the sweep come back for it.
-/// v47 is not a schema change but a repair: a session recorded on
-/// `wsl:$WSL_DISTRO_NAME` is a local session that a loopback WSL host
-/// relabelled, and it is restored as local. Auto-discovery offered the distro
-/// thurbox runs *inside* as a host; being shareable by default it was then
-/// mirrored, and its database is this database — so the pass rewrote our own
-/// local rows as remote and every operation on them went out through
-/// `wsl.exe`. `HostDef::is_wsl_loopback` stops the host being registered.
+/// v47 is not a schema change but a *mark*: a session recorded on a loopback
+/// WSL host is a local session that host relabelled, and the mark records that
+/// putting it back is owed. Auto-discovery offered the distro thurbox runs
+/// *inside* as a host; being shareable by default it was then mirrored, and its
+/// database is this database — so the pass rewrote our own local rows as remote
+/// and every operation on them went out through `wsl.exe`.
+/// `HostDef::is_wsl_loopback` stops the host being registered. Which backend
+/// names the bug can have written is decided by the host registry, which
+/// `storage` may not read, so `session_ops::repair_wsl_loopback_rows` performs
+/// the repair once and clears the mark.
 /// Gaps in the step table are fine (there is no v18 step either).
 pub const SCHEMA_VERSION: u32 = 47;
 
@@ -374,7 +377,7 @@ fn migrate(conn: &Connection) -> rusqlite::Result<()> {
         (44, migrate_v44_reports_as),
         (45, migrate_v45_host_updated_at),
         (46, migrate_v46_teardown_owed),
-        (47, migrate_v47_wsl_loopback_is_local),
+        (47, migrate_v47_wsl_loopback_repair_owed),
     ];
 
     for &(target, step) in steps {
@@ -479,6 +482,7 @@ pub(super) fn rename_column_if_present(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rusqlite::OptionalExtension;
 
     #[test]
     fn initialize_sets_busy_timeout() {
@@ -682,167 +686,71 @@ mod tests {
         assert_eq!(version, SCHEMA_VERSION.to_string());
     }
 
+    /// v47 does not relabel anything; it records that the repair is owed, for
+    /// `session_ops::repair_wsl_loopback_rows` to perform once from a layer
+    /// that can see the host registry. The rows themselves are left alone
+    /// here — including a `wsl:` one, which only the registry can classify.
     #[test]
-    fn migrate_from_v46_restores_loopback_rows_as_local() {
-        crate::session::host_def::with_wsl_distro(Some("MagicDebian"), || {
-            let conn = Connection::open_in_memory().unwrap();
-            conn.execute_batch(
-                "CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL);
-                 INSERT INTO metadata (key, value) VALUES ('schema_version', '46');
-                 CREATE TABLE sessions (
-                    id TEXT PRIMARY KEY, name TEXT NOT NULL, backend_type TEXT NOT NULL,
-                    created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL,
-                    deleted_at INTEGER);
-                 INSERT INTO sessions (id, name, backend_type, created_at, updated_at)
-                    VALUES ('a', 'relabelled', 'wsl:MagicDebian', 0, 0),
-                           ('b', 'sibling', 'wsl:MagicDebianPerso', 0, 0),
-                           ('c', 'remote', 'ssh:devbox', 0, 0),
-                           ('d', 'local', 'local-tmux', 0, 0);
-                 CREATE TABLE repo_bookmarks (
-                    host TEXT NOT NULL DEFAULT '', repo_path TEXT NOT NULL,
-                    label TEXT, last_used_at INTEGER NOT NULL,
-                    use_count INTEGER NOT NULL DEFAULT 1,
-                    is_parent INTEGER NOT NULL DEFAULT 0,
-                    PRIMARY KEY (host, repo_path));
-                 INSERT INTO repo_bookmarks (host, repo_path, last_used_at)
-                    VALUES ('wsl:MagicDebian', '/home/me/repo', 0);",
+    fn migrate_from_v46_marks_the_loopback_repair_owed() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+             INSERT INTO metadata (key, value) VALUES ('schema_version', '46');
+             CREATE TABLE sessions (
+                id TEXT PRIMARY KEY, name TEXT NOT NULL, backend_type TEXT NOT NULL,
+                created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL,
+                deleted_at INTEGER);
+             INSERT INTO sessions (id, name, backend_type, created_at, updated_at)
+                VALUES ('a', 'maybe-relabelled', 'wsl:MagicDebian', 0, 0);",
+        )
+        .unwrap();
+
+        migrate(&conn).unwrap();
+
+        let owed: String = conn
+            .query_row(
+                "SELECT value FROM metadata WHERE key = 'wsl_loopback_repair_owed'",
+                [],
+                |r| r.get(0),
             )
             .unwrap();
+        assert_eq!(owed, "1");
 
-            migrate(&conn).unwrap();
+        let backend: String = conn
+            .query_row(
+                "SELECT backend_type FROM sessions WHERE id = 'a'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(backend, "wsl:MagicDebian");
 
-            let backend = |id: &str| -> String {
-                conn.query_row(
-                    "SELECT backend_type FROM sessions WHERE id = ?1",
-                    [id],
-                    |r| r.get(0),
-                )
-                .unwrap()
-            };
-            // Only the loopback moves: a sibling distro and an SSH host are
-            // genuinely off-local, and the local row was never wrong.
-            assert_eq!(backend("a"), "local-tmux");
-            assert_eq!(backend("b"), "wsl:MagicDebianPerso");
-            assert_eq!(backend("c"), "ssh:devbox");
-            assert_eq!(backend("d"), "local-tmux");
-
-            let host: String = conn
-                .query_row("SELECT host FROM repo_bookmarks LIMIT 1", [], |r| r.get(0))
-                .unwrap();
-            assert_eq!(host, "", "a bookmark on the loopback is a local bookmark");
-
-            let version: String = conn
-                .query_row(
-                    "SELECT value FROM metadata WHERE key = 'schema_version'",
-                    [],
-                    |row| row.get(0),
-                )
-                .unwrap();
-            assert_eq!(version, SCHEMA_VERSION.to_string());
-        });
+        let version: String = conn
+            .query_row(
+                "SELECT value FROM metadata WHERE key = 'schema_version'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(version, SCHEMA_VERSION.to_string());
     }
 
-    /// `(host, repo_path)` is the bookmark key, so a path bookmarked both
-    /// before the bug and during it collides on the relabel. The pair is one
-    /// path used locally twice, so the more recent reading survives — and a
-    /// tie keeps the local row rather than the artifact of the bug.
+    /// A database created at the current version has no bug-written rows, so
+    /// nothing is owed and the repair never runs.
     #[test]
-    fn migrate_from_v46_resolves_colliding_bookmarks_on_recency() {
-        crate::session::host_def::with_wsl_distro(Some("MagicDebian"), || {
-            let conn = Connection::open_in_memory().unwrap();
-            conn.execute_batch(
-                "CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL);
-                 INSERT INTO metadata (key, value) VALUES ('schema_version', '46');
-                 CREATE TABLE repo_bookmarks (
-                    host TEXT NOT NULL DEFAULT '', repo_path TEXT NOT NULL,
-                    label TEXT, last_used_at INTEGER NOT NULL,
-                    use_count INTEGER NOT NULL DEFAULT 1,
-                    is_parent INTEGER NOT NULL DEFAULT 0,
-                    PRIMARY KEY (host, repo_path));
-                 INSERT INTO repo_bookmarks (host, repo_path, label, last_used_at) VALUES
-                    ('',                '/local-newer',   'keep', 200),
-                    ('wsl:MagicDebian', '/local-newer',   'drop', 100),
-                    ('',                '/loopback-newer','drop', 100),
-                    ('wsl:MagicDebian', '/loopback-newer','keep', 200),
-                    ('',                '/tie',           'keep', 300),
-                    ('wsl:MagicDebian', '/tie',           'drop', 300),
-                    ('wsl:MagicDebian', '/only-loopback', 'keep', 100),
-                    ('ssh:devbox',      '/local-newer',   'keep', 100);",
+    fn a_fresh_database_owes_no_loopback_repair() {
+        let conn = Connection::open_in_memory().unwrap();
+        initialize(&conn).unwrap();
+
+        let owed: Option<String> = conn
+            .query_row(
+                "SELECT value FROM metadata WHERE key = 'wsl_loopback_repair_owed'",
+                [],
+                |r| r.get(0),
             )
+            .optional()
             .unwrap();
-
-            migrate(&conn).unwrap();
-
-            let rows: Vec<(String, String, String)> = conn
-                .prepare(
-                    "SELECT host, repo_path, label FROM repo_bookmarks ORDER BY repo_path, host",
-                )
-                .unwrap()
-                .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)))
-                .unwrap()
-                .map(Result::unwrap)
-                .collect();
-
-            assert_eq!(
-                rows,
-                vec![
-                    (
-                        "".to_string(),
-                        "/local-newer".to_string(),
-                        "keep".to_string()
-                    ),
-                    // A genuinely remote bookmark for the same path is a
-                    // different key and never part of the collision.
-                    (
-                        "ssh:devbox".to_string(),
-                        "/local-newer".to_string(),
-                        "keep".to_string()
-                    ),
-                    (
-                        "".to_string(),
-                        "/loopback-newer".to_string(),
-                        "keep".to_string()
-                    ),
-                    (
-                        "".to_string(),
-                        "/only-loopback".to_string(),
-                        "keep".to_string()
-                    ),
-                    ("".to_string(), "/tie".to_string(), "keep".to_string()),
-                ]
-            );
-        });
-    }
-
-    #[test]
-    fn migrate_from_v46_off_wsl_touches_nothing() {
-        crate::session::host_def::with_wsl_distro(None, || {
-            let conn = Connection::open_in_memory().unwrap();
-            conn.execute_batch(
-                "CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL);
-                 INSERT INTO metadata (key, value) VALUES ('schema_version', '46');
-                 CREATE TABLE sessions (
-                    id TEXT PRIMARY KEY, name TEXT NOT NULL, backend_type TEXT NOT NULL,
-                    created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL,
-                    deleted_at INTEGER);
-                 INSERT INTO sessions (id, name, backend_type, created_at, updated_at)
-                    VALUES ('a', 'remote', 'wsl:MagicDebian', 0, 0);",
-            )
-            .unwrap();
-
-            migrate(&conn).unwrap();
-
-            // A Windows (or plain Linux) thurbox driving that distro is the
-            // case the repair must not touch.
-            let backend: String = conn
-                .query_row(
-                    "SELECT backend_type FROM sessions WHERE id = 'a'",
-                    [],
-                    |r| r.get(0),
-                )
-                .unwrap();
-            assert_eq!(backend, "wsl:MagicDebian");
-        });
+        assert_eq!(owed, None);
     }
 
     #[test]

--- a/src/storage/schema/mod.rs
+++ b/src/storage/schema/mod.rs
@@ -48,8 +48,15 @@ use rusqlite::Connection;
 /// one-shot best-effort attempt was the only one that would ever be made, and
 /// the agent it failed to kill outlived the session forever. The mark is what
 /// lets the sweep come back for it.
+/// v47 is not a schema change but a repair: a session recorded on
+/// `wsl:$WSL_DISTRO_NAME` is a local session that a loopback WSL host
+/// relabelled, and it is restored as local. Auto-discovery offered the distro
+/// thurbox runs *inside* as a host; being shareable by default it was then
+/// mirrored, and its database is this database — so the pass rewrote our own
+/// local rows as remote and every operation on them went out through
+/// `wsl.exe`. `HostDef::is_wsl_loopback` stops the host being registered.
 /// Gaps in the step table are fine (there is no v18 step either).
-pub const SCHEMA_VERSION: u32 = 46;
+pub const SCHEMA_VERSION: u32 = 47;
 
 /// A single migration step: applied when the stored version is below `target`.
 type MigrationStep = (u32, fn(&Connection) -> rusqlite::Result<()>);
@@ -367,6 +374,7 @@ fn migrate(conn: &Connection) -> rusqlite::Result<()> {
         (44, migrate_v44_reports_as),
         (45, migrate_v45_host_updated_at),
         (46, migrate_v46_teardown_owed),
+        (47, migrate_v47_wsl_loopback_is_local),
     ];
 
     for &(target, step) in steps {
@@ -672,6 +680,97 @@ mod tests {
             )
             .unwrap();
         assert_eq!(version, SCHEMA_VERSION.to_string());
+    }
+
+    #[test]
+    fn migrate_from_v46_restores_loopback_rows_as_local() {
+        crate::session::host_def::with_wsl_distro(Some("MagicDebian"), || {
+            let conn = Connection::open_in_memory().unwrap();
+            conn.execute_batch(
+                "CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+                 INSERT INTO metadata (key, value) VALUES ('schema_version', '46');
+                 CREATE TABLE sessions (
+                    id TEXT PRIMARY KEY, name TEXT NOT NULL, backend_type TEXT NOT NULL,
+                    created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL,
+                    deleted_at INTEGER);
+                 INSERT INTO sessions (id, name, backend_type, created_at, updated_at)
+                    VALUES ('a', 'relabelled', 'wsl:MagicDebian', 0, 0),
+                           ('b', 'sibling', 'wsl:MagicDebianPerso', 0, 0),
+                           ('c', 'remote', 'ssh:devbox', 0, 0),
+                           ('d', 'local', 'local-tmux', 0, 0);
+                 CREATE TABLE repo_bookmarks (
+                    host TEXT NOT NULL DEFAULT '', repo_path TEXT NOT NULL,
+                    label TEXT, last_used_at INTEGER NOT NULL,
+                    use_count INTEGER NOT NULL DEFAULT 1,
+                    is_parent INTEGER NOT NULL DEFAULT 0,
+                    PRIMARY KEY (host, repo_path));
+                 INSERT INTO repo_bookmarks (host, repo_path, last_used_at)
+                    VALUES ('wsl:MagicDebian', '/home/me/repo', 0);",
+            )
+            .unwrap();
+
+            migrate(&conn).unwrap();
+
+            let backend = |id: &str| -> String {
+                conn.query_row(
+                    "SELECT backend_type FROM sessions WHERE id = ?1",
+                    [id],
+                    |r| r.get(0),
+                )
+                .unwrap()
+            };
+            // Only the loopback moves: a sibling distro and an SSH host are
+            // genuinely off-local, and the local row was never wrong.
+            assert_eq!(backend("a"), "local-tmux");
+            assert_eq!(backend("b"), "wsl:MagicDebianPerso");
+            assert_eq!(backend("c"), "ssh:devbox");
+            assert_eq!(backend("d"), "local-tmux");
+
+            let host: String = conn
+                .query_row("SELECT host FROM repo_bookmarks LIMIT 1", [], |r| r.get(0))
+                .unwrap();
+            assert_eq!(host, "", "a bookmark on the loopback is a local bookmark");
+
+            let version: String = conn
+                .query_row(
+                    "SELECT value FROM metadata WHERE key = 'schema_version'",
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(version, SCHEMA_VERSION.to_string());
+        });
+    }
+
+    #[test]
+    fn migrate_from_v46_off_wsl_touches_nothing() {
+        crate::session::host_def::with_wsl_distro(None, || {
+            let conn = Connection::open_in_memory().unwrap();
+            conn.execute_batch(
+                "CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+                 INSERT INTO metadata (key, value) VALUES ('schema_version', '46');
+                 CREATE TABLE sessions (
+                    id TEXT PRIMARY KEY, name TEXT NOT NULL, backend_type TEXT NOT NULL,
+                    created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL,
+                    deleted_at INTEGER);
+                 INSERT INTO sessions (id, name, backend_type, created_at, updated_at)
+                    VALUES ('a', 'remote', 'wsl:MagicDebian', 0, 0);",
+            )
+            .unwrap();
+
+            migrate(&conn).unwrap();
+
+            // A Windows (or plain Linux) thurbox driving that distro is the
+            // case the repair must not touch.
+            let backend: String = conn
+                .query_row(
+                    "SELECT backend_type FROM sessions WHERE id = 'a'",
+                    [],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(backend, "wsl:MagicDebian");
+        });
     }
 
     #[test]

--- a/src/storage/schema/mod.rs
+++ b/src/storage/schema/mod.rs
@@ -742,6 +742,78 @@ mod tests {
         });
     }
 
+    /// `(host, repo_path)` is the bookmark key, so a path bookmarked both
+    /// before the bug and during it collides on the relabel. The pair is one
+    /// path used locally twice, so the more recent reading survives — and a
+    /// tie keeps the local row rather than the artifact of the bug.
+    #[test]
+    fn migrate_from_v46_resolves_colliding_bookmarks_on_recency() {
+        crate::session::host_def::with_wsl_distro(Some("MagicDebian"), || {
+            let conn = Connection::open_in_memory().unwrap();
+            conn.execute_batch(
+                "CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+                 INSERT INTO metadata (key, value) VALUES ('schema_version', '46');
+                 CREATE TABLE repo_bookmarks (
+                    host TEXT NOT NULL DEFAULT '', repo_path TEXT NOT NULL,
+                    label TEXT, last_used_at INTEGER NOT NULL,
+                    use_count INTEGER NOT NULL DEFAULT 1,
+                    is_parent INTEGER NOT NULL DEFAULT 0,
+                    PRIMARY KEY (host, repo_path));
+                 INSERT INTO repo_bookmarks (host, repo_path, label, last_used_at) VALUES
+                    ('',                '/local-newer',   'keep', 200),
+                    ('wsl:MagicDebian', '/local-newer',   'drop', 100),
+                    ('',                '/loopback-newer','drop', 100),
+                    ('wsl:MagicDebian', '/loopback-newer','keep', 200),
+                    ('',                '/tie',           'keep', 300),
+                    ('wsl:MagicDebian', '/tie',           'drop', 300),
+                    ('wsl:MagicDebian', '/only-loopback', 'keep', 100),
+                    ('ssh:devbox',      '/local-newer',   'keep', 100);",
+            )
+            .unwrap();
+
+            migrate(&conn).unwrap();
+
+            let rows: Vec<(String, String, String)> = conn
+                .prepare(
+                    "SELECT host, repo_path, label FROM repo_bookmarks ORDER BY repo_path, host",
+                )
+                .unwrap()
+                .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)))
+                .unwrap()
+                .map(Result::unwrap)
+                .collect();
+
+            assert_eq!(
+                rows,
+                vec![
+                    (
+                        "".to_string(),
+                        "/local-newer".to_string(),
+                        "keep".to_string()
+                    ),
+                    // A genuinely remote bookmark for the same path is a
+                    // different key and never part of the collision.
+                    (
+                        "ssh:devbox".to_string(),
+                        "/local-newer".to_string(),
+                        "keep".to_string()
+                    ),
+                    (
+                        "".to_string(),
+                        "/loopback-newer".to_string(),
+                        "keep".to_string()
+                    ),
+                    (
+                        "".to_string(),
+                        "/only-loopback".to_string(),
+                        "keep".to_string()
+                    ),
+                    ("".to_string(), "/tie".to_string(), "keep".to_string()),
+                ]
+            );
+        });
+    }
+
     #[test]
     fn migrate_from_v46_off_wsl_touches_nothing() {
         crate::session::host_def::with_wsl_distro(None, || {

--- a/src/storage/wsl_repair.rs
+++ b/src/storage/wsl_repair.rs
@@ -37,13 +37,6 @@ pub struct WslLoopbackRepair {
     pub bookmarks_superseded: usize,
 }
 
-impl WslLoopbackRepair {
-    /// Whether the pass changed anything worth telling the user about.
-    pub fn is_empty(&self) -> bool {
-        *self == Self::default()
-    }
-}
-
 /// A `repo_bookmarks` row in one heal's collision group, as the resolution
 /// below reads it.
 struct Candidate<'a> {
@@ -365,10 +358,10 @@ mod tests {
         session(&db, "a", "wsl:MagicDebian");
         bookmark(&db, "wsl:MagicDebian", "/repo", "keep", 1);
 
-        assert!(db
-            .apply_wsl_repair_plan(&WslRepairPlan::default())
-            .unwrap()
-            .is_empty());
+        assert_eq!(
+            db.apply_wsl_repair_plan(&WslRepairPlan::default()).unwrap(),
+            WslLoopbackRepair::default()
+        );
 
         assert_eq!(backends(&db), vec![("a".into(), "wsl:MagicDebian".into())]);
         assert_eq!(

--- a/src/storage/wsl_repair.rs
+++ b/src/storage/wsl_repair.rs
@@ -182,6 +182,39 @@ impl Database {
         Ok(())
     }
 
+    /// How many sessions and repo bookmarks are recorded under any of
+    /// `backends`, matched case-insensitively the way the heal matches them.
+    ///
+    /// What the repair *withheld* is only worth telling the user about when
+    /// something is actually recorded there: an entry that claims a spelling
+    /// but never wrote a row is an ordinary config, and the notice is the one
+    /// message its owner would ever see.
+    pub fn rows_recorded_on(&self, backends: &[String]) -> rusqlite::Result<(usize, usize)> {
+        if backends.is_empty() {
+            return Ok((0, 0));
+        }
+        let list = std::iter::repeat("?")
+            .take(backends.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let count = |sql: String| -> rusqlite::Result<usize> {
+            let n: i64 =
+                self.conn
+                    .query_row(&sql, rusqlite::params_from_iter(backends.iter()), |row| {
+                        row.get(0)
+                    })?;
+            Ok(n as usize)
+        };
+        Ok((
+            count(format!(
+                "SELECT COUNT(*) FROM sessions WHERE backend_type COLLATE NOCASE IN ({list})"
+            ))?,
+            count(format!(
+                "SELECT COUNT(*) FROM repo_bookmarks WHERE host COLLATE NOCASE IN ({list})"
+            ))?,
+        ))
+    }
+
     /// Apply `plan`: rows recorded under a
     /// [`to_local`](WslRepairPlan::to_local) name become this machine's own
     /// (`backend_type` = [`LOCAL_BACKEND_TYPE`], bookmark `host` = `''`). One

--- a/src/storage/wsl_repair.rs
+++ b/src/storage/wsl_repair.rs
@@ -1,28 +1,35 @@
-//! The one-time repair of rows the WSL loopback bug recorded as remote.
+//! The one-time repair of rows a WSL loopback or shadow host recorded wrong.
 //!
 //! Two halves live apart on purpose. Schema v47 only *marks* the repair as
-//! owed, because which backend names to heal is decided by the host registry
-//! (`hosts.toml` + WSL discovery) and `storage` may not read it; the set is
-//! computed by `agent::host_config::wsl_loopback_backend_names` and handed to
-//! [`Database::relabel_wsl_loopback_rows`] by
+//! owed, because what to rewrite is decided by the host registry — which entry
+//! claims `wsl:<us>`, and which distro it really reaches — and `storage` may
+//! not read `hosts.toml`. The plan is built by
+//! `agent::host_config::wsl_repair_plan` and handed to
+//! [`Database::apply_wsl_repair_plan`] by
 //! `session_ops::repair_wsl_loopback_rows`. What stays here is the SQL, which
 //! is this module's job whoever decides the policy.
 
 use rusqlite::{params, OptionalExtension};
 
+use crate::session::WslRepairPlan;
+
 use super::Database;
 
-/// Metadata key set by schema v47 to record that the loopback repair is owed,
-/// and cleared once it has run.
+/// Metadata key set by schema v47 to record that the repair is owed, and
+/// cleared once it has run.
 pub(super) const WSL_LOOPBACK_REPAIR_OWED_KEY: &str = "wsl_loopback_repair_owed";
 
 /// What one repair pass changed.
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct WslLoopbackRepair {
-    /// Sessions moved from a loopback backend name back to local.
-    pub sessions: usize,
-    /// Bookmarks relabelled from a loopback host to local.
-    pub bookmarks: usize,
+    /// Sessions restored as this machine's own.
+    pub sessions_local: usize,
+    /// Bookmarks restored as this machine's own.
+    pub bookmarks_local: usize,
+    /// Sessions moved onto the host that actually reaches their distro.
+    pub sessions_moved: usize,
+    /// Bookmarks moved onto that host.
+    pub bookmarks_moved: usize,
     /// Bookmarks deleted because another reading of the same path won on
     /// recency — `(host, repo_path)` is the key, so only one can survive.
     pub bookmarks_superseded: usize,
@@ -35,32 +42,100 @@ impl WslLoopbackRepair {
     }
 }
 
-/// One `repo_bookmarks` row, as the collision resolution below reads it.
-struct Bookmark {
-    host: String,
-    repo_path: String,
+/// A `repo_bookmarks` row in one move's collision group, as the resolution
+/// below reads it.
+struct Candidate<'a> {
+    host: &'a str,
     last_used_at: i64,
+    /// Whether this row already carries the host the move writes, so it needs
+    /// no rewrite and wins a tie.
+    at_destination: bool,
 }
 
-impl Bookmark {
-    fn is_local(&self) -> bool {
-        self.host.is_empty()
-    }
-
-    /// Descending sort key: most recent first, a tie kept by the local row,
-    /// and a tie between two loopback spellings broken by name so the outcome
-    /// does not depend on row order.
+impl Candidate<'_> {
+    /// Descending sort key: most recent first, a tie kept by the row already
+    /// at the destination, and a tie between two spellings of the source
+    /// broken by name so the outcome does not depend on row order.
     fn precedence(&self) -> (i64, bool, std::cmp::Reverse<&str>) {
         (
             self.last_used_at,
-            self.is_local(),
-            std::cmp::Reverse(self.host.as_str()),
+            self.at_destination,
+            std::cmp::Reverse(self.host),
         )
     }
 }
 
+/// Move every row recorded under `from` (matched case-insensitively, the way
+/// `wsl.exe -d` matches a distro name, so several spellings of one distro move
+/// together) to `session_to` / `bookmark_to`.
+///
+/// The bookmark half cannot be a bare `UPDATE`: `(host, repo_path)` is the
+/// primary key and it is BINARY, so `wsl:Ubuntu`, `wsl:ubuntu` and a row
+/// already at the destination can all hold the same `repo_path`, and the
+/// rewrite would collide. Every such group is one path reached one way, so it
+/// is resolved on recency — most recent reading wins, a tie keeps the row
+/// already at the destination — and the losers are deleted before the survivor
+/// is rewritten. A `use_count` merge was considered and rejected: this is an
+/// MRU hint.
+///
+/// Returns `(sessions, bookmarks, bookmarks_superseded)`.
+fn move_rows(
+    tx: &rusqlite::Transaction<'_>,
+    from: &str,
+    session_to: &str,
+    bookmark_to: &str,
+) -> rusqlite::Result<(usize, usize, usize)> {
+    let sessions = tx.execute(
+        "UPDATE sessions SET backend_type = ?1 WHERE backend_type = ?2 COLLATE NOCASE",
+        params![session_to, from],
+    )?;
+
+    let rows: Vec<(String, String, i64)> = tx
+        .prepare("SELECT host, repo_path, last_used_at FROM repo_bookmarks")?
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))?
+        .collect::<rusqlite::Result<_>>()?;
+
+    let mut by_path: std::collections::BTreeMap<&str, Vec<Candidate>> =
+        std::collections::BTreeMap::new();
+    for (host, repo_path, last_used_at) in &rows {
+        let at_destination = host == bookmark_to;
+        if at_destination || host.eq_ignore_ascii_case(from) {
+            by_path.entry(repo_path).or_default().push(Candidate {
+                host,
+                last_used_at: *last_used_at,
+                at_destination,
+            });
+        }
+    }
+
+    let mut moved = 0;
+    let mut superseded = 0;
+    for (repo_path, mut group) in by_path {
+        if !group.iter().any(|c| !c.at_destination) {
+            continue;
+        }
+        group.sort_by(|a, b| b.precedence().cmp(&a.precedence()));
+        let (winner, losers) = group.split_first().expect("group is never empty");
+        for loser in losers {
+            tx.execute(
+                "DELETE FROM repo_bookmarks WHERE host = ?1 AND repo_path = ?2",
+                params![loser.host, repo_path],
+            )?;
+            superseded += 1;
+        }
+        if !winner.at_destination {
+            tx.execute(
+                "UPDATE repo_bookmarks SET host = ?1 WHERE host = ?2 AND repo_path = ?3",
+                params![bookmark_to, winner.host, repo_path],
+            )?;
+            moved += 1;
+        }
+    }
+    Ok((sessions, moved, superseded))
+}
+
 impl Database {
-    /// Whether the WSL-loopback repair schema v47 recorded is still owed.
+    /// Whether the WSL repair schema v47 recorded is still owed.
     pub fn wsl_loopback_repair_owed(&self) -> rusqlite::Result<bool> {
         let raw: Option<String> = self
             .conn
@@ -83,79 +158,37 @@ impl Database {
         Ok(())
     }
 
-    /// Relabel every row recorded under one of `heal` as local: a session's
-    /// `backend_type` to [`crate::session::LOCAL_BACKEND_TYPE`], a bookmark's
-    /// `host` to `''`.
+    /// Apply `plan`: rows recorded under a
+    /// [`to_local`](WslRepairPlan::to_local) name become this machine's own
+    /// (`backend_type` = [`crate::session::LOCAL_BACKEND_TYPE`], bookmark
+    /// `host` = `''`), and each [`rename`](WslRepairPlan::renames) moves its
+    /// rows onto another host's backend name.
     ///
-    /// Matching is case-insensitive, the way `wsl.exe -d` matches a distro
-    /// name, so several spellings of one distro heal together. That is also
-    /// why the bookmark half cannot be a bare `UPDATE`: `(host, repo_path)` is
-    /// the primary key and it is BINARY, so `wsl:Ubuntu`, `wsl:ubuntu` and a
-    /// pre-bug local row can all hold the same `repo_path` and the relabel
-    /// would collide. Every such group is one path used locally, so it is
-    /// resolved on recency — most recent reading wins, a tie keeps the local
-    /// row — and the losers are deleted before the survivor is relabelled.
-    /// A `use_count` merge was considered and rejected: this is an MRU hint.
-    pub fn relabel_wsl_loopback_rows(
+    /// One transaction, and `to_local` first — the plan's own ordering rule,
+    /// which is what stops a renamed row being carried straight on to local
+    /// when a loopback happens to be named after the rename's destination.
+    pub fn apply_wsl_repair_plan(
         &self,
-        heal: &[String],
+        plan: &WslRepairPlan,
     ) -> rusqlite::Result<WslLoopbackRepair> {
         let mut report = WslLoopbackRepair::default();
-        if heal.is_empty() {
+        if plan.is_empty() {
             return Ok(report);
         }
-        let matches_heal = |host: &str| {
-            !host.is_empty() && heal.iter().any(|name| name.eq_ignore_ascii_case(host))
-        };
-
         let tx = self.write_transaction()?;
 
-        for name in heal {
-            report.sessions += tx.execute(
-                "UPDATE sessions SET backend_type = ?1 WHERE backend_type = ?2 COLLATE NOCASE",
-                params![crate::session::LOCAL_BACKEND_TYPE, name],
-            )?;
+        for from in &plan.to_local {
+            let (sessions, bookmarks, superseded) =
+                move_rows(&tx, from, crate::session::LOCAL_BACKEND_TYPE, "")?;
+            report.sessions_local += sessions;
+            report.bookmarks_local += bookmarks;
+            report.bookmarks_superseded += superseded;
         }
-
-        let rows: Vec<Bookmark> = tx
-            .prepare("SELECT host, repo_path, last_used_at FROM repo_bookmarks")?
-            .query_map([], |row| {
-                Ok(Bookmark {
-                    host: row.get(0)?,
-                    repo_path: row.get(1)?,
-                    last_used_at: row.get(2)?,
-                })
-            })?
-            .collect::<rusqlite::Result<_>>()?;
-
-        let mut by_path: std::collections::BTreeMap<&str, Vec<&Bookmark>> =
-            std::collections::BTreeMap::new();
-        for row in &rows {
-            if row.is_local() || matches_heal(&row.host) {
-                by_path.entry(&row.repo_path).or_default().push(row);
-            }
-        }
-
-        for (repo_path, mut group) in by_path {
-            if !group.iter().any(|b| matches_heal(&b.host)) {
-                continue;
-            }
-            group.sort_by(|a, b| b.precedence().cmp(&a.precedence()));
-            let (winner, superseded) = group.split_first().expect("group is never empty");
-            for loser in superseded {
-                tx.execute(
-                    "DELETE FROM repo_bookmarks WHERE host = ?1 AND repo_path = ?2",
-                    params![loser.host, repo_path],
-                )?;
-                report.bookmarks_superseded += 1;
-            }
-            if !winner.is_local() {
-                tx.execute(
-                    "UPDATE repo_bookmarks SET host = '' WHERE host = ?1 AND repo_path = ?2",
-                    params![winner.host, repo_path],
-                )?;
-                report.bookmarks += 1;
-            }
+        for (from, to) in &plan.renames {
+            let (sessions, bookmarks, superseded) = move_rows(&tx, from, to, to)?;
+            report.sessions_moved += sessions;
+            report.bookmarks_moved += bookmarks;
+            report.bookmarks_superseded += superseded;
         }
 
         tx.commit()?;
@@ -169,6 +202,13 @@ mod tests {
 
     fn db() -> Database {
         Database::open_in_memory().unwrap()
+    }
+
+    fn to_local(names: &[&str]) -> WslRepairPlan {
+        WslRepairPlan {
+            to_local: names.iter().map(|n| n.to_string()).collect(),
+            renames: Vec::new(),
+        }
     }
 
     fn bookmark(db: &Database, host: &str, repo_path: &str, label: &str, last_used_at: i64) {
@@ -221,10 +261,13 @@ mod tests {
         session(&db, "e", "local-tmux");
 
         let report = db
-            .relabel_wsl_loopback_rows(&["wsl:MagicDebian".to_string()])
+            .apply_wsl_repair_plan(&to_local(&["wsl:MagicDebian"]))
             .unwrap();
 
-        assert_eq!(report.sessions, 2, "a spelling variant is the same distro");
+        assert_eq!(
+            report.sessions_local, 2,
+            "a spelling variant is the same distro"
+        );
         assert_eq!(
             backends(&db),
             vec![
@@ -238,12 +281,15 @@ mod tests {
     }
 
     #[test]
-    fn an_empty_set_changes_nothing() {
+    fn an_empty_plan_changes_nothing() {
         let db = db();
         session(&db, "a", "wsl:MagicDebian");
         bookmark(&db, "wsl:MagicDebian", "/repo", "keep", 1);
 
-        assert!(db.relabel_wsl_loopback_rows(&[]).unwrap().is_empty());
+        assert!(db
+            .apply_wsl_repair_plan(&WslRepairPlan::default())
+            .unwrap()
+            .is_empty());
 
         assert_eq!(backends(&db), vec![("a".into(), "wsl:MagicDebian".into())]);
         assert_eq!(
@@ -253,7 +299,7 @@ mod tests {
     }
 
     /// `(host, repo_path)` is the bookmark key, so a path bookmarked both
-    /// before the bug and during it collides on the relabel. The pair is one
+    /// before the bug and during it collides on the rewrite. The pair is one
     /// path used locally twice, so the more recent reading survives — and a
     /// tie keeps the local row rather than the artifact of the bug.
     #[test]
@@ -270,9 +316,9 @@ mod tests {
         bookmark(&db, "ssh:devbox", "/local-newer", "keep", 100);
 
         let report = db
-            .relabel_wsl_loopback_rows(&["wsl:MagicDebian".to_string()])
+            .apply_wsl_repair_plan(&to_local(&["wsl:MagicDebian"]))
             .unwrap();
-        assert_eq!(report.bookmarks, 2);
+        assert_eq!(report.bookmarks_local, 2);
         assert_eq!(report.bookmarks_superseded, 3);
 
         assert_eq!(
@@ -291,7 +337,7 @@ mod tests {
     }
 
     /// The failure mode this must rule out: two case-variant loopback
-    /// spellings bookmarking one repo both relabel to `host = ''`, which is
+    /// spellings bookmarking one repo both rewrite to `host = ''`, which is
     /// one BINARY primary key for two rows. Raising SQLITE_CONSTRAINT here
     /// would repeat on every start.
     #[test]
@@ -302,9 +348,9 @@ mod tests {
         bookmark(&db, "wsl:UBUNTU", "/other", "only", 100);
 
         let report = db
-            .relabel_wsl_loopback_rows(&["wsl:Ubuntu".to_string(), "wsl:ubuntu".to_string()])
+            .apply_wsl_repair_plan(&to_local(&["wsl:Ubuntu", "wsl:ubuntu"]))
             .unwrap();
-        assert_eq!(report.bookmarks, 2);
+        assert_eq!(report.bookmarks_local, 2);
         assert_eq!(report.bookmarks_superseded, 1);
 
         assert_eq!(
@@ -312,6 +358,82 @@ mod tests {
             vec![
                 ("".into(), "/other".into(), "only".into()),
                 ("".into(), "/repo".into(), "newer".into()),
+            ]
+        );
+    }
+
+    /// A rename carries the rows onto another host's backend name, and its
+    /// collisions resolve the same way — with the row already at the
+    /// destination playing the part the local row plays for a heal.
+    #[test]
+    fn a_rename_moves_rows_onto_the_destination_backend() {
+        let db = db();
+        session(&db, "a", "wsl:MagicDebian");
+        session(&db, "b", "local-tmux");
+        bookmark(&db, "wsl:MagicDebian", "/only-source", "keep", 100);
+        bookmark(&db, "wsl:MagicDebian", "/both", "keep", 200);
+        bookmark(&db, "wsl:MagicDebianPerso", "/both", "drop", 100);
+        bookmark(&db, "", "/both", "keep", 300);
+
+        let report = db
+            .apply_wsl_repair_plan(&WslRepairPlan {
+                to_local: Vec::new(),
+                renames: vec![(
+                    "wsl:MagicDebian".to_string(),
+                    "wsl:MagicDebianPerso".to_string(),
+                )],
+            })
+            .unwrap();
+
+        assert_eq!((report.sessions_moved, report.sessions_local), (1, 0));
+        assert_eq!(report.bookmarks_moved, 2);
+        assert_eq!(report.bookmarks_superseded, 1);
+        assert_eq!(
+            backends(&db),
+            vec![
+                ("a".into(), "wsl:MagicDebianPerso".into()),
+                ("b".into(), "local-tmux".into()),
+            ]
+        );
+        assert_eq!(
+            bookmarks(&db),
+            vec![
+                // The local row for the same path is a different key: a
+                // rename's destination is not local, so it is left alone.
+                ("".into(), "/both".into(), "keep".into()),
+                ("wsl:MagicDebianPerso".into(), "/both".into(), "keep".into()),
+                (
+                    "wsl:MagicDebianPerso".into(),
+                    "/only-source".into(),
+                    "keep".into()
+                ),
+            ]
+        );
+    }
+
+    /// `to_local` runs first, and that is what keeps the two arms from
+    /// disagreeing: a loopback named after a rename's destination sends its
+    /// own rows local without carrying the renamed ones along with them.
+    #[test]
+    fn a_heal_named_after_a_renames_destination_does_not_swallow_it() {
+        let db = db();
+        session(&db, "a", "wsl:MagicDebianPerso");
+        session(&db, "b", "wsl:MagicDebian");
+
+        db.apply_wsl_repair_plan(&WslRepairPlan {
+            to_local: vec!["wsl:MagicDebianPerso".to_string()],
+            renames: vec![(
+                "wsl:MagicDebian".to_string(),
+                "wsl:MagicDebianPerso".to_string(),
+            )],
+        })
+        .unwrap();
+
+        assert_eq!(
+            backends(&db),
+            vec![
+                ("a".into(), "local-tmux".into()),
+                ("b".into(), "wsl:MagicDebianPerso".into()),
             ]
         );
     }

--- a/src/storage/wsl_repair.rs
+++ b/src/storage/wsl_repair.rs
@@ -1,0 +1,333 @@
+//! The one-time repair of rows the WSL loopback bug recorded as remote.
+//!
+//! Two halves live apart on purpose. Schema v47 only *marks* the repair as
+//! owed, because which backend names to heal is decided by the host registry
+//! (`hosts.toml` + WSL discovery) and `storage` may not read it; the set is
+//! computed by `agent::host_config::wsl_loopback_backend_names` and handed to
+//! [`Database::relabel_wsl_loopback_rows`] by
+//! `session_ops::repair_wsl_loopback_rows`. What stays here is the SQL, which
+//! is this module's job whoever decides the policy.
+
+use rusqlite::{params, OptionalExtension};
+
+use super::Database;
+
+/// Metadata key set by schema v47 to record that the loopback repair is owed,
+/// and cleared once it has run.
+pub(super) const WSL_LOOPBACK_REPAIR_OWED_KEY: &str = "wsl_loopback_repair_owed";
+
+/// What one repair pass changed.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct WslLoopbackRepair {
+    /// Sessions moved from a loopback backend name back to local.
+    pub sessions: usize,
+    /// Bookmarks relabelled from a loopback host to local.
+    pub bookmarks: usize,
+    /// Bookmarks deleted because another reading of the same path won on
+    /// recency — `(host, repo_path)` is the key, so only one can survive.
+    pub bookmarks_superseded: usize,
+}
+
+impl WslLoopbackRepair {
+    /// Whether the pass changed anything worth telling the user about.
+    pub fn is_empty(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
+/// One `repo_bookmarks` row, as the collision resolution below reads it.
+struct Bookmark {
+    host: String,
+    repo_path: String,
+    last_used_at: i64,
+}
+
+impl Bookmark {
+    fn is_local(&self) -> bool {
+        self.host.is_empty()
+    }
+
+    /// Descending sort key: most recent first, a tie kept by the local row,
+    /// and a tie between two loopback spellings broken by name so the outcome
+    /// does not depend on row order.
+    fn precedence(&self) -> (i64, bool, std::cmp::Reverse<&str>) {
+        (
+            self.last_used_at,
+            self.is_local(),
+            std::cmp::Reverse(self.host.as_str()),
+        )
+    }
+}
+
+impl Database {
+    /// Whether the WSL-loopback repair schema v47 recorded is still owed.
+    pub fn wsl_loopback_repair_owed(&self) -> rusqlite::Result<bool> {
+        let raw: Option<String> = self
+            .conn
+            .query_row(
+                "SELECT value FROM metadata WHERE key = ?1",
+                params![WSL_LOOPBACK_REPAIR_OWED_KEY],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?;
+        Ok(raw.as_deref() == Some("1"))
+    }
+
+    /// Clear the mark, so the repair runs once per database rather than once
+    /// per start.
+    pub fn clear_wsl_loopback_repair_owed(&self) -> rusqlite::Result<()> {
+        self.conn.execute(
+            "DELETE FROM metadata WHERE key = ?1",
+            params![WSL_LOOPBACK_REPAIR_OWED_KEY],
+        )?;
+        Ok(())
+    }
+
+    /// Relabel every row recorded under one of `heal` as local: a session's
+    /// `backend_type` to [`crate::session::LOCAL_BACKEND_TYPE`], a bookmark's
+    /// `host` to `''`.
+    ///
+    /// Matching is case-insensitive, the way `wsl.exe -d` matches a distro
+    /// name, so several spellings of one distro heal together. That is also
+    /// why the bookmark half cannot be a bare `UPDATE`: `(host, repo_path)` is
+    /// the primary key and it is BINARY, so `wsl:Ubuntu`, `wsl:ubuntu` and a
+    /// pre-bug local row can all hold the same `repo_path` and the relabel
+    /// would collide. Every such group is one path used locally, so it is
+    /// resolved on recency — most recent reading wins, a tie keeps the local
+    /// row — and the losers are deleted before the survivor is relabelled.
+    /// A `use_count` merge was considered and rejected: this is an MRU hint.
+    pub fn relabel_wsl_loopback_rows(
+        &self,
+        heal: &[String],
+    ) -> rusqlite::Result<WslLoopbackRepair> {
+        let mut report = WslLoopbackRepair::default();
+        if heal.is_empty() {
+            return Ok(report);
+        }
+        let matches_heal = |host: &str| {
+            !host.is_empty() && heal.iter().any(|name| name.eq_ignore_ascii_case(host))
+        };
+
+        let tx = self.write_transaction()?;
+
+        for name in heal {
+            report.sessions += tx.execute(
+                "UPDATE sessions SET backend_type = ?1 WHERE backend_type = ?2 COLLATE NOCASE",
+                params![crate::session::LOCAL_BACKEND_TYPE, name],
+            )?;
+        }
+
+        let rows: Vec<Bookmark> = tx
+            .prepare("SELECT host, repo_path, last_used_at FROM repo_bookmarks")?
+            .query_map([], |row| {
+                Ok(Bookmark {
+                    host: row.get(0)?,
+                    repo_path: row.get(1)?,
+                    last_used_at: row.get(2)?,
+                })
+            })?
+            .collect::<rusqlite::Result<_>>()?;
+
+        let mut by_path: std::collections::BTreeMap<&str, Vec<&Bookmark>> =
+            std::collections::BTreeMap::new();
+        for row in &rows {
+            if row.is_local() || matches_heal(&row.host) {
+                by_path.entry(&row.repo_path).or_default().push(row);
+            }
+        }
+
+        for (repo_path, mut group) in by_path {
+            if !group.iter().any(|b| matches_heal(&b.host)) {
+                continue;
+            }
+            group.sort_by(|a, b| b.precedence().cmp(&a.precedence()));
+            let (winner, superseded) = group.split_first().expect("group is never empty");
+            for loser in superseded {
+                tx.execute(
+                    "DELETE FROM repo_bookmarks WHERE host = ?1 AND repo_path = ?2",
+                    params![loser.host, repo_path],
+                )?;
+                report.bookmarks_superseded += 1;
+            }
+            if !winner.is_local() {
+                tx.execute(
+                    "UPDATE repo_bookmarks SET host = '' WHERE host = ?1 AND repo_path = ?2",
+                    params![winner.host, repo_path],
+                )?;
+                report.bookmarks += 1;
+            }
+        }
+
+        tx.commit()?;
+        Ok(report)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn db() -> Database {
+        Database::open_in_memory().unwrap()
+    }
+
+    fn bookmark(db: &Database, host: &str, repo_path: &str, label: &str, last_used_at: i64) {
+        db.conn
+            .execute(
+                "INSERT INTO repo_bookmarks (host, repo_path, label, last_used_at) \
+                 VALUES (?1, ?2, ?3, ?4)",
+                params![host, repo_path, label, last_used_at],
+            )
+            .unwrap();
+    }
+
+    fn session(db: &Database, id: &str, backend_type: &str) {
+        db.conn
+            .execute(
+                "INSERT INTO sessions (id, name, agent, backend_type, backend_id, \
+                 created_at, updated_at) VALUES (?1, ?1, 'claude', ?2, '%1', 0, 0)",
+                params![id, backend_type],
+            )
+            .unwrap();
+    }
+
+    fn backends(db: &Database) -> Vec<(String, String)> {
+        db.conn
+            .prepare("SELECT id, backend_type FROM sessions ORDER BY id")
+            .unwrap()
+            .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))
+            .unwrap()
+            .map(Result::unwrap)
+            .collect()
+    }
+
+    fn bookmarks(db: &Database) -> Vec<(String, String, String)> {
+        db.conn
+            .prepare("SELECT host, repo_path, label FROM repo_bookmarks ORDER BY repo_path, host")
+            .unwrap()
+            .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)))
+            .unwrap()
+            .map(Result::unwrap)
+            .collect()
+    }
+
+    #[test]
+    fn only_the_named_backends_become_local() {
+        let db = db();
+        session(&db, "a", "wsl:MagicDebian");
+        session(&db, "b", "wsl:magicdebian");
+        session(&db, "c", "wsl:MagicDebianPerso");
+        session(&db, "d", "ssh:devbox");
+        session(&db, "e", "local-tmux");
+
+        let report = db
+            .relabel_wsl_loopback_rows(&["wsl:MagicDebian".to_string()])
+            .unwrap();
+
+        assert_eq!(report.sessions, 2, "a spelling variant is the same distro");
+        assert_eq!(
+            backends(&db),
+            vec![
+                ("a".into(), "local-tmux".into()),
+                ("b".into(), "local-tmux".into()),
+                ("c".into(), "wsl:MagicDebianPerso".into()),
+                ("d".into(), "ssh:devbox".into()),
+                ("e".into(), "local-tmux".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn an_empty_set_changes_nothing() {
+        let db = db();
+        session(&db, "a", "wsl:MagicDebian");
+        bookmark(&db, "wsl:MagicDebian", "/repo", "keep", 1);
+
+        assert!(db.relabel_wsl_loopback_rows(&[]).unwrap().is_empty());
+
+        assert_eq!(backends(&db), vec![("a".into(), "wsl:MagicDebian".into())]);
+        assert_eq!(
+            bookmarks(&db),
+            vec![("wsl:MagicDebian".into(), "/repo".into(), "keep".into())]
+        );
+    }
+
+    /// `(host, repo_path)` is the bookmark key, so a path bookmarked both
+    /// before the bug and during it collides on the relabel. The pair is one
+    /// path used locally twice, so the more recent reading survives — and a
+    /// tie keeps the local row rather than the artifact of the bug.
+    #[test]
+    fn colliding_bookmarks_resolve_on_recency() {
+        let db = db();
+        bookmark(&db, "", "/local-newer", "keep", 200);
+        bookmark(&db, "wsl:MagicDebian", "/local-newer", "drop", 100);
+        bookmark(&db, "", "/loopback-newer", "drop", 100);
+        bookmark(&db, "wsl:MagicDebian", "/loopback-newer", "keep", 200);
+        bookmark(&db, "", "/tie", "keep", 300);
+        bookmark(&db, "wsl:MagicDebian", "/tie", "drop", 300);
+        bookmark(&db, "wsl:MagicDebian", "/only-loopback", "keep", 100);
+        bookmark(&db, "", "/untouched", "keep", 100);
+        bookmark(&db, "ssh:devbox", "/local-newer", "keep", 100);
+
+        let report = db
+            .relabel_wsl_loopback_rows(&["wsl:MagicDebian".to_string()])
+            .unwrap();
+        assert_eq!(report.bookmarks, 2);
+        assert_eq!(report.bookmarks_superseded, 3);
+
+        assert_eq!(
+            bookmarks(&db),
+            vec![
+                ("".into(), "/local-newer".into(), "keep".into()),
+                // A genuinely remote bookmark for the same path is a different
+                // key and never part of the collision.
+                ("ssh:devbox".into(), "/local-newer".into(), "keep".into()),
+                ("".into(), "/loopback-newer".into(), "keep".into()),
+                ("".into(), "/only-loopback".into(), "keep".into()),
+                ("".into(), "/tie".into(), "keep".into()),
+                ("".into(), "/untouched".into(), "keep".into()),
+            ]
+        );
+    }
+
+    /// The failure mode this must rule out: two case-variant loopback
+    /// spellings bookmarking one repo both relabel to `host = ''`, which is
+    /// one BINARY primary key for two rows. Raising SQLITE_CONSTRAINT here
+    /// would repeat on every start.
+    #[test]
+    fn two_loopback_spellings_of_one_repo_do_not_violate_the_key() {
+        let db = db();
+        bookmark(&db, "wsl:Ubuntu", "/repo", "older", 100);
+        bookmark(&db, "wsl:ubuntu", "/repo", "newer", 200);
+        bookmark(&db, "wsl:UBUNTU", "/other", "only", 100);
+
+        let report = db
+            .relabel_wsl_loopback_rows(&["wsl:Ubuntu".to_string(), "wsl:ubuntu".to_string()])
+            .unwrap();
+        assert_eq!(report.bookmarks, 2);
+        assert_eq!(report.bookmarks_superseded, 1);
+
+        assert_eq!(
+            bookmarks(&db),
+            vec![
+                ("".into(), "/other".into(), "only".into()),
+                ("".into(), "/repo".into(), "newer".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn the_owed_mark_is_read_and_cleared() {
+        let db = db();
+        assert!(!db.wsl_loopback_repair_owed().unwrap());
+        db.conn
+            .execute(
+                "INSERT INTO metadata (key, value) VALUES (?1, '1')",
+                params![WSL_LOOPBACK_REPAIR_OWED_KEY],
+            )
+            .unwrap();
+        assert!(db.wsl_loopback_repair_owed().unwrap());
+        db.clear_wsl_loopback_repair_owed().unwrap();
+        assert!(!db.wsl_loopback_repair_owed().unwrap());
+    }
+}

--- a/src/storage/wsl_repair.rs
+++ b/src/storage/wsl_repair.rs
@@ -1,9 +1,10 @@
-//! The one-time repair of rows a WSL loopback or shadow host recorded wrong.
+//! The one-time repair of rows a WSL loopback host recorded as remote.
 //!
 //! Two halves live apart on purpose. Schema v47 only *marks* the repair as
-//! owed, because what to rewrite is decided by the host registry — which entry
-//! claims `wsl:<us>`, and which distro it really reaches — and `storage` may
-//! not read `hosts.toml`. The plan is built by
+//! owed, because what to rewrite is decided by the host registry — which
+//! backend names a loopback entry can have written, and which one spelling a
+//! host merely *named* after the current distro puts out of reach — and
+//! `storage` may not read `hosts.toml`. The plan is built by
 //! `agent::host_config::wsl_repair_plan` and handed to
 //! [`Database::apply_wsl_repair_plan`] by
 //! `session_ops::repair_wsl_loopback_rows`. What stays here is the SQL, which
@@ -11,13 +12,18 @@
 
 use rusqlite::{params, OptionalExtension};
 
-use crate::session::WslRepairPlan;
+use crate::session::{WslRepairPlan, LOCAL_BACKEND_TYPE};
 
 use super::Database;
 
 /// Metadata key set by schema v47 to record that the repair is owed, and
 /// cleared once it has run.
 pub(super) const WSL_LOOPBACK_REPAIR_OWED_KEY: &str = "wsl_loopback_repair_owed";
+
+/// The local bookmark `host`: `repo_bookmarks` spells "this machine" as the
+/// empty string, where `sessions.backend_type` spells it
+/// [`LOCAL_BACKEND_TYPE`].
+const LOCAL_BOOKMARK_HOST: &str = "";
 
 /// What one repair pass changed.
 #[derive(Debug, Default, PartialEq, Eq)]
@@ -26,10 +32,6 @@ pub struct WslLoopbackRepair {
     pub sessions_local: usize,
     /// Bookmarks restored as this machine's own.
     pub bookmarks_local: usize,
-    /// Sessions moved onto the host that actually reaches their distro.
-    pub sessions_moved: usize,
-    /// Bookmarks moved onto that host.
-    pub bookmarks_moved: usize,
     /// Bookmarks deleted because another reading of the same path won on
     /// recency — `(host, repo_path)` is the key, so only one can survive.
     pub bookmarks_superseded: usize,
@@ -42,79 +44,94 @@ impl WslLoopbackRepair {
     }
 }
 
-/// A `repo_bookmarks` row in one move's collision group, as the resolution
+/// A `repo_bookmarks` row in one heal's collision group, as the resolution
 /// below reads it.
 struct Candidate<'a> {
     host: &'a str,
     last_used_at: i64,
-    /// Whether this row already carries the host the move writes, so it needs
-    /// no rewrite and wins a tie.
-    at_destination: bool,
+    /// Whether this row is already this machine's own, so it needs no rewrite
+    /// and wins a tie.
+    local: bool,
+    is_parent: bool,
+    parent_path: Option<&'a str>,
 }
 
 impl Candidate<'_> {
-    /// Descending sort key: most recent first, a tie kept by the row already
-    /// at the destination, and a tie between two spellings of the source
-    /// broken by name so the outcome does not depend on row order.
+    /// Descending sort key: most recent first, a tie kept by the row that is
+    /// already local, and a tie between two spellings of the loopback broken
+    /// by name so the outcome does not depend on row order.
     fn precedence(&self) -> (i64, bool, std::cmp::Reverse<&str>) {
-        (
-            self.last_used_at,
-            self.at_destination,
-            std::cmp::Reverse(self.host),
-        )
+        (self.last_used_at, self.local, std::cmp::Reverse(self.host))
     }
 }
 
-/// Move every row recorded under `from` (matched case-insensitively, the way
-/// `wsl.exe -d` matches a distro name, so several spellings of one distro move
-/// together) to `session_to` / `bookmark_to`.
+/// Restore every row recorded under `from` (matched case-insensitively, the
+/// way `wsl.exe -d` matches a distro name, so several spellings of one distro
+/// heal together) as this machine's own.
 ///
 /// The bookmark half cannot be a bare `UPDATE`: `(host, repo_path)` is the
-/// primary key and it is BINARY, so `wsl:Ubuntu`, `wsl:ubuntu` and a row
-/// already at the destination can all hold the same `repo_path`, and the
-/// rewrite would collide. Every such group is one path reached one way, so it
-/// is resolved on recency — most recent reading wins, a tie keeps the row
-/// already at the destination — and the losers are deleted before the survivor
-/// is rewritten. A `use_count` merge was considered and rejected: this is an
-/// MRU hint.
+/// primary key and it is BINARY, so `wsl:Ubuntu`, `wsl:ubuntu` and a local row
+/// can all hold the same `repo_path`, and the rewrite would collide. Every
+/// such group is one local path read several ways, so it is resolved on
+/// recency — most recent reading wins, a tie keeps the row that is already
+/// local — and the losers are deleted before the survivor is rewritten. A
+/// `use_count` merge was considered and rejected: this is an MRU hint.
+///
+/// The survivor also inherits the group's place in the bookmark tree
+/// (`is_parent` if any reading carried it, the most recent `parent_path`),
+/// because the resolution is per `repo_path` while a parent's children are
+/// rows of their own: without the merge a surviving parent could lose the mark
+/// its children hang off, or a surviving child its filing under a parent.
 ///
 /// Returns `(sessions, bookmarks, bookmarks_superseded)`.
-fn move_rows(
+fn heal_rows(
     tx: &rusqlite::Transaction<'_>,
     from: &str,
-    session_to: &str,
-    bookmark_to: &str,
 ) -> rusqlite::Result<(usize, usize, usize)> {
     let sessions = tx.execute(
         "UPDATE sessions SET backend_type = ?1 WHERE backend_type = ?2 COLLATE NOCASE",
-        params![session_to, from],
+        params![LOCAL_BACKEND_TYPE, from],
     )?;
 
-    let rows: Vec<(String, String, i64)> = tx
-        .prepare("SELECT host, repo_path, last_used_at FROM repo_bookmarks")?
-        .query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))?
+    let rows: Vec<(String, String, i64, bool, Option<String>)> = tx
+        .prepare(
+            "SELECT host, repo_path, last_used_at, is_parent, parent_path FROM repo_bookmarks",
+        )?
+        .query_map([], |row| {
+            Ok((
+                row.get(0)?,
+                row.get(1)?,
+                row.get(2)?,
+                row.get::<_, i64>(3)? != 0,
+                row.get(4)?,
+            ))
+        })?
         .collect::<rusqlite::Result<_>>()?;
 
     let mut by_path: std::collections::BTreeMap<&str, Vec<Candidate>> =
         std::collections::BTreeMap::new();
-    for (host, repo_path, last_used_at) in &rows {
-        let at_destination = host == bookmark_to;
-        if at_destination || host.eq_ignore_ascii_case(from) {
+    for (host, repo_path, last_used_at, is_parent, parent_path) in &rows {
+        let local = host == LOCAL_BOOKMARK_HOST;
+        if local || host.eq_ignore_ascii_case(from) {
             by_path.entry(repo_path).or_default().push(Candidate {
                 host,
                 last_used_at: *last_used_at,
-                at_destination,
+                local,
+                is_parent: *is_parent,
+                parent_path: parent_path.as_deref(),
             });
         }
     }
 
-    let mut moved = 0;
+    let mut healed = 0;
     let mut superseded = 0;
     for (repo_path, mut group) in by_path {
-        if !group.iter().any(|c| !c.at_destination) {
+        if !group.iter().any(|c| !c.local) {
             continue;
         }
         group.sort_by(|a, b| b.precedence().cmp(&a.precedence()));
+        let is_parent = group.iter().any(|c| c.is_parent);
+        let parent_path = group.iter().find_map(|c| c.parent_path);
         let (winner, losers) = group.split_first().expect("group is never empty");
         for loser in losers {
             tx.execute(
@@ -123,15 +140,22 @@ fn move_rows(
             )?;
             superseded += 1;
         }
-        if !winner.at_destination {
-            tx.execute(
-                "UPDATE repo_bookmarks SET host = ?1 WHERE host = ?2 AND repo_path = ?3",
-                params![bookmark_to, winner.host, repo_path],
-            )?;
-            moved += 1;
+        tx.execute(
+            "UPDATE repo_bookmarks SET host = ?1, is_parent = ?2, parent_path = ?3 \
+             WHERE host = ?4 AND repo_path = ?5",
+            params![
+                LOCAL_BOOKMARK_HOST,
+                is_parent as i64,
+                parent_path,
+                winner.host,
+                repo_path
+            ],
+        )?;
+        if !winner.local {
+            healed += 1;
         }
     }
-    Ok((sessions, moved, superseded))
+    Ok((sessions, healed, superseded))
 }
 
 impl Database {
@@ -160,13 +184,8 @@ impl Database {
 
     /// Apply `plan`: rows recorded under a
     /// [`to_local`](WslRepairPlan::to_local) name become this machine's own
-    /// (`backend_type` = [`crate::session::LOCAL_BACKEND_TYPE`], bookmark
-    /// `host` = `''`), and each [`rename`](WslRepairPlan::renames) moves its
-    /// rows onto another host's backend name.
-    ///
-    /// One transaction, and `to_local` first — the plan's own ordering rule,
-    /// which is what stops a renamed row being carried straight on to local
-    /// when a loopback happens to be named after the rename's destination.
+    /// (`backend_type` = [`LOCAL_BACKEND_TYPE`], bookmark `host` = `''`). One
+    /// transaction, so a database is never left half-repaired.
     pub fn apply_wsl_repair_plan(
         &self,
         plan: &WslRepairPlan,
@@ -178,16 +197,9 @@ impl Database {
         let tx = self.write_transaction()?;
 
         for from in &plan.to_local {
-            let (sessions, bookmarks, superseded) =
-                move_rows(&tx, from, crate::session::LOCAL_BACKEND_TYPE, "")?;
+            let (sessions, bookmarks, superseded) = heal_rows(&tx, from)?;
             report.sessions_local += sessions;
             report.bookmarks_local += bookmarks;
-            report.bookmarks_superseded += superseded;
-        }
-        for (from, to) in &plan.renames {
-            let (sessions, bookmarks, superseded) = move_rows(&tx, from, to, to)?;
-            report.sessions_moved += sessions;
-            report.bookmarks_moved += bookmarks;
             report.bookmarks_superseded += superseded;
         }
 
@@ -207,7 +219,6 @@ mod tests {
     fn to_local(names: &[&str]) -> WslRepairPlan {
         WslRepairPlan {
             to_local: names.iter().map(|n| n.to_string()).collect(),
-            renames: Vec::new(),
         }
     }
 
@@ -229,6 +240,40 @@ mod tests {
                 params![id, backend_type],
             )
             .unwrap();
+    }
+
+    fn parent(db: &Database, host: &str) {
+        db.conn
+            .execute(
+                "UPDATE repo_bookmarks SET is_parent = 1 WHERE host = ?1 AND repo_path = '/parent'",
+                params![host],
+            )
+            .unwrap();
+    }
+
+    fn child(db: &Database, host: &str, repo_path: &str, parent_path: &str) {
+        db.conn
+            .execute(
+                "UPDATE repo_bookmarks SET parent_path = ?3 WHERE host = ?1 AND repo_path = ?2",
+                params![host, repo_path, parent_path],
+            )
+            .unwrap();
+    }
+
+    /// Every *local* bookmark as `(repo_path, is_parent, parent_path)`: a row
+    /// left remote is absent, so asserting the whole list also asserts the
+    /// heal reached all of them.
+    fn tree(db: &Database) -> Vec<(String, bool, Option<String>)> {
+        db.conn
+            .prepare(
+                "SELECT repo_path, is_parent, parent_path FROM repo_bookmarks \
+                 WHERE host = '' ORDER BY repo_path",
+            )
+            .unwrap()
+            .query_map([], |r| Ok((r.get(0)?, r.get::<_, i64>(1)? != 0, r.get(2)?)))
+            .unwrap()
+            .map(Result::unwrap)
+            .collect()
     }
 
     fn backends(db: &Database) -> Vec<(String, String)> {
@@ -362,79 +407,48 @@ mod tests {
         );
     }
 
-    /// A rename carries the rows onto another host's backend name, and its
-    /// collisions resolve the same way — with the row already at the
-    /// destination playing the part the local row plays for a heal.
+    /// A bookmark can be a persisted *parent* with child rows filed under it
+    /// (`parent_path`). The collision resolution is per `repo_path`, so
+    /// without merging the group's tree columns the survivor could keep the
+    /// recency it won on and lose the tree it belongs to — a parent no longer
+    /// marked as one, or a child no longer filed under its parent. Whichever
+    /// reading of a path wins, the subtree survives with it.
     #[test]
-    fn a_rename_moves_rows_onto_the_destination_backend() {
+    fn a_healed_bookmark_keeps_its_place_in_the_tree() {
         let db = db();
-        session(&db, "a", "wsl:MagicDebian");
-        session(&db, "b", "local-tmux");
-        bookmark(&db, "wsl:MagicDebian", "/only-source", "keep", 100);
-        bookmark(&db, "wsl:MagicDebian", "/both", "keep", 200);
-        bookmark(&db, "wsl:MagicDebianPerso", "/both", "drop", 100);
-        bookmark(&db, "", "/both", "keep", 300);
+        // The parent: the loopback row is the more recent reading, so it wins
+        // and must carry the local row's `is_parent`.
+        bookmark(&db, "", "/parent", "local", 100);
+        parent(&db, "");
+        bookmark(&db, "wsl:MagicDebian", "/parent", "loopback", 200);
+        // A child: the local reading wins on recency and must inherit the
+        // loopback row's filing under the parent.
+        bookmark(&db, "", "/parent/child", "local", 300);
+        bookmark(&db, "wsl:MagicDebian", "/parent/child", "loopback", 200);
+        child(&db, "wsl:MagicDebian", "/parent/child", "/parent");
+        // A child with no local rival moves as it is.
+        bookmark(&db, "wsl:MagicDebian", "/parent/other", "loopback", 100);
+        child(&db, "wsl:MagicDebian", "/parent/other", "/parent");
 
-        let report = db
-            .apply_wsl_repair_plan(&WslRepairPlan {
-                to_local: Vec::new(),
-                renames: vec![(
-                    "wsl:MagicDebian".to_string(),
-                    "wsl:MagicDebianPerso".to_string(),
-                )],
-            })
+        db.apply_wsl_repair_plan(&to_local(&["wsl:MagicDebian"]))
             .unwrap();
 
-        assert_eq!((report.sessions_moved, report.sessions_local), (1, 0));
-        assert_eq!(report.bookmarks_moved, 2);
-        assert_eq!(report.bookmarks_superseded, 1);
         assert_eq!(
-            backends(&db),
+            tree(&db),
             vec![
-                ("a".into(), "wsl:MagicDebianPerso".into()),
-                ("b".into(), "local-tmux".into()),
-            ]
-        );
-        assert_eq!(
-            bookmarks(&db),
-            vec![
-                // The local row for the same path is a different key: a
-                // rename's destination is not local, so it is left alone.
-                ("".into(), "/both".into(), "keep".into()),
-                ("wsl:MagicDebianPerso".into(), "/both".into(), "keep".into()),
+                ("/parent".to_string(), true, None),
                 (
-                    "wsl:MagicDebianPerso".into(),
-                    "/only-source".into(),
-                    "keep".into()
+                    "/parent/child".to_string(),
+                    false,
+                    Some("/parent".to_string())
                 ),
-            ]
-        );
-    }
-
-    /// `to_local` runs first, and that is what keeps the two arms from
-    /// disagreeing: a loopback named after a rename's destination sends its
-    /// own rows local without carrying the renamed ones along with them.
-    #[test]
-    fn a_heal_named_after_a_renames_destination_does_not_swallow_it() {
-        let db = db();
-        session(&db, "a", "wsl:MagicDebianPerso");
-        session(&db, "b", "wsl:MagicDebian");
-
-        db.apply_wsl_repair_plan(&WslRepairPlan {
-            to_local: vec!["wsl:MagicDebianPerso".to_string()],
-            renames: vec![(
-                "wsl:MagicDebian".to_string(),
-                "wsl:MagicDebianPerso".to_string(),
-            )],
-        })
-        .unwrap();
-
-        assert_eq!(
-            backends(&db),
-            vec![
-                ("a".into(), "local-tmux".into()),
-                ("b".into(), "wsl:MagicDebianPerso".into()),
-            ]
+                (
+                    "/parent/other".to_string(),
+                    false,
+                    Some("/parent".to_string())
+                ),
+            ],
+            "one local parent with both its children still filed under it"
         );
     }
 

--- a/src/storage/wsl_repair.rs
+++ b/src/storage/wsl_repair.rs
@@ -2,9 +2,9 @@
 //!
 //! Two halves live apart on purpose. Schema v47 only *marks* the repair as
 //! owed, because what to rewrite is decided by the host registry — which
-//! backend names a loopback entry can have written, and which one spelling a
-//! host merely *named* after the current distro puts out of reach — and
-//! `storage` may not read `hosts.toml`. The plan is built by
+//! backend names a loopback entry can have written, and which of those a host
+//! thurbox still serves claims — and `storage` may not read `hosts.toml`. The
+//! plan is built by
 //! `agent::host_config::wsl_repair_plan` and handed to
 //! [`Database::apply_wsl_repair_plan`] by
 //! `session_ops::repair_wsl_loopback_rows`. What stays here is the SQL, which
@@ -219,6 +219,7 @@ mod tests {
     fn to_local(names: &[&str]) -> WslRepairPlan {
         WslRepairPlan {
             to_local: names.iter().map(|n| n.to_string()).collect(),
+            withheld: Vec::new(),
         }
     }
 

--- a/tests/wsl_loopback_repair_cli.rs
+++ b/tests/wsl_loopback_repair_cli.rs
@@ -105,12 +105,22 @@ fn a_cli_invocation_repairs_the_rows_a_loopback_host_relabelled() {
     plant_a_relabelled_session(&env.db_path(), "wsl:MagicDebian");
 
     // No TUI in sight: the next CLI invocation is what has to put it back.
-    let rows = sessions(&env.run(&["session", "list", "--json"]));
+    let out = env.run(&["session", "list", "--json"]);
+    let rows = sessions(&out);
 
     assert_eq!(
         backend_of(&rows, "relabelled"),
         "local-tmux",
         "a session on the distro thurbox runs in is local to it"
+    );
+    // The rewrite is one-shot and clears its own mark, so this notice is the
+    // only record the user ever gets that persisted rows changed. The CLI
+    // logger filters to WARN, so an `info!` here would be swallowed on
+    // precisely the headless installs this path exists for.
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("restored them as local"),
+        "the repair notice reaches stderr: {stderr}"
     );
 }
 

--- a/tests/wsl_loopback_repair_cli.rs
+++ b/tests/wsl_loopback_repair_cli.rs
@@ -1,0 +1,153 @@
+//! The one-time WSL row repair runs from `thurbox-cli`, not only from the TUI.
+//!
+//! Schema v47 marks the repair as owed on whichever binary opens the database
+//! first, and a headless-driven install (an automation, the heartbeat keeper,
+//! an agent's status hook) need never launch the interface. Until the repair
+//! runs, a session local to the distro reads as remote — `is_remote_backend`
+//! is true of `wsl:<us>` — so a reap sweep refuses to kill its windows and
+//! leaks the agent process.
+//!
+//! Driven through the real binary, because the thing under test is the
+//! entrypoint's own wiring: nothing below `main` can observe whether the CLI
+//! ever calls the repair.
+
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+use serde_json::Value;
+
+/// A throwaway thurbox instance, pretending to run inside WSL distro
+/// `MagicDebian`: its own config, data and home, so nothing here reads or
+/// writes the operator's.
+struct Env {
+    root: tempfile::TempDir,
+}
+
+impl Env {
+    fn new() -> Self {
+        let root = tempfile::TempDir::new().expect("tempdir");
+        for sub in ["home", "config", "data"] {
+            std::fs::create_dir_all(root.path().join(sub)).expect("mkdir");
+        }
+        Self { root }
+    }
+
+    fn path(&self, sub: &str) -> PathBuf {
+        self.root.path().join(sub)
+    }
+
+    fn db_path(&self) -> PathBuf {
+        self.path("data").join("thurbox.db")
+    }
+
+    fn run(&self, args: &[&str]) -> Output {
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_thurbox-cli"));
+        cmd.args(args);
+        cmd.env("HOME", self.path("home"));
+        cmd.env("USERPROFILE", self.path("home"));
+        cmd.env("THURBOX_CONFIG_DIR", self.path("config"));
+        cmd.env("THURBOX_DATA_DIR", self.path("data"));
+        cmd.env("WSL_DISTRO_NAME", "MagicDebian");
+        cmd.env_remove("THURBOX_SOCKET");
+        cmd.env_remove("THURBOX_SESSION");
+        cmd.env_remove("THURBOX_SESSION_ID");
+        cmd.output().expect("run thurbox-cli")
+    }
+}
+
+/// Roll the database back to v46 and plant one session recorded the way the
+/// released build recorded it: local to this distro, but stamped with the
+/// distro's own backend name. The next open migrates to v47, which marks the
+/// repair owed — exactly the state an upgrading user is in.
+fn plant_a_relabelled_session(db: &PathBuf, backend_type: &str) {
+    let conn = rusqlite::Connection::open(db).expect("open");
+    conn.execute(
+        "UPDATE metadata SET value = '46' WHERE key = 'schema_version'",
+        [],
+    )
+    .expect("downgrade");
+    conn.execute(
+        "INSERT INTO sessions (id, name, agent, backend_type, backend_id, created_at, \
+         updated_at) VALUES ('11111111-1111-4111-8111-111111111111', 'relabelled', \
+         'claude', ?1, '%1', 0, 0)",
+        [backend_type],
+    )
+    .expect("insert session");
+}
+
+fn sessions(out: &Output) -> Vec<Value> {
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "session list succeeded:\nstdout: {stdout}\nstderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    match serde_json::from_slice(&out.stdout).expect("stdout is JSON") {
+        Value::Array(rows) => rows,
+        other => panic!("session list returns an array, got {other}"),
+    }
+}
+
+fn backend_of(rows: &[Value], name: &str) -> String {
+    rows.iter()
+        .find(|r| r["name"] == name)
+        .unwrap_or_else(|| panic!("session '{name}' is listed: {rows:?}"))["backend_type"]
+        .as_str()
+        .expect("backend_type is a string")
+        .to_string()
+}
+
+#[test]
+fn a_cli_invocation_repairs_the_rows_a_loopback_host_relabelled() {
+    let env = Env::new();
+    // First run creates the database at the current schema.
+    assert!(env.run(&["session", "list", "--json"]).status.success());
+    plant_a_relabelled_session(&env.db_path(), "wsl:MagicDebian");
+
+    // No TUI in sight: the next CLI invocation is what has to put it back.
+    let rows = sessions(&env.run(&["session", "list", "--json"]));
+
+    assert_eq!(
+        backend_of(&rows, "relabelled"),
+        "local-tmux",
+        "a session on the distro thurbox runs in is local to it"
+    );
+}
+
+#[test]
+fn a_cli_invocation_leaves_a_sibling_distros_sessions_remote() {
+    let env = Env::new();
+    assert!(env.run(&["session", "list", "--json"]).status.success());
+    plant_a_relabelled_session(&env.db_path(), "wsl:MagicDebianPerso");
+
+    let rows = sessions(&env.run(&["session", "list", "--json"]));
+
+    assert_eq!(
+        backend_of(&rows, "relabelled"),
+        "wsl:MagicDebianPerso",
+        "reaching a sibling from inside one distro is an ordinary remote session"
+    );
+}
+
+/// The rows a host *named* after the current distro wrote are remote — they
+/// run on the sibling it reaches — so the repair moves them onto that distro's
+/// backend name rather than relabelling them local, and the host follows.
+#[test]
+fn a_cli_invocation_moves_a_shadow_hosts_sessions_onto_its_real_distro() {
+    let env = Env::new();
+    assert!(env.run(&["session", "list", "--json"]).status.success());
+    std::fs::write(
+        env.path("config").join("hosts.toml"),
+        "[[hosts]]\nname = \"MagicDebian\"\nkind = \"wsl\"\ndistro = \"MagicDebianPerso\"\n",
+    )
+    .expect("write hosts.toml");
+    plant_a_relabelled_session(&env.db_path(), "wsl:MagicDebian");
+
+    let rows = sessions(&env.run(&["session", "list", "--json"]));
+
+    assert_eq!(
+        backend_of(&rows, "relabelled"),
+        "wsl:MagicDebianPerso",
+        "the entry reached a sibling, so its sessions are that sibling's"
+    );
+}

--- a/tests/wsl_loopback_repair_cli.rs
+++ b/tests/wsl_loopback_repair_cli.rs
@@ -129,11 +129,12 @@ fn a_cli_invocation_leaves_a_sibling_distros_sessions_remote() {
     );
 }
 
-/// The rows a host *named* after the current distro wrote are remote — they
-/// run on the sibling it reaches — so the repair moves them onto that distro's
-/// backend name rather than relabelling them local, and the host follows.
+/// The rows under the name a host *named* after the current distro registers
+/// as are two populations at once — that host's own sibling sessions, and
+/// local ones an older thurbox mislabelled — so the repair leaves them alone
+/// rather than rewriting half of them onto the wrong machine.
 #[test]
-fn a_cli_invocation_moves_a_shadow_hosts_sessions_onto_its_real_distro() {
+fn a_cli_invocation_leaves_a_shadow_hosts_sessions_alone() {
     let env = Env::new();
     assert!(env.run(&["session", "list", "--json"]).status.success());
     std::fs::write(
@@ -147,7 +148,7 @@ fn a_cli_invocation_moves_a_shadow_hosts_sessions_onto_its_real_distro() {
 
     assert_eq!(
         backend_of(&rows, "relabelled"),
-        "wsl:MagicDebianPerso",
-        "the entry reached a sibling, so its sessions are that sibling's"
+        "wsl:MagicDebian",
+        "an entry claims that name, so nothing under it can be classified"
     );
 }


### PR DESCRIPTION
Sessions created **inside** a WSL distro were recorded as remote.

WSL auto-discovery offered every distro `wsl.exe -l -q` lists — including the
one thurbox is itself running in. That host *is* this machine, and being
shareable by default (ADR-24) it was mirrored: its "own" database being this
database, the pass read our local rows back and rewrote each `backend_type` to
`wsl:<us>`. Every local session on the machine became remote, and every attach,
diff and delete afterwards went out through `wsl.exe` at the host it started
on — including the reap sweep, which then refused to kill windows it believed
were elsewhere and leaked them.

## The fix

**Never register that distro.** A loopback (`HostDef::is_wsl_loopback`, keyed on
`$WSL_DISTRO_NAME`) is dropped at the registry — the chokepoint every caller
shares — from the discovered half and the configured half alike. Sibling distros
are untouched: reaching one from inside another is supported and stays an
ordinary remote session.

**Repair the rows a released build already relabelled.** Schema v47 only *marks*
the repair owed; `session_ops::repair_wsl_loopback_rows` performs it, from the
TUI boot and the `thurbox-cli` entrypoint alike, so a headless-driven install
heals without ever launching the interface. Which spellings to heal is decided
by the host registry, not by pattern-matching a name — `storage` may reference
`session` but not `agent`, which is why the two halves live apart.

The heal **withholds any spelling something else still claims**, computed against
the final registry (configured survivors plus discovery), so a dropped loopback's
own name can never relabel a live sibling's rows. A transient failure — an
unreadable `hosts.toml`, distros that could not be enumerated — is not an answer:
it touches nothing and keeps the mark. A settled answer is final and retires it.

Bookmark collisions on `(host, repo_path)` resolve on recency, ties to the local
row, carrying `is_parent`/`parent_path` subtrees with them.

## A design that was built and withdrawn

An earlier revision of this branch **re-registered** a "shadow" entry (`name` =
the current distro, `distro` = a sibling) under the distro it reaches and
relabelled its rows to match, so nothing would be stranded. That is gone, and
should not come back.

A shadow's backend name *is* `wsl:$WSL_DISTRO_NAME` — that is what makes it a
shadow. So rows under that spelling are two populations at once: local rows an
older release mislabelled *before* the entry existed, and the host's own remote
rows created through it *after*. Nothing in the database separates them.
Renaming them all onto the sibling misassigns the local ones; relabelling them
all local misassigns the sibling's. Narrowing *which* host the rename targets
does not help — the ambiguity is in the rows, not the target.

So a shadow is now left registered exactly as written. Nothing is dropped,
renamed or relabelled, so nothing is stranded or misrouted; its spelling is
simply withheld from the heal, and the warning says plainly that thurbox cannot
tell a mislabelled local session under that name from one of the host's own and
has left every row alone. The residue — that one spelling's pre-existing
corruption goes unhealed for such a user — is damage the old release did, and
leaving it is the only outcome that never acts on the wrong machine.
`docs/ARCHITECTURE.md` records this so the next reader does not reintroduce it.

## Verified

`just lint` clean, `cargo nextest run --all` green, rustdoc `-D warnings` clean,
`architecture_rules` pass. Beyond the suite, the change was driven live on real
binaries in an isolated profile with `WSL_DISTRO_NAME` set:

- a session recorded `wsl:<us>` by the released build is restored to
  `local-tmux` on the next **headless** `thurbox-cli` invocation; sibling and
  `ssh:` rows untouched;
- side by side with a real agent in a real tmux window — on an unrepaired
  database `session delete --force` warns `left its window + worktrees in place`
  and the window survives; on this build the repair runs first and the delete
  reaps it;
- adversarial: an unparseable `hosts.toml` defers and changes nothing, then
  completes once it parses; off WSL nothing is touched; a loopback and a shadow
  declared together resolve without collision.

## Out of scope, recorded not fixed

- `delete.rs` collapses an unknown host to `None` via `resolve_host(..).flatten()`
  and falls through to `finish_locally`, contradicting `resolve_host`'s own doc
  that an unresolvable host is a refusal and never a fallback to local.
- An SSH host pointing at this machine (`destination = "me@localhost"`) has the
  same mirror-rewrites-local-rows failure the WSL loopback had, with no
  equivalent heal.

Both pre-existing; each belongs in its own change.
