### PR TITLE
feat(core): warn instead of failing when tmux/psmux or a coding agent is missing

### DIFF
--- a/.agents/skills/thurbox-cli/SKILL.md
+++ b/.agents/skills/thurbox-cli/SKILL.md
@@ -110,8 +110,10 @@ Three rules it is written under, each of which a change here must keep:
   no knowledge of any agent's installer.
 
 `Presence` is three-valued on purpose: `unknown` is not `missing`. A remote
-host's binaries live on the host and were never looked at, and reporting one as
-the other is the conflation the module exists to end.
+host's binaries live on the host, and a relative `command` (e.g. `./bin/agent`)
+is resolved from the session's own directory rather than thurbox's — in both
+cases nothing was looked at, and reporting either as `missing` is the
+conflation the module exists to end (see `docs/CONFIG.md` for the full rule).
 
 A failure to *launch* the multiplexer goes through
 `preflight::launch_failure`, which turns only a `NotFound` into that sentence

--- a/.agents/skills/thurbox-cli/SKILL.md
+++ b/.agents/skills/thurbox-cli/SKILL.md
@@ -70,7 +70,53 @@ printing the `layout.lua` line to add — `list` is the same inventory the setti
 modal's Interface tab shows, and
 `events` lists every event a plugin may subscribe to with its payload, and
 `install|sync|update|remove|available` manage panes from a declarative spec
-— see `docs/PLUGINS.md`).
+— see `docs/PLUGINS.md`), `doctor`
+(whether **this machine** has what a session needs: the multiplexer and its
+version, every registered agent's `command`, the launcher for each configured
+host, and the full search path. The companion to `session doctor`, which asks
+whether an *existing* session's status hooks are wired — this one names no
+session, so it answers on a machine where nothing has been created yet. `fail`
+and a non-zero exit only for what must work: no multiplexer, or no registered
+agent that resolves anywhere; a partly-installed registry is `warn` and exits 0.
+See "What is missing, before you hit it" below).
+
+### What is missing, before you hit it
+
+thurbox starts with **no** multiplexer and no agent installed, deliberately.
+`agent::preflight` is the one answer to "is the thing that would run this
+actually there?", and it is asked in four places: the create-session flow (an
+agent that resolves nowhere is marked on its row; a missing multiplexer is
+stated from the flow's first step), the empty session list, the spawn error, and
+`thurbox-cli doctor`.
+
+Three rules it is written under, each of which a change here must keep:
+
+- **It never blocks.** A `Missing` answer is a warning on the choice, not a
+  refusal — a `command` may be a shell function, an alias, or something
+  installed a second later. Same rule as `tmux::resolve_local_program`:
+  resolution is an improvement where it succeeds, never a new way to fail.
+  `session create` reports it as a `warnings` entry beside `hook_failures`, and
+  still creates the session.
+- **It is never on a hot path.** The probe is a `stat` per absolute `PATH` entry
+  per binary (no process spawn), run from `SnapshotStore::poll_preflight` on the
+  kernel's schedule behind a 10-second window, and published in the snapshot.
+  A plugin *reads* `thurbox.preflight.mux` and each agent row's `presence`; it
+  never probes. `kernel::snapshot::tests::the_preflight_answer_is_cached_…`
+  pins that.
+- **It never invents an install command.** Windows is pointed at psmux, never at
+  tmux; where the command depends on a distribution the package name is given
+  with a link to the project's own install page. A missing *agent* is answered
+  with the `agents.toml` entry that decides what runs, because thurbox bakes in
+  no knowledge of any agent's installer.
+
+`Presence` is three-valued on purpose: `unknown` is not `missing`. A remote
+host's binaries live on the host and were never looked at, and reporting one as
+the other is the conflation the module exists to end.
+
+A failure to *launch* the multiplexer goes through
+`preflight::launch_failure`, which turns only a `NotFound` into that sentence
+and leaves every other io error alone — a permission error is not something an
+install fixes.
 
 ### A session reference is a name, a UUID, or an id prefix
 

--- a/.agents/skills/thurbox-kernel/SKILL.md
+++ b/.agents/skills/thurbox-kernel/SKILL.md
@@ -310,7 +310,9 @@ lookup itself would be running a `PATH` walk per frame, per keystroke or per
 row — the regression the window exists to prevent; `kernel::snapshot::tests::
 the_preflight_answer_is_cached_rather_than_probed_on_every_tick` pins it.
 `presence` is three-valued (`present`/`missing`/`unknown`) because a remote
-host's binaries were never looked at, and `unknown` is not `missing`.
+host's binaries, and a relative `command`'s (resolved from the session's own
+directory), were never looked at, and `unknown` is not `missing` (see
+`docs/CONFIG.md`).
 
 **Panes are installable** (`kernel::packages`, `session::plugin_spec`). `plugins.toml`
 in the interface directory lists a `src` (a bare name resolving to `examples/panes/<name>`

--- a/.agents/skills/thurbox-kernel/SKILL.md
+++ b/.agents/skills/thurbox-kernel/SKILL.md
@@ -298,6 +298,20 @@ symptom is not "reloads too often" but "stops reloading while git is busy".
 `thurbox.platform` is published so a plugin shipping several binaries picks one
 itself; platform selection is deliberately not a manifest field.
 
+**`thurbox.preflight` is a read, not a probe.** Whether the multiplexer is
+installed, and whether each agent's `command` resolves, is answered by
+`agent::preflight` from `SnapshotStore::poll_preflight` — on the kernel's
+schedule, behind a 10-second window, and published in the snapshot as
+`thurbox.preflight.mux` and each agent row's `presence`. It is polled from
+`refresh_if_due` rather than from `refresh`, because `refresh` stops running
+altogether on a database nobody writes to, which is exactly the state thurbox is
+in while the user is off installing what was missing. A plugin that ran the
+lookup itself would be running a `PATH` walk per frame, per keystroke or per
+row — the regression the window exists to prevent; `kernel::snapshot::tests::
+the_preflight_answer_is_cached_rather_than_probed_on_every_tick` pins it.
+`presence` is three-valued (`present`/`missing`/`unknown`) because a remote
+host's binaries were never looked at, and `unknown` is not `missing`.
+
 **Panes are installable** (`kernel::packages`, `session::plugin_spec`). `plugins.toml`
 in the interface directory lists a `src` (a bare name resolving to `examples/panes/<name>`
 at the binary's release tag, a URL, or a path — `extension_config::resolve_source_in`,

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -190,6 +190,43 @@ because the resolved path is handed to a process with a working directory of its
 own — honouring it would let a `claude` sitting in the repo you are working on
 shadow the real one, which is the dependence this removes rather than moves.
 
+### What happens when it is *not* installed
+
+thurbox starts with no multiplexer and no agent on the machine, and that is
+deliberate — browsing, reading and configuring must work on a fresh box. So the
+same lookup runs a second time, as a **preflight**, in the places where knowing
+early is worth something:
+
+- the **create-session flow** marks an agent whose `command` resolves nowhere
+  (`⚠ not installed`) and says so on the step that offers it, and states a
+  missing multiplexer from the flow's first step. It never blocks: the answer is
+  a warning on the choice, because a `command` may still be launchable (a shell
+  function, or something installed a second later).
+- the **empty session list** — the one screen a first run always reaches — says
+  the multiplexer is missing, with the fix.
+- a **spawn failure** caused by a missing binary names the binary, the
+  directories thurbox searched and the one thing to do about it, instead of the
+  launcher's errno or the multiplexer's exit code.
+- `thurbox-cli doctor` answers the whole question directly: the multiplexer and
+  its version, every registered agent's `command`, the launcher for each
+  configured host, and the full search path. It is the companion to `thurbox-cli
+  session doctor`, which asks whether an *existing* session's status hooks are
+  wired.
+
+The probe is a `stat` per absolute `PATH` entry per binary — no process spawn —
+and it runs on the kernel's own schedule behind a 10-second window, never on a
+render, a keystroke or a list row. A remote host is reported as **unknown**
+rather than missing: its binaries live on the host, and thurbox has not looked
+there.
+
+The advice is platform-specific and never invented. A Windows user is pointed at
+[psmux](https://github.com/psmux/psmux), never at `tmux`; where the install
+command depends on a distribution, the package name is given and the link is
+tmux's own [install page](https://github.com/tmux/tmux/wiki/Installing) rather
+than a guessed invocation. A missing **agent** is answered with the `agents.toml`
+entry that decides what gets run, because thurbox bakes in no knowledge of any
+agent's installer.
+
 `hook_schema` is optional. Custom agents are agent-neutral, so the built-in
 **hooks** extension normally wires status hooks only for the built-ins it knows
 by name. Set `hook_schema = "claude"` on a **rebranded** agent (one whose

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -215,9 +215,13 @@ early is worth something:
 
 The probe is a `stat` per absolute `PATH` entry per binary — no process spawn —
 and it runs on the kernel's own schedule behind a 10-second window, never on a
-render, a keystroke or a list row. A remote host is reported as **unknown**
-rather than missing: its binaries live on the host, and thurbox has not looked
-there.
+render, a keystroke or a list row. Two things are reported as **unknown** rather
+than missing, because in both cases nothing was looked at: a **remote host**,
+whose binaries live on the host, and a **relative** `command` such as
+`./bin/agent`, which is resolved by whoever launches it from the *session's*
+own directory. Answering the latter from thurbox's working directory would call
+a binary that launches fine missing, and one that does not present — the same
+"absolute only" rule the resolver above is written under, for the same reason.
 
 The advice is platform-specific and never invented. A Windows user is pointed at
 [psmux](https://github.com/psmux/psmux), never at `tmux`; where the install

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -346,7 +346,28 @@ not applicable.
 5. **New branch name** — worktree mode only.
 6. **Agent picker** — choose which coding agent runs in this
    session. Skipped when only one agent is defined in
-   `agents.toml`.
+   `agents.toml`. An agent whose `command` resolves nowhere on `PATH`
+   is marked `⚠ not installed` on its own row, so the cost of the
+   choice is visible while the cursor is still moving over the
+   alternatives.
+
+**The flow says what is missing before you commit.** thurbox starts with no
+multiplexer and no agent installed — that is deliberate, and browsing and
+configuring keep working — but it used to mean the check landed at the worst
+possible moment: you committed to a session and got back a number
+(`tmux new-window exited exit status: 127`), naming neither the binary, nor
+where thurbox looked, nor what to install. Now the flow already knows. A missing
+multiplexer is stated from the flow's **first** step, because nothing can be
+created without it; a missing agent is stated on the step that offers it. Never
+a modal that blocks — a `command` may still be launchable (a shell function, or
+something installed a second later), so the answer is a warning on the choice,
+not a refusal of it. The empty session list carries the same line, since that is
+the one screen a first run always reaches, and `thurbox-cli doctor` answers the
+whole question directly. See
+[CONFIG.md](CONFIG.md#what-happens-when-it-is-not-installed) for the cost model
+(a `stat` walk on the kernel's schedule behind a 10-second window — never on a
+render, a keystroke or a list row) and for why a remote host is reported as
+*unknown* rather than missing.
 
 **Creating a session moves nothing — unless you ask it to.** By default the new
 row appears in the list and waits to be picked; the selection, the pane showing

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -366,8 +366,8 @@ the one screen a first run always reaches, and `thurbox-cli doctor` answers the
 whole question directly. See
 [CONFIG.md](CONFIG.md#what-happens-when-it-is-not-installed) for the cost model
 (a `stat` walk on the kernel's schedule behind a 10-second window — never on a
-render, a keystroke or a list row) and for why a remote host is reported as
-*unknown* rather than missing.
+render, a keystroke or a list row) and for why a remote host or a relative
+`command` is reported as *unknown* rather than missing.
 
 **Creating a session moves nothing — unless you ask it to.** By default the new
 row appears in the list and waits to be picked; the selection, the pane showing

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -189,6 +189,7 @@ function Invoke-Install {
     Write-Host "`nNext steps" -ForegroundColor Magenta
     Write-Step '* Install psmux (the Windows multiplexer): https://github.com/psmux/psmux'
     Write-Step '* Install a coding-agent CLI (claude, codex, antigravity, opencode, aider, ...)'
+    Write-Step '* Check both:        thurbox-cli doctor'
     Write-Step '* Launch the TUI:    thurbox'
     Write-Step '* Scriptable CLI:    thurbox-cli'
     Write-Host ''

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -194,6 +194,7 @@ show_success() {
   printf '\n%b\n' "${C_BOLD}${C_MAGENTA}Next steps${C_RESET}" >&2
   step "• Install tmux >= 3.2"
   step "• Install a coding-agent CLI (claude, codex, antigravity, opencode, aider, …)"
+  step "• Check both:        ${C_CYAN}thurbox-cli doctor${C_RESET}"
   step "• Launch the TUI:    ${C_CYAN}thurbox${C_RESET}"
   step "• Scriptable CLI:    ${C_CYAN}thurbox-cli${C_RESET}"
 }

--- a/src/agent/control_mode/mod.rs
+++ b/src/agent/control_mode/mod.rs
@@ -733,7 +733,16 @@ impl ControlMode {
             .stdout(Stdio::piped())
             .stderr(Stdio::null())
             .spawn()
-            .context("Failed to start tmux control mode")?;
+            // No `tmux`/`ssh`/`wsl.exe` on this machine at all: the message
+            // names which, where thurbox looked and the fix, rather than the
+            // errno the launcher raised.
+            .map_err(|e| {
+                crate::agent::preflight::launch_failure(
+                    transport,
+                    "Failed to start tmux control mode",
+                    e,
+                )
+            })?;
 
         let stdin = child
             .stdin

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -8,6 +8,7 @@ pub mod host_config;
 pub mod input;
 pub mod json_merge;
 mod osc8;
+pub mod preflight;
 pub mod provider;
 pub mod registry;
 pub mod self_update;

--- a/src/agent/preflight.rs
+++ b/src/agent/preflight.rs
@@ -378,15 +378,30 @@ mod tests {
 
     #[test]
     fn the_search_phrase_summarizes_a_long_path_instead_of_printing_it() {
-        let many: Vec<String> = (0..20).map(|i| format!("/opt/dir{i}")).collect();
-        let phrase = crate::paths::with_path(many.join(":"), || searched("tmux"));
-        assert!(phrase.contains("/opt/dir0"), "{phrase}");
+        // Built with the platform's own absolute-path shape and joined with
+        // `env::join_paths` rather than a hardcoded `/opt/dirN` + `:`: on
+        // Windows neither holds (the separator is `;`, and a prefix-less
+        // `/opt/dirN` is not `Path::is_absolute`), so `path_dirs()` would
+        // filter every entry out and this test would exercise the "PATH is
+        // unset" branch instead of the one it's named for.
+        let many: Vec<std::path::PathBuf> = (0..20)
+            .map(|i| {
+                if cfg!(windows) {
+                    std::path::PathBuf::from(format!("C:\\dir{i}"))
+                } else {
+                    std::path::PathBuf::from(format!("/opt/dir{i}"))
+                }
+            })
+            .collect();
+        let path = std::env::join_paths(&many).unwrap();
+        let phrase = crate::paths::with_path(path, || searched("tmux"));
+        assert!(phrase.contains(&many[0].display().to_string()), "{phrase}");
         assert!(
             phrase.contains(&format!("and {} more", 20 - DIRS_IN_A_MESSAGE)),
             "{phrase}"
         );
         assert!(
-            !phrase.contains("/opt/dir19"),
+            !phrase.contains(&many[19].display().to_string()),
             "the whole PATH landed in a one-line message: {phrase}"
         );
     }

--- a/src/agent/preflight.rs
+++ b/src/agent/preflight.rs
@@ -365,8 +365,14 @@ mod tests {
     fn a_command_spelled_as_a_path_is_checked_where_the_user_pointed() {
         // Not a PATH lookup at all: no directory on PATH could make this true
         // or false, so answering from PATH would answer about the wrong file.
+        // Built from a tempdir rather than a hardcoded `/definitely/not/here`:
+        // that literal has a root but no prefix on Windows, so it is not
+        // `Path::is_absolute()` there and this exercised the relative-path
+        // (`Unknown`) branch instead of the one it's named for.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let missing = dir.path().join("definitely-not-here").join("agent-xyz");
         assert_eq!(
-            look_up("/definitely/not/here/agent-xyz"),
+            look_up(&missing.display().to_string()),
             Presence::Missing,
             "a path that is not there is missing, whatever PATH holds"
         );

--- a/src/agent/preflight.rs
+++ b/src/agent/preflight.rs
@@ -69,14 +69,25 @@ impl Presence {
 /// detector that called psmux missing on every Windows machine would be worse
 /// than no detector at all.
 ///
-/// A command spelled as a path is not a `PATH` lookup: it is checked where the
-/// user pointed, which is the only place it could come from.
+/// A command spelled as a path is not a `PATH` lookup. An **absolute** one is
+/// checked where the user pointed, which is the only place it could come from.
+/// A **relative** one is [`Presence::Unknown`]: it is resolved by whoever
+/// launches it, from the *session's* working directory — the repo or worktree
+/// the window opens in — and answering it from this process's directory would
+/// report a binary that launches fine as missing, and one that does not as
+/// present. That is the same "absolute only" rule
+/// [`crate::paths::resolve_on_path`] is written under, for the same reason:
+/// whose current directory is the entire question.
 pub fn look_up(exe: &str) -> Presence {
     if exe.is_empty() {
         return Presence::Unknown;
     }
     if exe.contains('/') || exe.contains(std::path::MAIN_SEPARATOR) {
-        return present_if(crate::paths::is_executable_file(Path::new(exe)));
+        let path = Path::new(exe);
+        if !path.is_absolute() {
+            return Presence::Unknown;
+        }
+        return present_if(crate::paths::is_executable_file(path));
     }
     let names = names_to_try(exe);
     for dir in crate::paths::path_dirs() {
@@ -321,6 +332,34 @@ pub fn local_multiplexer() -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn a_relative_command_is_unknown_because_its_directory_is_not_ours() {
+        // `./bin/agent` is resolved by whoever launches it, from the *session's*
+        // working directory — the repo or worktree the window is opened in, not
+        // thurbox's own. Answering from this process's directory would report a
+        // binary that launches fine as missing, and one that does not as
+        // present. Not looking is the honest answer, and `Unknown` is how this
+        // module says it.
+        assert_eq!(look_up("./bin/agent"), Presence::Unknown);
+        assert_eq!(look_up("bin/agent"), Presence::Unknown);
+    }
+
+    #[test]
+    fn an_absolute_command_is_still_answered_where_the_user_pointed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let agent = dir.path().join("agent");
+        std::fs::write(&agent, b"#!/bin/sh\n").expect("write");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&agent, std::fs::Permissions::from_mode(0o700))
+                .expect("chmod");
+        }
+        // An absolute path means the same thing from every working directory,
+        // so it is the one spelling this can answer without guessing.
+        assert_eq!(look_up(&agent.display().to_string()), Presence::Present);
+    }
 
     #[test]
     fn a_command_spelled_as_a_path_is_checked_where_the_user_pointed() {

--- a/src/agent/preflight.rs
+++ b/src/agent/preflight.rs
@@ -21,7 +21,7 @@
 //! being made, not a refusal: an agent `command` can be a shell function, an
 //! alias or something installed a second later, and treating "not on `PATH`"
 //! as fatal would turn an improvement into a new way to fail — the same rule
-//! [`crate::agent::tmux::resolve_local_program`] is written under.
+//! `crate::agent::tmux::resolve_local_program` is written under.
 
 use std::path::Path;
 
@@ -65,7 +65,7 @@ impl Presence {
 /// Windows: the same walk, but a bare name is also tried with each extension in
 /// `PATHEXT`, because that is how the loader finds `psmux.exe` given `psmux`.
 /// The *spawn* path deliberately has no such munging (see
-/// [`crate::agent::tmux::resolve_local_program`]) — this is detection, and a
+/// `crate::agent::tmux::resolve_local_program`) — this is detection, and a
 /// detector that called psmux missing on every Windows machine would be worse
 /// than no detector at all.
 ///

--- a/src/agent/preflight.rs
+++ b/src/agent/preflight.rs
@@ -1,0 +1,393 @@
+//! Whether the binaries a session needs are actually installed.
+//!
+//! thurbox deliberately starts with no multiplexer and no coding agent on the
+//! machine (`docs/CONSTITUTION.md`) — browsing, reading and configuring must
+//! work on a fresh box. The cost is that the check used to happen at the worst
+//! possible moment: the user committed to creating a session and got a number
+//! back (`tmux new-window exited exit status: 127`), which names neither the
+//! binary, nor where thurbox looked, nor what to install.
+//!
+//! This module is the one answer to "is the thing that would run this actually
+//! there?", asked in three places:
+//!
+//! - the create-session flow, so the answer arrives *before* the user commits
+//!   ([`crate::kernel::snapshot`] publishes it; probed on a TTL, never per
+//!   frame);
+//! - the spawn error, so a failure names the binary, the directories searched
+//!   and the fix ([`crate::agent::tmux`]);
+//! - `thurbox-cli doctor`, so it can be asked directly.
+//!
+//! It never blocks anything. A `Missing` answer is a warning on the choice
+//! being made, not a refusal: an agent `command` can be a shell function, an
+//! alias or something installed a second later, and treating "not on `PATH`"
+//! as fatal would turn an improvement into a new way to fail — the same rule
+//! [`crate::agent::tmux::resolve_local_program`] is written under.
+
+use std::path::Path;
+
+use crate::agent::transport::{TmuxTransport, DEFAULT_MUX};
+
+/// How many search directories a one-line message names before it summarizes
+/// the rest. A `PATH` of thirty entries is ordinary; a message that prints all
+/// of them is unreadable in a TUI's one-line message row, and `thurbox-cli
+/// doctor` prints the full list for the case where every entry matters.
+const DIRS_IN_A_MESSAGE: usize = 6;
+
+/// What thurbox found when it looked for a binary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Presence {
+    /// A file that can be executed is there.
+    Present,
+    /// Every directory on `PATH` was searched and nothing runnable matched.
+    Missing,
+    /// Not answerable from here. A remote host's binaries live on the *host*,
+    /// and asking would mean a round trip on every keystroke; a command with no
+    /// name at all is nothing to look for. Deliberately distinct from
+    /// [`Presence::Missing`] — reporting "not installed" about a machine that
+    /// was never looked at is the conflation this whole module exists to end.
+    Unknown,
+}
+
+impl Presence {
+    /// The stable word a plugin and `--json` branch on.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Presence::Present => "present",
+            Presence::Missing => "missing",
+            Presence::Unknown => "unknown",
+        }
+    }
+}
+
+/// Whether `exe` is runnable, looked up the way this platform's loader would.
+///
+/// Unix: the absolute-only `PATH` walk [`crate::paths::resolve_on_path`] does.
+/// Windows: the same walk, but a bare name is also tried with each extension in
+/// `PATHEXT`, because that is how the loader finds `psmux.exe` given `psmux`.
+/// The *spawn* path deliberately has no such munging (see
+/// [`crate::agent::tmux::resolve_local_program`]) — this is detection, and a
+/// detector that called psmux missing on every Windows machine would be worse
+/// than no detector at all.
+///
+/// A command spelled as a path is not a `PATH` lookup: it is checked where the
+/// user pointed, which is the only place it could come from.
+pub fn look_up(exe: &str) -> Presence {
+    if exe.is_empty() {
+        return Presence::Unknown;
+    }
+    if exe.contains('/') || exe.contains(std::path::MAIN_SEPARATOR) {
+        return present_if(crate::paths::is_executable_file(Path::new(exe)));
+    }
+    let names = names_to_try(exe);
+    for dir in crate::paths::path_dirs() {
+        for name in &names {
+            if crate::paths::is_executable_file(&dir.join(name)) {
+                return Presence::Present;
+            }
+        }
+    }
+    Presence::Missing
+}
+
+fn present_if(found: bool) -> Presence {
+    if found {
+        Presence::Present
+    } else {
+        Presence::Missing
+    }
+}
+
+/// The file names a bare `exe` could be on disk.
+///
+/// One on Unix. On Windows the loader also tries each `PATHEXT` suffix, so a
+/// registry entry of `psmux` has to match `psmux.exe`; the default list is
+/// used when the variable is unset, which is what a stripped environment
+/// (a service, a CI runner) leaves behind.
+fn names_to_try(exe: &str) -> Vec<String> {
+    if !cfg!(windows) {
+        return vec![exe.to_string()];
+    }
+    let pathext = std::env::var("PATHEXT").unwrap_or_else(|_| ".COM;.EXE;.BAT;.CMD".to_string());
+    let mut names = vec![exe.to_string()];
+    names.extend(
+        pathext
+            .split(';')
+            .map(str::trim)
+            .filter(|ext| ext.starts_with('.'))
+            .map(|ext| format!("{exe}{ext}")),
+    );
+    names
+}
+
+/// A binary thurbox needs, and what a user does about it not being there.
+///
+/// Carries the *role* rather than the bare name because the fix depends on it:
+/// a multiplexer is a package to install, an agent is a CLI thurbox knows
+/// nothing about beyond the `command` the registry gives it.
+#[derive(Debug, Clone, Copy)]
+pub enum Dependency<'a> {
+    /// The multiplexer a *local* session's window lives in: `tmux`, or `psmux`
+    /// on native Windows.
+    LocalMultiplexer,
+    /// What reaches a remote host's multiplexer from this machine: `ssh`, or
+    /// `wsl.exe` for a WSL distro.
+    Launcher(&'a str),
+    /// A coding agent's CLI, as its `agents.toml` entry spells `command`.
+    Agent { name: &'a str, command: &'a str },
+}
+
+impl Dependency<'_> {
+    /// The binary this is about.
+    pub fn binary(&self) -> &str {
+        match self {
+            Dependency::LocalMultiplexer => DEFAULT_MUX,
+            Dependency::Launcher(bin) => bin,
+            Dependency::Agent { command, .. } => command,
+        }
+    }
+
+    /// How the user thinks of it, for the front of a sentence.
+    ///
+    /// Short on purpose, apposition included: this leads a message row that is
+    /// as wide as the terminal and no wider, so every word here is a word the
+    /// fix behind it does not get.
+    fn role(&self) -> String {
+        match self {
+            Dependency::LocalMultiplexer => {
+                format!("{DEFAULT_MUX} (thurbox's multiplexer)")
+            }
+            Dependency::Launcher(bin) => format!("{bin} (how thurbox reaches a host)"),
+            Dependency::Agent { name, command } if name == command => {
+                format!("{name} (a coding agent)")
+            }
+            Dependency::Agent { name, command } => {
+                format!("{command} (the CLI the coding agent {name} runs)")
+            }
+        }
+    }
+
+    /// The one thing to do about it, on *this* platform.
+    ///
+    /// Never a package-manager line thurbox has not verified: where the command
+    /// depends on a distribution, this names the package and links the
+    /// project's own install page instead of guessing an invocation. thurbox
+    /// bakes in no agent knowledge either (`docs/AGENTS.md`), so a missing
+    /// agent is answered with the registry entry that decides what gets run
+    /// rather than with an install command for a CLI thurbox does not know.
+    pub fn fix(&self) -> String {
+        match self {
+            Dependency::LocalMultiplexer if cfg!(windows) => {
+                "install psmux, the Windows multiplexer: https://github.com/psmux/psmux".to_string()
+            }
+            Dependency::LocalMultiplexer if cfg!(target_os = "macos") => {
+                "install tmux 3.2 or newer (`brew install tmux`), or see \
+                 https://github.com/tmux/tmux/wiki/Installing"
+                    .to_string()
+            }
+            Dependency::LocalMultiplexer => {
+                "install tmux 3.2 or newer — the package is called `tmux` on every major \
+                 distribution; see https://github.com/tmux/tmux/wiki/Installing"
+                    .to_string()
+            }
+            Dependency::Launcher(bin) if bin.starts_with("wsl") => {
+                "wsl.exe comes with the Windows Subsystem for Linux: \
+                 https://learn.microsoft.com/windows/wsl/install"
+                    .to_string()
+            }
+            Dependency::Launcher(_) => {
+                "install an OpenSSH client: https://www.openssh.com/".to_string()
+            }
+            Dependency::Agent { name, .. } => {
+                let registry = crate::agent::agent_config::agents_config_path()
+                    .map(|p| p.display().to_string())
+                    .unwrap_or_else(|| "agents.toml".to_string());
+                format!(
+                    "install its CLI, or point the `command` of the `{name}` entry in {registry} \
+                     at the binary"
+                )
+            }
+        }
+    }
+
+    /// The short form, for a report that prints the search path once of its
+    /// own accord. Repeating twenty absolute directories on every row of a
+    /// ten-agent registry buries the one word that differs between them.
+    pub fn missing_summary(&self) -> String {
+        format!("`{}` was not found on PATH; {}", self.binary(), self.fix())
+    }
+
+    /// The whole sentence: what is missing, the fix, and where thurbox looked.
+    ///
+    /// One line, and in that order deliberately. It is rendered in a TUI
+    /// message row, which is as wide as the terminal and no wider, so what
+    /// comes last is what a narrow screen loses — and of the three, the list of
+    /// directories is both the longest and the one `thurbox-cli doctor` prints
+    /// in full anyway. A reader who sees only the first clause still knows what
+    /// is missing and roughly what to do.
+    pub fn missing_message(&self) -> String {
+        format!(
+            "{} is not installed, or not on thurbox's own PATH. Fix: {}. {}",
+            self.role(),
+            self.fix(),
+            searched(self.binary()),
+        )
+    }
+}
+
+/// Where thurbox looked for `binary`, as a phrase.
+///
+/// Reads [`crate::paths::path_dirs`] rather than re-deriving the list, so the
+/// message can never name a search the resolver did not do.
+fn searched(binary: &str) -> String {
+    let dirs = crate::paths::path_dirs();
+    if dirs.is_empty() {
+        return format!("There was nowhere to look for `{binary}`: PATH is unset.");
+    }
+    let shown: Vec<String> = dirs
+        .iter()
+        .take(DIRS_IN_A_MESSAGE)
+        .map(|d| d.display().to_string())
+        .collect();
+    let rest = dirs.len().saturating_sub(shown.len());
+    let tail = if rest > 0 {
+        format!(" (and {rest} more)")
+    } else {
+        String::new()
+    };
+    format!("Looked in {}{tail}.", shown.join(", "))
+}
+
+/// What a failure to *launch* the multiplexer means, in words a user can act on.
+///
+/// [`std::process::Command`]'s `spawn`/`output` fails before anything has run,
+/// so a `NotFound` here is exactly one thing: the program named is not
+/// installed, or is not on the `PATH` thurbox was started with. That is the
+/// whole content of the report this module exists for, and it used to reach the
+/// user as `No such file or directory (os error 2)` under a context line that
+/// named tmux without saying tmux was the thing that was missing.
+///
+/// Every other io error keeps `context` and its own text: a permission error or
+/// a broken pipe is not something an install fixes, and dressing one as a
+/// missing binary sends the reader somewhere there is nothing to find.
+pub fn launch_failure(
+    transport: &TmuxTransport,
+    context: &'static str,
+    err: std::io::Error,
+) -> anyhow::Error {
+    if err.kind() != std::io::ErrorKind::NotFound {
+        return anyhow::Error::new(err).context(context);
+    }
+    let launcher = transport.launcher();
+    let dependency = if transport.is_remote() {
+        Dependency::Launcher(launcher)
+    } else {
+        Dependency::LocalMultiplexer
+    };
+    anyhow::Error::new(MissingDependency(dependency.missing_message()))
+}
+
+/// A binary a session needs is not installed.
+///
+/// A type rather than a plain message so the callers between here and the
+/// screen can *recognise* it: its `Display` is already the whole story, and
+/// every context line one of them would otherwise add ("Failed to spawn tmux
+/// window", "Failed to create tmux session") pushes the part that names the
+/// binary and the fix off the end of a one-line message row. See
+/// [`is_missing_dependency`].
+#[derive(Debug)]
+pub struct MissingDependency(pub String);
+
+impl std::fmt::Display for MissingDependency {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for MissingDependency {}
+
+/// Whether `err`, or anything it wraps, is a [`MissingDependency`].
+///
+/// What a caller checks before adding a context line of its own, and before
+/// rendering the chain rather than the message.
+pub fn is_missing_dependency(err: &anyhow::Error) -> bool {
+    err.chain().any(|e| e.is::<MissingDependency>())
+}
+
+/// The multiplexer a local session would run in on this platform.
+pub fn local_multiplexer() -> &'static str {
+    DEFAULT_MUX
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_command_spelled_as_a_path_is_checked_where_the_user_pointed() {
+        // Not a PATH lookup at all: no directory on PATH could make this true
+        // or false, so answering from PATH would answer about the wrong file.
+        assert_eq!(
+            look_up("/definitely/not/here/agent-xyz"),
+            Presence::Missing,
+            "a path that is not there is missing, whatever PATH holds"
+        );
+    }
+
+    #[test]
+    fn an_empty_command_is_unknown_rather_than_missing() {
+        // There is nothing to look for, which is not the same claim as having
+        // looked and found nothing.
+        assert_eq!(look_up(""), Presence::Unknown);
+    }
+
+    #[test]
+    fn a_missing_binary_names_itself_the_search_and_a_fix() {
+        let dep = Dependency::Agent {
+            name: "claude",
+            command: "claude",
+        };
+        let message = dep.missing_message();
+        assert!(message.contains("claude"), "{message}");
+        assert!(message.contains("Looked in"), "{message}");
+        assert!(message.contains("agents.toml"), "{message}");
+    }
+
+    #[test]
+    fn the_multiplexer_fix_is_the_one_for_this_platform() {
+        let fix = Dependency::LocalMultiplexer.fix();
+        if cfg!(windows) {
+            assert!(fix.contains("psmux"), "{fix}");
+            assert!(
+                !fix.contains("tmux"),
+                "a Windows user is never sent to tmux"
+            );
+        } else {
+            assert!(fix.contains("tmux"), "{fix}");
+            assert!(
+                !fix.contains("apt install"),
+                "the distribution is not thurbox's to guess: {fix}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_unset_path_says_so_rather_than_listing_nothing() {
+        let phrase = crate::paths::with_path("", || searched("tmux"));
+        assert!(phrase.contains("PATH is unset"), "{phrase}");
+    }
+
+    #[test]
+    fn the_search_phrase_summarizes_a_long_path_instead_of_printing_it() {
+        let many: Vec<String> = (0..20).map(|i| format!("/opt/dir{i}")).collect();
+        let phrase = crate::paths::with_path(many.join(":"), || searched("tmux"));
+        assert!(phrase.contains("/opt/dir0"), "{phrase}");
+        assert!(
+            phrase.contains(&format!("and {} more", 20 - DIRS_IN_A_MESSAGE)),
+            "{phrase}"
+        );
+        assert!(
+            !phrase.contains("/opt/dir19"),
+            "the whole PATH landed in a one-line message: {phrase}"
+        );
+    }
+}

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -209,6 +209,16 @@ fn local_mux_command(args: &[&str]) -> Command {
     cmd
 }
 
+/// What a **local** one-shot reports when the multiplexer will not start.
+///
+/// Every helper here bypasses the [`TmuxTransport`] seam because it is
+/// local-only, so the transport that failed is always the local one. See
+/// [`crate::agent::preflight::launch_failure`] for why a `NotFound` is answered
+/// with a sentence rather than with `os error 2`.
+fn local_launch_failure(context: &'static str, err: std::io::Error) -> anyhow::Error {
+    crate::agent::preflight::launch_failure(&TmuxTransport::Local, context, err)
+}
+
 /// Window-name prefix for thurbox-managed tmux windows. Combined with the
 /// sanitized session name (`{prefix}{sanitized_name}`) to form the tmux
 /// window target.
@@ -942,8 +952,15 @@ impl TmuxBackend {
             .stderr(Stdio::piped())
             .output()
             // The launcher would not even start — no `ssh`/`wsl.exe`/`tmux` on
-            // this machine. Nothing was asked, so nothing was answered.
-            .context("Failed to run tmux command")?;
+            // this machine. Nothing was asked, so nothing was answered, and
+            // `launch_failure` says which of the three is not there.
+            .map_err(|e| {
+                crate::agent::preflight::launch_failure(
+                    &self.transport,
+                    "Failed to run tmux command",
+                    e,
+                )
+            })?;
         if output.status.success() {
             return Ok(String::from_utf8_lossy(&output.stdout)
                 .lines()
@@ -984,7 +1001,13 @@ impl TmuxBackend {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .output()
-            .context("Failed to run tmux command")?;
+            .map_err(|e| {
+                crate::agent::preflight::launch_failure(
+                    &self.transport,
+                    "Failed to run tmux command",
+                    e,
+                )
+            })?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -1125,6 +1148,13 @@ impl TmuxBackend {
                 // winner got. The session we wanted exists either way, so ask
                 // rather than assume, and only report a failure that left none.
                 if !self.session_exists() {
+                    // A launcher that never started is already the whole story
+                    // (`preflight::launch_failure`), and this context in front
+                    // of it costs the reader the part that names the binary and
+                    // the fix — a message row is one line wide.
+                    if crate::agent::preflight::is_missing_dependency(&e) {
+                        return Err(e);
+                    }
                     return Err(e).context("Failed to create tmux session");
                 }
                 debug!(
@@ -2411,7 +2441,7 @@ pub fn capture_pane_text(
     }
     let output = local_mux_command(&args)
         .output()
-        .context("Failed to run tmux capture-pane")?;
+        .map_err(|e| local_launch_failure("Failed to run tmux capture-pane", e))?;
     if !output.status.success() {
         bail!(
             "tmux capture-pane exited with status {}: {}",
@@ -2826,7 +2856,7 @@ pub fn spawn_window(
 
     let output = tmux
         .output()
-        .context("Failed to run tmux new-window for headless spawn")?;
+        .map_err(|e| local_launch_failure("Failed to run tmux new-window for headless spawn", e))?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         bail!(

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -564,28 +564,55 @@ impl WindowIndex {
         role: WindowRole,
         live_only: bool,
     ) -> Located {
-        let usable = |w: &&ListedWindow| !live_only || w.alive;
-        if !session_id.is_empty() {
-            if let Some(entries) = self.stamped.get(&(session_id.to_string(), role)) {
-                match entries.as_slice() {
-                    [] => {}
-                    // One session, one window per role — two is a listing
-                    // nobody can act on rather than a choice to make. This
-                    // holds regardless of liveness: a dead entry does not
-                    // make the ambiguity go away, and must never fall
-                    // through to a same-named window that belongs to
-                    // somebody else.
-                    [_, _, ..] => return Located::Unknown,
-                    [only] => {
-                        return if !live_only || only.alive {
-                            Located::At(only.pane.clone())
-                        } else {
-                            Located::Absent
-                        };
-                    }
-                }
-            }
+        match self.stamped_match(session_id, role, live_only) {
+            Some(found) => found,
+            None => self.named_match(session_id, session_name, role, live_only),
         }
+    }
+
+    /// The stamp half: proof, and so taken first.
+    ///
+    /// `None` means there is no stamp to go on and the name is all that is
+    /// left — which is not the same as an answer of [`Located::Absent`], and is
+    /// why this is an `Option` rather than a `Located`.
+    fn stamped_match(
+        &self,
+        session_id: &str,
+        role: WindowRole,
+        live_only: bool,
+    ) -> Option<Located> {
+        if session_id.is_empty() {
+            return None;
+        }
+        match self
+            .stamped
+            .get(&(session_id.to_string(), role))?
+            .as_slice()
+        {
+            [] => None,
+            // One session, one window per role — two is a listing nobody can
+            // act on rather than a choice to make. This holds regardless of
+            // liveness: a dead entry does not make the ambiguity go away, and
+            // must never fall through to a same-named window that belongs to
+            // somebody else.
+            [_, _, ..] => Some(Located::Unknown),
+            [only] => Some(if !live_only || only.alive {
+                Located::At(only.pane.clone())
+            } else {
+                Located::Absent
+            }),
+        }
+    }
+
+    /// The name half, reached only when no stamp decided it.
+    fn named_match(
+        &self,
+        session_id: &str,
+        session_name: &str,
+        role: WindowRole,
+        live_only: bool,
+    ) -> Located {
+        let usable = |w: &&ListedWindow| !live_only || w.alive;
         let window = window_name_for(role, session_name);
         let named: Vec<&ListedWindow> = self
             .by_name

--- a/src/agent/transport.rs
+++ b/src/agent/transport.rs
@@ -129,6 +129,21 @@ impl TmuxTransport {
         }
     }
 
+    /// The program this transport actually executes on **this** machine.
+    ///
+    /// The multiplexer itself locally; the launcher (`ssh`, `wsl.exe`) for a
+    /// remote backend, whose own multiplexer runs on the host and cannot be
+    /// what failed to start here. Read by
+    /// [`crate::agent::preflight::launch_failure`], which has to name the
+    /// binary that is missing rather than the one it was on the way to.
+    pub fn launcher(&self) -> &str {
+        match self {
+            TmuxTransport::Local => DEFAULT_MUX,
+            TmuxTransport::Ssh { .. } => "ssh",
+            TmuxTransport::Wsl { .. } => "wsl.exe",
+        }
+    }
+
     /// Whether the multiplexer is reached over `ssh`, and so whether ssh's own
     /// exit conventions apply to a failed command.
     ///

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -262,3 +262,40 @@ fn version_suffix(mux: &str) -> String {
         None => String::new(),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::AgentDef;
+
+    /// Before the `Presence::Unknown` fix, `look_up` answered a relative
+    /// `command` as `Missing` (checked against thurbox's own directory, not
+    /// the session's), so this row read as a `warn` telling the user to
+    /// install a CLI that was already there. Reproduces with `left: Warn`.
+    #[test]
+    fn a_relative_agent_command_is_reported_ok_not_a_warning() {
+        let agent = AgentDef {
+            name: "custom".into(),
+            command: "./bin/agent".into(),
+            ..Default::default()
+        };
+        let finding = agent_finding(&agent);
+        assert_eq!(finding.level, Level::Ok, "{}", finding.detail);
+        assert!(
+            finding.detail.contains("resolved from the session's own directory"),
+            "{}",
+            finding.detail
+        );
+    }
+
+    #[test]
+    fn a_missing_agent_command_is_still_a_warning() {
+        let agent = AgentDef {
+            name: "custom".into(),
+            command: "definitely-not-a-real-binary-xyz".into(),
+            ..Default::default()
+        };
+        let finding = agent_finding(&agent);
+        assert_eq!(finding.level, Level::Warn, "{}", finding.detail);
+    }
+}

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -282,7 +282,9 @@ mod tests {
         let finding = agent_finding(&agent);
         assert_eq!(finding.level, Level::Ok, "{}", finding.detail);
         assert!(
-            finding.detail.contains("resolved from the session's own directory"),
+            finding
+                .detail
+                .contains("resolved from the session's own directory"),
             "{}",
             finding.detail
         );

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -62,10 +62,33 @@ struct Finding {
 /// registry is a `warn` and exits 0 — having `claude` but not `aider` is an
 /// ordinary machine, not breakage.
 pub fn run() -> Result<CommandOutput, CommandError> {
-    let mut findings = Vec::new();
+    let mut findings = vec![multiplexer_finding()];
+    findings.extend(agent_findings());
+    findings.extend(host_findings());
 
+    let verdict = findings.iter().map(|f| f.level).max().unwrap_or(Level::Ok);
+    let human = render(&findings, verdict);
+    let json = document(&findings, verdict);
+
+    Ok(match verdict {
+        Level::Fail => CommandOutput::failed(
+            json,
+            human,
+            "this machine is missing something a session needs — see the FAIL checks above"
+                .to_string(),
+        ),
+        _ => CommandOutput::new(json, human),
+    })
+}
+
+/// Whether the multiplexer every local session's window is made of is there.
+///
+/// The one check that fails the report: without it nothing can be created at
+/// all, so an `Unknown` here is treated as a failure too — the only way the
+/// lookup answers that for a bare name is a `PATH` it could not read.
+fn multiplexer_finding() -> Finding {
     let mux = crate::agent::preflight::local_multiplexer();
-    findings.push(match crate::agent::preflight::look_up(mux) {
+    match crate::agent::preflight::look_up(mux) {
         crate::agent::preflight::Presence::Present => Finding {
             key: "multiplexer".into(),
             level: Level::Ok,
@@ -76,35 +99,22 @@ pub fn run() -> Result<CommandOutput, CommandError> {
             level: Level::Fail,
             detail: crate::agent::preflight::Dependency::LocalMultiplexer.missing_summary(),
         },
-    });
-
-    let registry = crate::agent::agent_config::load_or_seed();
-    let mut resolved = 0usize;
-    for agent in &registry.agents {
-        let present = crate::agent::preflight::look_up(&agent.command)
-            == crate::agent::preflight::Presence::Present;
-        resolved += usize::from(present);
-        findings.push(Finding {
-            key: format!("agent:{}", agent.name),
-            level: if present { Level::Ok } else { Level::Warn },
-            detail: if present {
-                format!("{} runs `{}`", agent.name, agent.command)
-            } else {
-                // The short form: the search path is printed once below, and
-                // repeating it on every row of a ten-agent registry buries the
-                // name that differs between them.
-                crate::agent::preflight::Dependency::Agent {
-                    name: &agent.name,
-                    command: &agent.command,
-                }
-                .missing_summary()
-            },
-        });
     }
-    if !registry.agents.is_empty() && resolved == 0 {
-        // Every individual miss above is a warning; all of them together is
-        // not. A machine where no registered agent resolves can create a
-        // session, and every one of them will open a pane that exits.
+}
+
+/// One row per registered agent, plus the verdict on the registry as a whole.
+fn agent_findings() -> Vec<Finding> {
+    let registry = crate::agent::agent_config::load_or_seed();
+    let mut findings: Vec<Finding> = registry.agents.iter().map(agent_finding).collect();
+
+    // Every individual miss above is a warning; all of them together is not. A
+    // machine where no registered agent resolves can still create a session,
+    // and every one of them will open a pane that exits. An agent whose
+    // presence is *unknown* counts as resolving: it may well launch, and
+    // failing the report over a machine nothing looked at is the conflation
+    // `Presence` exists to prevent.
+    let missing = findings.iter().filter(|f| f.level == Level::Warn).count();
+    if !registry.agents.is_empty() && missing == registry.agents.len() {
         findings.push(Finding {
             key: "agents".into(),
             level: Level::Fail,
@@ -115,39 +125,88 @@ pub fn run() -> Result<CommandOutput, CommandError> {
             ),
         });
     }
+    findings
+}
 
-    // A remote host's own binaries are on the host and are not probed here: the
-    // answer would be a round trip per host, and `session doctor` is what
-    // reports on a session once one exists there. What *is* checkable from here
-    // is the launcher that would carry the request.
-    let (hosts, _warnings) = crate::agent::host_config::cached_registry();
-    for host in &hosts.hosts {
-        let launcher = if host.backend_name().starts_with("wsl:") {
-            "wsl.exe"
-        } else {
-            "ssh"
-        };
-        let present = crate::agent::preflight::look_up(launcher)
-            == crate::agent::preflight::Presence::Present;
-        findings.push(Finding {
-            key: format!("host:{}", host.name),
-            level: if present { Level::Ok } else { Level::Fail },
-            detail: if present {
-                format!(
-                    "{} is reached with {launcher}, which is installed (the multiplexer and \
-                     agents on {} are not probed from here)",
-                    host.name, host.name
-                )
-            } else {
-                crate::agent::preflight::Dependency::Launcher(launcher).missing_summary()
-            },
-        });
+/// What one agent's `command` resolves to.
+///
+/// Three answers, not two. A relative `command` is launched from the session's
+/// own directory, so this machine's answer about it would be about the wrong
+/// directory — reported as such rather than guessed.
+fn agent_finding(agent: &crate::session::AgentDef) -> Finding {
+    let key = format!("agent:{}", agent.name);
+    match crate::agent::preflight::look_up(&agent.command) {
+        crate::agent::preflight::Presence::Present => Finding {
+            key,
+            level: Level::Ok,
+            detail: format!("{} runs `{}`", agent.name, agent.command),
+        },
+        crate::agent::preflight::Presence::Unknown => Finding {
+            key,
+            level: Level::Ok,
+            detail: format!(
+                "{} runs `{}`, which is resolved from the session's own directory — not \
+                 something this machine can answer",
+                agent.name, agent.command
+            ),
+        },
+        // The short form: the search path is printed once below, and repeating
+        // it on every row of a ten-agent registry buries the name that differs
+        // between them.
+        crate::agent::preflight::Presence::Missing => Finding {
+            key,
+            level: Level::Warn,
+            detail: crate::agent::preflight::Dependency::Agent {
+                name: &agent.name,
+                command: &agent.command,
+            }
+            .missing_summary(),
+        },
     }
+}
 
-    let verdict = findings.iter().map(|f| f.level).max().unwrap_or(Level::Ok);
+/// One row per configured host, about the launcher only.
+///
+/// A remote host's own binaries are on the host and are not probed here: the
+/// answer would be a round trip per host, and `session doctor` is what reports
+/// on a session once one exists there. What *is* checkable from here is the
+/// launcher that would carry the request.
+fn host_findings() -> Vec<Finding> {
+    let (hosts, _warnings) = crate::agent::host_config::cached_registry();
+    hosts
+        .hosts
+        .iter()
+        .map(|host| {
+            let launcher = if host.backend_name().starts_with("wsl:") {
+                "wsl.exe"
+            } else {
+                "ssh"
+            };
+            let present = crate::agent::preflight::look_up(launcher)
+                == crate::agent::preflight::Presence::Present;
+            Finding {
+                key: format!("host:{}", host.name),
+                level: if present { Level::Ok } else { Level::Fail },
+                detail: if present {
+                    format!(
+                        "{} is reached with {launcher}, which is installed (the multiplexer and \
+                         agents on {} are not probed from here)",
+                        host.name, host.name
+                    )
+                } else {
+                    crate::agent::preflight::Dependency::Launcher(launcher).missing_summary()
+                },
+            }
+        })
+        .collect()
+}
 
+/// The report as a terminal reads it: the verdict, one line per check, then
+/// every directory searched — in full here, because this is the surface that
+/// has room for it.
+fn render(findings: &[Finding], verdict: Level) -> String {
     let mut human = format!("This machine — {}\n", verdict.as_str().to_uppercase());
-    for f in &findings {
+    for f in findings {
         human.push_str(&format!(
             "  {}  {:<20} {}\n",
             f.level.mark(),
@@ -155,18 +214,21 @@ pub fn run() -> Result<CommandOutput, CommandError> {
             f.detail
         ));
     }
-    human.push_str(&format!(
-        "\nPATH searched ({}):\n",
-        crate::paths::path_dirs().len()
-    ));
-    for dir in crate::paths::path_dirs() {
+    let dirs = crate::paths::path_dirs();
+    human.push_str(&format!("\nPATH searched ({}):\n", dirs.len()));
+    for dir in &dirs {
         human.push_str(&format!("  {}\n", dir.display()));
     }
     human.push_str("\nWiring of an existing session: thurbox-cli session doctor");
+    human
+}
 
-    let json = json!({
+/// The same report as one JSON document, for a script that branches on `key`
+/// and `level` rather than parsing the sentences.
+fn document(findings: &[Finding], verdict: Level) -> Value {
+    json!({
         "verdict": verdict.as_str(),
-        "multiplexer": mux,
+        "multiplexer": crate::agent::preflight::local_multiplexer(),
         "path": crate::paths::path_dirs()
             .iter()
             .map(|p| p.display().to_string())
@@ -179,16 +241,6 @@ pub fn run() -> Result<CommandOutput, CommandError> {
                 "detail": f.detail,
             }))
             .collect::<Vec<Value>>(),
-    });
-
-    Ok(match verdict {
-        Level::Fail => CommandOutput::failed(
-            json,
-            human,
-            "this machine is missing something a session needs — see the FAIL checks above"
-                .to_string(),
-        ),
-        _ => CommandOutput::new(json, human),
     })
 }
 

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -1,0 +1,212 @@
+//! `thurbox-cli doctor` — whether this machine has what a session needs
+//! *before* anyone tries to create one.
+//!
+//! The companion to `session doctor`, and deliberately the same shape: that one
+//! asks whether an existing session's status hooks are wired, this one asks
+//! whether the binaries a session is made of are installed at all. Splitting
+//! them rather than growing one command follows what they are asked about — one
+//! takes a session id, the other cannot, because on a fresh machine there are
+//! no sessions to name.
+//!
+//! It reads; it never installs. Each `fail`/`warn` carries the one thing to do,
+//! and where the answer depends on a distribution it names the package and
+//! links the project's own install page rather than guessing an invocation.
+
+use serde_json::{json, Value};
+
+use crate::cli::output::CommandOutput;
+use crate::cli::CommandError;
+
+/// Whether a check found a problem, and how bad.
+///
+/// The same three words `session doctor` uses, so a script that already
+/// branches on one branches on the other.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum Level {
+    Ok,
+    Warn,
+    Fail,
+}
+
+impl Level {
+    fn as_str(self) -> &'static str {
+        match self {
+            Level::Ok => "ok",
+            Level::Warn => "warn",
+            Level::Fail => "fail",
+        }
+    }
+
+    fn mark(self) -> &'static str {
+        match self {
+            Level::Ok => "ok  ",
+            Level::Warn => "warn",
+            Level::Fail => "FAIL",
+        }
+    }
+}
+
+/// A single thing checked, and what was found.
+struct Finding {
+    /// Short stable key, so a script branches on the problem rather than
+    /// parsing the sentence.
+    key: String,
+    level: Level,
+    detail: String,
+}
+
+/// Report on this machine's readiness to run a session.
+///
+/// Exits non-zero only when something that must work does not: no multiplexer,
+/// or no registered agent that resolves anywhere. A partially-installed
+/// registry is a `warn` and exits 0 — having `claude` but not `aider` is an
+/// ordinary machine, not breakage.
+pub fn run() -> Result<CommandOutput, CommandError> {
+    let mut findings = Vec::new();
+
+    let mux = crate::agent::preflight::local_multiplexer();
+    findings.push(match crate::agent::preflight::look_up(mux) {
+        crate::agent::preflight::Presence::Present => Finding {
+            key: "multiplexer".into(),
+            level: Level::Ok,
+            detail: format!("{mux} is installed{}", version_suffix(mux)),
+        },
+        _ => Finding {
+            key: "multiplexer".into(),
+            level: Level::Fail,
+            detail: crate::agent::preflight::Dependency::LocalMultiplexer.missing_summary(),
+        },
+    });
+
+    let registry = crate::agent::agent_config::load_or_seed();
+    let mut resolved = 0usize;
+    for agent in &registry.agents {
+        let present = crate::agent::preflight::look_up(&agent.command)
+            == crate::agent::preflight::Presence::Present;
+        resolved += usize::from(present);
+        findings.push(Finding {
+            key: format!("agent:{}", agent.name),
+            level: if present { Level::Ok } else { Level::Warn },
+            detail: if present {
+                format!("{} runs `{}`", agent.name, agent.command)
+            } else {
+                // The short form: the search path is printed once below, and
+                // repeating it on every row of a ten-agent registry buries the
+                // name that differs between them.
+                crate::agent::preflight::Dependency::Agent {
+                    name: &agent.name,
+                    command: &agent.command,
+                }
+                .missing_summary()
+            },
+        });
+    }
+    if !registry.agents.is_empty() && resolved == 0 {
+        // Every individual miss above is a warning; all of them together is
+        // not. A machine where no registered agent resolves can create a
+        // session, and every one of them will open a pane that exits.
+        findings.push(Finding {
+            key: "agents".into(),
+            level: Level::Fail,
+            detail: format!(
+                "none of the {} registered agents resolves on PATH — a session created now \
+                 would open a pane that exits immediately",
+                registry.agents.len()
+            ),
+        });
+    }
+
+    // A remote host's own binaries are on the host and are not probed here: the
+    // answer would be a round trip per host, and `session doctor` is what
+    // reports on a session once one exists there. What *is* checkable from here
+    // is the launcher that would carry the request.
+    let (hosts, _warnings) = crate::agent::host_config::cached_registry();
+    for host in &hosts.hosts {
+        let launcher = if host.backend_name().starts_with("wsl:") {
+            "wsl.exe"
+        } else {
+            "ssh"
+        };
+        let present = crate::agent::preflight::look_up(launcher)
+            == crate::agent::preflight::Presence::Present;
+        findings.push(Finding {
+            key: format!("host:{}", host.name),
+            level: if present { Level::Ok } else { Level::Fail },
+            detail: if present {
+                format!(
+                    "{} is reached with {launcher}, which is installed (the multiplexer and \
+                     agents on {} are not probed from here)",
+                    host.name, host.name
+                )
+            } else {
+                crate::agent::preflight::Dependency::Launcher(launcher).missing_summary()
+            },
+        });
+    }
+
+    let verdict = findings.iter().map(|f| f.level).max().unwrap_or(Level::Ok);
+
+    let mut human = format!("This machine — {}\n", verdict.as_str().to_uppercase());
+    for f in &findings {
+        human.push_str(&format!(
+            "  {}  {:<20} {}\n",
+            f.level.mark(),
+            f.key,
+            f.detail
+        ));
+    }
+    human.push_str(&format!(
+        "\nPATH searched ({}):\n",
+        crate::paths::path_dirs().len()
+    ));
+    for dir in crate::paths::path_dirs() {
+        human.push_str(&format!("  {}\n", dir.display()));
+    }
+    human.push_str("\nWiring of an existing session: thurbox-cli session doctor");
+
+    let json = json!({
+        "verdict": verdict.as_str(),
+        "multiplexer": mux,
+        "path": crate::paths::path_dirs()
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>(),
+        "checks": findings
+            .iter()
+            .map(|f| json!({
+                "key": f.key,
+                "level": f.level.as_str(),
+                "detail": f.detail,
+            }))
+            .collect::<Vec<Value>>(),
+    });
+
+    Ok(match verdict {
+        Level::Fail => CommandOutput::failed(
+            json,
+            human,
+            "this machine is missing something a session needs — see the FAIL checks above"
+                .to_string(),
+        ),
+        _ => CommandOutput::new(json, human),
+    })
+}
+
+/// ` (3.4)` when the multiplexer answers `-V`, empty when it does not.
+///
+/// Best-effort and never fatal: a version that cannot be read says nothing
+/// about whether the binary works, and thurbox's own requirement (tmux >= 3.2)
+/// is stated by the install advice rather than enforced here.
+fn version_suffix(mux: &str) -> String {
+    let Ok(out) = std::process::Command::new(mux).arg("-V").output() else {
+        return String::new();
+    };
+    if !out.status.success() {
+        return String::new();
+    }
+    let text = String::from_utf8_lossy(&out.stdout);
+    match text.split_whitespace().last() {
+        Some(version) => format!(" ({version})"),
+        None => String::new(),
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -44,6 +44,7 @@ pub mod action;
 pub mod agents;
 pub mod automations;
 pub mod config;
+pub mod doctor;
 pub mod editor;
 pub mod extensions;
 pub mod home;
@@ -203,6 +204,7 @@ Examples:
   thurbox-cli agent launch-args claude          what to run so its hooks report
   thurbox-cli message send --to <id> --kind result --body 'done'
   thurbox-cli session list --json | jq         full records for a script
+  thurbox-cli doctor                           is the multiplexer/agent installed?
 
 Output is human-readable in a terminal and TOON when piped; --json restores the
 full JSON record on any command.";
@@ -281,6 +283,13 @@ pub enum Command {
         #[command(subcommand)]
         action: plugins::Action,
     },
+    /// Whether this machine has what a session needs: the multiplexer, each
+    /// registered agent's command, and the launcher for every configured host.
+    ///
+    /// The companion to `session doctor`, which asks whether an *existing*
+    /// session's status hooks are wired. This one names no session, so it
+    /// answers on a machine where nothing has been created yet.
+    Doctor,
 }
 
 /// Build the additional-repo list for a multi-repo `Spawn` from the repeatable
@@ -429,6 +438,9 @@ fn dispatch(command: Command, db: &Database) -> Result<CommandOutput, CommandErr
         Command::Runtime { action } => runtime::run(action),
         // The only command that needs no database: a plugin is a file.
         Command::Plugin { action } => plugins::run(action)?,
+        // Reads the machine, not the database: what is installed is not
+        // something thurbox recorded.
+        Command::Doctor => doctor::run()?,
     })
 }
 

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -848,6 +848,12 @@ fn run_create(db: &Database, args: CreateArgs) -> Result<CommandOutput, CommandE
         human.push_str(&format!("\n  {note}"));
     }
     push_hook_failures(&mut human, &res.hook_failures);
+    // Above the record rather than buried in it: the session was created, and
+    // the one thing the caller needs to know is that the binary it launched is
+    // not there.
+    for warning in &res.warnings {
+        human.push_str(&format!("\n  warning: {warning}"));
+    }
     Ok(CommandOutput::new(
         json!({
             "id": res.session_id.to_string(),
@@ -863,6 +869,7 @@ fn run_create(db: &Database, args: CreateArgs) -> Result<CommandOutput, CommandE
             "cwd": res.cwd.display().to_string(),
             "parent_session_id": res.parent_session_id.map(|id| id.to_string()),
             "hook_failures": res.hook_failures,
+            "warnings": res.warnings,
             "sharing": res.sharing,
             "reports_as": reports_as,
             // Present here only so `--on-existing adopt` can answer in

--- a/src/kernel/host/publish.rs
+++ b/src/kernel/host/publish.rs
@@ -135,6 +135,21 @@ impl LuaHost {
         })?;
         set(&table, "hosts", hosts)?;
 
+        // Whether the multiplexer every local session's window lives in is
+        // installed. Same gate as `agents` — it is probed on the kernel's
+        // schedule behind a TTL and lands in the snapshot, so reading it here
+        // costs a table only when the answer moves.
+        let preflight = self.group("preflight", [epoch.snapshot, 0, 0, 0], || {
+            let table = self.lua.create_table().map_err(|e| e.to_string())?;
+            let mux = self.lua.create_table().map_err(|e| e.to_string())?;
+            set(&mux, "binary", snapshot.mux.binary.clone())?;
+            set(&mux, "presence", snapshot.mux.presence.as_str())?;
+            set(&mux, "advice", snapshot.mux.advice.clone())?;
+            set(&table, "mux", Value::Table(mux))?;
+            Ok(Value::Table(table))
+        })?;
+        set(&table, "preflight", preflight)?;
+
         self.publish_repo_reads(&table, repo_store, wants, epoch)?;
         self.publish_settings(&table, settings)?;
 
@@ -790,6 +805,12 @@ fn build_agents(lua: &Lua, snapshot: &Snapshot) -> Result<Value, String> {
         // v1's picker labels a row `name  (command)` when the two differ, so
         // the command travels with the name.
         set(&item, "command", agent.command.clone())?;
+        // `present` / `missing` / `unknown`, so a flow can warn on the choice
+        // being made instead of letting the user find out from a pane that
+        // died. Three words rather than a boolean: a remote host's binaries
+        // were never looked at, and saying "missing" about them would be a
+        // claim thurbox has not earned.
+        set(&item, "presence", agent.presence.as_str())?;
         agents.raw_set(index + 1, item).map_err(|e| e.to_string())?;
     }
     Ok(Value::Table(agents))

--- a/src/kernel/snapshot.rs
+++ b/src/kernel/snapshot.rs
@@ -243,7 +243,7 @@ pub struct AgentRow {
     /// commits: a missing agent binary leaves the multiplexer with a window
     /// whose pane exits instantly, which it reports as a successful create, so
     /// the answer never arrives on its own. Probed on a TTL, never per frame —
-    /// see [`SnapshotStore::poll_preflight`].
+    /// see `SnapshotStore::poll_preflight`.
     pub presence: crate::agent::preflight::Presence,
 }
 

--- a/src/kernel/snapshot.rs
+++ b/src/kernel/snapshot.rs
@@ -24,6 +24,18 @@ use crate::storage::Database;
 /// determines how out of date the answer may be.
 pub const REFRESH_INTERVAL: Duration = Duration::from_millis(400);
 
+/// How long "is the multiplexer installed, does each agent's command resolve"
+/// is trusted before it is asked again.
+///
+/// Asking is a `stat` per absolute `PATH` entry per binary and no process
+/// spawn, so the answer is cheap — but it is not free, and doing it on the
+/// render path (a `which` per frame, per keystroke or per list row) is the
+/// regression this window exists to prevent. Ten seconds is short enough that a
+/// user who reads "install tmux", installs it, and comes back sees the flow
+/// agree without restarting thurbox, and long enough that an idle instance
+/// costs a few `stat`s a minute.
+const PREFLIGHT_TTL: Duration = Duration::from_secs(10);
+
 /// A session's git working tree, when it has been computed.
 ///
 /// `None` on a row means *not computed yet*, which is deliberately distinct
@@ -225,6 +237,39 @@ pub struct RepoRow {
 pub struct AgentRow {
     pub name: String,
     pub command: String,
+    /// Whether `command` resolves to something runnable right now.
+    ///
+    /// Published so the create-session flow can say it *before* the user
+    /// commits: a missing agent binary leaves the multiplexer with a window
+    /// whose pane exits instantly, which it reports as a successful create, so
+    /// the answer never arrives on its own. Probed on a TTL, never per frame —
+    /// see [`SnapshotStore::poll_preflight`].
+    pub presence: crate::agent::preflight::Presence,
+}
+
+/// The local multiplexer every session's window is created in.
+///
+/// One row rather than a bare flag because the name differs by platform
+/// (`psmux` on native Windows) and the fix differs with it: a Windows user
+/// told to install tmux has been sent to the wrong project.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MuxRow {
+    pub binary: String,
+    pub presence: crate::agent::preflight::Presence,
+    /// What to do about it, empty when there is nothing to do.
+    pub advice: String,
+}
+
+impl Default for MuxRow {
+    /// What a snapshot with no store behind it reports: the binary this
+    /// platform would use, and no claim about whether it is there.
+    fn default() -> Self {
+        Self {
+            binary: crate::agent::preflight::local_multiplexer().to_string(),
+            presence: crate::agent::preflight::Presence::Unknown,
+            advice: String::new(),
+        }
+    }
 }
 
 /// A machine a session can be created on.
@@ -255,6 +300,9 @@ pub struct Snapshot {
     pub agent_default: String,
     /// Configured and discovered hosts; empty means local only.
     pub hosts: Vec<HostRow>,
+    /// Whether the local multiplexer is installed, for a flow that wants to
+    /// say so before the user commits to a session.
+    pub mux: MuxRow,
     pub tasks: Vec<TaskRow>,
     pub automations: Vec<AutomationRow>,
     /// Epoch milliseconds this snapshot represents. Readable by plugins so
@@ -547,6 +595,12 @@ pub struct SnapshotStore {
     agents: Vec<AgentRow>,
     agent_default: String,
     hosts: Vec<HostRow>,
+    /// Whether the local multiplexer is installed. Beside `agents` because it
+    /// is refreshed with them and for the same reason.
+    mux: MuxRow,
+    /// When the multiplexer and the agent commands were last looked for.
+    /// Gates [`Self::poll_preflight`]; see [`PREFLIGHT_TTL`].
+    preflight_at: Instant,
     current: Snapshot,
     last_refresh: Option<Instant>,
     /// `PRAGMA data_version` as of the last successful rebuild. `None` means
@@ -612,6 +666,8 @@ impl SnapshotStore {
             agent_default: registry.default_name().to_string(),
             registry,
             hosts: read_hosts(),
+            mux: read_mux(),
+            preflight_at: Instant::now(),
             current: Snapshot {
                 error,
                 ..Snapshot::default()
@@ -639,6 +695,8 @@ impl SnapshotStore {
             agent_default: registry.default_name().to_string(),
             registry,
             hosts: read_hosts(),
+            mux: read_mux(),
+            preflight_at: Instant::now(),
             current: Snapshot::default(),
             last_refresh: None,
             last_data_version: None,
@@ -693,6 +751,10 @@ impl SnapshotStore {
         // about them — and without asking on this path a verdict would be
         // requested once and never refreshed.
         let panes_moved = self.poll_pane_probes();
+        // Asked here rather than in `refresh`, which stops running altogether
+        // on a database nobody writes to — which is exactly the state thurbox
+        // is in while the user is off installing what was missing.
+        let preflight_moved = self.poll_preflight();
         if !panes_moved && self.rows_are_current() {
             self.last_refresh = Some(Instant::now());
             let stamp = taken_at_stamp();
@@ -703,7 +765,7 @@ impl SnapshotStore {
             // and dropping it without asking would have published a session's
             // new counts only on the next unrelated refresh.
             let git_moved = self.attach_git_stats();
-            if restamped || git_moved {
+            if restamped || git_moved || preflight_moved {
                 self.mark_changed();
             }
             return false;
@@ -1114,6 +1176,36 @@ impl SnapshotStore {
     ///
     /// A failed read keeps the previous rows and records the error, so a
     /// transient database lock degrades to stale data rather than a blank list.
+    /// Look for the multiplexer and each agent's command again, at most once
+    /// per [`PREFLIGHT_TTL`]. Returns whether any answer moved.
+    ///
+    /// The whole cost model of this feature lives here: the create-session flow
+    /// reads a *published* answer, so the probe happens on the kernel's
+    /// schedule and behind a window, never on a render, a keystroke or a row.
+    fn poll_preflight(&mut self) -> bool {
+        if self.preflight_at.elapsed() < PREFLIGHT_TTL {
+            return false;
+        }
+        self.preflight_at = Instant::now();
+        let mux = read_mux();
+        let mut moved = mux != self.mux;
+        self.mux = mux;
+        for row in &mut self.agents {
+            let presence = crate::agent::preflight::look_up(&row.command);
+            if presence != row.presence {
+                row.presence = presence;
+                moved = true;
+            }
+        }
+        if moved {
+            // `refresh` may not run for minutes on an idle database, and until
+            // it does `current` is what every reader sees.
+            self.current.mux = self.mux.clone();
+            self.current.agents = self.agents.clone();
+        }
+        moved
+    }
+
     pub fn refresh(&mut self) {
         self.last_refresh = Some(Instant::now());
         let taken_at_ms = taken_at_stamp();
@@ -1340,6 +1432,7 @@ impl SnapshotStore {
             agents: self.agents.clone(),
             agent_default: self.agent_default.clone(),
             hosts: self.hosts.clone(),
+            mux: self.mux.clone(),
             taken_at_ms,
             error: None,
         };
@@ -1413,8 +1506,23 @@ fn read_agents(registry: &AgentRegistry) -> Vec<AgentRow> {
         .map(|agent| AgentRow {
             name: agent.name.clone(),
             command: agent.command.clone(),
+            presence: crate::agent::preflight::look_up(&agent.command),
         })
         .collect()
+}
+
+/// Whether the local multiplexer is installed, and what to do when it is not.
+fn read_mux() -> MuxRow {
+    let binary = crate::agent::preflight::local_multiplexer();
+    let presence = crate::agent::preflight::look_up(binary);
+    MuxRow {
+        binary: binary.to_string(),
+        presence,
+        advice: match presence {
+            crate::agent::preflight::Presence::Present => String::new(),
+            _ => crate::agent::preflight::Dependency::LocalMultiplexer.fix(),
+        },
+    }
 }
 
 /// Configured and discovered hosts. Empty means local only, and the flow skips
@@ -1537,6 +1645,49 @@ mod tests {
         assert_eq!(repo_name(&cwd, Some(&repo)).as_deref(), Some("thurbox"));
         assert_eq!(repo_name(&cwd, None).as_deref(), Some("feature-x"));
         assert_eq!(repo_name(&None, None), None);
+    }
+
+    #[test]
+    fn the_preflight_answer_is_cached_rather_than_probed_on_every_tick() {
+        // The cost model of the whole feature. `refresh_if_due` runs on the
+        // event loop, so a probe there is a `PATH` walk per tick; the answer
+        // must come from the window instead. Removing the binary and finding
+        // the store still says `Present` is what proves nothing looked again.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mux = dir
+            .path()
+            .join(crate::agent::preflight::local_multiplexer());
+        std::fs::write(&mux, b"#!/bin/sh\n").expect("write");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&mux, std::fs::Permissions::from_mode(0o700)).expect("chmod");
+        }
+
+        crate::paths::with_path(dir.path(), || {
+            let database = Database::open_in_memory().expect("in-memory database opens");
+            let mut store = SnapshotStore::with_database(database);
+            assert_eq!(
+                store.current().mux.presence,
+                crate::agent::preflight::Presence::Present,
+                "the probe at construction must find the binary that is there"
+            );
+
+            std::fs::remove_file(&mux).expect("remove");
+            // Each tick has to clear REFRESH_INTERVAL, or `refresh_if_due`
+            // returns before reaching the probe at all and the assertion below
+            // would hold whether or not the window exists. Well inside
+            // PREFLIGHT_TTL, which is what is being pinned.
+            for _ in 0..3 {
+                std::thread::sleep(REFRESH_INTERVAL + Duration::from_millis(50));
+                store.refresh_if_due();
+            }
+            assert_eq!(
+                store.current().mux.presence,
+                crate::agent::preflight::Presence::Present,
+                "the answer moved inside the TTL, so something probed on the tick"
+            );
+        });
     }
 
     #[test]

--- a/src/paths/mod.rs
+++ b/src/paths/mod.rs
@@ -96,11 +96,28 @@ pub fn resolve_on_path(exe: &str) -> Option<PathBuf> {
     if exe.is_empty() || exe.contains(std::path::MAIN_SEPARATOR) || exe.contains('/') {
         return None;
     }
-    let path = std::env::var_os("PATH")?;
-    std::env::split_paths(&path)
-        .filter(|dir| dir.is_absolute())
+    path_dirs()
+        .into_iter()
         .map(|dir| dir.join(exe))
         .find(|candidate| is_executable_file(candidate))
+}
+
+/// The directories [`resolve_on_path`] searches, in the order it searches them.
+///
+/// Public because a lookup that finds nothing has to be able to say *where it
+/// looked*: an error naming only the binary leaves the reader unable to tell a
+/// missing install from a `PATH` thurbox was started without. Deriving that
+/// list a second time in the message would let the two drift, so the resolver
+/// and the message read the same function.
+///
+/// Empty when `PATH` is unset — which is itself the answer, and reads that way.
+pub fn path_dirs() -> Vec<PathBuf> {
+    let Some(path) = std::env::var_os("PATH") else {
+        return Vec::new();
+    };
+    std::env::split_paths(&path)
+        .filter(|dir| dir.is_absolute())
+        .collect()
 }
 
 /// Run `f` with `PATH` set to `path`, restoring what was there before.
@@ -128,7 +145,7 @@ pub(crate) fn with_path<T>(path: impl AsRef<OsStr>, f: impl FnOnce() -> T) -> T 
 }
 
 /// Whether `p` is a file this process could `exec`.
-fn is_executable_file(p: &Path) -> bool {
+pub(crate) fn is_executable_file(p: &Path) -> bool {
     let Ok(meta) = std::fs::metadata(p) else {
         return false;
     };

--- a/src/session_ops/restart.rs
+++ b/src/session_ops/restart.rs
@@ -421,7 +421,14 @@ pub fn restart_session_headless_with(
                 plan.cwd.as_deref(),
                 &plan.env,
             )
-            .map_err(|e| format!("Failed to re-spawn tmux window: {e}"))?;
+            .map_err(
+                |e| match crate::agent::preflight::is_missing_dependency(&e) {
+                    // Already a sentence naming the binary, the search and the fix;
+                    // a prefix in front of it only pushes the fix off the row.
+                    true => format!("{e}"),
+                    false => format!("Failed to re-spawn tmux window: {e:#}"),
+                },
+            )?;
 
             // The new pane is a different one, and the id is how every later
             // read finds it — leaving the old one persisted would point the

--- a/src/session_ops/spawn.rs
+++ b/src/session_ops/spawn.rs
@@ -725,38 +725,11 @@ fn resolve_dirs(
     req: &SpawnRequest,
     host: Option<&HostDef>,
 ) -> Result<(PathBuf, Vec<SharedWorktree>, Vec<PathBuf>), String> {
-    let mut additional_dirs: Vec<PathBuf> = Vec::new();
-
-    // Plan every worktree creation before running any, so a local multi-repo
-    // spawn can fan them out. Plan order is input order — primary first, then
-    // the extras — and each position holds its `(repo, base)` or the error the
-    // old serial loop surfaced when it *reached* that position, so the first
-    // failure in input order is still the one reported.
     let shared_branch = req.worktree_branch.as_deref();
-    let primary_base = req.base_branch.as_deref().unwrap_or(DEFAULT_BASE_BRANCH);
-    let mut plans: Vec<WorktreePlan<'_>> = Vec::new();
     // An existing worktree is opened, never planned: it is already checked out,
     // so `git worktree add` would refuse the branch outright.
     let opening = req.existing_worktree.is_some();
-    if shared_branch.is_some() && !opening {
-        plans.push(Ok((req.repo_path.as_path(), primary_base)));
-    }
-    for extra in &req.extra_repos {
-        if extra.worktree {
-            plans.push(match shared_branch {
-                Some(_) => Ok((
-                    extra.repo_path.as_path(),
-                    extra.base_branch.as_deref().unwrap_or(primary_base),
-                )),
-                None => Err(
-                    "a worktree extra-repo requires --worktree-branch (the shared branch)"
-                        .to_string(),
-                ),
-            });
-        } else {
-            additional_dirs.push(extra.repo_path.clone());
-        }
-    }
+    let (plans, additional_dirs) = plan_members(req, shared_branch, opening);
 
     let branch = shared_branch.unwrap_or_default();
     let created = create_worktrees(host, branch, &plans)?;
@@ -815,6 +788,44 @@ fn resolve_dirs(
     }
 
     Ok((primary_cwd, worktrees, additional_dirs))
+}
+
+/// Sort this spawn's repositories into worktrees to create and directories to
+/// attach as they are.
+///
+/// Every creation is planned before any runs, so a local multi-repo spawn can
+/// fan them out. Plan order is input order — primary first, then the extras —
+/// and each position holds its `(repo, base)` or the error the old serial loop
+/// surfaced when it *reached* that position, so the first failure in input
+/// order is still the one reported.
+fn plan_members<'a>(
+    req: &'a SpawnRequest,
+    shared_branch: Option<&'a str>,
+    opening: bool,
+) -> (Vec<WorktreePlan<'a>>, Vec<PathBuf>) {
+    let primary_base = req.base_branch.as_deref().unwrap_or(DEFAULT_BASE_BRANCH);
+    let mut plans: Vec<WorktreePlan<'a>> = Vec::new();
+    let mut additional_dirs: Vec<PathBuf> = Vec::new();
+
+    if shared_branch.is_some() && !opening {
+        plans.push(Ok((req.repo_path.as_path(), primary_base)));
+    }
+    for extra in &req.extra_repos {
+        if !extra.worktree {
+            additional_dirs.push(extra.repo_path.clone());
+            continue;
+        }
+        plans.push(match shared_branch {
+            Some(_) => Ok((
+                extra.repo_path.as_path(),
+                extra.base_branch.as_deref().unwrap_or(primary_base),
+            )),
+            None => Err(
+                "a worktree extra-repo requires --worktree-branch (the shared branch)".to_string(),
+            ),
+        });
+    }
+    (plans, additional_dirs)
 }
 
 /// One planned worktree creation — `(repo, base)`, or the per-position error

--- a/src/session_ops/spawn.rs
+++ b/src/session_ops/spawn.rs
@@ -118,6 +118,17 @@ pub struct SpawnResult {
     /// `session.post_create` hooks that failed. The session exists and is
     /// running regardless; these are for the caller's report.
     pub hook_failures: Vec<String>,
+    /// What was already known to be missing when this session was launched —
+    /// today, an agent command that resolves nowhere on `PATH`.
+    ///
+    /// A report, never a refusal. The multiplexer answers a `new-window` whose
+    /// pane exits instantly with a perfectly successful create, so without this
+    /// the caller is told the session exists and finds a row with no pane and
+    /// no reason. It is not an error because the command may still be
+    /// launchable — a shell function, or something installed a second later —
+    /// which is the same rule `agent::tmux::resolve_local_program` is written
+    /// under.
+    pub warnings: Vec<String>,
     /// Why this session on a remote host was **not** created by the host's own
     /// CLI — sharing is off for the host, or no `thurbox-cli` could be found
     /// or provisioned there — so it was driven from here the way every remote
@@ -351,6 +362,24 @@ pub fn spawn_session_headless_with_progress(
     report(SpawnPhase::Backend);
     let (command, args) = super::build_agent_invocation(&agent_def, &config);
 
+    // Asked before the launch rather than after it: this is the one moment
+    // thurbox knows both which binary it is about to ask for and that the user
+    // has committed. Only for a local session — a remote host's binaries are on
+    // the host, and `Presence::Unknown` is the honest answer about a machine
+    // this one has not looked at.
+    let mut warnings = Vec::new();
+    if host.is_none()
+        && crate::agent::preflight::look_up(&command) == crate::agent::preflight::Presence::Missing
+    {
+        warnings.push(
+            crate::agent::preflight::Dependency::Agent {
+                name: &agent_name,
+                command: &command,
+            }
+            .missing_message(),
+        );
+    }
+
     report(SpawnPhase::Launching);
     // The window is stamped with the row's id as it is created (ADR-25), which
     // is what every later lookup resolves: a window *name* is not unique (two
@@ -369,7 +398,14 @@ pub fn spawn_session_headless_with_progress(
             Some(&launch_cwd),
             &config.env,
         )
-        .map_err(|e| format!("Failed to spawn remote tmux window: {e:#}"))?,
+        .map_err(
+            |e| match crate::agent::preflight::is_missing_dependency(&e) {
+                // `ssh`/`wsl.exe` missing on *this* machine: already a sentence
+                // naming it, the search and the fix.
+                true => format!("{e}"),
+                false => format!("Failed to spawn remote tmux window: {e:#}"),
+            },
+        )?,
         None => crate::agent::tmux::spawn_window(
             &stamp,
             &req.name,
@@ -378,7 +414,14 @@ pub fn spawn_session_headless_with_progress(
             Some(&launch_cwd),
             &config.env,
         )
-        .map_err(|e| format!("Failed to spawn tmux window: {e}"))?,
+        .map_err(
+            |e| match crate::agent::preflight::is_missing_dependency(&e) {
+                // Already a sentence naming the binary, the search and the fix;
+                // a prefix in front of it only pushes the fix off the row.
+                true => format!("{e}"),
+                false => format!("Failed to spawn tmux window: {e:#}"),
+            },
+        )?,
     };
 
     report(SpawnPhase::Persisting);
@@ -496,6 +539,7 @@ pub fn spawn_session_headless_with_progress(
         worktrees,
         parent_session_id: req.parent_session_id,
         hook_failures,
+        warnings,
         sharing,
     })
 }
@@ -644,6 +688,9 @@ fn spawn_delegated(
         worktrees: row.worktrees,
         parent_session_id: row.parent_session_id,
         hook_failures,
+        // The host's own CLI ran the spawn, and its preflight is about the
+        // host's `PATH`, not this machine's — it reports there.
+        warnings: Vec::new(),
         sharing: None,
     })
 }

--- a/tests/missing_dependency_messages.rs
+++ b/tests/missing_dependency_messages.rs
@@ -1,0 +1,62 @@
+//! A spawn that fails because a binary is not installed must say which one,
+//! where thurbox looked, and what to do about it.
+//!
+//! The report this pins comes from a user whose local spawn failed with
+//! `tmux new-window exited exit status: 127 for window tb-test01`: a number,
+//! with nothing naming the missing binary, the directories searched, or the
+//! fix. The same setup answered `Failed to create tmux session` through the
+//! headless path — no better.
+//!
+//! Its own test binary because it sets `PATH` for the whole process, which a
+//! sibling test in the same binary would see.
+
+#![cfg(unix)]
+
+use std::collections::HashMap;
+
+/// Run `f` with `PATH` pointing at one directory that holds no multiplexer.
+fn without_a_multiplexer<T>(f: impl FnOnce() -> T) -> T {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let saved = std::env::var_os("PATH");
+    std::env::set_var("PATH", dir.path());
+    let out = f();
+    match saved {
+        Some(v) => std::env::set_var("PATH", v),
+        None => std::env::remove_var("PATH"),
+    }
+    out
+}
+
+#[test]
+fn a_spawn_with_no_multiplexer_installed_names_it_the_search_and_the_fix() {
+    let message = without_a_multiplexer(|| {
+        let err = thurbox::agent::tmux::spawn_window(
+            "00000000-0000-0000-0000-000000000000",
+            "test01",
+            "some-agent",
+            &[],
+            None,
+            &HashMap::new(),
+        )
+        .expect_err("no multiplexer is installed, so this cannot succeed");
+        format!("{err:#}")
+    });
+
+    let mux = thurbox::agent::transport::DEFAULT_MUX;
+    assert!(
+        message.contains(mux),
+        "the message never names the missing binary: {message}"
+    );
+    assert!(
+        message.contains("Looked in"),
+        "the message never says where thurbox looked: {message}"
+    );
+    assert!(
+        message.contains("http"),
+        "the message offers nowhere to get it: {message}"
+    );
+    assert!(
+        !message.contains("os error 2"),
+        "the message still leans on a raw errno: {message}"
+    );
+}

--- a/tests/new_session.rs
+++ b/tests/new_session.rs
@@ -15,6 +15,7 @@ use ratatui::backend::TestBackend;
 use ratatui::layout::Rect;
 use ratatui::Terminal;
 
+use thurbox::agent::preflight::Presence;
 use thurbox::git::ExistingWorktree;
 use thurbox::kernel::command::{BookmarkEdit, Command};
 use thurbox::kernel::host::{KeyPress, LuaHost, Published, RenderContext};
@@ -45,10 +46,12 @@ fn snapshot() -> Snapshot {
             AgentRow {
                 name: "claude".into(),
                 command: "claude".into(),
+                presence: Presence::Present,
             },
             AgentRow {
                 name: "codex".into(),
                 command: "codex".into(),
+                presence: Presence::Present,
             },
         ],
         agent_default: "claude".into(),
@@ -1202,6 +1205,7 @@ fn one_agent_is_not_a_question() {
     world.snapshot.agents = vec![AgentRow {
         name: "claude".into(),
         command: "claude".into(),
+        presence: Presence::Present,
     }];
     open(&host, &world);
     press(&host, &world, "space");
@@ -1777,4 +1781,159 @@ fn a_branch_name_that_prefilled_to_nothing_offers_no_pill() {
     type_text(&h, &world, "b");
     let typed = drawn(&h, &world);
     assert!(typed.contains("[ Next ]"), "{typed}");
+}
+
+// ── What is missing, said before the user commits ──────────────────────────
+
+/// Draw the sessions pane and return its screen.
+///
+/// The flow's own `drawn` renders the float; the first-run notice lives on the
+/// list behind it, which is the one screen a machine with no sessions reaches.
+fn sessions_screen(host: &LuaHost, world: &World, width: u16, height: u16) -> String {
+    publish(host, world);
+    let index = index_of(host, "sessions");
+    let rendered = host
+        .render(
+            index,
+            RenderContext {
+                width,
+                height,
+                focused: false,
+                elapsed: 0.0,
+                frame: 0,
+            },
+        )
+        .expect("render");
+    let mut terminal = Terminal::new(TestBackend::new(width, height)).expect("terminal");
+    terminal
+        .draw(|frame| {
+            thurbox::kernel::paint::render_recording(
+                frame,
+                Rect::new(0, 0, width, height),
+                &rendered.node,
+                &thurbox::kernel::terminal::Terminals::new(),
+                &mut Vec::new(),
+            );
+        })
+        .expect("draw");
+    let buffer = terminal.backend().buffer().clone();
+    (0..buffer.area.height)
+        .map(|y| {
+            (0..buffer.area.width)
+                .map(|x| buffer[(x, y)].symbol())
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// A snapshot whose multiplexer is not installed.
+fn without_a_multiplexer(world: &mut World) {
+    world.snapshot.mux = thurbox::kernel::snapshot::MuxRow {
+        binary: "tmux".into(),
+        presence: Presence::Missing,
+        advice: "install tmux 3.2 or newer".into(),
+    };
+}
+
+#[test]
+fn a_missing_agent_is_marked_on_the_row_that_would_launch_it() {
+    // The whole point of publishing presence: the cost of the choice is on the
+    // choice, while the cursor is still moving over the alternatives — not in a
+    // pane that exits after the user has committed.
+    let host = host();
+    let mut world = World::default();
+    world.snapshot.agents[1].presence = Presence::Missing;
+    open(&host, &world);
+    press(&host, &world, "space");
+    press(&host, &world, "enter");
+    type_text(&host, &world, "work");
+    press(&host, &world, "enter");
+    let screen = drawn(&host, &world);
+    assert!(screen.contains("Coding Agent"), "{screen}");
+    assert!(
+        screen.contains("not installed"),
+        "the agent that would fail is not marked: {screen}"
+    );
+}
+
+#[test]
+fn a_missing_agent_warns_only_once_it_is_the_question() {
+    // `codex` is missing, but the repository step is not where that is decided,
+    // and warning about an agent the user has not been offered yet reads as a
+    // refusal of the step they are on.
+    let host = host();
+    let mut world = World::default();
+    world.snapshot.agents[1].presence = Presence::Missing;
+    open(&host, &world);
+    let screen = drawn(&host, &world);
+    assert!(
+        !screen.contains("pane will exit at once"),
+        "the repository step warned about an agent nobody has chosen: {screen}"
+    );
+}
+
+#[test]
+fn a_missing_multiplexer_is_stated_from_the_first_step_of_the_flow() {
+    // Nothing can be created without it, so it outranks every other warning and
+    // does not wait for a step the user may never reach.
+    let host = host();
+    let mut world = World::default();
+    without_a_multiplexer(&mut world);
+    open(&host, &world);
+    let screen = drawn(&host, &world);
+    assert!(
+        screen.contains("tmux is not installed"),
+        "the flow never says the multiplexer is missing: {screen}"
+    );
+}
+
+#[test]
+fn a_remote_host_is_never_reported_as_missing_the_local_multiplexer() {
+    // The local machine's tmux has nothing to do with a session that will run on
+    // a host — and `unknown` is not `missing`.
+    let host = host();
+    let mut world = World::default();
+    without_a_multiplexer(&mut world);
+    world.snapshot.hosts = vec![HostRow {
+        name: "devbox".into(),
+        detail: "me@devbox".into(),
+        backend: "ssh:devbox".into(),
+    }];
+    open(&host, &world);
+    press(&host, &world, "j");
+    press(&host, &world, "enter");
+    let screen = drawn(&host, &world);
+    assert!(
+        !screen.contains("is not installed"),
+        "a remote flow reported the local machine's multiplexer: {screen}"
+    );
+}
+
+#[test]
+fn the_empty_session_list_says_the_multiplexer_is_missing() {
+    // The one screen a first run always reaches. Absent on a machine that has
+    // it, which is the normal case.
+    let host = host();
+    let mut world = World::default();
+    without_a_multiplexer(&mut world);
+    // The width a real sidebar has: the note must still be readable there, not
+    // truncated to its first clause.
+    let screen = sessions_screen(&host, &world, 28, 14);
+    assert!(screen.contains("No sessions yet"), "{screen}");
+    assert!(
+        screen.contains("tmux is not installed"),
+        "the first-run screen says nothing about the missing multiplexer: {screen}"
+    );
+    assert!(
+        screen.contains("thurbox-cli doctor"),
+        "the note names nowhere to get the whole answer: {screen}"
+    );
+
+    let quiet = World::default();
+    let screen = sessions_screen(&host, &quiet, 28, 14);
+    assert!(
+        !screen.contains("is not installed"),
+        "a machine that has everything was still warned: {screen}"
+    );
 }

--- a/tests/new_session.rs
+++ b/tests/new_session.rs
@@ -1911,6 +1911,38 @@ fn a_remote_host_is_never_reported_as_missing_the_local_multiplexer() {
 }
 
 #[test]
+fn a_remote_agent_is_never_reported_as_missing_by_local_presence() {
+    // Presence is published from THIS machine's PATH — a remote host's binaries
+    // live on the host and were never looked at, and the agent row must say
+    // nothing rather than borrow the wrong machine's answer.
+    let host = host();
+    let mut world = World::default();
+    world.snapshot.hosts = vec![HostRow {
+        name: "devbox".into(),
+        detail: "me@devbox".into(),
+        backend: "ssh:devbox".into(),
+    }];
+    world.snapshot.agents[1].presence = Presence::Missing;
+    world
+        .repos
+        .set_bookmarks_for_test("ssh:devbox", vec![bookmark("/srv/thurbox", Some(true))]);
+    open(&host, &world);
+    press(&host, &world, "j"); // local → devbox
+    press(&host, &world, "enter");
+    world.wants.bookmarks = Some("ssh:devbox".into());
+    press(&host, &world, "space");
+    press(&host, &world, "enter");
+    type_text(&host, &world, "remote");
+    press(&host, &world, "enter");
+    let screen = drawn(&host, &world);
+    assert!(screen.contains("Coding Agent"), "{screen}");
+    assert!(
+        !screen.contains("not installed"),
+        "a remote host's agent was judged by the local machine's PATH: {screen}"
+    );
+}
+
+#[test]
 fn the_empty_session_list_says_the_multiplexer_is_missing() {
     // The one screen a first run always reaches. Absent on a machine that has
     // it, which is the normal case.

--- a/tests/new_session.rs
+++ b/tests/new_session.rs
@@ -23,8 +23,9 @@ use thurbox::kernel::registry::Registry;
 use thurbox::kernel::repos::{
     BookmarkRow, Branches, BrowseEntry, Listing, RepoStore, Wants, Worktrees,
 };
-use thurbox::kernel::snapshot::{AgentRow, HostRow, Snapshot};
+use thurbox::kernel::snapshot::{AgentRow, HostRow, SessionRow, Snapshot};
 use thurbox::kernel::theme::Themes;
+use thurbox::session::SessionState;
 
 const PLUGIN: &str = "new_session";
 
@@ -81,6 +82,36 @@ fn offered() -> BookmarkRow {
         label: Some("Thurbox interface — edit your panes".into()),
         offered: true,
         ..bookmark(INTERFACE_DIR, Some(false))
+    }
+}
+
+/// A session to fork — its own agent is what the fork would actually run,
+/// never the first row of `agents()`.
+fn source_session() -> SessionRow {
+    SessionRow {
+        id: "fix-osc52-0000-0000-0000-000000000000".into(),
+        name: "fix-osc52".into(),
+        agent: "aider".into(),
+        status: SessionState::Idle,
+        cwd: Some("/src/thurbox".into()),
+        repo: Some("thurbox".into()),
+        repos: Vec::new(),
+        member_dirs: Vec::new(),
+        branch: Some("feat/fix-osc52".into()),
+        base_branch: None,
+        backend: "local-tmux".into(),
+        backend_id: Some("%1".into()),
+        remote_host: None,
+        agent_session_id: None,
+        parent_id: None,
+        display_order: None,
+        worktree_count: 1,
+        git: None,
+        stopped: false,
+        hook_state: None,
+        reports_as: None,
+        detected_agent: None,
+        shell_backend_id: None,
     }
 }
 
@@ -1967,5 +1998,38 @@ fn the_empty_session_list_says_the_multiplexer_is_missing() {
     assert!(
         !screen.contains("is not installed"),
         "a machine that has everything was still warned: {screen}"
+    );
+}
+
+#[test]
+fn a_fork_never_warns_about_the_wrong_agent() {
+    // A fork's agent is the source session's, resolved server-side by the
+    // kernel — flow.agent_index is never assigned for one, so indexing
+    // agents() by it would read whichever agent happens to sort first in
+    // agents.toml, not the one the fork will actually run.
+    let host = host();
+    let mut world = World::default();
+    world.snapshot.agents[0].presence = Presence::Missing;
+    world.snapshot.sessions = vec![source_session()];
+    publish(&host, &world);
+    // Rendering is what settles the cursor onto the session row.
+    host.render(
+        index_of(&host, "sessions"),
+        RenderContext {
+            width: 40,
+            height: 12,
+            focused: true,
+            elapsed: 1.0,
+            frame: 1,
+        },
+    )
+    .expect("render the sessions list");
+    host.on_action(index_of(&host, "sessions"), "sessions.fork")
+        .expect("sessions.fork");
+    let screen = drawn(&host, &world);
+    assert!(screen.contains("Session Name"), "{screen}");
+    assert!(
+        !screen.contains("pane will exit at once"),
+        "the fork flow warned about an agent it was never asked to pick: {screen}"
     );
 }

--- a/thurbox.yml
+++ b/thurbox.yml
@@ -304,6 +304,10 @@ globals:
     property: read-only
   thurbox.hosts:
     property: read-only
+  # Whether the multiplexer a session's window needs is installed, so a flow can
+  # say so before the user commits.
+  thurbox.preflight.mux:
+    property: read-only
   thurbox.tasks:
     property: read-only
   thurbox.automations:

--- a/ui/lib/thurbox.d.lua
+++ b/ui/lib/thurbox.d.lua
@@ -376,14 +376,32 @@
 ---@field path string
 ---@field name string
 
+---@alias thurbox.Presence
+---| "present"
+---| "missing"
+---| "unknown"
+
 ---@class (exact) thurbox.Agent
 ---@field name string
 ---@field command string
+---@field presence thurbox.Presence Whether `command` resolves to something runnable. `unknown` is not `missing`: it means nothing was looked at.
 
 ---@class (exact) thurbox.Host
 ---@field name string
 ---@field detail string
 ---@field backend string
+
+--- The local multiplexer every session's window is created in.
+---@class (exact) thurbox.Mux
+---@field binary string `tmux`, or `psmux` on native Windows.
+---@field presence thurbox.Presence
+---@field advice string What to do about it; empty when there is nothing to do.
+
+--- Whether the binaries a session needs are installed, as the kernel last
+--- looked. Probed on the kernel's schedule behind a TTL — reading it is a table
+--- lookup, never a `which`.
+---@class (exact) thurbox.Preflight
+---@field mux thurbox.Mux
 
 ---@class (exact) thurbox.Task
 ---@field id integer
@@ -619,6 +637,7 @@
 ---@field branches thurbox.Branches
 ---@field worktrees thurbox.Worktrees
 ---@field hosts thurbox.Host[]
+---@field preflight thurbox.Preflight
 ---@field tasks thurbox.Task[]
 ---@field automations thurbox.Automation[]
 ---@field commands thurbox.InFlight[]

--- a/ui/lib/ui.lua
+++ b/ui/lib/ui.lua
@@ -484,9 +484,11 @@ end
 
 -- ── The empty state ─────────────────────────────────────────────────────────
 
-local function centred(sentence, width)
+local function centred(sentence, width, colour)
   local pad = math.max(0, math.floor((width - widgets.len(sentence)) / 2))
-  return { { text = string.rep(" ", pad) .. sentence, style = { fg = theme.muted } } }
+  return {
+    { text = string.rep(" ", pad) .. sentence, style = { fg = colour or theme.muted } },
+  }
 end
 
 --- The one empty state: a blank line, the sentence, and the way out.
@@ -499,7 +501,15 @@ end
 --- nothing is bound: an empty state advertising a chord that does nothing is
 --- the failure this whole indirection exists to prevent.
 ---
---- opts: title, width, hint (a format string taking the chord), hint_action
+--- `note` is one line, or a list of them, below the hint in `note_colour`: the
+--- empty list is the one screen a first run is guaranteed to reach, so it is
+--- where "the thing that would run your session is not installed" belongs.
+--- Absent on every machine that has what it needs, which is the normal case.
+--- Keep each line short — this state is drawn in a sidebar, where anything
+--- longer is truncated to its first clause.
+---
+--- opts: title, width, hint (a format string taking the chord), hint_action,
+--- note, note_colour
 ---@param opts table
 ---@return thurbox.Span[][]
 function ui.empty(opts)
@@ -508,6 +518,13 @@ function ui.empty(opts)
   local chord = opts.hint_action and ui.chord(opts.hint_action)
   if chord and opts.hint then
     lines[#lines + 1] = centred(string.format(opts.hint, chord), width)
+  end
+  if opts.note then
+    lines[#lines + 1] = {}
+    local note = type(opts.note) == "table" and opts.note or { opts.note }
+    for _, sentence in ipairs(note) do
+      lines[#lines + 1] = centred(sentence, width, opts.note_colour)
+    end
   end
   return lines
 end

--- a/ui/plugins/10_sessions.lua
+++ b/ui/plugins/10_sessions.lua
@@ -108,6 +108,24 @@ local function agent_status_text(session)
   return nil
 end
 
+--- The multiplexer that is not installed, as short lines, or nil when it is.
+---
+--- Already an answer: the kernel probes on its own schedule behind a TTL, so
+--- this is a table lookup on the render path rather than a `which`.
+---
+--- Deliberately short, and deliberately not the advice itself: this is drawn in
+--- a sidebar around twenty-six cells wide, where the full sentence is truncated
+--- to its first clause and says less than nothing. The command it names prints
+--- the whole thing, with the search path — and the create-session flow, which
+--- has the width for it, states the advice in full.
+local function missing_multiplexer()
+  local mux = (thurbox and thurbox.preflight and thurbox.preflight.mux) or nil
+  if not mux or mux.presence ~= "missing" then
+    return nil
+  end
+  return { "⚠ " .. mux.binary .. " is not installed", "run: thurbox-cli doctor" }
+end
+
 --- The live search query, or nil when nothing is being searched.
 ---
 --- Read from `store` rather than handed over by the search pane: the pane
@@ -637,6 +655,12 @@ return {
           width = inner_width,
           hint = "Press %s to create one",
           hint_action = "new_session.open",
+          -- The empty list is the one screen a first run always reaches, and
+          -- the multiplexer is what a session's window is made of: saying it is
+          -- missing here is the difference between reading it now and finding
+          -- out from a pane that died. Nil on any machine that has it.
+          note = missing_multiplexer(),
+          note_colour = theme.bad,
         }),
       }),
     })

--- a/ui/plugins/70_new_session.lua
+++ b/ui/plugins/70_new_session.lua
@@ -61,6 +61,13 @@ local function agents()
   return (thurbox and thurbox.agents) or {}
 end
 
+--- Whether the binaries this session needs are installed, as the kernel last
+--- looked. Already an answer — the kernel probes on its own schedule behind a
+--- TTL, so reading it here costs a table lookup, never a `which`.
+local function preflight()
+  return (thurbox and thurbox.preflight) or {}
+end
+
 --- The spinner frame for this paint, from the flow's own clock.
 local function spinner(flow)
   return theme.spinner_frame(flow.elapsed)
@@ -279,15 +286,27 @@ local function frame(title, rows_height, children, flow)
   })
 end
 
+--- Assigned below, once `spawns_directly` exists: the warning needs to know
+--- whether this step is the last one before the session is created.
+local preflight_warning
+
 --- A refusal this flow made itself, on its own row. Empty when there is none, so
 --- the row is spent either way and the modal does not change height as messages
 --- come and go.
+---
+--- The same row carries the preflight warning when there is no refusal to show:
+--- what is already known to be missing is exactly as urgent as a refusal, and
+--- spending a second row on it would move every step's height for a state most
+--- machines are never in.
 local function message_row(flow)
-  local text = flow.message
+  local text, colour = flow.message, theme.bad
+  if not text then
+    text, colour = preflight_warning(flow)
+  end
   return {
     type = "text",
     len = 1,
-    text = { { { text = text and (" " .. text) or "", style = { fg = theme.bad } } } },
+    text = { { { text = text and (" " .. text) or "", style = { fg = colour } } } },
   }
 end
 
@@ -415,6 +434,47 @@ end
 --- their pills and `after_name` cannot drift apart.
 local function spawns_directly(flow)
   return flow.fork ~= nil or #agents() <= 1
+end
+
+--- What is already known to be missing for the session about to be created.
+---
+--- The whole point of the flow knowing this: the multiplexer and the agent are
+--- looked for *while the user is still choosing*, so the answer does not arrive
+--- as a dead pane after they have committed. Returns the sentence and the
+--- colour to draw it in, or nothing when there is nothing to say.
+---
+--- Only ever about the local machine. A remote host's binaries live on the
+--- host, and thurbox has not looked there — `unknown` is not `missing`, and
+--- reporting one as the other is a claim it has not earned.
+preflight_warning = function(flow)
+  if (flow.host or "") ~= "" then
+    return nil
+  end
+  local mux = preflight().mux
+  if mux and mux.presence == "missing" then
+    -- Nothing can be created at all without it, so it outranks the agent.
+    --
+    -- The advice in full where it fits, and where it does not — every phrasing
+    -- that names a package *and* a link is longer than this row — the command
+    -- that prints it along with every directory searched. A sentence cut off at
+    -- "install tmux 3.2 or newer — the p" is worse than one that ends.
+    local sentence = "⚠ " .. mux.binary .. " is not installed — " .. (mux.advice or "")
+    if widgets.len(sentence) > ROW_COLS then
+      sentence = "⚠ " .. mux.binary .. " is not installed — run: thurbox-cli doctor"
+    end
+    return sentence, theme.bad
+  end
+  -- The agent is the last question, so it is only settled on that step; a flow
+  -- with a single agent never asks, and the answer is settled from the start.
+  if flow.step ~= "agent" and not spawns_directly(flow) then
+    return nil
+  end
+  local picked = agents()[widgets.clamp(flow.agent_index, #agents())]
+  if picked and picked.presence == "missing" then
+    return "⚠ " .. picked.command .. " is not installed — its pane will exit at once",
+      theme.warn
+  end
+  return nil
 end
 
 local function render_repo(flow)
@@ -747,8 +807,14 @@ local function render_agent(flow)
   -- (command)`, so two entries wrapping the same CLI are distinguishable.
   local labels = {}
   for _, agent in ipairs(agents()) do
-    labels[#labels + 1] = (agent.name == agent.command) and agent.name
+    local label = (agent.name == agent.command) and agent.name
       or (agent.name .. "  (" .. agent.command .. ")")
+    -- Marked on the row rather than only in the warning below it, so the cost
+    -- of each choice is visible while the cursor is moving over the others.
+    if agent.presence == "missing" then
+      label = label .. "  ⚠ not installed"
+    end
+    labels[#labels + 1] = label
   end
   local height = math.max(1, math.min(#labels, REPO_LIST_MAX))
   return frame("Coding Agent", height + 4, {

--- a/ui/plugins/70_new_session.lua
+++ b/ui/plugins/70_new_session.lua
@@ -464,6 +464,12 @@ preflight_warning = function(flow)
     end
     return sentence, theme.bad
   end
+  -- A fork's agent is the source session's, resolved server-side (see
+  -- `commit`) — flow.agent_index was never assigned to mean anything for one,
+  -- so there is nothing here to check.
+  if flow.fork then
+    return nil
+  end
   -- The agent is the last question, so it is only settled on that step; a flow
   -- with a single agent never asks, and the answer is settled from the start.
   if flow.step ~= "agent" and not spawns_directly(flow) then

--- a/ui/plugins/70_new_session.lua
+++ b/ui/plugins/70_new_session.lua
@@ -805,13 +805,17 @@ end
 local function render_agent(flow)
   -- v1's label: the name alone when the two are the same, else `name
   -- (command)`, so two entries wrapping the same CLI are distinguishable.
+  --
+  -- Local presence only, same as preflight_warning above: a remote host's
+  -- binaries live on the host and thurbox has not looked there.
+  local local_host = (flow.host or "") == ""
   local labels = {}
   for _, agent in ipairs(agents()) do
     local label = (agent.name == agent.command) and agent.name
       or (agent.name .. "  (" .. agent.command .. ")")
     -- Marked on the row rather than only in the warning below it, so the cost
     -- of each choice is visible while the cursor is moving over the others.
-    if agent.presence == "missing" then
+    if local_host and agent.presence == "missing" then
       label = label .. "  ⚠ not installed"
     end
     labels[#labels + 1] = label


### PR DESCRIPTION
## Intent

Re-attestation only. PR #1104 is reviewed and green - 21 CI checks pass, 2 skipped, Greptile 5/5 'appears safe to merge' - and the operator has asked for it to be merged. The single thing blocking it is that the no-mistakes attestation names 0e49a968 while the head is 47674510: the CI monitor pushed its own 'no-mistakes: apply CI fixes' commit after the attestation was written, so the body attests a push that is no longer what would merge. Fleet's standing policy requires attestation and head to be the same commit, and thurbox is in fleet's auto-merge set, so an attestation naming an older commit must not be what merges.

DO NOT CHANGE THE CODE. The content on this branch is reviewed, green and approved; this run exists to validate and attest exactly what is already there. Do not refactor, do not add tests, do not 'improve' anything you would otherwise flag - if something looks imperfect but is not a correctness defect on the commit that would merge, approve it and let the attestation land. Fix the PR in place: do not open a second pull request, do not close or merge it, and rebase rather than merging the base branch in.

What the branch contains, for a reviewer with no other context. The feature: thurbox starts deliberately with no multiplexer and no coding agent installed, which meant the check landed at the worst possible moment - the user committed to creating a session and got back a bare exit code. src/agent/preflight.rs is now the one answer to 'is the thing that would run this actually there?', read in four places: the create-session flow (a missing multiplexer is stated from the first step; an agent whose command resolves nowhere is marked on its own row), the empty session list (the one screen a first run always reaches), the spawn error (which now names the binary, the fix and the directories searched instead of an errno or exit 127), and a new thurbox-cli doctor.

Standing constraints, all deliberate: a missing dependency must NEVER block startup - the preflight only ever warns, because a command may be a shell function, an alias, or installed a second later, the same 'never a new way to fail' rule agent::tmux::resolve_local_program is written under. No probe on a hot path - SnapshotStore::poll_preflight does a stat per absolute PATH entry per binary, no process spawn, on the kernel's schedule behind a 10-second TTL, published in the snapshot; plugins read thurbox.preflight.mux and each agent row's presence, they never probe; it is polled from refresh_if_due rather than refresh because refresh stops running on an idle database, exactly the state thurbox is in while the user installs what was missing. No invented install instructions - Windows is pointed at psmux and never at tmux, Linux gets the package name plus tmux's own install page rather than a guessed apt/dnf/pacman line, and a missing agent is answered with the agents.toml entry that decides what runs, because thurbox bakes in no agent knowledge. No new dependency; detection reuses paths::resolve_on_path and paths::path_dirs so the resolver and the error message read the same list. Presence is three-valued on purpose: unknown is NOT missing - a remote host's binaries were never looked at, and neither was the session directory a relative command resolves against.

Fixes already on the branch from earlier rounds, all to be preserved: the relative-command Unknown answer (Greptile P2); cognitive-complexity splits of cli::doctor::run, agent::tmux::WindowIndex::locate into stamped_match/named_match, and session_ops::spawn::resolve_dirs into plan_members - all behaviour-preserving, and locate/resolve_dirs were byte-identical to main and flagged only because the PR touched their files; the fork gate in ui/plugins/70_new_session.lua (a fork's agent is the source session's, resolved server-side, so flow.agent_index means nothing for one); the remote-host gate on the agent row labels; and two Windows-portability corrections to my own tests, where a POSIX-shaped literal path has a root but no prefix on Windows and so is not Path::is_absolute() there.

Repo conventions: Conventional Commits (cocogitto); comments are why-not-what and a stale comment is worse than none; a change invalidating a documented decision updates the doc in the same PR. MSRV 1.75, Edition 2021.

## What Changed

- Add `src/agent/preflight.rs`, a dependency-presence check (three-valued: present/missing/unknown) surfaced in four places: the create-session flow, the empty session list, the spawn error message (which now names the missing binary, the fix, and the directories searched), and a new `thurbox-cli doctor` command (`src/cli/doctor.rs`).
- Detection reuses `paths::resolve_on_path`/`paths::path_dirs` (no new dependency) and is polled off the hot path via `SnapshotStore::poll_preflight` (a stat per PATH entry per binary, no process spawn) on a 10-second TTL through `refresh_if_due`, publishing `thurbox.preflight.mux` and per-agent presence for UI plugins to read (`src/kernel/snapshot.rs`, `src/kernel/host/publish.rs`, `ui/lib/thurbox.d.lua`, `ui/plugins/10_sessions.lua`, `ui/plugins/70_new_session.lua`).
- Update `src/agent/tmux.rs`, `src/agent/transport.rs`, `src/agent/control_mode/mod.rs`, `src/session_ops/spawn.rs`, and `src/session_ops/restart.rs` so a missing dependency only ever warns and never blocks startup; split `WindowIndex::locate` and `spawn::resolve_dirs` into smaller functions to reduce cognitive complexity, and answer `Unknown` (not `Missing`) for relative agent commands and remote-host binaries.
- Add tests (`tests/missing_dependency_messages.rs`, expanded `tests/new_session.rs`) and update docs/skills (`docs/CONFIG.md`, `docs/FEATURES.md`, `.agents/skills/thurbox-cli/SKILL.md`, `.agents/skills/thurbox-kernel/SKILL.md`) plus the install scripts and `thurbox.yml` for the new lint surface.

## Risk Assessment

✅ Low: Since the last attestation (0e49a96) the only change is a one-file, 7-line test fix (src/agent/preflight.rs) replacing a hardcoded POSIX-shaped path with a tempdir-derived one so the test exercises the intended absolute-path branch on Windows too; it's behaviorally correct, matches the intent's own description of this exact pending fix, and the branch's substantive logic (preflight gating, fork/remote-host warning gates, relative-path Unknown handling) verified in the target commit matches what earlier review rounds already required and fixed.

## Testing

Baseline `cargo nextest run --all` already passed. On top of that I ran the targeted suites most relevant to this preflight feature (tests/missing_dependency_messages.rs, tests/new_session.rs — 68 tests — and the agent::preflight/cli::doctor unit tests — 10 tests), all passing, then manually ran the built `thurbox-cli doctor` binary against an isolated config directory under two different PATH conditions to observe the actual warn-not-block behavior and message wording end-to-end, which is captured as a transcript artifact. No source files were modified, consistent with the re-attestation-only intent.

<details>
<summary>Evidence: thurbox-cli doctor transcript (isolated config, two PATH scenarios)</summary>

```text
CLI transcript: `thurbox-cli doctor --text` on target commit 47674510fcc7102f1a0ecb6224392cf934d3e3af
Isolated config/data dirs (THURBOX_CONFIG_DIR/THURBOX_DATA_DIR) so this does not touch the real user install.

=== Case 1: normal dev machine PATH — most agents present, some deliberately absent ===
$ THURBOX_CONFIG_DIR=/tmp/thurbox-doctor-test/config THURBOX_DATA_DIR=/tmp/thurbox-doctor-test/data ./target/debug/thurbox-cli doctor --text

This machine — WARN
  ok    multiplexer          tmux is installed (3.7c)
  ok    agent:claude         claude runs `claude`
  ok    agent:codex          codex runs `codex`
  ok    agent:antigravity    antigravity runs `agy`
  ok    agent:opencode       opencode runs `opencode`
  ok    agent:aider          aider runs `aider`
  ok    agent:copilot        copilot runs `copilot`
  warn  agent:vibe           `vibe` was not found on PATH; install its CLI, or point the `command` of the `vibe` entry in /tmp/thurbox-doctor-test/config/agents.toml at the binary
  ok    agent:pi             pi runs `pi`
  warn  agent:omp            `omp` was not found on PATH; install its CLI, or point the `command` of the `omp` entry in /tmp/thurbox-doctor-test/config/agents.toml at the binary
  ok    agent:shell          shell runs `bash`

PATH searched (28): [dev machine PATH, truncated here — full list in stdout above]

Wiring of an existing session: thurbox-cli session doctor
Exit code: 0

=== Case 2: PATH restricted to /usr/bin:/bin — claude now unresolved too ===
$ THURBOX_CONFIG_DIR=/tmp/thurbox-doctor-test/config THURBOX_DATA_DIR=/tmp/thurbox-doctor-test/data PATH=/usr/bin:/bin ./target/debug/thurbox-cli doctor --text

This machine — WARN
  ok    multiplexer          tmux is installed (3.7c)
  warn  agent:claude         `claude` was not found on PATH; install its CLI, or point the `command` of the `claude` entry in /tmp/thurbox-doctor-test/config/agents.toml at the binary
  ok    agent:codex          codex runs `codex`
  ok    agent:antigravity    antigravity runs `agy`
  ok    agent:opencode       opencode runs `opencode`
  ok    agent:aider          aider runs `aider`
  ok    agent:copilot        copilot runs `copilot`
  warn  agent:vibe           `vibe` was not found on PATH; install its CLI, or point the `command` of the `vibe` entry in /tmp/thurbox-doctor-test/config/agents.toml at the binary
  ok    agent:pi             pi runs `pi`
  warn  agent:omp            `omp` was not found on PATH; install its CLI, or point the `command` of the `omp` entry in /tmp/thurbox-doctor-test/config/agents.toml at the binary
  ok    agent:shell          shell runs `bash`

PATH searched (2):
  /usr/bin
  /bin

Wiring of an existing session: thurbox-cli session doctor
Exit code: 0

=== Observation ===
Both runs exit 0 (process not blocked) despite warnings — matches the standing constraint
"a missing dependency must NEVER block startup". The message for each missing agent names
the binary, the fix (install or edit agents.toml), and the exact agents.toml path — matching
the "no invented install instructions" / "names the agents.toml entry" design intent.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"47674510fcc7102f1a0ecb6224392cf934d3e3af","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `cargo nextest run --all`
- `cargo nextest run --test missing_dependency_messages --test new_session (68 passed)`
- `cargo nextest run --lib cli::doctor agent::preflight kernel::snapshot::poll_preflight (10 passed)`
- `cargo build --bin thurbox-cli`
- `manual: THURBOX_CONFIG_DIR=... THURBOX_DATA_DIR=... ./target/debug/thurbox-cli doctor --text (normal PATH)`
- `manual: THURBOX_CONFIG_DIR=... THURBOX_DATA_DIR=... PATH=/usr/bin:/bin ./target/debug/thurbox-cli doctor --text (restricted PATH, confirms exit 0 / non-blocking)`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
