### PR TITLE
fix(core): give Ctrl+V to the agent when the clipboard holds an image

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -144,13 +144,30 @@ last text copied — a paste there inserts something stale rather than nothing,
 which is worse. `clipboard::ImageProbe` asks `powershell.exe`
 (`Clipboard::ContainsImage`) instead. That costs ~0.42 s measured, which is why
 it is the seventh instance of the worker pattern rather than a call on the loop:
-the press is claimed immediately and acted on when the answer lands, by which
-time focus is re-resolved. Off WSL nothing is asked — the local clipboard is the
-one being copied into, and arboard's answer is the whole truth.
+the press is claimed immediately and acted on when the answer lands. Off WSL
+nothing is asked — the local clipboard is the one being copied into, and
+arboard's answer is the whole truth.
+
+Three bounds make that latency safe. The **target** is the session the press was
+aimed at, taken at the press: 0.42 s is long enough to change panes, and a paste
+landing in a pane nobody aimed it at corrupts what is being typed there. **One
+question runs at a time** — key auto-repeat makes presses tens of times faster
+than the answer, and a `powershell.exe` per repeat is a held key bringing the
+machine down — with the presses that arrive while it is out kept (at most eight)
+and asked about separately, because an answer may only classify presses that
+predate it. And the child has a **five-second deadline**, after which it is
+killed and read as "no image": WSL interop can wedge outright, and the question
+after this one waits on its answer.
 
 **Rejected**: *a second chord for "give the paste to the agent"* — cheap and
 exact, but it leaves the ordinary `Ctrl+V` after copying an image still pasting
 stale text, which is the half of the bug that corrupts a prompt silently.
+*Resolving the focus when the answer lands* — it reads as "paste where the
+person is looking", but the intent belongs to the press, and a paste that
+arrives in a pane it was not aimed at is the same corruption seen from the other
+side. *Spending one answer on every press waiting behind it* — the clipboard can
+change while the question is out, and a press classified by what preceded it is
+exactly the stale paste this section is about.
 *Detecting the image with arboard* — thurbox builds it with
 `default-features = false`, the build without `get_image`, and the X clipboard
 it would read does not carry the Windows image anyway.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -129,6 +129,32 @@ are handled in one place.
   crossterm's internal byte representation doesn't match xterm
   sequences. Modifier keys, in particular, would break.
 
+### An image on the clipboard is the agent's paste, not ours
+
+thurbox's clipboard transport carries text (`clipboard::copy`/`paste`, and the
+OSC 52 leg by construction). An image therefore cannot be pasted here at all —
+but the CLI in the pane can fetch one itself when it sees the paste chord, so
+`Ctrl+V` is **handed to it** rather than swallowed. `kernel.paste` declines the
+chord, the same `Some(false)` answer `kernel.copy` uses when there is no
+selection, and the press falls through to the focused terminal.
+
+Inside WSL the decision cannot be made locally: WSLg bridges the clipboard's
+*text* only, so while Windows holds an image the X clipboard still hands out the
+last text copied — a paste there inserts something stale rather than nothing,
+which is worse. `clipboard::ImageProbe` asks `powershell.exe`
+(`Clipboard::ContainsImage`) instead. That costs ~0.42 s measured, which is why
+it is the seventh instance of the worker pattern rather than a call on the loop:
+the press is claimed immediately and acted on when the answer lands, by which
+time focus is re-resolved. Off WSL nothing is asked — the local clipboard is the
+one being copied into, and arboard's answer is the whole truth.
+
+**Rejected**: *a second chord for "give the paste to the agent"* — cheap and
+exact, but it leaves the ordinary `Ctrl+V` after copying an image still pasting
+stale text, which is the half of the bug that corrupts a prompt silently.
+*Detecting the image with arboard* — thurbox builds it with
+`default-features = false`, the build without `get_image`, and the X clipboard
+it would read does not carry the Windows image anyway.
+
 ### A paste on Windows arrives as keys, not as a paste
 
 `Event::Paste` is unix-only. crossterm's Windows source reads console

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -156,8 +156,10 @@ than the answer, and a `powershell.exe` per repeat is a held key bringing the
 machine down — with the presses that arrive while it is out kept (at most eight)
 and asked about separately, because an answer may only classify presses that
 predate it. And the child has a **five-second deadline**, after which it is
-killed and read as "no image": WSL interop can wedge outright, and the question
-after this one waits on its answer.
+killed and the press handed to the agent unanswered: WSL interop can wedge
+outright, and the question after this one waits on its answer. A probe that was
+killed is never read as "no image" — that reading is exactly the stale paste
+this path exists to stop.
 
 **Rejected**: *a second chord for "give the paste to the agent"* — cheap and
 exact, but it leaves the ordinary `Ctrl+V` after copying an image still pasting

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -2524,7 +2524,10 @@ confined to the active pane bounds.
   newlines, the multi-line task description keeps them). While **any**
   modal is open the paste is swallowed so it can never leak into the
   terminal in the pane behind the overlay; otherwise it pastes into
-  the active PTY.
+  the active PTY. The rule is about the **press**: a press made while
+  an overlay is up never had a pane to name. An answer owed to a press
+  made *before* the overlay went up is still delivered where that press
+  was aimed — see "Pasting images".
 - **`Ctrl+V` with an image on the clipboard**: handed to the agent in
   the pane instead of pasted — see "Pasting images" below.
 - **`Ctrl+Shift+V`** (your terminal's paste): the way to paste when
@@ -2644,7 +2647,16 @@ answered by a question of their own, and a question that has not come back in
 five seconds is abandoned — an unanswerable question is handed to the agent, not
 read as "no image", because the text it would paste instead is the stale one.
 Nothing is asked off WSL, where the local clipboard is the one being copied
-into.
+into, and nothing is asked on a distro where no `powershell.exe` could be found
+twice running — there is nobody to answer, and every paste would pay the wait.
+
+**A late answer still goes where the press was aimed.** No question is asked
+while a modal or a float owns typed input, so an overlay stops pastes starting
+underneath it. An overlay that goes up *after* the press, while the question is
+out, does not redirect or cancel it: the pane was named when the key was pressed,
+and a paste that vanished because someone opened a float for a third of a second
+would be the silent loss this path exists to end. Because that delivery can land
+out of sight, it says so on screen.
 
 **On macOS the byte is synthesised.** `Cmd+V` is the paste binding there, and a
 `Cmd` chord has no pty encoding at all — handing it on by declining it would

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -2525,6 +2525,8 @@ confined to the active pane bounds.
   modal is open the paste is swallowed so it can never leak into the
   terminal in the pane behind the overlay; otherwise it pastes into
   the active PTY.
+- **`Ctrl+V` with an image on the clipboard**: handed to the agent in
+  the pane instead of pasted — see "Pasting images" below.
 - **`Ctrl+Shift+V`** (your terminal's paste): the way to paste when
   thurbox runs over SSH — see "Pasting over SSH" below.
 - **`Cmd+C` / `Cmd+V`** (macOS): the same two actions, declared beside the
@@ -2620,6 +2622,23 @@ for one can stall for seconds. When no local clipboard is reachable,
 `Ctrl+V` shows a hint pointing at your terminal's own paste
 (usually **`Ctrl+Shift+V`**), which delivers the text as an ordinary
 bracketed paste that thurbox routes exactly like `Ctrl+V`.
+
+### Pasting images
+
+thurbox pastes text. An image on the clipboard is handed to the **agent**
+instead: `Ctrl+V` is sent to the pane as-is, and a CLI that knows how to read
+the clipboard itself picks the image up from there (Claude Code shells out to
+`xclip`/`wl-paste`, or to PowerShell under WSL). Swallowing the press instead
+is what used to make pasting a screenshot do nothing at all.
+
+**Inside WSL this needs asking Windows.** WSLg bridges the clipboard's *text*
+only: copy a screenshot in Windows and the Linux side is not updated — it keeps
+handing out whatever text was copied before, so a paste inserts something stale
+rather than the image. thurbox therefore asks `powershell.exe` whether the
+Windows clipboard holds an image before deciding what `Ctrl+V` means. The call
+costs about 0.4 s, so it runs **on a worker**: the interface keeps drawing and
+the paste lands when the answer does. Nothing is asked off WSL, where the local
+clipboard is the one being copied into.
 
 ### Pasting on Windows
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -2637,8 +2637,12 @@ handing out whatever text was copied before, so a paste inserts something stale
 rather than the image. thurbox therefore asks `powershell.exe` whether the
 Windows clipboard holds an image before deciding what `Ctrl+V` means. The call
 costs about 0.4 s, so it runs **on a worker**: the interface keeps drawing and
-the paste lands when the answer does. Nothing is asked off WSL, where the local
-clipboard is the one being copied into.
+the paste lands when the answer does — in the pane the press was aimed at, not
+whichever one is focused by then. One question runs at a time (a held `Ctrl+V`
+would otherwise start a PowerShell per repeat), presses made while it is out are
+answered by a question of their own, and a question that has not come back in
+five seconds is abandoned and read as "no image". Nothing is asked off WSL,
+where the local clipboard is the one being copied into.
 
 ### Pasting on Windows
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -2641,8 +2641,21 @@ the paste lands when the answer does — in the pane the press was aimed at, not
 whichever one is focused by then. One question runs at a time (a held `Ctrl+V`
 would otherwise start a PowerShell per repeat), presses made while it is out are
 answered by a question of their own, and a question that has not come back in
-five seconds is abandoned and read as "no image". Nothing is asked off WSL,
-where the local clipboard is the one being copied into.
+five seconds is abandoned — an unanswerable question is handed to the agent, not
+read as "no image", because the text it would paste instead is the stale one.
+Nothing is asked off WSL, where the local clipboard is the one being copied
+into.
+
+**On macOS the byte is synthesised.** `Cmd+V` is the paste binding there, and a
+`Cmd` chord has no pty encoding at all — handing it on by declining it would
+drop it — so thurbox sends the literal `Ctrl+V` byte the agent watches for.
+Written from the encoding rules rather than from a Mac: the decision is covered
+by a test, the round trip on real hardware is not.
+
+**What the agent reads, thurbox has not seen.** This is the one paste path where
+what you copied reaches the agent as content it fetches itself, rather than as
+text thurbox brackets and sends — and an image carries instructions as readily
+as text does. The press is yours, but the content arrives unread.
 
 ### Pasting on Windows
 

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -52,8 +52,9 @@
 //! arrives as an ordinary bracketed paste.
 
 use std::io::Write;
-use std::process::{Command, Stdio};
+use std::process::{Child, Command, Stdio};
 use std::sync::mpsc::{channel, Receiver, Sender};
+use std::time::{Duration, Instant};
 
 use base64::Engine as _;
 
@@ -270,6 +271,11 @@ pub const PASTE_UNAVAILABLE_HINT: &str =
 #[derive(Default)]
 pub struct ImageProbe {
     channel: Option<(Sender<bool>, Receiver<bool>)>,
+    /// Whether a question is out. One at a time: the clipboard does not change
+    /// between two presses a fifth of a second apart, so a second `powershell.exe`
+    /// would buy nothing and cost another cold start — and key auto-repeat can
+    /// hold `Ctrl+V` down, which without this is a process per repeat.
+    in_flight: bool,
 }
 
 /// How PowerShell is found. `powershell.exe` is on `PATH` inside a distro
@@ -296,10 +302,16 @@ impl ImageProbe {
 
     /// Ask Windows, on a thread. The answer arrives at a later [`Self::poll`].
     ///
-    /// Repeated presses each ask: two pastes are two pastes, and the answers
-    /// come back in the order the threads finish, which for a question this
-    /// small is the order they were asked.
+    /// A press made while an earlier question is still out does **not** ask
+    /// again: one answer serves every press waiting on it, because what is being
+    /// asked about cannot have changed in the time between them. Which presses
+    /// those were is the caller's to remember — this end of the wire only knows
+    /// what the clipboard holds.
     pub fn ask(&mut self) {
+        if self.in_flight {
+            return;
+        }
+        self.in_flight = true;
         let tx = self.channel.get_or_insert_with(channel).0.clone();
         std::thread::spawn(move || {
             let _ = tx.send(windows_clipboard_has_image());
@@ -307,9 +319,15 @@ impl ImageProbe {
     }
 
     /// The answer to one earlier [`Self::ask`], if one has come back.
+    ///
+    /// Taking the answer is what frees the next question: a probe that is never
+    /// polled is never re-asked, which is the behaviour that keeps one wedged
+    /// `powershell.exe` from becoming one per press.
     pub fn poll(&mut self) -> Option<bool> {
         let (_, rx) = self.channel.as_ref()?;
-        rx.try_recv().ok()
+        let answer = rx.try_recv().ok()?;
+        self.in_flight = false;
+        Some(answer)
     }
 }
 
@@ -317,20 +335,65 @@ impl ImageProbe {
 /// the question could not be put: a machine that cannot answer is one whose
 /// clipboard thurbox pastes as text, which is what it did before this existed.
 fn windows_clipboard_has_image() -> bool {
-    let ask = |exe: &str| {
-        Command::new(exe)
+    let ask = |exe: &str| -> std::io::Result<bool> {
+        let mut child = Command::new(exe)
             .args(["-NoProfile", "-NonInteractive", "-Sta", "-Command"])
             .arg(CONTAINS_IMAGE)
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null())
-            .status()
+            .spawn()?;
+        // Past the spawn, every way this can go wrong is still just "no image":
+        // the fallback below is for a `powershell.exe` that could not be *found*,
+        // and running a second one because the first became unreadable would be
+        // two wedged processes instead of one.
+        Ok(wait_bounded(&mut child, PROBE_TIMEOUT))
     };
     match ask(POWERSHELL) {
-        Ok(status) => status.success(),
+        Ok(answer) => answer,
         Err(e) => {
             tracing::debug!("{POWERSHELL} is not on PATH ({e}); trying the interop path");
-            ask(POWERSHELL_FALLBACK).is_ok_and(|status| status.success())
+            ask(POWERSHELL_FALLBACK).unwrap_or(false)
+        }
+    }
+}
+
+/// How long the probe waits for Windows before giving up on it.
+///
+/// The round trip is ~0.42 s measured, so this is not a budget anyone reaches
+/// by being slow — it is there because WSL interop can wedge outright (this
+/// machine has logged `UtilAcceptVsock:273: accept4 failed 110`), and a wedged
+/// question with no deadline is a `powershell.exe` and a thread that never end,
+/// one per press, for as long as the interface runs.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// How often the wait looks. Next to a 0.42 s round trip this is noise, and it
+/// costs nothing while the probe is out: the thread is asleep.
+const PROBE_POLL: Duration = Duration::from_millis(25);
+
+/// Whether `child` exited successfully within `timeout`, killing it if not.
+///
+/// `false` for a child that overran, was killed, or became unreadable — the
+/// answer that keeps thurbox doing what it did before the probe existed.
+fn wait_bounded(child: &mut Child, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return status.success(),
+            Ok(None) if Instant::now() >= deadline => {
+                tracing::warn!(
+                    "the Windows clipboard probe did not answer within {timeout:?}; \
+                     treating the clipboard as text"
+                );
+                let _ = child.kill();
+                let _ = child.wait();
+                return false;
+            }
+            Ok(None) => std::thread::sleep(PROBE_POLL),
+            Err(e) => {
+                tracing::debug!("could not wait for the Windows clipboard probe: {e}");
+                return false;
+            }
         }
     }
 }
@@ -394,6 +457,86 @@ mod tests {
         assert!(
             windows_clipboard_has_image(),
             "PowerShell says the clipboard holds an image and the probe did not"
+        );
+    }
+
+    /// A probe that never answers is killed, not waited on.
+    ///
+    /// WSL interop wedges (`UtilAcceptVsock:273: accept4 failed 110` on this
+    /// machine): the child is started and simply never returns. Without a
+    /// deadline the worker thread and its `powershell.exe` live for the rest of
+    /// the session — and because the probe is only re-asked once its answer is
+    /// taken, the paste chord would stop being answered at all from then on.
+    ///
+    /// Driven with a real child that really hangs, because the claim is about
+    /// the waiting: a helper asked to time out against nothing proves nothing.
+    #[cfg(unix)]
+    #[test]
+    fn a_probe_that_never_answers_is_killed_rather_than_waited_on() {
+        let mut child = Command::new("sh")
+            .args(["-c", "sleep 30"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn a hanging child");
+
+        let started = Instant::now();
+        let answered = wait_bounded(&mut child, Duration::from_millis(200));
+        let waited = started.elapsed();
+
+        assert!(!answered, "a child that never exited was read as an answer");
+        assert!(
+            waited < Duration::from_secs(5),
+            "the wait ran past its deadline: {waited:?}"
+        );
+        // Killed, not merely abandoned: an abandoned one holds the interop pipe.
+        assert!(
+            matches!(child.try_wait(), Ok(Some(_))),
+            "the child outlived the wait that gave up on it"
+        );
+    }
+
+    /// A press made while a question is out does not ask a second one.
+    ///
+    /// Key auto-repeat holds `Ctrl+V` down at tens of presses a second, and each
+    /// one used to spawn its own `powershell.exe` — ~0.42 s of cold start each,
+    /// all asking the same question about a clipboard that cannot have changed
+    /// in between. One question, one answer, however many presses are waiting
+    /// on it.
+    ///
+    /// Asserted by counting answers rather than processes: a second question
+    /// would deliver a second `true`/`false` down the same channel, so a probe
+    /// that answers exactly once is a probe that asked exactly once. Runs
+    /// anywhere — off WSL the command cannot start and the failure is the
+    /// answer, which is the same one answer.
+    #[test]
+    fn one_question_is_asked_at_a_time() {
+        let mut probe = ImageProbe::default();
+        probe.ask();
+        probe.ask();
+
+        let deadline = Instant::now() + Duration::from_secs(30);
+        let mut first = None;
+        while first.is_none() && Instant::now() < deadline {
+            first = probe.poll();
+            if first.is_none() {
+                std::thread::sleep(Duration::from_millis(20));
+            }
+        }
+        assert!(
+            first.is_some(),
+            "the probe never answered at all, so this asserts nothing about a \
+             second one"
+        );
+
+        // A second question was asked at the same moment as the first, so its
+        // answer would already be queued behind the one just taken.
+        std::thread::sleep(Duration::from_millis(500));
+        assert_eq!(
+            probe.poll(),
+            None,
+            "a press made while a question was out asked Windows again"
         );
     }
 

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -455,7 +455,7 @@ fn wait_bounded(child: &mut Child, timeout: Duration) -> bool {
             Ok(None) if Instant::now() >= deadline => {
                 tracing::warn!(
                     "the Windows clipboard probe did not answer within {timeout:?}; \
-                     treating the clipboard as text"
+                     what the clipboard holds stays unknown and the press goes to the agent"
                 );
                 let _ = child.kill();
                 let _ = child.wait();

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -541,10 +541,11 @@ mod tests {
     fn only_a_wsl_distro_asks_windows() {
         use crate::session::host_def::with_wsl_distro;
 
-        assert!(
+        assert_eq!(
             with_wsl_distro(Some("Ubuntu"), ImageProbe::applies),
+            cfg!(unix),
             "inside a distro the X clipboard is not the one being copied into, \
-             so Windows has to be asked"
+             so Windows has to be asked — and a native Windows build asks nobody"
         );
         assert!(
             !with_wsl_distro(None, ImageProbe::applies),

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -52,6 +52,7 @@
 //! arrives as an ordinary bracketed paste.
 
 use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::time::{Duration, Instant};
@@ -283,6 +284,23 @@ pub struct ImageProbe {
 const POWERSHELL: &str = "powershell.exe";
 const POWERSHELL_FALLBACK: &str = "/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe";
 
+/// Where PowerShell is looked for, in the order it is tried.
+///
+/// The `PATH` search goes through [`crate::paths::resolve_on_path`] rather than
+/// through `Command::new`'s own: the OS search treats an **empty** entry in
+/// `PATH` (a stray leading, trailing or doubled `:`) as the current directory,
+/// so a file named `powershell.exe` sitting in whatever repository thurbox was
+/// launched from would answer this question on every `Ctrl+V`. `resolve_on_path`
+/// keeps absolute entries only, which is the rule #1100 landed for agent
+/// spawns; there is no reason for this path to hold a weaker one.
+fn powershell_candidates() -> Vec<PathBuf> {
+    let mut found: Vec<PathBuf> = crate::paths::resolve_on_path(POWERSHELL)
+        .into_iter()
+        .collect();
+    found.push(PathBuf::from(POWERSHELL_FALLBACK));
+    found
+}
+
 /// What Windows said about its clipboard.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Verdict {
@@ -372,7 +390,7 @@ impl ImageProbe {
 /// apart. Every way the question could not be put — spawn, deadline, an answer
 /// that is neither word — is [`Verdict::Unknown`], never `NotImage`.
 fn windows_clipboard_has_image() -> Verdict {
-    let ask = |exe: &str| -> std::io::Result<Verdict> {
+    let ask = |exe: &Path| -> std::io::Result<Verdict> {
         let mut child = Command::new(exe)
             .args(["-NoProfile", "-NonInteractive", "-Sta", "-Command"])
             .arg(CLIPBOARD_KIND)
@@ -402,13 +420,13 @@ fn windows_clipboard_has_image() -> Verdict {
             }
         })
     };
-    match ask(POWERSHELL) {
-        Ok(verdict) => verdict,
-        Err(e) => {
-            tracing::debug!("{POWERSHELL} is not on PATH ({e}); trying the interop path");
-            ask(POWERSHELL_FALLBACK).unwrap_or(Verdict::Unknown)
+    for exe in powershell_candidates() {
+        match ask(&exe) {
+            Ok(verdict) => return verdict,
+            Err(e) => tracing::debug!("{} could not be run ({e})", exe.display()),
         }
     }
+    Verdict::Unknown
 }
 
 /// How long the probe waits for Windows before giving up on it.
@@ -455,6 +473,63 @@ fn wait_bounded(child: &mut Child, timeout: Duration) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The probe never runs a `powershell.exe` the working directory can reach.
+    ///
+    /// An empty entry in `PATH` — a stray leading, trailing or doubled `:` —
+    /// means "here" to the OS search, and a relative entry is resolved against
+    /// wherever thurbox was launched from, so a file of that name in a
+    /// repository would answer every `Ctrl+V` on a WSL box. #1100 closed the
+    /// same hole for agent spawns; this is that rule holding on the clipboard
+    /// path. Planted where a relative `PATH` entry really does find it, since
+    /// a lookup that cannot see the file proves nothing about the rule.
+    #[test]
+    #[cfg(unix)]
+    fn the_probe_looks_only_at_absolute_path_entries() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // Relative to the working directory a unit test runs in — the package
+        // root — and inside the build directory, which is not tracked.
+        let relative = std::path::Path::new("target").join("tbx-powershell-probe");
+        std::fs::create_dir_all(&relative).unwrap();
+        let planted = relative.join(POWERSHELL);
+        std::fs::write(&planted, b"#!/bin/sh\n").unwrap();
+        std::fs::set_permissions(&planted, std::fs::Permissions::from_mode(0o700)).unwrap();
+        assert!(
+            planted.exists(),
+            "the plant has to be findable to prove anything"
+        );
+
+        let reachable = format!(":{}", relative.display());
+        let candidates = crate::paths::with_path(&reachable, powershell_candidates);
+        let _ = std::fs::remove_dir_all(&relative);
+
+        assert_eq!(
+            candidates,
+            vec![PathBuf::from(POWERSHELL_FALLBACK)],
+            "a PATH entry the working directory resolves reached the probe"
+        );
+    }
+
+    /// And the interop PowerShell an absolute entry names is still what is
+    /// tried before the hard-coded path.
+    #[test]
+    #[cfg(unix)]
+    fn an_absolute_path_entry_is_what_the_probe_prefers() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let planted = dir.path().join(POWERSHELL);
+        std::fs::write(&planted, b"#!/bin/sh\n").unwrap();
+        std::fs::set_permissions(&planted, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+        let candidates = crate::paths::with_path(dir.path(), powershell_candidates);
+
+        assert_eq!(
+            candidates.first().map(PathBuf::as_path),
+            Some(planted.as_path())
+        );
+    }
 
     /// The probe fires inside a WSL distro and nowhere else.
     ///

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -271,10 +271,9 @@ pub const PASTE_UNAVAILABLE_HINT: &str =
 #[derive(Default)]
 pub struct ImageProbe {
     channel: Option<(Sender<Verdict>, Receiver<Verdict>)>,
-    /// Whether a question is out. One at a time: the clipboard does not change
-    /// between two presses a fifth of a second apart, so a second `powershell.exe`
-    /// would buy nothing and cost another cold start — and key auto-repeat can
-    /// hold `Ctrl+V` down, which without this is a process per repeat.
+    /// Whether a question is out. At most one at a time, because key
+    /// auto-repeat holds `Ctrl+V` down far faster than the ~0.42 s answer and
+    /// a process per repeat is a machine brought to its knees by a held key.
     in_flight: bool,
 }
 
@@ -282,8 +281,7 @@ pub struct ImageProbe {
 /// through WSL interop; the absolute path is the fallback for a `PATH` that
 /// interop did not reach, and is the one Claude Code itself falls back to.
 const POWERSHELL: &str = "powershell.exe";
-const POWERSHELL_FALLBACK: &str =
-    "/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe";
+const POWERSHELL_FALLBACK: &str = "/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe";
 
 /// What Windows said about its clipboard.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -340,15 +338,12 @@ impl ImageProbe {
     /// Ask Windows, on a thread. The answer arrives at a later [`Self::poll`].
     ///
     /// `true` when a question was actually put, `false` when one was already
-    /// out — at most one `powershell.exe` runs at a time, because key
-    /// auto-repeat makes presses far faster than the ~0.42 s answer and a
-    /// process per repeat is a machine brought to its knees by a held key.
+    /// out (see `in_flight`).
     ///
-    /// The answer that comes back describes the clipboard **as of this call**,
-    /// so it may only be applied to presses already made: the caller keeps the
-    /// presses and re-asks for any that arrived after — see
-    /// `poll_image_probe`. This end of the wire only knows what the clipboard
-    /// holds, never who is waiting.
+    /// The answer describes the clipboard **as of this call**, so it may only
+    /// be applied to presses already made: the caller keeps the presses and
+    /// re-asks for any that arrived after — see `poll_image_probe`. This end of
+    /// the wire only knows what the clipboard holds, never who is waiting.
     pub fn ask(&mut self) -> bool {
         if self.in_flight {
             return false;
@@ -363,9 +358,8 @@ impl ImageProbe {
 
     /// The answer to one earlier [`Self::ask`], if one has come back.
     ///
-    /// Taking the answer is what frees the next question: a probe that is never
-    /// polled is never re-asked, which is the behaviour that keeps one wedged
-    /// `powershell.exe` from becoming one per press.
+    /// Taking it is what frees the next question, so a probe nobody polls is a
+    /// probe nobody re-asks.
     pub fn poll(&mut self) -> Option<Verdict> {
         let (_, rx) = self.channel.as_ref()?;
         let answer = rx.try_recv().ok()?;
@@ -374,9 +368,9 @@ impl ImageProbe {
     }
 }
 
-/// One PowerShell round trip. `false` for "no image", and also for every way
-/// the question could not be put: a machine that cannot answer is one whose
-/// clipboard thurbox pastes as text, which is what it did before this existed.
+/// One PowerShell round trip, and the only place the three verdicts are told
+/// apart. Every way the question could not be put — spawn, deadline, an answer
+/// that is neither word — is [`Verdict::Unknown`], never `NotImage`.
 fn windows_clipboard_has_image() -> Verdict {
     let ask = |exe: &str| -> std::io::Result<Verdict> {
         let mut child = Command::new(exe)
@@ -432,8 +426,9 @@ const PROBE_POLL: Duration = Duration::from_millis(25);
 
 /// Whether `child` exited successfully within `timeout`, killing it if not.
 ///
-/// `false` for a child that overran, was killed, or became unreadable — the
-/// answer that keeps thurbox doing what it did before the probe existed.
+/// A child that overran, was killed, or became unreadable is `false`, which the
+/// caller reads as [`Verdict::Unknown`]: the deadline exists to stop a wedged
+/// interop from leaking processes, not to decide what is on the clipboard.
 fn wait_bounded(child: &mut Child, timeout: Duration) -> bool {
     let deadline = Instant::now() + timeout;
     loop {
@@ -521,9 +516,12 @@ mod tests {
             eprintln!("skipping: no powershell.exe on PATH");
             return;
         };
-        let said = String::from_utf8_lossy(&oracle.stdout).trim().to_lowercase();
+        let said = String::from_utf8_lossy(&oracle.stdout)
+            .trim()
+            .to_lowercase();
         let words: Vec<&str> = said.split_whitespace().collect();
-        let (Some(&image), Some(&text), true) = (words.first(), words.get(1), oracle.status.success())
+        let (Some(&image), Some(&text), true) =
+            (words.first(), words.get(1), oracle.status.success())
         else {
             eprintln!(
                 "skipping: PowerShell could not be asked (status {:?}, said {said:?}) — \

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -54,6 +54,7 @@
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::time::{Duration, Instant};
 
@@ -318,6 +319,61 @@ pub enum Verdict {
     Unknown,
 }
 
+/// Rounds that found no `powershell.exe` anywhere, in a row.
+///
+/// Reset by any answer at all, so this counts a *standing* absence rather than
+/// a total: a machine that answered once has interop, whatever happens next.
+static POWERSHELL_ABSENT_ROUNDS: AtomicUsize = AtomicUsize::new(0);
+
+/// How many such rounds stop the question being asked at all.
+///
+/// Two rather than one because the first can be lost to a race nobody controls:
+/// interop mounts `/mnt/c` and publishes `powershell.exe` on `PATH` a moment
+/// after a distro starts, and a paste in that moment would otherwise silence
+/// the probe for the rest of the session.
+const ABSENT_ROUNDS_BEFORE_LATCH: usize = 2;
+
+/// Whether this machine has been shown to have no PowerShell to ask.
+///
+/// The cost this saves is the reason the gate exists at all: on a box with no
+/// interop every paste otherwise spawns nothing, waits for nothing and still
+/// walks the candidate list before answering [`Verdict::Unknown`] — and the
+/// press reaches the agent a round trip later than it needed to.
+fn powershell_is_absent() -> bool {
+    POWERSHELL_ABSENT_ROUNDS.load(Ordering::Relaxed) >= ABSENT_ROUNDS_BEFORE_LATCH
+}
+
+/// What one round of candidates says about the machine, as opposed to about
+/// the clipboard.
+///
+/// Only [`std::io::ErrorKind::NotFound`] means "there is no PowerShell here".
+/// `PermissionDenied`, an exec format error, a policy that refuses the spawn —
+/// those are a machine that **has** one and would not run it this time, and
+/// latching on them would turn a transient or administrative failure into a
+/// permanent one. They stay [`Verdict::Unknown`] with the question still asked
+/// next time.
+fn is_absence(errors: &[std::io::ErrorKind]) -> bool {
+    !errors.is_empty() && errors.iter().all(|k| *k == std::io::ErrorKind::NotFound)
+}
+
+/// Records what a round found, and reports whether the question is now latched
+/// off. A round that reached PowerShell at all clears the count.
+fn note_round(errors: &[std::io::ErrorKind]) -> bool {
+    if is_absence(errors) {
+        POWERSHELL_ABSENT_ROUNDS.fetch_add(1, Ordering::Relaxed);
+    } else {
+        POWERSHELL_ABSENT_ROUNDS.store(0, Ordering::Relaxed);
+    }
+    powershell_is_absent()
+}
+
+/// Clears what [`note_round`] counted. Tests only: the latch is deliberately
+/// for the life of the process, and nothing in production wants it back.
+#[cfg(test)]
+fn forget_powershell_absence() {
+    POWERSHELL_ABSENT_ROUNDS.store(0, Ordering::Relaxed);
+}
+
 /// Asks only what *kind* of thing is there — deliberately not for the image
 /// itself: not carrying pixels over the boundary keeps the call cheap.
 ///
@@ -349,8 +405,15 @@ impl ImageProbe {
     /// Only inside a WSL distro: everywhere else the local clipboard *is* the
     /// one being copied into, so arboard's answer is the whole truth and no
     /// subprocess is worth spawning.
+    ///
+    /// And only while a PowerShell to ask still looks reachable — see
+    /// [`powershell_is_absent`]. A distro without interop would otherwise pay
+    /// the gate's whole cost for a question that cannot be answered, on every
+    /// paste, for as long as the session lasts.
     pub fn applies() -> bool {
-        cfg!(unix) && crate::session::host_def::current_wsl_distro().is_some()
+        cfg!(unix)
+            && !powershell_is_absent()
+            && crate::session::host_def::current_wsl_distro().is_some()
     }
 
     /// Ask Windows, on a thread. The answer arrives at a later [`Self::poll`].
@@ -420,11 +483,24 @@ fn windows_clipboard_has_image() -> Verdict {
             }
         })
     };
+    let mut failures = Vec::new();
     for exe in powershell_candidates() {
         match ask(&exe) {
-            Ok(verdict) => return verdict,
-            Err(e) => tracing::debug!("{} could not be run ({e})", exe.display()),
+            Ok(verdict) => {
+                note_round(&[]);
+                return verdict;
+            }
+            Err(e) => {
+                tracing::debug!("{} could not be run ({e})", exe.display());
+                failures.push(e.kind());
+            }
         }
+    }
+    if note_round(&failures) {
+        tracing::info!(
+            "no powershell.exe on this machine after {ABSENT_ROUNDS_BEFORE_LATCH} tries; \
+             pastes go straight to the agent from here on"
+        );
     }
     Verdict::Unknown
 }
@@ -541,6 +617,8 @@ mod tests {
     fn only_a_wsl_distro_asks_windows() {
         use crate::session::host_def::with_wsl_distro;
 
+        forget_powershell_absence();
+
         assert_eq!(
             with_wsl_distro(Some("Ubuntu"), ImageProbe::applies),
             cfg!(unix),
@@ -551,6 +629,56 @@ mod tests {
             !with_wsl_distro(None, ImageProbe::applies),
             "off WSL the local clipboard is the whole truth — asking would only \
              cost every paste a subprocess"
+        );
+    }
+
+    /// A machine with no interop stops being asked — and only that machine.
+    ///
+    /// The three cases are one test because the latch is one counter and what
+    /// matters is which outcomes move it: absence twice latches, anything that
+    /// reached PowerShell clears it, and a refusal to run is not an absence.
+    ///
+    /// Process-global state, so this relies on the suite's runner (nextest)
+    /// giving each test its own process, the way the `PATH`-mutating tests
+    /// above already do.
+    #[test]
+    fn only_a_machine_without_powershell_stops_being_asked() {
+        use crate::session::host_def::with_wsl_distro;
+        use std::io::ErrorKind;
+
+        forget_powershell_absence();
+        assert!(
+            !note_round(&[ErrorKind::NotFound]),
+            "one round is not proof"
+        );
+        assert!(
+            note_round(&[ErrorKind::NotFound]),
+            "two rounds without a powershell.exe anywhere are"
+        );
+        if cfg!(unix) {
+            assert!(
+                !with_wsl_distro(Some("Ubuntu"), ImageProbe::applies),
+                "a latched machine must stop paying ~0.42 s for a question \
+                 nothing can answer"
+            );
+        }
+
+        forget_powershell_absence();
+        assert!(
+            !note_round(&[ErrorKind::PermissionDenied, ErrorKind::PermissionDenied]),
+            "a PowerShell that would not run is a machine that has one"
+        );
+        assert!(
+            !note_round(&[ErrorKind::PermissionDenied, ErrorKind::PermissionDenied]),
+            "and no number of refusals makes it missing"
+        );
+
+        forget_powershell_absence();
+        note_round(&[ErrorKind::NotFound]);
+        note_round(&[]);
+        assert!(
+            !note_round(&[ErrorKind::NotFound]),
+            "an answer in between means the count starts again, not resumes"
         );
     }
 

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -407,7 +407,7 @@ impl ImageProbe {
     /// subprocess is worth spawning.
     ///
     /// And only while a PowerShell to ask still looks reachable — see
-    /// [`powershell_is_absent`]. A distro without interop would otherwise pay
+    /// `powershell_is_absent`. A distro without interop would otherwise pay
     /// the gate's whole cost for a question that cannot be answered, on every
     /// paste, for as long as the session lasts.
     pub fn applies() -> bool {

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -52,6 +52,8 @@
 //! arrives as an ordinary bracketed paste.
 
 use std::io::Write;
+use std::process::{Command, Stdio};
+use std::sync::mpsc::{channel, Receiver, Sender};
 
 use base64::Engine as _;
 
@@ -238,9 +240,162 @@ pub fn paste(native: Option<&mut arboard::Clipboard>) -> Option<String> {
 pub const PASTE_UNAVAILABLE_HINT: &str =
     "No local clipboard — use your terminal's paste (Ctrl+Shift+V)";
 
+/// Whether the **Windows** clipboard holds an image, asked off the event loop.
+///
+/// ## Why Windows has to be asked at all
+///
+/// Inside WSL the X clipboard is not the clipboard the person is copying into.
+/// WSLg bridges **text only**: copy a screenshot in Windows and the X side is
+/// not updated at all — it still hands out whatever text was copied before
+/// (measured on WSLg, Ubuntu: `Clipboard::get_text` returned an IP address
+/// copied minutes earlier while Windows held a 1594x535 PNG). So `Ctrl+V` on a
+/// copied image does not paste nothing, it pastes something *stale*, which is
+/// worse. arboard cannot tell us either: thurbox builds it with
+/// `default-features = false`, which is the build without `get_image`.
+///
+/// ## Why the answer is worth waiting for
+///
+/// thurbox cannot paste an image — but the agent in the pane can fetch one
+/// itself when it sees the paste chord (Claude Code shells out to
+/// `xclip`/`wl-paste`, and under WSL to this same PowerShell). So the only
+/// thing the question decides is who handles the press, and getting it wrong
+/// silently corrupts a prompt.
+///
+/// ## Why it is a worker
+///
+/// Spawning `powershell.exe` costs ~0.42 s (measured, three runs: 0.42/0.41/
+/// 0.43). That is far too long to hold the event loop for, and it is paid on
+/// *every* paste, not just image ones. So this is the seventh instance of the
+/// worker pattern: ask, keep drawing, act when the answer arrives.
+#[derive(Default)]
+pub struct ImageProbe {
+    channel: Option<(Sender<bool>, Receiver<bool>)>,
+}
+
+/// How PowerShell is found. `powershell.exe` is on `PATH` inside a distro
+/// through WSL interop; the absolute path is the fallback for a `PATH` that
+/// interop did not reach, and is the one Claude Code itself falls back to.
+const POWERSHELL: &str = "powershell.exe";
+const POWERSHELL_FALLBACK: &str =
+    "/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe";
+
+/// Asks only whether an image is there — deliberately not for the image. An
+/// exit code is all the caller needs, and not carrying pixels over the boundary
+/// keeps the call cheap.
+const CONTAINS_IMAGE: &str = "Add-Type -AssemblyName System.Windows.Forms;      if (-not [System.Windows.Forms.Clipboard]::ContainsImage()) { exit 1 }";
+
+impl ImageProbe {
+    /// Whether this machine is one where the question even arises.
+    ///
+    /// Only inside a WSL distro: everywhere else the local clipboard *is* the
+    /// one being copied into, so arboard's answer is the whole truth and no
+    /// subprocess is worth spawning.
+    pub fn applies() -> bool {
+        cfg!(unix) && crate::session::host_def::current_wsl_distro().is_some()
+    }
+
+    /// Ask Windows, on a thread. The answer arrives at a later [`Self::poll`].
+    ///
+    /// Repeated presses each ask: two pastes are two pastes, and the answers
+    /// come back in the order the threads finish, which for a question this
+    /// small is the order they were asked.
+    pub fn ask(&mut self) {
+        let tx = self.channel.get_or_insert_with(channel).0.clone();
+        std::thread::spawn(move || {
+            let _ = tx.send(windows_clipboard_has_image());
+        });
+    }
+
+    /// The answer to one earlier [`Self::ask`], if one has come back.
+    pub fn poll(&mut self) -> Option<bool> {
+        let (_, rx) = self.channel.as_ref()?;
+        rx.try_recv().ok()
+    }
+}
+
+/// One PowerShell round trip. `false` for "no image", and also for every way
+/// the question could not be put: a machine that cannot answer is one whose
+/// clipboard thurbox pastes as text, which is what it did before this existed.
+fn windows_clipboard_has_image() -> bool {
+    let ask = |exe: &str| {
+        Command::new(exe)
+            .args(["-NoProfile", "-NonInteractive", "-Sta", "-Command"])
+            .arg(CONTAINS_IMAGE)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+    };
+    match ask(POWERSHELL) {
+        Ok(status) => status.success(),
+        Err(e) => {
+            tracing::debug!("{POWERSHELL} is not on PATH ({e}); trying the interop path");
+            ask(POWERSHELL_FALLBACK).is_ok_and(|status| status.success())
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The probe fires inside a WSL distro and nowhere else.
+    ///
+    /// The gate is the whole cost control: every paste on a machine that asks
+    /// pays ~0.42 s for a `powershell.exe` that a plain Linux or macOS box has
+    /// no reason to run. A gate that answered "yes" everywhere would be a
+    /// third-of-a-second added to every `Ctrl+V` on every platform.
+    #[test]
+    fn only_a_wsl_distro_asks_windows() {
+        use crate::session::host_def::with_wsl_distro;
+
+        assert!(
+            with_wsl_distro(Some("Ubuntu"), ImageProbe::applies),
+            "inside a distro the X clipboard is not the one being copied into, \
+             so Windows has to be asked"
+        );
+        assert!(
+            !with_wsl_distro(None, ImageProbe::applies),
+            "off WSL the local clipboard is the whole truth — asking would only \
+             cost every paste a subprocess"
+        );
+    }
+
+    /// The PowerShell round trip reports what PowerShell itself reports.
+    ///
+    /// Run against the real Windows clipboard, because what is being tested is
+    /// the wiring — the argument list, `-Sta` (without it `Add-Type` throws and
+    /// every answer becomes "no image"), the `PATH`/interop fallback, and
+    /// reading the answer off the *exit code* rather than stdout. A helper
+    /// returning `false` would pass every test that stubbed this out.
+    ///
+    /// Skipped where it cannot discriminate: off WSL, with no PowerShell, or
+    /// with no image on the clipboard — in that last case both a working probe
+    /// and a broken one say "no". Nothing here writes to the clipboard: a test
+    /// suite that destroys what you copied is worse than a test that skips.
+    #[test]
+    fn the_windows_probe_agrees_with_powershell() {
+        if !ImageProbe::applies() {
+            eprintln!("skipping: not inside a WSL distro");
+            return;
+        }
+        let oracle = Command::new(POWERSHELL)
+            .args(["-NoProfile", "-NonInteractive", "-Sta", "-Command"])
+            .arg("Add-Type -AssemblyName System.Windows.Forms; [System.Windows.Forms.Clipboard]::ContainsImage()")
+            .output();
+        let Ok(oracle) = oracle else {
+            eprintln!("skipping: no powershell.exe on PATH");
+            return;
+        };
+        if !String::from_utf8_lossy(&oracle.stdout).trim().eq_ignore_ascii_case("true") {
+            eprintln!("skipping: no image on the Windows clipboard to recognise");
+            return;
+        }
+        assert!(
+            windows_clipboard_has_image(),
+            "PowerShell says the clipboard holds an image and the probe did not"
+        );
+    }
 
     #[test]
     fn osc52_sequence_is_bel_terminated_base64() {

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -302,20 +302,26 @@ impl ImageProbe {
 
     /// Ask Windows, on a thread. The answer arrives at a later [`Self::poll`].
     ///
-    /// A press made while an earlier question is still out does **not** ask
-    /// again: one answer serves every press waiting on it, because what is being
-    /// asked about cannot have changed in the time between them. Which presses
-    /// those were is the caller's to remember — this end of the wire only knows
-    /// what the clipboard holds.
-    pub fn ask(&mut self) {
+    /// `true` when a question was actually put, `false` when one was already
+    /// out — at most one `powershell.exe` runs at a time, because key
+    /// auto-repeat makes presses far faster than the ~0.42 s answer and a
+    /// process per repeat is a machine brought to its knees by a held key.
+    ///
+    /// The answer that comes back describes the clipboard **as of this call**,
+    /// so it may only be applied to presses already made: the caller keeps the
+    /// presses and re-asks for any that arrived after — see
+    /// `poll_image_probe`. This end of the wire only knows what the clipboard
+    /// holds, never who is waiting.
+    pub fn ask(&mut self) -> bool {
         if self.in_flight {
-            return;
+            return false;
         }
         self.in_flight = true;
         let tx = self.channel.get_or_insert_with(channel).0.clone();
         std::thread::spawn(move || {
             let _ = tx.send(windows_clipboard_has_image());
         });
+        true
     }
 
     /// The answer to one earlier [`Self::ask`], if one has come back.
@@ -513,8 +519,13 @@ mod tests {
     #[test]
     fn one_question_is_asked_at_a_time() {
         let mut probe = ImageProbe::default();
-        probe.ask();
-        probe.ask();
+        assert!(probe.ask(), "the first press put no question at all");
+        assert!(
+            !probe.ask(),
+            "a press made while a question was out started a second one; the \
+             caller reads this as its press being covered by an answer that was \
+             asked for before it happened"
+        );
 
         let deadline = Instant::now() + Duration::from_secs(30);
         let mut first = None;
@@ -537,6 +548,14 @@ mod tests {
             probe.poll(),
             None,
             "a press made while a question was out asked Windows again"
+        );
+
+        // And taking the answer frees the next question: the press that was
+        // refused above is asked for now, against the clipboard as it is now.
+        assert!(
+            probe.ask(),
+            "no question could be put after the previous answer was taken; a \
+             press waiting on a fresh one would wait for ever"
         );
     }
 

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -51,7 +51,7 @@
 //! Terminal). Paste over SSH is the terminal's own `Ctrl+Shift+V`, which
 //! arrives as an ordinary bracketed paste.
 
-use std::io::Write;
+use std::io::{Read, Write};
 use std::process::{Child, Command, Stdio};
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::time::{Duration, Instant};
@@ -270,7 +270,7 @@ pub const PASTE_UNAVAILABLE_HINT: &str =
 /// worker pattern: ask, keep drawing, act when the answer arrives.
 #[derive(Default)]
 pub struct ImageProbe {
-    channel: Option<(Sender<bool>, Receiver<bool>)>,
+    channel: Option<(Sender<Verdict>, Receiver<Verdict>)>,
     /// Whether a question is out. One at a time: the clipboard does not change
     /// between two presses a fifth of a second apart, so a second `powershell.exe`
     /// would buy nothing and cost another cold start — and key auto-repeat can
@@ -285,10 +285,47 @@ const POWERSHELL: &str = "powershell.exe";
 const POWERSHELL_FALLBACK: &str =
     "/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe";
 
-/// Asks only whether an image is there — deliberately not for the image. An
-/// exit code is all the caller needs, and not carrying pixels over the boundary
-/// keeps the call cheap.
-const CONTAINS_IMAGE: &str = "Add-Type -AssemblyName System.Windows.Forms;      if (-not [System.Windows.Forms.Clipboard]::ContainsImage()) { exit 1 }";
+/// What Windows said about its clipboard.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Verdict {
+    /// A picture and nothing else — the press belongs to the agent, which can
+    /// fetch it.
+    Image,
+    /// Something thurbox can paste itself, or nothing at all.
+    NotImage,
+    /// Windows could not be asked. Deliberately **not** folded into
+    /// [`Verdict::NotImage`]: WSL interop wedges intermittently (this machine
+    /// logs `UtilAcceptVsock:273: accept4 failed 110` roughly once in ten cold
+    /// calls), and reading that as "no image" pastes the stale X-clipboard text
+    /// this whole path exists to stop. An unanswerable question is given to the
+    /// agent, which asks Windows itself and may get further.
+    Unknown,
+}
+
+/// Asks only what *kind* of thing is there — deliberately not for the image
+/// itself: not carrying pixels over the boundary keeps the call cheap.
+///
+/// The answer is a word on stdout rather than an exit code, because an exit
+/// code cannot say "I could not ask". PowerShell exits non-zero for a wedged
+/// interop, a missing assembly and a clipboard without a picture alike, and
+/// only one of those three means "paste the text".
+///
+/// `ContainsText` is the tie-break, and it is what makes an ordinary copy
+/// survive: Excel, Word, Outlook and browsers all put a **bitmap alongside the
+/// text** on a normal copy, so `ContainsImage` alone is true for copying a
+/// spreadsheet row — and the press would be handed to the agent, which would
+/// fetch a picture of the row the person meant to paste as text. Only a
+/// clipboard that carries a picture and no text is an image paste.
+const CLIPBOARD_KIND: &str = "Add-Type -AssemblyName System.Windows.Forms; \
+     $c = [System.Windows.Forms.Clipboard]; \
+     if ($c::ContainsImage() -and -not $c::ContainsText()) { 'image' } else { 'other' }";
+
+/// What [`CLIPBOARD_KIND`] prints for a clipboard holding only a picture.
+const IMAGE_ANSWER: &str = "image";
+/// And for everything else. Named so an answer that is neither — a PowerShell
+/// banner, a profile's stray output, an error — is read as "could not ask"
+/// rather than as one of the two real answers.
+const OTHER_ANSWER: &str = "other";
 
 impl ImageProbe {
     /// Whether this machine is one where the question even arises.
@@ -329,7 +366,7 @@ impl ImageProbe {
     /// Taking the answer is what frees the next question: a probe that is never
     /// polled is never re-asked, which is the behaviour that keeps one wedged
     /// `powershell.exe` from becoming one per press.
-    pub fn poll(&mut self) -> Option<bool> {
+    pub fn poll(&mut self) -> Option<Verdict> {
         let (_, rx) = self.channel.as_ref()?;
         let answer = rx.try_recv().ok()?;
         self.in_flight = false;
@@ -340,26 +377,42 @@ impl ImageProbe {
 /// One PowerShell round trip. `false` for "no image", and also for every way
 /// the question could not be put: a machine that cannot answer is one whose
 /// clipboard thurbox pastes as text, which is what it did before this existed.
-fn windows_clipboard_has_image() -> bool {
-    let ask = |exe: &str| -> std::io::Result<bool> {
+fn windows_clipboard_has_image() -> Verdict {
+    let ask = |exe: &str| -> std::io::Result<Verdict> {
         let mut child = Command::new(exe)
             .args(["-NoProfile", "-NonInteractive", "-Sta", "-Command"])
-            .arg(CONTAINS_IMAGE)
+            .arg(CLIPBOARD_KIND)
             .stdin(Stdio::null())
-            .stdout(Stdio::null())
+            .stdout(Stdio::piped())
             .stderr(Stdio::null())
             .spawn()?;
-        // Past the spawn, every way this can go wrong is still just "no image":
-        // the fallback below is for a `powershell.exe` that could not be *found*,
-        // and running a second one because the first became unreadable would be
-        // two wedged processes instead of one.
-        Ok(wait_bounded(&mut child, PROBE_TIMEOUT))
+        // Past the spawn, a failure is a failure of *this* attempt: the fallback
+        // below is for a `powershell.exe` that could not be found, and running a
+        // second one because the first wedged would be two wedged processes
+        // instead of one — with the person waiting through both deadlines.
+        if !wait_bounded(&mut child, PROBE_TIMEOUT) {
+            return Ok(Verdict::Unknown);
+        }
+        let mut answer = String::new();
+        if let Some(mut out) = child.stdout.take() {
+            // A word, read after the child is gone: the pipe holds it, and
+            // nothing this small can fill the buffer and deadlock the wait.
+            let _ = out.read_to_string(&mut answer);
+        }
+        Ok(match answer.trim() {
+            IMAGE_ANSWER => Verdict::Image,
+            OTHER_ANSWER => Verdict::NotImage,
+            other => {
+                tracing::debug!("the Windows clipboard probe answered {other:?}");
+                Verdict::Unknown
+            }
+        })
     };
     match ask(POWERSHELL) {
-        Ok(answer) => answer,
+        Ok(verdict) => verdict,
         Err(e) => {
             tracing::debug!("{POWERSHELL} is not on PATH ({e}); trying the interop path");
-            ask(POWERSHELL_FALLBACK).unwrap_or(false)
+            ask(POWERSHELL_FALLBACK).unwrap_or(Verdict::Unknown)
         }
     }
 }
@@ -434,14 +487,22 @@ mod tests {
     ///
     /// Run against the real Windows clipboard, because what is being tested is
     /// the wiring — the argument list, `-Sta` (without it `Add-Type` throws and
-    /// every answer becomes "no image"), the `PATH`/interop fallback, and
-    /// reading the answer off the *exit code* rather than stdout. A helper
-    /// returning `false` would pass every test that stubbed this out.
+    /// every answer becomes "other"), the `PATH`/interop fallback, and reading
+    /// a word off stdout rather than a status. A helper returning a constant
+    /// would pass every test that stubbed this out.
     ///
-    /// Skipped where it cannot discriminate: off WSL, with no PowerShell, or
-    /// with no image on the clipboard — in that last case both a working probe
-    /// and a broken one say "no". Nothing here writes to the clipboard: a test
-    /// suite that destroys what you copied is worse than a test that skips.
+    /// The oracle is asked for both halves of the question, because the probe's
+    /// answer is a tie-break between them: a clipboard carrying a picture *and*
+    /// text is an ordinary rich copy (Excel, Word, a browser) and must paste as
+    /// text.
+    ///
+    /// Skipped where it cannot discriminate — off WSL, with no PowerShell —
+    /// and, importantly, **not** skipped merely because the oracle was unhappy:
+    /// a wedged interop exits non-zero with nothing on stdout, which the first
+    /// version of this test read as "no image on the clipboard" and passed on.
+    /// A skip says which of the two it was. Nothing here writes to the
+    /// clipboard: a test suite that destroys what you copied is worse than a
+    /// test that skips.
     #[test]
     fn the_windows_probe_agrees_with_powershell() {
         if !ImageProbe::applies() {
@@ -450,19 +511,37 @@ mod tests {
         }
         let oracle = Command::new(POWERSHELL)
             .args(["-NoProfile", "-NonInteractive", "-Sta", "-Command"])
-            .arg("Add-Type -AssemblyName System.Windows.Forms; [System.Windows.Forms.Clipboard]::ContainsImage()")
+            .arg(
+                "Add-Type -AssemblyName System.Windows.Forms; \
+                 $c = [System.Windows.Forms.Clipboard]; \
+                 \"$($c::ContainsImage()) $($c::ContainsText())\"",
+            )
             .output();
         let Ok(oracle) = oracle else {
             eprintln!("skipping: no powershell.exe on PATH");
             return;
         };
-        if !String::from_utf8_lossy(&oracle.stdout).trim().eq_ignore_ascii_case("true") {
-            eprintln!("skipping: no image on the Windows clipboard to recognise");
+        let said = String::from_utf8_lossy(&oracle.stdout).trim().to_lowercase();
+        let words: Vec<&str> = said.split_whitespace().collect();
+        let (Some(&image), Some(&text), true) = (words.first(), words.get(1), oracle.status.success())
+        else {
+            eprintln!(
+                "skipping: PowerShell could not be asked (status {:?}, said {said:?}) — \
+                 which is NOT the same as the clipboard holding no image",
+                oracle.status.code()
+            );
             return;
-        }
-        assert!(
+        };
+        let expected = if image == "true" && text != "true" {
+            Verdict::Image
+        } else {
+            Verdict::NotImage
+        };
+        assert_eq!(
             windows_clipboard_has_image(),
-            "PowerShell says the clipboard holds an image and the probe did not"
+            expected,
+            "PowerShell reports ContainsImage={image} ContainsText={text} and the \
+             probe disagreed"
         );
     }
 

--- a/src/coordinator/boot.rs
+++ b/src/coordinator/boot.rs
@@ -181,6 +181,7 @@ pub(crate) async fn run() -> Result<(), Box<dyn Error>> {
         repos: thurbox::kernel::repos::RepoStore::new(),
         metrics: Metrics::new(),
         clipboard: arboard::Clipboard::new().ok(),
+        image_probe: thurbox::clipboard::ImageProbe::default(),
         perf: Counters::default(),
         timings: thurbox::kernel::perf::Timings::default(),
         startup,

--- a/src/coordinator/boot.rs
+++ b/src/coordinator/boot.rs
@@ -183,6 +183,7 @@ pub(crate) async fn run() -> Result<(), Box<dyn Error>> {
         clipboard: arboard::Clipboard::new().ok(),
         image_probe: thurbox::clipboard::ImageProbe::default(),
         paste_targets: Vec::new(),
+        probed_presses: 0,
         perf: Counters::default(),
         timings: thurbox::kernel::perf::Timings::default(),
         startup,

--- a/src/coordinator/boot.rs
+++ b/src/coordinator/boot.rs
@@ -182,6 +182,7 @@ pub(crate) async fn run() -> Result<(), Box<dyn Error>> {
         metrics: Metrics::new(),
         clipboard: arboard::Clipboard::new().ok(),
         image_probe: thurbox::clipboard::ImageProbe::default(),
+        paste_targets: Vec::new(),
         perf: Counters::default(),
         timings: thurbox::kernel::perf::Timings::default(),
         startup,

--- a/src/coordinator/input.rs
+++ b/src/coordinator/input.rs
@@ -678,7 +678,12 @@ impl App {
             return true;
         }
         self.paste_targets.push(session);
-        self.image_probe.ask();
+        if self.image_probe.ask() {
+            // This question describes the clipboard as it is now, so it answers
+            // for the presses made by now — no more. A press that arrives while
+            // it is out gets one of its own, asked when this one comes back.
+            self.probed_presses = self.paste_targets.len();
+        }
         true
     }
 
@@ -708,19 +713,32 @@ impl App {
         true
     }
 
-    /// Act on what Windows said about its clipboard, for every press that was
-    /// waiting on the answer.
+    /// Act on what Windows said about its clipboard, for the presses that
+    /// question was asked for.
     ///
-    /// One answer serves them all: the question is about the clipboard, not
-    /// about the press, and it cannot have changed in the fifth of a second
-    /// between two of them. Each press is delivered to the session it was aimed
-    /// at, in the order they were made.
+    /// Only those: the answer describes the clipboard as it was when the
+    /// question went out, and what is copied can change while it is out — the
+    /// round trip is ~0.42 s, and a wedged one runs to its five-second
+    /// deadline. Applying it to a press made *after* it was asked is how an
+    /// image copied in between gets pasted as the text that preceded it, which
+    /// is the failure this whole path exists to prevent. Those presses are kept
+    /// and a fresh question is put for them here.
+    ///
+    /// Each press is delivered to the session it was aimed at, in the order
+    /// they were made.
     pub(crate) fn poll_image_probe(&mut self) {
         let Some(has_image) = self.image_probe.poll() else {
             return;
         };
-        for session in std::mem::take(&mut self.paste_targets) {
+        let answered = self.probed_presses.min(self.paste_targets.len());
+        self.probed_presses = 0;
+        let waiting = self.paste_targets.split_off(answered);
+        let answered = std::mem::replace(&mut self.paste_targets, waiting);
+        for session in answered {
             self.deliver_probed_paste(has_image, &session);
+        }
+        if !self.paste_targets.is_empty() && self.image_probe.ask() {
+            self.probed_presses = self.paste_targets.len();
         }
     }
 

--- a/src/coordinator/input.rs
+++ b/src/coordinator/input.rs
@@ -149,7 +149,7 @@ impl App {
         if self.dispatch_reserved(key) {
             return;
         }
-        if self.dispatch_clipboard(kernel_action.as_deref()) {
+        if self.dispatch_clipboard(kernel_action.as_deref(), key) {
             return;
         }
         if self.dispatch_grabbed(&press) {
@@ -269,8 +269,44 @@ impl App {
     /// They "must work from any pane", and a pane that grabs every key would
     /// otherwise swallow them. Any other kernel action falls through: this step
     /// claims only the two it knows.
-    pub(crate) fn dispatch_clipboard(&mut self, action: Option<&str>) -> bool {
-        action.is_some_and(|action| self.run_clipboard_action(action) == Some(true))
+    pub(crate) fn dispatch_clipboard(&mut self, action: Option<&str>, key: &KeyEvent) -> bool {
+        let Some(action) = action else {
+            return false;
+        };
+        match self.run_clipboard_action(action) {
+            Some(true) => true,
+            Some(false) => {
+                action == clipboard::PASTE_ACTION && self.hand_unencodable_paste_over(key)
+            }
+            None => false,
+        }
+    }
+
+    /// Hand on a declined paste the rest of `on_key` cannot deliver.
+    ///
+    /// Declining is how the chord reaches the agent, which fetches the image
+    /// itself — and it works because the press falls through to
+    /// [`Self::dispatch_session_input`], which encodes it for the pty. `Cmd+V`
+    /// has no such encoding: `key_to_bytes` returns `None` for every chord
+    /// carrying `SUPER`, so on macOS the chord a person actually presses was
+    /// dropped in silence, where before this it at least produced a (wrong)
+    /// hint. The byte is synthesised here instead, the way
+    /// [`Self::deliver_probed_paste`] does for an answer that arrives after the
+    /// press is gone.
+    ///
+    /// Only where the fall-through would itself have delivered: no overlay
+    /// owning typed input, and a focused pane that asked for raw session input.
+    fn hand_unencodable_paste_over(&mut self, key: &KeyEvent) -> bool {
+        if reaches_the_pty(key) {
+            return false;
+        }
+        if self.overlay_owns_input() || !self.focused_wants_session_input() {
+            return false;
+        }
+        let Some(surface) = self.focused_surface.clone() else {
+            return false;
+        };
+        self.send_to_surface(&surface, vec![CTRL_V])
     }
 
     /// Run the kernel's own clipboard actions, or report that this was not one.
@@ -725,15 +761,18 @@ impl App {
     /// terminals disable clipboard *reads* by default and probing for one can
     /// stall for seconds.
     fn paste_text_or_decline(&mut self) -> bool {
-        if self.clipboard.is_none() {
-            self.toast(thurbox::clipboard::PASTE_UNAVAILABLE_HINT);
-            return true;
+        let text = thurbox::clipboard::paste(self.clipboard.as_mut());
+        match (paste_route(self.clipboard.is_some(), text.is_some()), text) {
+            (PasteRoute::Hint, _) => {
+                self.toast(thurbox::clipboard::PASTE_UNAVAILABLE_HINT);
+                true
+            }
+            (PasteRoute::Send, Some(text)) => {
+                self.on_paste(text);
+                true
+            }
+            _ => false,
         }
-        let Some(text) = thurbox::clipboard::paste(self.clipboard.as_mut()) else {
-            return false;
-        };
-        self.on_paste(text);
-        true
     }
 
     /// Act on what Windows said about its clipboard, for the presses that
@@ -782,21 +821,68 @@ impl App {
     fn deliver_probed_paste(&mut self, verdict: thurbox::clipboard::Verdict, surface: &str) {
         use thurbox::clipboard::Verdict;
         if verdict == Verdict::NotImage {
-            if self.clipboard.is_none() {
-                self.toast(thurbox::clipboard::PASTE_UNAVAILABLE_HINT);
-                return;
-            }
-            if let Some(text) = thurbox::clipboard::paste(self.clipboard.as_mut()) {
-                self.paste_text_into(surface, &text);
-                return;
+            // The same decision the unprobed press makes, read from the same
+            // function: what Windows answered says only whether this press is
+            // thurbox's to handle, never what handling it looks like.
+            let text = thurbox::clipboard::paste(self.clipboard.as_mut());
+            match (paste_route(self.clipboard.is_some(), text.is_some()), text) {
+                (PasteRoute::Hint, _) => {
+                    self.toast(thurbox::clipboard::PASTE_UNAVAILABLE_HINT);
+                    return;
+                }
+                (PasteRoute::Send, Some(text)) => {
+                    self.paste_text_into(surface, &text);
+                    return;
+                }
+                _ => {}
             }
         }
-        const CTRL_V: u8 = 0x16;
         if !self.send_to_surface(surface, vec![CTRL_V]) {
             self.toast("no live terminal to paste into");
         }
     }
 }
+
+/// What a paste press does with the clipboard this machine has.
+///
+/// Two facts decide it, and this is the only place they are read together —
+/// the press that asks Windows first ends up here too, since the verdict says
+/// only whose press it is, never what to do with it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PasteRoute {
+    /// No local clipboard at all: the SSH case, where the terminal's own paste
+    /// is the way through and neither thurbox nor the agent can read anything.
+    Hint,
+    /// Text thurbox can carry itself.
+    Send,
+    /// Something thurbox cannot carry — a picture, or a clipboard it cannot
+    /// read. The chord is worth more to the agent, which fetches it itself.
+    GiveToAgent,
+}
+
+fn paste_route(clipboard_present: bool, yielded_text: bool) -> PasteRoute {
+    match (clipboard_present, yielded_text) {
+        (false, _) => PasteRoute::Hint,
+        (true, true) => PasteRoute::Send,
+        (true, false) => PasteRoute::GiveToAgent,
+    }
+}
+
+/// Whether declining this press hands it to the agent by itself.
+///
+/// A declined chord reaches the pane through `dispatch_session_input`, which
+/// can only send what `key_to_bytes` encodes. `SUPER` chords have no legacy
+/// encoding at all, so `Cmd+V` — the paste chord on macOS — falls through to
+/// nothing.
+fn reaches_the_pty(key: &KeyEvent) -> bool {
+    key_to_bytes(key.code, key.modifiers).is_some()
+}
+
+/// The paste chord as one byte on the wire — what an agent watches for before
+/// reading the clipboard itself, and the only spelling of a paste that survives
+/// both a press that has no pty encoding and an answer that arrives after the
+/// press is gone.
+const CTRL_V: u8 = 0x16;
 
 /// What a paste with nothing focused says. One message, because it is one
 /// situation: the press was made with no session's terminal in front of it.
@@ -855,6 +941,37 @@ fn resolve_altgr(key: KeyEvent, windows: bool) -> KeyEvent {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The half of this change that reaches every platform: a reachable
+    /// clipboard holding no text hands the press on instead of swallowing it,
+    /// which is what made pasting an image do nothing at all. Put `Some(true)`
+    /// back in `run_clipboard_action` and this is what says so.
+    #[test]
+    fn a_clipboard_with_nothing_to_paste_hands_the_press_on() {
+        assert_eq!(paste_route(true, false), PasteRoute::GiveToAgent);
+        assert_eq!(paste_route(true, true), PasteRoute::Send);
+        assert_eq!(
+            paste_route(false, false),
+            PasteRoute::Hint,
+            "with no clipboard on this machine there is nothing for the agent \
+             to read either"
+        );
+    }
+
+    /// And handing it on is only a hand-off for a chord the pty can carry.
+    ///
+    /// `Cmd+V` cannot be encoded, so a decline drops it: on macOS that is the
+    /// chord the paste binding is actually on.
+    #[test]
+    fn a_cmd_chord_cannot_be_handed_on_by_declining_it() {
+        let cmd_v = KeyEvent::new(KeyCode::Char('v'), KeyModifiers::SUPER);
+        let ctrl_v = KeyEvent::new(KeyCode::Char('v'), KeyModifiers::CONTROL);
+        assert!(
+            !reaches_the_pty(&cmd_v),
+            "a declined Cmd+V would reach the agent on its own"
+        );
+        assert!(reaches_the_pty(&ctrl_v));
+    }
 
     fn altgr(ch: char) -> KeyEvent {
         KeyEvent::new(KeyCode::Char(ch), KeyModifiers::CONTROL | KeyModifiers::ALT)

--- a/src/coordinator/input.rs
+++ b/src/coordinator/input.rs
@@ -420,17 +420,7 @@ impl App {
         let Some(bytes) = key_to_bytes(key.code, key.modifiers) else {
             return false;
         };
-        // Whether it lands is the terminal's business; either way the key belongs
-        // to the pane that asked for raw input and is not offered to anything
-        // else.
-        //
-        // Routed by what the pane is SHOWING. A program pane's keys go to that
-        // program and to nothing else — and a pane with nothing behind it
-        // swallows nothing, since neither send finds a target.
-        let delivered = match self.terminals.program_key(&surface).cloned() {
-            Some(program) => self.terminals.send_to_program(&program, bytes),
-            None => self.terminals.send(&surface, bytes),
-        };
+        let delivered = self.send_to_surface(&surface, bytes);
         // Delivered means consumed, which is what the rule above says and what
         // this now enforces. Falling through sent `Esc` to a program AND
         // dismissed the pane under it in one keypress — a game opening its menu
@@ -672,12 +662,12 @@ impl App {
         self.modals.is_open() || self.grabbed.is_some()
     }
 
-    /// Send `bytes` to a surface the way a keystroke reaches it.
+    /// Send `bytes` to a surface, routed by what the pane is **showing**.
     ///
-    /// The one routing rule: a pane showing a plugin's program talks to that
-    /// program, everything else to the session's terminal — the same match
-    /// `dispatch_session_input` makes, so a paste cannot land somewhere a
-    /// keystroke would not.
+    /// A pane showing a plugin's program talks to that program and nothing
+    /// else; everything else goes to the session's terminal. The one rule, so a
+    /// paste cannot land somewhere a keystroke would not — and a pane with
+    /// nothing behind it delivers nothing, since neither send finds a target.
     fn send_to_surface(&mut self, surface: &str, bytes: Vec<u8>) -> bool {
         match self.terminals.program_key(surface).cloned() {
             Some(program) => self.terminals.send_to_program(&program, bytes),
@@ -777,27 +767,21 @@ impl App {
 
     /// One press, answered.
     ///
-    /// A picture goes to the agent, which reads it itself; anything thurbox can
-    /// carry is an ordinary text paste. Two cases are given away rather than
-    /// swallowed: a clipboard with nothing on it for us, and an answer that
-    /// never came — an unanswerable question must not become "paste the text",
-    /// because the text under WSL is the stale one this path exists to stop.
-    /// `Ctrl+V` is one byte on the wire, and it is what Claude Code watches for
-    /// before reading the clipboard itself (`xclip`/`wl-paste`, or PowerShell
-    /// under WSL); sent directly rather than by letting the chord fall through,
-    /// because by the time the answer arrives the key press is long gone.
+    /// A picture is given to the agent, which reads it itself — and so is an
+    /// answer that never came, because an unanswerable question must not become
+    /// "paste the text" when the text under WSL is the stale one this path
+    /// exists to stop. The hand-off is a literal `Ctrl+V` byte rather than a
+    /// fall-through to the chord, since by now the key press is long gone; that
+    /// byte is what Claude Code watches for before reading the clipboard itself
+    /// (`xclip`/`wl-paste`, or PowerShell under WSL).
     ///
-    /// Delivered even if a modal or a float has gone up since — unlike a
-    /// keystroke, this press already named its destination, so putting it there
-    /// is not a leak past the overlay but the thing that was asked for. What an
-    /// overlay does prevent is the *question*, which is never asked while one
-    /// is up.
+    /// Delivered even if a modal or a float has gone up since: this press
+    /// already named its destination, so putting it there is not a leak past
+    /// the overlay but the thing that was asked for. What an overlay prevents
+    /// is the *question* — see [`Self::paste_into_focused`].
     fn deliver_probed_paste(&mut self, verdict: thurbox::clipboard::Verdict, surface: &str) {
         use thurbox::clipboard::Verdict;
         if verdict == Verdict::NotImage {
-            // No local clipboard at all — the SSH case — is the one decline that
-            // would help nobody: there is nothing on that machine for the agent
-            // to read either.
             if self.clipboard.is_none() {
                 self.toast(thurbox::clipboard::PASTE_UNAVAILABLE_HINT);
                 return;

--- a/src/coordinator/input.rs
+++ b/src/coordinator/input.rs
@@ -275,11 +275,11 @@ impl App {
 
     /// Run the kernel's own clipboard actions, or report that this was not one.
     ///
-    /// `Some(false)` is the load-bearing answer: copy with **no selection**
-    /// declines the chord, so `Ctrl+C` falls through to the focused agent and
-    /// still interrupts a turn. That is the one case where thurbox wins the
-    /// chord back from the terminal, and it is decided per press rather than by
-    /// the binding — see [`thurbox::kernel::clipboard`].
+    /// `Some(false)` is the load-bearing answer, and both chords use it: copy
+    /// with **no selection** declines, so `Ctrl+C` falls through to the focused
+    /// agent and still interrupts a turn; paste with **nothing pasteable**
+    /// declines for the reason [`Self::paste_into_focused`] gives. Decided per
+    /// press rather than by the binding — see [`thurbox::kernel::clipboard`].
     pub(crate) fn run_clipboard_action(&mut self, action: &str) -> Option<bool> {
         match action {
             clipboard::COPY_ACTION => {
@@ -292,10 +292,7 @@ impl App {
                 self.copy_selection();
                 Some(true)
             }
-            clipboard::PASTE_ACTION => {
-                self.paste_into_focused();
-                Some(true)
-            }
+            clipboard::PASTE_ACTION => Some(self.paste_into_focused()),
             _ => None,
         }
     }
@@ -511,11 +508,17 @@ impl App {
                 return;
             }
             // Chosen by name rather than pressed, so a decline falls through to
-            // nothing and would look like a dead row: say why instead.
+            // nothing and would look like a dead row: say why instead. Both
+            // chords can decline and they decline for different reasons, so the
+            // message follows the action rather than assuming copy.
             match self.run_clipboard_action(action) {
                 Some(true) => return,
                 Some(false) => {
-                    self.toast("nothing to copy");
+                    self.toast(if action == thurbox::kernel::clipboard::PASTE_ACTION {
+                        "nothing to paste — the clipboard holds no text"
+                    } else {
+                        "nothing to copy"
+                    });
                     return;
                 }
                 None => {}
@@ -610,21 +613,109 @@ impl App {
         });
     }
 
-    /// Paste the clipboard into the focused session's terminal.
+    /// Paste the clipboard into the focused session's terminal, or decline the
+    /// chord when there is no text to paste.
     ///
     /// Sent as a bracketed paste, so a multi-line paste arrives as text rather
     /// than as a series of submissions — an agent prompt with newlines in it
     /// would otherwise fire on the first one.
-    pub(crate) fn paste_into_focused(&mut self) {
-        let Some(text) = thurbox::clipboard::paste(self.clipboard.as_mut()) else {
-            // No OSC 52 read fallback: terminals disable clipboard *reads* by
-            // default and probing for one can stall for seconds. The route that
-            // does work here is the terminal's own paste chord, which arrives as
-            // `Event::Paste` — so point at it rather than reporting a dead end.
+    ///
+    /// **A local clipboard holding no text is not an error, it is someone else's
+    /// paste.** An image is the case that matters: thurbox can only send text, so
+    /// swallowing `Ctrl+V` there means the press does nothing at all — which is
+    /// what "pasting a screenshot into claude through thurbox does nothing" was.
+    /// The agent in the pane does know how to fetch it: Claude Code reads the
+    /// clipboard itself when it sees `Ctrl+V`, shelling out to `xclip`/`wl-paste`
+    /// (and, under WSL, to PowerShell). Declining lets the press reach it.
+    ///
+    /// No clipboard **at all** — the SSH case — still gets the hint instead:
+    /// there is nothing on that machine for the agent to read either, and the
+    /// route that does work is the terminal's own paste chord, which arrives as
+    /// `Event::Paste`. There is no OSC 52 read fallback because terminals
+    /// disable clipboard *reads* by default and probing for one can stall for
+    /// seconds.
+    pub(crate) fn paste_into_focused(&mut self) -> bool {
+        // Inside WSL the local clipboard is not the one being copied into, so
+        // this press cannot be answered here at all: Windows has to be asked,
+        // and asking costs ~0.42 s. The press is claimed, the answer acts on it
+        // — [`Self::poll_image_probe`].
+        if thurbox::clipboard::ImageProbe::applies() {
+            self.image_probe.ask();
+            return true;
+        }
+        self.paste_text_or_decline()
+    }
+
+    /// Paste the clipboard's text, or decline the chord when there is none.
+    ///
+    /// Declining is what makes an image paste work at all. thurbox can only
+    /// send text, so swallowing the press there means it does nothing — which
+    /// is what "pasting a screenshot into claude through thurbox does nothing"
+    /// was. The agent in the pane *can* fetch an image, and does so on seeing
+    /// the paste chord itself, so the press is worth more to it than to us.
+    ///
+    /// No clipboard **at all** — the SSH case — is the one decline that would
+    /// help nobody: there is nothing on that machine for the agent to read
+    /// either. That gets the hint pointing at the terminal's own paste, which
+    /// arrives as `Event::Paste`. There is no OSC 52 read fallback, because
+    /// terminals disable clipboard *reads* by default and probing for one can
+    /// stall for seconds.
+    fn paste_text_or_decline(&mut self) -> bool {
+        if self.clipboard.is_none() {
             self.toast(thurbox::clipboard::PASTE_UNAVAILABLE_HINT);
-            return;
+            return true;
+        }
+        let Some(text) = thurbox::clipboard::paste(self.clipboard.as_mut()) else {
+            return false;
         };
         self.on_paste(text);
+        true
+    }
+
+    /// Act on what Windows said about its clipboard, one paste press ago.
+    ///
+    /// An image goes to the agent, which reads it itself; anything else is an
+    /// ordinary text paste. "Neither" — no image on the Windows side and no
+    /// text on ours — also goes to the agent: thurbox has nothing to offer and
+    /// the press is better spent on something that might.
+    ///
+    /// Focus is resolved now rather than remembered from the press: 0.42 s is
+    /// long enough to change panes, and a paste belongs in the pane the person
+    /// is looking at when it lands.
+    pub(crate) fn poll_image_probe(&mut self) {
+        let Some(has_image) = self.image_probe.poll() else {
+            return;
+        };
+        if has_image || !self.paste_text_or_decline() {
+            self.forward_paste_chord();
+        }
+    }
+
+    /// Send the paste chord itself to the focused terminal.
+    ///
+    /// `Ctrl+V` is one byte on the wire, and it is what Claude Code watches for
+    /// before reading the clipboard itself (`xclip`/`wl-paste`, or PowerShell
+    /// under WSL). Sent directly rather than by letting the chord fall through,
+    /// because by the time the answer arrives the key press is long gone.
+    fn forward_paste_chord(&mut self) {
+        const CTRL_V: u8 = 0x16;
+        // A modal or a float owns typed input while it is up, and a paste must
+        // never leak into the terminal behind the overlay — the same rule
+        // `on_paste` follows. There is nothing to hand an image to here (a name
+        // field cannot take one), so the press is dropped rather than routed.
+        if self.modals.is_open() || self.grabbed.is_some() {
+            return;
+        }
+        let Some(session) = self.focused_session.clone() else {
+            self.report(
+                "nothing to paste into — focus a session's terminal first",
+                Level::Error,
+            );
+            return;
+        };
+        if !self.terminals.send(&session, vec![CTRL_V]) {
+            self.toast("no live terminal to paste into");
+        }
     }
 }
 

--- a/src/coordinator/input.rs
+++ b/src/coordinator/input.rs
@@ -837,7 +837,17 @@ impl App {
                 _ => {}
             }
         }
-        if !self.send_to_surface(surface, vec![CTRL_V]) {
+        // Said out loud, because this is the one delivery the person may not
+        // see happen: the press can land behind a modal or a float that went up
+        // while the question was out, and what arrives there is a byte the
+        // agent acts on rather than text appearing in a prompt. The text path
+        // (`paste_text_into`) already reports itself the same way.
+        if self.send_to_surface(surface, vec![CTRL_V]) {
+            self.toast(match verdict {
+                Verdict::Image => "image left to the agent to fetch",
+                _ => "Windows could not be asked; the paste went to the agent",
+            });
+        } else {
             self.toast("no live terminal to paste into");
         }
     }

--- a/src/coordinator/input.rs
+++ b/src/coordinator/input.rs
@@ -594,20 +594,24 @@ impl App {
             return;
         }
 
-        let Some(session) = self.focused_session.clone() else {
+        let Some(surface) = self.focused_surface.clone() else {
             self.report(NOTHING_TO_PASTE_INTO, Level::Error);
             return;
         };
-        self.paste_text_into(&session, &text);
+        self.paste_text_into(&surface, &text);
     }
 
-    /// Send `text` to one session's terminal as a bracketed paste.
+    /// Send `text` to one surface as a bracketed paste.
     ///
-    /// Takes the session rather than reading the focus, because not every paste
+    /// Takes the surface rather than reading the focus, because not every paste
     /// is delivered in the same turn it was asked for: the WSL image probe
     /// answers ~0.42 s later, and the pane the press was aimed at is the one it
     /// belongs in — see [`Self::poll_image_probe`].
-    fn paste_text_into(&mut self, session: &str, text: &str) {
+    ///
+    /// A *surface*, not a session, so a paste lands where a keystroke would:
+    /// `dispatch_session_input` routes by what the pane is showing, and a pane
+    /// showing a plugin's program used to take typing and refuse pastes.
+    fn paste_text_into(&mut self, surface: &str, text: &str) {
         if text.is_empty() {
             return;
         }
@@ -616,7 +620,8 @@ impl App {
         bytes.extend_from_slice(text.as_bytes());
         bytes.extend_from_slice(b"\x1b[201~");
 
-        self.toast(if self.terminals.send(session, bytes) {
+        let delivered = self.send_to_surface(surface, bytes);
+        self.toast(if delivered {
             format!("pasted {} character(s)", text.chars().count())
         } else {
             "no live terminal to paste into".to_string()
@@ -649,10 +654,35 @@ impl App {
         // this press cannot be answered here at all: Windows has to be asked,
         // and asking costs ~0.42 s. The press is claimed, the answer acts on it
         // — [`Self::poll_image_probe`].
-        if thurbox::clipboard::ImageProbe::applies() {
+        //
+        // Not while an overlay owns typed input, though: a float's name field
+        // cannot take a picture, so the question has no answer worth 0.42 s —
+        // and asking anyway used to *swallow* the press, because the clipboard
+        // stage runs before `dispatch_grabbed` and the answer then found the
+        // float still up. Pasting a repository path into the new-session wizard
+        // did nothing at all under WSL.
+        if thurbox::clipboard::ImageProbe::applies() && !self.overlay_owns_input() {
             return self.ask_windows_about_this_press();
         }
         self.paste_text_or_decline()
+    }
+
+    /// Whether a modal or a float is taking typed input right now.
+    fn overlay_owns_input(&self) -> bool {
+        self.modals.is_open() || self.grabbed.is_some()
+    }
+
+    /// Send `bytes` to a surface the way a keystroke reaches it.
+    ///
+    /// The one routing rule: a pane showing a plugin's program talks to that
+    /// program, everything else to the session's terminal — the same match
+    /// `dispatch_session_input` makes, so a paste cannot land somewhere a
+    /// keystroke would not.
+    fn send_to_surface(&mut self, surface: &str, bytes: Vec<u8>) -> bool {
+        match self.terminals.program_key(surface).cloned() {
+            Some(program) => self.terminals.send_to_program(&program, bytes),
+            None => self.terminals.send(surface, bytes),
+        }
     }
 
     /// Claim this press and put the question to Windows, remembering where the
@@ -666,7 +696,7 @@ impl App {
     /// Nothing focused is answered at once rather than by asking: the press has
     /// nowhere to land whatever Windows says.
     fn ask_windows_about_this_press(&mut self) -> bool {
-        let Some(session) = self.focused_session.clone() else {
+        let Some(surface) = self.focused_surface.clone() else {
             self.report(NOTHING_TO_PASTE_INTO, Level::Error);
             return true;
         };
@@ -675,9 +705,12 @@ impl App {
         // every one of them is a paste owed. Past this many the repeat is no
         // longer someone asking for another paste.
         if self.paste_targets.len() >= MAX_WAITING_PASTES {
+            tracing::debug!(
+                "{MAX_WAITING_PASTES} pastes are already waiting on Windows; dropping this press"
+            );
             return true;
         }
-        self.paste_targets.push(session);
+        self.paste_targets.push(surface);
         if self.image_probe.ask() {
             // This question describes the clipboard as it is now, so it answers
             // for the presses made by now — no more. A press that arrives while
@@ -727,15 +760,15 @@ impl App {
     /// Each press is delivered to the session it was aimed at, in the order
     /// they were made.
     pub(crate) fn poll_image_probe(&mut self) {
-        let Some(has_image) = self.image_probe.poll() else {
+        let Some(verdict) = self.image_probe.poll() else {
             return;
         };
         let answered = self.probed_presses.min(self.paste_targets.len());
         self.probed_presses = 0;
         let waiting = self.paste_targets.split_off(answered);
         let answered = std::mem::replace(&mut self.paste_targets, waiting);
-        for session in answered {
-            self.deliver_probed_paste(has_image, &session);
+        for surface in answered {
+            self.deliver_probed_paste(verdict, &surface);
         }
         if !self.paste_targets.is_empty() && self.image_probe.ask() {
             self.probed_presses = self.paste_targets.len();
@@ -744,23 +777,24 @@ impl App {
 
     /// One press, answered.
     ///
-    /// An image goes to the agent, which reads it itself; anything else is an
-    /// ordinary text paste. "Neither" — no image on the Windows side and no text
-    /// on ours — also goes to the agent: thurbox has nothing to offer and the
-    /// press is better spent on something that might. `Ctrl+V` is one byte on
-    /// the wire, and it is what Claude Code watches for before reading the
-    /// clipboard itself (`xclip`/`wl-paste`, or PowerShell under WSL); sent
-    /// directly rather than by letting the chord fall through, because by the
-    /// time the answer arrives the key press is long gone.
-    fn deliver_probed_paste(&mut self, has_image: bool, session: &str) {
-        // A modal or a float owns typed input while it is up, and a paste must
-        // never leak into the terminal behind the overlay — the same rule
-        // `on_paste` follows. One opened while the question was out, so this is
-        // checked here and not only at the press.
-        if self.modals.is_open() || self.grabbed.is_some() {
-            return;
-        }
-        if !has_image {
+    /// A picture goes to the agent, which reads it itself; anything thurbox can
+    /// carry is an ordinary text paste. Two cases are given away rather than
+    /// swallowed: a clipboard with nothing on it for us, and an answer that
+    /// never came — an unanswerable question must not become "paste the text",
+    /// because the text under WSL is the stale one this path exists to stop.
+    /// `Ctrl+V` is one byte on the wire, and it is what Claude Code watches for
+    /// before reading the clipboard itself (`xclip`/`wl-paste`, or PowerShell
+    /// under WSL); sent directly rather than by letting the chord fall through,
+    /// because by the time the answer arrives the key press is long gone.
+    ///
+    /// Delivered even if a modal or a float has gone up since — unlike a
+    /// keystroke, this press already named its destination, so putting it there
+    /// is not a leak past the overlay but the thing that was asked for. What an
+    /// overlay does prevent is the *question*, which is never asked while one
+    /// is up.
+    fn deliver_probed_paste(&mut self, verdict: thurbox::clipboard::Verdict, surface: &str) {
+        use thurbox::clipboard::Verdict;
+        if verdict == Verdict::NotImage {
             // No local clipboard at all — the SSH case — is the one decline that
             // would help nobody: there is nothing on that machine for the agent
             // to read either.
@@ -769,12 +803,12 @@ impl App {
                 return;
             }
             if let Some(text) = thurbox::clipboard::paste(self.clipboard.as_mut()) {
-                self.paste_text_into(session, &text);
+                self.paste_text_into(surface, &text);
                 return;
             }
         }
         const CTRL_V: u8 = 0x16;
-        if !self.terminals.send(session, vec![CTRL_V]) {
+        if !self.send_to_surface(surface, vec![CTRL_V]) {
             self.toast("no live terminal to paste into");
         }
     }

--- a/src/coordinator/input.rs
+++ b/src/coordinator/input.rs
@@ -595,18 +595,28 @@ impl App {
         }
 
         let Some(session) = self.focused_session.clone() else {
-            self.report(
-                "nothing to paste into — focus a session's terminal first",
-                Level::Error,
-            );
+            self.report(NOTHING_TO_PASTE_INTO, Level::Error);
             return;
         };
+        self.paste_text_into(&session, &text);
+    }
+
+    /// Send `text` to one session's terminal as a bracketed paste.
+    ///
+    /// Takes the session rather than reading the focus, because not every paste
+    /// is delivered in the same turn it was asked for: the WSL image probe
+    /// answers ~0.42 s later, and the pane the press was aimed at is the one it
+    /// belongs in — see [`Self::poll_image_probe`].
+    fn paste_text_into(&mut self, session: &str, text: &str) {
+        if text.is_empty() {
+            return;
+        }
         let mut bytes = Vec::with_capacity(text.len() + 12);
         bytes.extend_from_slice(b"\x1b[200~");
         bytes.extend_from_slice(text.as_bytes());
         bytes.extend_from_slice(b"\x1b[201~");
 
-        self.toast(if self.terminals.send(&session, bytes) {
+        self.toast(if self.terminals.send(session, bytes) {
             format!("pasted {} character(s)", text.chars().count())
         } else {
             "no live terminal to paste into".to_string()
@@ -640,10 +650,36 @@ impl App {
         // and asking costs ~0.42 s. The press is claimed, the answer acts on it
         // — [`Self::poll_image_probe`].
         if thurbox::clipboard::ImageProbe::applies() {
-            self.image_probe.ask();
-            return true;
+            return self.ask_windows_about_this_press();
         }
         self.paste_text_or_decline()
+    }
+
+    /// Claim this press and put the question to Windows, remembering where the
+    /// press was aimed.
+    ///
+    /// The target is resolved **now**: the answer is ~0.42 s away, which is long
+    /// enough to focus another pane, and a paste that lands in a pane it was not
+    /// aimed at corrupts whatever is being typed there — the same failure, in
+    /// the other direction, as pasting stale text.
+    ///
+    /// Nothing focused is answered at once rather than by asking: the press has
+    /// nowhere to land whatever Windows says.
+    fn ask_windows_about_this_press(&mut self) -> bool {
+        let Some(session) = self.focused_session.clone() else {
+            self.report(NOTHING_TO_PASTE_INTO, Level::Error);
+            return true;
+        };
+        // Key auto-repeat outruns the answer: holding `Ctrl+V` makes presses at
+        // tens a second against a question that takes a fifth of a second, and
+        // every one of them is a paste owed. Past this many the repeat is no
+        // longer someone asking for another paste.
+        if self.paste_targets.len() >= MAX_WAITING_PASTES {
+            return true;
+        }
+        self.paste_targets.push(session);
+        self.image_probe.ask();
+        true
     }
 
     /// Paste the clipboard's text, or decline the chord when there is none.
@@ -672,52 +708,68 @@ impl App {
         true
     }
 
-    /// Act on what Windows said about its clipboard, one paste press ago.
+    /// Act on what Windows said about its clipboard, for every press that was
+    /// waiting on the answer.
     ///
-    /// An image goes to the agent, which reads it itself; anything else is an
-    /// ordinary text paste. "Neither" — no image on the Windows side and no
-    /// text on ours — also goes to the agent: thurbox has nothing to offer and
-    /// the press is better spent on something that might.
-    ///
-    /// Focus is resolved now rather than remembered from the press: 0.42 s is
-    /// long enough to change panes, and a paste belongs in the pane the person
-    /// is looking at when it lands.
+    /// One answer serves them all: the question is about the clipboard, not
+    /// about the press, and it cannot have changed in the fifth of a second
+    /// between two of them. Each press is delivered to the session it was aimed
+    /// at, in the order they were made.
     pub(crate) fn poll_image_probe(&mut self) {
         let Some(has_image) = self.image_probe.poll() else {
             return;
         };
-        if has_image || !self.paste_text_or_decline() {
-            self.forward_paste_chord();
+        for session in std::mem::take(&mut self.paste_targets) {
+            self.deliver_probed_paste(has_image, &session);
         }
     }
 
-    /// Send the paste chord itself to the focused terminal.
+    /// One press, answered.
     ///
-    /// `Ctrl+V` is one byte on the wire, and it is what Claude Code watches for
-    /// before reading the clipboard itself (`xclip`/`wl-paste`, or PowerShell
-    /// under WSL). Sent directly rather than by letting the chord fall through,
-    /// because by the time the answer arrives the key press is long gone.
-    fn forward_paste_chord(&mut self) {
-        const CTRL_V: u8 = 0x16;
+    /// An image goes to the agent, which reads it itself; anything else is an
+    /// ordinary text paste. "Neither" — no image on the Windows side and no text
+    /// on ours — also goes to the agent: thurbox has nothing to offer and the
+    /// press is better spent on something that might. `Ctrl+V` is one byte on
+    /// the wire, and it is what Claude Code watches for before reading the
+    /// clipboard itself (`xclip`/`wl-paste`, or PowerShell under WSL); sent
+    /// directly rather than by letting the chord fall through, because by the
+    /// time the answer arrives the key press is long gone.
+    fn deliver_probed_paste(&mut self, has_image: bool, session: &str) {
         // A modal or a float owns typed input while it is up, and a paste must
         // never leak into the terminal behind the overlay — the same rule
-        // `on_paste` follows. There is nothing to hand an image to here (a name
-        // field cannot take one), so the press is dropped rather than routed.
+        // `on_paste` follows. One opened while the question was out, so this is
+        // checked here and not only at the press.
         if self.modals.is_open() || self.grabbed.is_some() {
             return;
         }
-        let Some(session) = self.focused_session.clone() else {
-            self.report(
-                "nothing to paste into — focus a session's terminal first",
-                Level::Error,
-            );
-            return;
-        };
-        if !self.terminals.send(&session, vec![CTRL_V]) {
+        if !has_image {
+            // No local clipboard at all — the SSH case — is the one decline that
+            // would help nobody: there is nothing on that machine for the agent
+            // to read either.
+            if self.clipboard.is_none() {
+                self.toast(thurbox::clipboard::PASTE_UNAVAILABLE_HINT);
+                return;
+            }
+            if let Some(text) = thurbox::clipboard::paste(self.clipboard.as_mut()) {
+                self.paste_text_into(session, &text);
+                return;
+            }
+        }
+        const CTRL_V: u8 = 0x16;
+        if !self.terminals.send(session, vec![CTRL_V]) {
             self.toast("no live terminal to paste into");
         }
     }
 }
+
+/// What a paste with nothing focused says. One message, because it is one
+/// situation: the press was made with no session's terminal in front of it.
+const NOTHING_TO_PASTE_INTO: &str = "nothing to paste into — focus a session's terminal first";
+
+/// How many presses may be waiting on one answer. Well above a person pressing
+/// `Ctrl+V` twice and well below what auto-repeat produces in the ~0.42 s the
+/// answer takes.
+const MAX_WAITING_PASTES: usize = 8;
 
 /// Undo Windows' spelling of AltGr, which is `Ctrl+Alt`.
 ///

--- a/src/coordinator/mod.rs
+++ b/src/coordinator/mod.rs
@@ -351,6 +351,10 @@ impl App {
                 .dispatch(thurbox::kernel::command::Command::Reap);
         }
 
+        // What Windows said about its clipboard, for a paste press that could
+        // not be answered when it happened (WSL only — `clipboard::ImageProbe`).
+        self.poll_image_probe();
+
         // An update that replaced binaries is worth saying once; a check that
         // merely found a release shows up in the header instead.
         if let Some(message) = self.updates.poll() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -243,6 +243,16 @@ struct App {
     /// clipboard rather than the one being copied into — see
     /// [`thurbox::clipboard::ImageProbe`].
     image_probe: thurbox::clipboard::ImageProbe,
+    /// The sessions the presses waiting on [`Self::image_probe`] were aimed at,
+    /// in the order they were made.
+    ///
+    /// Remembered rather than resolved when the answer lands: the question takes
+    /// ~0.42 s, which is long enough to change panes, and a paste belongs where
+    /// it was aimed — a prompt typed into whichever pane happened to be focused
+    /// a third of a second later is the corruption this whole path exists to
+    /// avoid. Bounded, because key auto-repeat makes presses faster than
+    /// answers.
+    paste_targets: Vec<String>,
     notifier: Notifier,
     perf: Counters,
     /// Wall-clock stats, populated only while timing is active (ADR-P11).

--- a/src/main.rs
+++ b/src/main.rs
@@ -237,6 +237,12 @@ struct App {
     /// is exactly what happened while this field did not exist. v1 holds the
     /// same handle for the same reason.
     clipboard: Option<arboard::Clipboard>,
+    /// Whether the Windows clipboard holds an image, asked on a thread.
+    ///
+    /// Only ever used inside WSL, where [`Self::clipboard`] answers about the X
+    /// clipboard rather than the one being copied into — see
+    /// [`thurbox::clipboard::ImageProbe`].
+    image_probe: thurbox::clipboard::ImageProbe,
     notifier: Notifier,
     perf: Counters,
     /// Wall-clock stats, populated only while timing is active (ADR-P11).

--- a/src/main.rs
+++ b/src/main.rs
@@ -253,6 +253,12 @@ struct App {
     /// avoid. Bounded, because key auto-repeat makes presses faster than
     /// answers.
     paste_targets: Vec<String>,
+    /// How many of [`Self::paste_targets`] the question now out was asked for.
+    ///
+    /// The answer describes the clipboard at the moment it was asked, so it is
+    /// spent only on the presses already made by then; the rest wait for a
+    /// question of their own.
+    probed_presses: usize,
     notifier: Notifier,
     perf: Counters,
     /// Wall-clock stats, populated only while timing is active (ADR-P11).

--- a/tests/architecture_rules.rs
+++ b/tests/architecture_rules.rs
@@ -194,7 +194,7 @@ const MODULE_RULES: &[ModuleRules] = &[
     // and never reaches into agent / ui / app / storage.
     ModuleRules {
         name: "clipboard",
-        allowed: &["session"],
+        allowed: &["paths", "session"],
         allowed_path_only: &[],
     },
 ];

--- a/tests/tui_e2e.rs
+++ b/tests/tui_e2e.rs
@@ -850,6 +850,12 @@ fn repo(under: &Path) -> PathBuf {
 /// agent-neutral, so a shell is as good an agent as any and the only one CI
 /// has.
 fn shell_session() -> Option<(Profile, Tui)> {
+    shell_session_with(|_| {})
+}
+
+/// The same, with the binary's environment adjusted — for the cases where what
+/// is being tested is what thurbox does with the machine it thinks it is on.
+fn shell_session_with(adjust: impl FnOnce(&mut Command)) -> Option<(Profile, Tui)> {
     if !have_tmux() {
         eprintln!("skipping: tmux is not installed");
         return None;
@@ -877,7 +883,7 @@ fn shell_session() -> Option<(Profile, Tui)> {
     // headless answer to it.
     profile.cli(&["config", "accept-interface"]);
 
-    let tui = Tui::spawn(&profile, 40, 120);
+    let tui = Tui::spawn_with(&profile, 40, 120, adjust);
     tui.wait_for("probe");
 
     // The agent pane has focus at boot, and the action band names the focused
@@ -1262,6 +1268,126 @@ fn the_scrollbar_can_be_pressed_and_dragged() {
     // And a press on the track alone is a jump, with no drag behind it.
     tui.drag_down((column, top + 1), top + 1);
     tui.wait_for("tb-bar-marker");
+
+    let status = tui.quit();
+    assert!(status.success(), "exit must be clean: {status:?}");
+}
+
+// --- the WSL image probe, through the real binary ---------------------------
+
+/// A stand-in for `powershell.exe` that records every call and answers `answer`.
+///
+/// The probe resolves PowerShell through `PATH` (`clipboard::POWERSHELL`), so a
+/// directory in front of the real one is the whole trick — no Windows, and no
+/// need for a real clipboard to be in any particular state.
+fn stub_powershell(dir: &Path, answer: &str) -> PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+    let bin = dir.join("winbin");
+    std::fs::create_dir_all(&bin).expect("mkdir winbin");
+    let script = bin.join("powershell.exe");
+    std::fs::write(
+        &script,
+        format!("#!/bin/sh\necho call >> \"$(dirname \"$0\")/asked\"\necho {answer}\n"),
+    )
+    .expect("write the stub");
+    std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+    bin
+}
+
+/// How many times the stub has been asked.
+fn asked(bin: &Path) -> usize {
+    std::fs::read_to_string(bin.join("asked"))
+        .map(|log| log.lines().count())
+        .unwrap_or(0)
+}
+
+/// Waits for the stub to have been asked `n` times, and says so if it never is.
+fn wait_for_asks(bin: &Path, n: usize, tui: &Tui) {
+    let deadline = Instant::now() + Duration::from_secs(20);
+    while asked(bin) < n && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert_eq!(
+        asked(bin),
+        n,
+        "Windows was asked {} times, not {n}\n--- frame ---\n{}",
+        asked(bin),
+        tui.frame()
+    );
+}
+
+/// Inside WSL every `Ctrl+V` asks Windows — one question per press, and none at
+/// all while a float is holding the keyboard.
+///
+/// The whole route, through the real binary: the press is claimed by the
+/// clipboard stage, the question goes out on a worker, the answer is polled
+/// back on the loop and spent, and only then can the next question be asked.
+/// Nothing below the binary is stubbed except Windows itself — a directory in
+/// front of `PATH` holding a `powershell.exe` that counts its calls.
+///
+/// Two failures are covered that unit tests cannot reach:
+///
+/// - **the answer is never polled.** Deleting `poll_image_probe` from the loop
+///   leaves every unit test green, because `ImageProbe` is perfectly happy
+///   never to be asked again — but the interface then swallows every paste for
+///   the rest of the session. Here the second press has to reach Windows, which
+///   it can only do after the first answer was taken.
+/// - **a float's paste is swallowed.** The clipboard stage runs *before*
+///   `dispatch_grabbed`, so asking Windows while the new-session wizard is up
+///   claims a press that the float should have had — and the answer, arriving
+///   0.42 s later, finds the float still there and drops it. Pasting a path
+///   into the wizard did nothing at all under WSL.
+#[test]
+fn a_paste_under_wsl_asks_windows_once_per_press_and_never_from_a_float() {
+    let windows = tempfile::tempdir().expect("tempdir");
+    // "image" so the answer is spent on forwarding the chord to the shell,
+    // which leaves the message band clean for the float's own report below.
+    let bin = stub_powershell(windows.path(), "image");
+    let path = format!(
+        "{}:{}",
+        bin.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    let Some((_profile, mut tui)) = shell_session_with(|cmd| {
+        cmd.env("WSL_DISTRO_NAME", "Ubuntu");
+        cmd.env("PATH", path);
+        // No X clipboard, so the float below reports the one thing it can
+        // report rather than pasting whatever this machine happens to hold.
+        cmd.env_remove("DISPLAY");
+        cmd.env_remove("WAYLAND_DISPLAY");
+    }) else {
+        return;
+    };
+
+    const CTRL_V: &[u8] = &[0x16];
+    const CTRL_N: &[u8] = &[0x0e];
+
+    tui.send(CTRL_V);
+    wait_for_asks(&bin, 1, &tui);
+    // The second press is the assertion: it can only reach Windows if the first
+    // answer came back, was polled on the loop, and freed the question.
+    tui.send(CTRL_V);
+    wait_for_asks(&bin, 2, &tui);
+
+    // Now the wizard, which floats and therefore holds the keyboard.
+    tui.send(CTRL_N);
+    // Its first question is "Run On" where the machine has hosts and "Select
+    // Repos" where it has none — this one has sibling WSL distros, so which it
+    // is depends on the machine and neither is the point.
+    tui.wait_until("the new-session wizard to be up", |frame| {
+        frame.contains("Run On") || frame.contains("Select Repos")
+    });
+    tui.send(CTRL_V);
+    // It has nothing to paste from — that is what the missing X clipboard
+    // buys — and saying so is proof the press was handled here rather than
+    // spent on a question the float could never use the answer to.
+    tui.wait_for("No local clipboard");
+    assert_eq!(
+        asked(&bin),
+        2,
+        "a press made into a float asked Windows about an image a name field \
+         could not take"
+    );
 
     let status = tui.quit();
     assert!(status.success(), "exit must be clean: {status:?}");


### PR DESCRIPTION
Pasting a screenshot into an agent pane did nothing. `Ctrl+V` is a global binding that always claims the press, and thurbox's clipboard transport carries text — so the image was dropped and the press never reached the CLI in the pane, which is the one thing here that can read an image.

Claude Code fetches it itself on seeing `Ctrl+V` — its trigger is the key event (`if(e.key!=="v")return false; if(e.ctrl&&!e.meta) return platform!=="windows"`), and it then shells out to `xclip`/`wl-paste`, or to PowerShell under WSL. So the fix is to stop swallowing the chord: `kernel.paste` declines with `Some(false)` when there is no text to paste — the same answer `kernel.copy` already gives with no selection — and the press falls through to the focused terminal.

**Inside WSL that decision cannot be made locally.** WSLg bridges the clipboard's *text* only. Copy an image in Windows and the X clipboard is not updated at all: it keeps handing out the last text copied. Measured here — `Clipboard::get_text()` returned an IP address copied minutes earlier while Windows held a 1594x535 PNG — so the paste inserted something *stale* rather than nothing, which is the worse half of the bug. arboard cannot see the image either: thurbox builds it with `default-features = false`, the build without `get_image`.

So `clipboard::ImageProbe` asks `powershell.exe` whether the Windows clipboard holds an image. That costs ~0.42 s (three runs: 0.42/0.41/0.43), which is far too long to hold the event loop for and is paid on *every* paste, not just image ones — so it is another instance of the worker pattern: the press is claimed, the interface keeps drawing, and the answer decides who gets it. Nothing is asked off WSL, where the local clipboard is the one being copied into.

A forwarded chord is dropped while a modal is open, for the reason a pasted text is: it must not leak into the terminal behind the overlay.

### Testing

`only_a_wsl_distro_asks_windows` pins the gate — it is the whole cost control, since a gate that answered "yes" everywhere would add a third of a second to every `Ctrl+V` on every platform.

`the_windows_probe_agrees_with_powershell` runs the real round trip against the real Windows clipboard, because the wiring is what breaks: the argument list, `-Sta` (without it `Add-Type` throws and every answer becomes "no image"), the `PATH`/interop fallback, and reading the answer off the exit code. It skips where it cannot discriminate — off WSL, with no PowerShell, or with no image on the clipboard — and deliberately never writes to the clipboard: a suite that destroys what you copied is worse than one that skips. Both tests were checked with the fix stubbed out and fail.

### Rejected

- *A second chord for "give the paste to the agent"* — cheap and exact, but it leaves the ordinary `Ctrl+V` after copying an image still pasting stale text, which is the half that corrupts a prompt silently.
- *Detecting the image with arboard* — the feature is not in this build, and the X clipboard it would read does not carry the Windows image anyway.
- *Asking PowerShell on the loop* — 0.42 s of frozen interface per paste.