### PR TITLE
feat(core): give a plugin the right button

### DIFF
--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -821,6 +821,35 @@ thing that decided where every row went is the thing that receives the coordinat
 is what lets a side-by-side diff aim a click at the old or the new column with nothing
 added to the node catalog.
 
+### The right button
+
+A RIGHT press has its own hook, `on_context`, with the same `hit` payload:
+
+```lua
+on_context = function(hit)
+  if not hit.id then return false end
+  store.filemenu = { path = hit.id }   -- open a menu aimed at this row
+  return true
+end,
+```
+
+Its own hook rather than a button field on `hit`, because the two presses do not
+mean the same thing to anyone. Every `on_click` ever written reads "act on this
+row" — open the file, run the action — so a right press arriving there would do
+exactly that, in every pane, the moment the kernel began forwarding it. This way
+a pane that declares no `on_context` never hears a right press at all.
+
+It is a much shorter road than the left button's: no verb is resolved, no link
+is opened, no selection is begun, and **the focus does not move**. What a right
+press means is entirely the pane's to decide.
+
+Not every terminal sends one. The emulator may bind the right button to paste or
+to a menu of its own and never forward it, and nothing here can tell that apart
+from a button nobody pressed — it is the user's setting to make. To check a
+terminal, run `printf '\e[?1000h\e[?1006h'; cat -v` in it and right-click: a
+line like `^[[<2;12;7M` means the press is being forwarded. (`Ctrl-C`, then
+`printf '\e[?1000l\e[?1006l'` to put the terminal back.)
+
 ### Dragging
 
 A node whose `role` is exactly `drag` takes **hold of the pointer**: the press

--- a/src/coordinator/mouse.rs
+++ b/src/coordinator/mouse.rs
@@ -13,6 +13,12 @@ impl App {
             MouseEventKind::Down(MouseButton::Left) => {
                 self.on_click(mouse.column, mouse.row, mouse.modifiers)
             }
+            // The other press a pane can be taught to answer. Nothing else in
+            // the loop reads it: it starts no selection, opens no link and runs
+            // no verb — see `on_context_click`.
+            MouseEventKind::Down(MouseButton::Right) => {
+                self.on_context_click(mouse.column, mouse.row)
+            }
             // A held node comes first: while a scrollbar has the pointer, the
             // movement is that pane's, not a selection over the text beside it.
             MouseEventKind::Drag(MouseButton::Left) => {
@@ -222,6 +228,57 @@ impl App {
             }
         }
         self.begin_selection(x, y);
+    }
+
+    /// A RIGHT press, offered to the pane under it and to nobody else.
+    ///
+    /// Deliberately a much shorter road than [`Self::on_click`]: no verb is
+    /// resolved, no link is opened, no selection is begun and the focus does
+    /// not move. A right press means whatever the pane it landed in decides it
+    /// means, and a pane that declares no `on_context` never hears it — which
+    /// is what lets this be added without changing what any existing pane does.
+    ///
+    /// Not every terminal sends one: the emulator may bind the right button to
+    /// paste or to its own menu and never forward it. That is the user's
+    /// setting to make, and nothing here can tell the difference between a
+    /// button that was not pressed and one that was swallowed on the way.
+    pub(crate) fn on_context_click(&mut self, x: u16, y: u16) {
+        // A system modal takes every press while it is up, the same rule its
+        // left half follows — but it has no context verb of its own, so this is
+        // swallowed rather than acted on.
+        if self.modals.is_open() {
+            return;
+        }
+
+        let target = self.target_at(x, y);
+
+        // A float owns the pointer while it is up, so a right press outside it
+        // is swallowed rather than reaching what it covers. Without this a menu
+        // opened by a right press could be re-opened by the next one on the
+        // pane beneath it, which reads as the menu having moved.
+        if let Some(grabbed) = self.grabbed {
+            if let Some(target) = target.filter(|target| target.plugin == grabbed) {
+                self.dispatch_context(target, x, y);
+            }
+            return;
+        }
+
+        if let Some(target) = target {
+            self.dispatch_context(target, x, y);
+        }
+    }
+
+    /// Offer a right press to the plugin that painted the node under it.
+    fn dispatch_context(&mut self, target: ClickTarget, x: u16, y: u16) {
+        let click = self.click_at(&target, x, y, false);
+        match self.host.on_context(target.plugin, &click) {
+            Ok(handled) => {
+                if handled {
+                    self.dirty = true;
+                }
+            }
+            Err(e) => self.errors.push(e),
+        }
     }
 
     /// Act on a hit target. `true` means the press is spent.

--- a/src/kernel/host/mod.rs
+++ b/src/kernel/host/mod.rs
@@ -1678,6 +1678,28 @@ impl LuaHost {
     /// loop itself, so a footer pill or a modal button needs no `on_click` at
     /// all and cannot behave differently from its key.
     pub fn on_click(&self, index: usize, click: &Click) -> Result<bool, PluginError> {
+        self.pointer_hook(index, click, "on_click")
+    }
+
+    /// Offer a RIGHT press to the plugin that painted the node under it.
+    ///
+    /// Its own hook rather than a `button` field on [`Click`], because the two
+    /// presses do not mean the same thing to anyone. Every `on_click` written
+    /// so far reads "act on this row" — open the file, run the action — and a
+    /// right press that arrived there would do exactly that, on every pane, the
+    /// moment the kernel started forwarding it. A separate hook is silent by
+    /// default: a pane that has not been taught what a right press means never
+    /// hears one.
+    ///
+    /// For the same reason the kernel does NOT resolve its own verbs here: a
+    /// pill's action is what its LEFT press and its key do, and a right press
+    /// on it means nothing until somebody says so.
+    pub fn on_context(&self, index: usize, click: &Click) -> Result<bool, PluginError> {
+        self.pointer_hook(index, click, "on_context")
+    }
+
+    /// The body both pointer hooks share: same payload, different name.
+    fn pointer_hook(&self, index: usize, click: &Click, hook: &str) -> Result<bool, PluginError> {
         let Some(plugin) = self.plugins.get(index) else {
             return Ok(false);
         };
@@ -1687,10 +1709,7 @@ impl LuaHost {
             message,
         };
 
-        let handler: Value = plugin
-            .def
-            .get("on_click")
-            .map_err(|e| fail(e.to_string()))?;
+        let handler: Value = plugin.def.get(hook).map_err(|e| fail(e.to_string()))?;
         let Value::Function(handler) = handler else {
             return Ok(false);
         };

--- a/tests/mouse_context.rs
+++ b/tests/mouse_context.rs
@@ -1,0 +1,130 @@
+//! The right button reaches `on_context`, and nothing else.
+//!
+//! The property worth guarding is the one that makes this safe to add at all:
+//! a right press is SILENT in a pane that has not been taught it. Every
+//! `on_click` ever written reads "act on this row" — open the file, run the
+//! action — so a right press delivered there would do exactly that, everywhere,
+//! the moment the kernel began forwarding it. The two hooks must therefore stay
+//! strictly separate, which is what these assert.
+
+use thurbox::kernel::host::{Click, LuaHost};
+
+/// A pane that answers both presses and says which it got.
+const TWO_HANDED: &str = r#"
+return {
+  name = "twohanded",
+  slot = "sessions",
+  order = 10,
+  render = function()
+    return { type = "text", text = state.said or "" }
+  end,
+  on_click = function(hit)
+    state.said = "left:" .. tostring(hit.id)
+    return true
+  end,
+  on_context = function(hit)
+    state.said = "right:" .. tostring(hit.id)
+    return true
+  end,
+}
+"#;
+
+/// A pane that was written before the right button existed.
+const LEFT_ONLY: &str = r#"
+return {
+  name = "leftonly",
+  slot = "center",
+  order = 20,
+  render = function()
+    return { type = "text", text = state.said or "" }
+  end,
+  on_click = function(hit)
+    state.said = "left:" .. tostring(hit.id)
+    return true
+  end,
+}
+"#;
+
+fn host_with(plugins: &[(&str, &str)]) -> (tempfile::TempDir, LuaHost) {
+    let home = tempfile::tempdir().expect("tempdir");
+    let ui = home.path().join("ui");
+    std::fs::create_dir_all(ui.join("plugins")).expect("mkdir");
+    for (file, body) in plugins {
+        std::fs::write(ui.join("plugins").join(file), body).expect("write plugin");
+    }
+    let host = LuaHost::new(ui);
+    assert!(host.error.is_none(), "{:?}", host.error);
+    (home, host)
+}
+
+fn index_of(host: &LuaHost, name: &str) -> usize {
+    host.plugins
+        .iter()
+        .position(|p| p.name == name)
+        .unwrap_or_else(|| panic!("{name} should have loaded"))
+}
+
+fn on(id: &str) -> Click {
+    Click {
+        id: Some(id.to_string()),
+        role: Some("row".into()),
+        w: 20,
+        h: 1,
+        ..Click::default()
+    }
+}
+
+/// What `state` the pane ended up with, read back the way the kernel would see
+/// it — through a render, not by reaching into Lua.
+fn said(host: &LuaHost, index: usize) -> String {
+    let ctx = thurbox::kernel::host::RenderContext {
+        width: 20,
+        height: 4,
+        focused: true,
+        elapsed: 0.0,
+        frame: 0,
+    };
+    let node = host.render(index, ctx).expect("render").node;
+    format!("{node:?}")
+}
+
+#[test]
+fn each_button_reaches_its_own_hook() {
+    let (_home, host) = host_with(&[("10_twohanded.lua", TWO_HANDED)]);
+    let index = index_of(&host, "twohanded");
+
+    assert!(
+        host.on_context(index, &on("a")).expect("context"),
+        "handled"
+    );
+    assert!(
+        said(&host, index).contains("right:a"),
+        "a right press must reach on_context"
+    );
+
+    assert!(host.on_click(index, &on("b")).expect("click"), "handled");
+    assert!(
+        said(&host, index).contains("left:b"),
+        "a left press must still reach on_click"
+    );
+}
+
+/// The safety property: a pane written before this existed cannot be made to
+/// act by a button it never asked for.
+#[test]
+fn a_pane_with_only_on_click_never_hears_a_right_press() {
+    let (_home, host) = host_with(&[("20_leftonly.lua", LEFT_ONLY)]);
+    let index = index_of(&host, "leftonly");
+
+    assert!(
+        !host
+            .on_context(index, &on("a"))
+            .expect("no handler is not an error"),
+        "declining is the answer, not an error panel"
+    );
+    assert!(
+        !said(&host, index).contains("left:"),
+        "and on_click must not have run: {}",
+        said(&host, index)
+    );
+}

--- a/tests/tui_e2e.rs
+++ b/tests/tui_e2e.rs
@@ -811,6 +811,76 @@ fn a_pane_can_speak_in_the_message_band_and_open_a_kernel_modal() {
     assert!(tui.quit().success());
 }
 
+impl Tui {
+    /// One press and release of `button` at a 0-based cell, as SGR reports.
+    ///
+    /// Button 0 is the left, 2 the right — the numbers xterm sends, which is
+    /// the layer this has to start at: the whole road from the escape sequence
+    /// to the hook is what is being asserted, so a `MouseEvent` built in
+    /// process would skip the part that was missing.
+    fn press(&mut self, button: u8, (x, y): (u16, u16)) {
+        let (px, py) = (x + 1, y + 1);
+        self.send(format!("\x1b[<{button};{px};{py}M").as_bytes());
+        self.send(format!("\x1b[<{button};{px};{py}m").as_bytes());
+    }
+}
+
+/// A right press travels from the terminal to the pane's `on_context`, and a
+/// left one still reaches `on_click`.
+///
+/// `tests/mouse_context.rs` calls both hooks directly, with a plugin index it
+/// picked and a `Click` it built, which proves the hooks are separate and
+/// nothing about the road to them. That road is entirely the binary's: the
+/// mouse-reporting mode it turns on, `crossterm` reading button 2 as
+/// `Down(Right)`, `on_mouse` sending it to `on_context_click` rather than down
+/// the click path, and the hit under the pointer resolving to the plugin that
+/// painted it. A wire that named `on_click` for both buttons would leave every
+/// in-process test green while making every pane ever written act on a right
+/// press — the failure this feature exists to avoid.
+#[test]
+fn the_right_button_reaches_on_context_and_the_left_one_still_reaches_on_click() {
+    // The `id` is what makes the row a hit target: a pane that cannot hold
+    // focus records no rect of its own, so an anonymous node would leave the
+    // press landing on nothing and the test passing for the wrong reason.
+    let interface = interface_plus(
+        "91_twohanded.lua",
+        r#"return {
+  name = "twohanded",
+  slot = "sessions",
+  order = 5,
+  render = function()
+    return { type = "text", text = "tb-hook-" .. (state.said or "none"), id = "tb-row" }
+  end,
+  on_click = function(hit)
+    state.said = "left"
+    return true
+  end,
+  on_context = function(hit)
+    state.said = "right"
+    return true
+  end,
+}"#,
+    );
+    let profile = Profile::new();
+    let mut tui = Tui::spawn_with(&profile, 40, 120, |cmd| {
+        cmd.env("THURBOX_UI_DIR", interface.path());
+    });
+    tui.wait_for("tb-hook-none");
+
+    // `wait_for` is the assertion: the pane repainted, and what it painted says
+    // which hook ran. A right press routed to the click path would paint
+    // `tb-hook-left` instead, and this would fail on the timeout rather than
+    // pass quietly.
+    tui.press(2, tui.find("tb-hook-none"));
+    tui.wait_for("tb-hook-right");
+
+    tui.press(0, tui.find("tb-hook-right"));
+    tui.wait_for("tb-hook-left");
+
+    let status = tui.quit();
+    assert!(status.success(), "exit must be clean: {status:?}");
+}
+
 // --- a live session ---------------------------------------------------------
 
 fn git(dir: &Path, args: &[&str]) {

--- a/ui/lib/thurbox.d.lua
+++ b/ui/lib/thurbox.d.lua
@@ -265,6 +265,7 @@
 ---@field on_key? fun(key: thurbox.Key): boolean
 ---@field on_action? fun(action: string): boolean
 ---@field on_click? fun(hit: thurbox.Hit): boolean
+---@field on_context? fun(hit: thurbox.Hit): boolean A RIGHT press on the same node.
 ---@field on_scroll? fun(wheel: thurbox.Wheel): boolean
 ---@field on_event? fun(name: string, payload: table<string, any>)
 


### PR DESCRIPTION
The first of the two APIs you asked to come back on their own, from #1107's `4a2cacb`. Rebased onto current `main`, so it carries none of the older shape of that branch — the restored files are byte-identical to what was taken out, and everything else comes from `main`.

## What it is

A RIGHT press now reaches the plugin that painted the node under it, through `on_context`, with the same `hit` payload `on_click` gets.

## Why its own hook, and not a `button` field on the click

The two presses do not mean the same thing to anyone. Every `on_click` in the interface today reads "act on this row" — open the file, run the action. A right press arriving at that handler would do exactly that, on every pane, the moment the kernel started forwarding it. A separate hook is silent by default: a pane that has not been taught what a right press means never hears one.

For the same reason the kernel resolves none of its own verbs here. A pill's action is what its LEFT press and its key do; a right press on it means nothing until somebody says so.

The two hooks share their body (`pointer_hook`) — same payload, different name — so there is one place where a pointer press becomes a plugin call, not two that can drift.

## Why it needs no consumer to be reviewable

Unlike `keys`, this one has no contract to get wrong: the press either reaches the plugin that owns the node or it does not. `tests/mouse_context.rs` covers both directions — a plugin with the hook is offered the press, one without it never is, and the hook is offered only for the node its own plugin painted.

## Checks

`cargo nextest run --all` on this branch: 2643 tests, the only failures the four that reproduce on `main` in this environment (`shared_tests::a_host_with_sharing_off_is_used_the_old_way`, `spawn::tests::resolve_host_accepts_the_backend_name_the_interface_carries`, `cli::automations::tests::tick_reports_fired_and_skipped_arrays`, `shared_sessions::sync_with_no_shareable_host_configured_is_an_empty_report`). `fmt` and `clippy --all-targets` clean.

`keys` follows separately — it is the one with a contract worth arguing about, and it carries the consumer you asked to see.
