### PR TITLE
fix(core): learn a pane's window when it is created, not after

### DIFF
--- a/src/agent/control_mode/mod.rs
+++ b/src/agent/control_mode/mod.rs
@@ -625,6 +625,18 @@ pub fn is_valid_pane_id(s: &str) -> bool {
         .is_some_and(|rest| !rest.is_empty() && rest.bytes().all(|b| b.is_ascii_digit()))
 }
 
+/// A tmux window id is `@<digits>`.
+///
+/// Checked for a different reason than the pane id: a window id is never
+/// interpolated into a command, only compared against the one `%window-close`
+/// carries. A value that is not an id would therefore never match and never
+/// complain — indistinguishable from a pane whose death is simply not
+/// announced, which is the failure this mapping exists to prevent.
+pub fn is_valid_window_id(s: &str) -> bool {
+    s.strip_prefix('@')
+        .is_some_and(|rest| !rest.is_empty() && rest.bytes().all(|b| b.is_ascii_digit()))
+}
+
 /// Parse `list-panes -F "#{pane_id} #{@thurbox_state}"` output into the
 /// `(pane_id, value)` pairs whose option is **set**: one `%<id> [value]` line
 /// per pane; empty values (option unset) and malformed lines are skipped —

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -299,6 +299,15 @@ pub(crate) fn program_window_name(owner: &str, pane: &str) -> String {
 const DISCOVER_FORMAT: &str =
     "#{pane_id}|#{window_name}|#{pane_dead}|#{@thurbox_session}|#{@thurbox_role}";
 
+/// What `new-window -P -F` is asked to answer with: the pane to attach to, and
+/// the window whose close will be that pane's death notice.
+///
+/// Both in one answer because the window is needed at the same moment the pane
+/// is — see `register_pane`, where asking for it separately used to leave a gap
+/// a short-lived program could end inside. `the_spawn_format_asks_for_the_window_too`
+/// pins it.
+const SPAWN_FORMAT: &str = "#{pane_id} #{window_id}";
+
 /// One `list-windows` line, or `None` for a window that is not thurbox's.
 ///
 /// Every thurbox prefix is discovered, not just the agent's: a `tbs-` shell and
@@ -1572,27 +1581,35 @@ impl TmuxBackend {
 
     /// Register a pane sender and return the corresponding reader.
     /// Multiple instances can register the same pane; output will be broadcast to all.
-    fn register_pane(&self, pane_id: &str) -> Result<ControlModeReader> {
-        // Asked BEFORE the sender is registered, and best-effort: tmux announces
-        // a pane's death only by the window it was in (`%window-close @3`), and
-        // this round trip is the one chance to learn which that is — afterwards
-        // the pane is gone and nothing can be asked about it. A backend that
-        // cannot answer (psmux) simply keeps the old behaviour: no mapping, so
-        // no EOF from a window close. One round trip per pane attached, on a
-        // path that already spawns or adopts a window.
+    ///
+    /// `window_id` is the window the pane lives in, when the caller already
+    /// knows it. tmux announces a pane's death only by the window it was in
+    /// (`%window-close @3`), so without that mapping a pane cannot notice its
+    /// own ending — and the announcement is one-shot, so learning the window
+    /// late is the same as never learning it.
+    fn register_pane(&self, pane_id: &str, window_id: Option<&str>) -> Result<ControlModeReader> {
+        // Handed in by whoever created the pane: `new-window` is already asked
+        // to answer (`-P -F`), and answering with the window as well as the
+        // pane costs nothing (see `SPAWN_FORMAT`). Asking separately is what
+        // this used to do, and it put a serialized control-mode round trip —
+        // queued behind every other command in flight — between the window
+        // existing and the mapping being written. A program that ended inside
+        // that gap had its `%window-close` arrive with nothing to match it
+        // against, and no later wait brings it back.
         //
-        // Two ways to end up with no mapping, both of which cost this pane the
-        // ability to notice its own death, and neither of which used to leave a
-        // trace: the round trip failing (a reconnecting control mode, a
-        // multiplexer without `display-message`), and the pane dying inside the
-        // round trip — the window close then arrives before there is anything
-        // to match it against. The first is logged here. The second is narrow
-        // and deliberately not paid for: closing it means asking again after
-        // registering, which is a second round trip on every pane attached, to
-        // catch a program that died in the millisecond it took to ask once.
-        let window_id =
-            match self.ctrl_command(&format!("display-message -t {pane_id} -p '#{{window_id}}'")) {
-                Ok(out) => Some(out.trim().to_string()).filter(|id| !id.is_empty()),
+        // Asked here only when nobody could hand it over: `adopt`, which is
+        // given a pane id out of the database and nothing else. Best-effort
+        // there, as it always was — a backend that cannot answer (psmux, a
+        // reconnecting control mode) keeps the old behaviour of no mapping and
+        // no EOF from a window close, and says so in the log.
+        let window_id = match window_id {
+            Some(id) => Some(id.to_string()),
+            None => match self
+                .ctrl_command(&format!("display-message -t {pane_id} -p '#{{window_id}}'"))
+            {
+                Ok(out) => {
+                    Some(out.trim().to_string()).filter(|id| control_mode::is_valid_window_id(id))
+                }
                 Err(e) => {
                     debug!(
                         "could not learn which window {pane_id} is in ({e:#}); its exit \
@@ -1600,7 +1617,8 @@ impl TmuxBackend {
                     );
                     None
                 }
-            };
+            },
+        };
         let (tx, rx) = sync_channel(PANE_CHANNEL_CAPACITY);
         self.with_control(|ctrl| {
             let mut senders = ctrl
@@ -1664,8 +1682,14 @@ impl TmuxBackend {
 
     /// Connect I/O to an existing pane: start monitoring, resize to correct
     /// dimensions, and create writer.
-    fn connect_pane(&self, pane_id: &str, rows: u16, cols: u16) -> Result<AdoptedSession> {
-        let reader = self.register_pane(pane_id)?;
+    fn connect_pane(
+        &self,
+        pane_id: &str,
+        window_id: Option<&str>,
+        rows: u16,
+        cols: u16,
+    ) -> Result<AdoptedSession> {
+        let reader = self.register_pane(pane_id, window_id)?;
         // Must use send_command (waited) here — a nowait call would leave an
         // unclaimed %begin/%end response in the stream that steals the next
         // send_command waiter.
@@ -1878,17 +1902,35 @@ impl SessionBackend for TmuxBackend {
         // `birth_options` for why neither can be a message of its own.
         let options = birth_options_suffix(window_name, psmux);
         let cmd = format!(
-            "new-window -t {session} -n {escaped_window_name} -P -F '#{{pane_id}}'{cwd_part}{env_part} {shell_cmd}{options}"
+            "new-window -t {session} -n {escaped_window_name} -P -F '{SPAWN_FORMAT}'{cwd_part}{env_part} {shell_cmd}{options}"
         );
         let result = self.ctrl_command(&cmd)?;
-        let pane_id = result.trim().to_string();
+        // Two fields, and the second is optional in practice: a multiplexer
+        // that prints only the pane id (psmux's `-P -F` support is unverified
+        // against the documented divergences, ADR-13) leaves `window_id` None
+        // and `register_pane` falls back to asking, exactly as before.
+        let answer = result.trim();
+        let (pane_id, window_id) = match answer.split_once(char::is_whitespace) {
+            Some((pane, window)) => (pane.trim().to_string(), Some(window.trim().to_string())),
+            None => (answer.to_string(), None),
+        };
         if !control_mode::is_valid_pane_id(&pane_id) {
             bail!("tmux new-window returned an invalid pane id: {pane_id:?}");
         }
+        // Dropped rather than fatal: a window id that is not one costs this pane
+        // the ability to notice its own ending, which is what the pre-#1107
+        // behaviour was — not a reason to refuse a window that started fine.
+        let window_id = window_id.filter(|id| {
+            let ok = control_mode::is_valid_window_id(id);
+            if !ok {
+                debug!("tmux new-window answered with an unusable window id: {id:?}");
+            }
+            ok
+        });
 
-        debug!(pane_id = %pane_id, "tmux window created via control mode");
+        debug!(pane_id = %pane_id, window_id = ?window_id, "tmux window created via control mode");
 
-        let connected = self.connect_pane(&pane_id, rows, cols)?;
+        let connected = self.connect_pane(&pane_id, window_id.as_deref(), rows, cols)?;
 
         Ok(SpawnedSession {
             backend_id: pane_id,
@@ -1928,7 +1970,9 @@ impl SessionBackend for TmuxBackend {
         let capture_ms = capture_start.map(|s| s.elapsed().as_millis() as u64);
 
         let connect_start = perf_log.then(std::time::Instant::now);
-        let connected = self.connect_pane(backend_id, rows, cols)?;
+        // No window id to hand over: `adopt` is given a pane id out of the
+        // database, so `register_pane` asks for the window itself.
+        let connected = self.connect_pane(backend_id, None, rows, cols)?;
         if let (Some(capture_ms), Some(start)) = (capture_ms, connect_start) {
             tracing::info!(
                 pane = %backend_id,
@@ -4391,6 +4435,30 @@ mod tests {
     fn the_discover_format_reads_both_stamps() {
         assert!(DISCOVER_FORMAT.contains(&format!("#{{{WINDOW_SESSION_OPTION}}}")));
         assert!(DISCOVER_FORMAT.contains(&format!("#{{{WINDOW_ROLE_OPTION}}}")));
+    }
+
+    /// A pane learns of its own ending only through the window it is in, and
+    /// the only free moment to learn which window that is, is the answer to the
+    /// command that made it. Dropping `#{window_id}` from here would cost
+    /// nothing visible — spawning still works, and the exit simply stops being
+    /// announced under load — so it is pinned.
+    #[test]
+    fn the_spawn_format_asks_for_the_window_too() {
+        assert!(SPAWN_FORMAT.contains("#{pane_id}"));
+        assert!(SPAWN_FORMAT.contains("#{window_id}"));
+        // Parsed by splitting on whitespace, so the two must be separable.
+        assert!(SPAWN_FORMAT.split_whitespace().count() == 2);
+    }
+
+    /// Both ids are read off the wire, so both are checked the same way.
+    #[test]
+    fn a_window_id_is_an_at_sign_and_digits() {
+        assert!(control_mode::is_valid_window_id("@0"));
+        assert!(control_mode::is_valid_window_id("@42"));
+        assert!(!control_mode::is_valid_window_id("@"));
+        assert!(!control_mode::is_valid_window_id("%3"));
+        assert!(!control_mode::is_valid_window_id("@3x"));
+        assert!(!control_mode::is_valid_window_id(""));
     }
 
     /// The stamp is the identity, so a window answers to its session whatever

--- a/tests/program_pane_exit.rs
+++ b/tests/program_pane_exit.rs
@@ -42,7 +42,7 @@ const SOCKET: &str = "thurbox-program-exit-e2e";
 
 /// Generous next to the notification, which arrives with the exit: the budget is
 /// for a loaded machine starting a tmux server, not for the signal itself.
-const DEADLINE: Duration = Duration::from_secs(20);
+const DEADLINE: Duration = Duration::from_secs(10);
 
 fn have_tmux() -> bool {
     Command::new("tmux")
@@ -134,23 +134,20 @@ async fn a_program_that_ends_reports_that_it_ended() {
     // is not padding: a program that exits instantly takes its pane with it
     // before `spawn` can size the window, and the spawn fails with "can't find
     // pane" — which this test used to report as a skipped environment and pass
-    // on, proving nothing at all. It also has to outlive `TmuxBackend::register_pane`'s
-    // own `display-message` round trip (registering which window the pane's
-    // death will be announced on, so the notification has somewhere to land):
-    // that round trip's own doc comment spells out that a program which exits
-    // before it returns costs this pane its exit notification *permanently* —
-    // the one-shot `%window-close` for that window has already come and gone
-    // with nothing yet in `pane_windows` to match it against, and no later
-    // wait, however long, makes it arrive a second time. On a loaded machine
-    // (this test's own failure mode: a full parallel `nextest` run stacking
-    // dozens of other tmux/pty-driving tests against a shared CPU budget) that
-    // round trip can stretch well past a few seconds. 1s cut it close, 3s
-    // still lost the race once in a large run; 8s gives it real headroom.
+    // on, proving nothing at all.
+    //
+    // A second, longer than that: the program had to outlive whatever stood
+    // between its window existing and `pane_windows` knowing about it, because
+    // a death inside that gap is announced once, to nobody, and never again.
+    // That gap used to be a serialized `display-message` round trip, which is
+    // why this budget kept being raised — 1s, then 3s, then 8s — without ever
+    // being enough. `new-window` now answers with the window id itself, so the
+    // gap is local work, and a second is a second again.
     let pane = ProgramPane::spawn(
         std::sync::Arc::clone(&backend) as std::sync::Arc<dyn SessionBackend>,
         "tbp-test-exiting",
         "sh",
-        &["-c".to_string(), "printf started; sleep 8".to_string()],
+        &["-c".to_string(), "printf started; sleep 1".to_string()],
         Some(dir.path()),
         &HashMap::new(),
         24,

--- a/tests/program_restart_exit.rs
+++ b/tests/program_restart_exit.rs
@@ -67,11 +67,10 @@ async fn restarting_a_finished_program_still_reports_the_ending() {
     // Lives for a moment, then ends on its own — an editor being quit. Not
     // instant: a program that exits before tmux has sized the window takes the
     // pane with it and the spawn fails outright, which would turn this into a
-    // skip that proves nothing. It also has to outlive the pane registration's
-    // own `display-message` round trip, which can stretch well past a second
-    // on a loaded machine — 1s cut that close under a full parallel `nextest`
-    // run; 3s gives it real headroom.
-    let short = ["-c".to_string(), "printf started; sleep 3".to_string()];
+    // skip that proves nothing. The registration round trip it also used to
+    // have to outlive is gone — `new-window` answers with the window id — so
+    // this is back to the moment it was written as.
+    let short = ["-c".to_string(), "printf started; sleep 1".to_string()];
     if let Err(e) = terminals.start_program(&key, "sh", &short, Some(dir.path()), 24, 80) {
         cleanup();
         // Not a skip: tmux is installed, so a pane that would not start is the


### PR DESCRIPTION
Your nit on #1107, taken up: `new-window` is already asked to answer, so it may as well answer with the window too.

## The defect this closes

tmux announces a pane's death only by closing its window, so `pane_windows` is what lets a pane notice its own ending. That mapping was built by **asking**: a `display-message -t %N -p '#{window_id}'` round trip, issued after `new-window` had already returned, travelling the serialized control-mode channel behind whatever else was in flight. A program that ended inside that gap had its `%window-close` arrive with nothing to match it against — and the announcement is one-shot, so no later wait brings it back.

`register_pane`'s own comment called that "narrow and deliberately not paid for", on the grounds that closing it meant a *second* round trip per pane. That was the wrong price: it takes none. `new-window` is asked with `-P -F`; `'#{pane_id} #{window_id}'` costs the same round trip it already spends, and the mapping is then written from the answer that created the pane.

`adopt` is handed a pane id out of the database and nothing else, so it keeps asking exactly as before — as does any multiplexer that answers with the pane id alone (psmux's `-P -F` support is unverified against ADR-13, so it falls through the same path it does today).

## Measured, not reasoned

**The mechanism, A/B.** A 1.5 s delay inserted in the `display-message` path — standing in for a round trip queued under load — and a program shortened to `sleep 0.2` so it ends inside it. Same test, same instrumentation, one difference:

| | path | result |
|---|---|---|
| A | window id arrives with the pane id | **passed**, 0.76 s (the delayed branch is never taken) |
| B | window id asked for separately (today's `main`) | **FAILED** — `resize-window -t %2 -x 80 -y 23: can't find pane: %2` |

Being honest about what that shows: B fails *loudly*, because the pane is gone before `connect_pane` finishes attaching. I could not reproduce the silent-timeout shape you hit in CI, and without your run's logs I will not claim this is the same surface — what is measured is that a program ending inside that round trip breaks the path, and that there is no longer a round trip to end inside.

**The suite, before and after.** Six full parallel `cargo nextest run --all` runs each, this machine, tmux 3.2a:

- **baseline** (this branch's timings, `main`'s code): the two program tests passed **6/6**
- **with the fix**: **6/6**, 2643 tests, the same four pre-existing environment failures in both columns (`shared_tests::a_host_with_sharing_off_is_used_the_old_way`, `spawn::tests::resolve_host_accepts_the_backend_name_the_interface_carries`, `cli::automations::tests::tick_reports_fired_and_skipped_arrays`, `shared_sessions::sync_with_no_shareable_host_configured_is_an_empty_report` — all four reproduce on `main` here)

So the flake never reproduced on this machine, at either timing. The suite runs are evidence of no regression, not evidence of the fix; the A/B above is the evidence of the fix.

## The timings from #1113 go back

`sleep 8` and the 20 s deadline in `program_pane_exit.rs`, `sleep 3` in `program_restart_exit.rs`. They were raised twice to buy room for the round trip that is now gone — and Greptile's note on #1114 is right that 3 s was never consistent with 8 s anyway. Their comments are rewritten to say what the second is actually for.

## What this does not do — and a question

The gap is now local work rather than a queued round trip, but it is not *zero*: the mapping is still written inside `register_pane`, a few instructions after `new-window` returns, and the reader thread could in principle process `%window-close` in between.

Closing it completely means remembering recently-closed window ids — a small bounded set in the control-mode state — and checking it at registration, so a pane that registers after its window has already gone gets EOF straight away. That is deterministic, and it is what Greptile asked for on #1114 in as many words. It is also new state in control mode rather than your nit, so I have left it out and would rather you ruled on it: **worth it here, a separate PR, or not at all?**

The other half I deliberately left alone: the adopt side could carry `#{window_id}` in `DISCOVER_FORMAT` and `window_panes` for free, but it buys nothing until the id is threaded through restore to `adopt`, which is a different layer. Say if you want it in the same change.

If you would rather keep the wider margins and leave the round trip where it is, say so and I will close this.
