### PR TITLE
feat(core): let a plugin type into a program it started

### DIFF
--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -1078,6 +1078,41 @@ survive being concatenated into a command line.
 Give one up with `command("program", { text = "watch", action = "close" })`. A
 plugin that is removed, renamed or turned off has its panes released for it.
 
+**Telling a running program something.** Starting is idempotent, so asking again
+with different `args` does nothing — the pane is already there. To change what a
+long-lived program is showing, type at it:
+
+```lua
+command("program", { text = "editor", keys = ":e " .. path .. "\r" })
+```
+
+The bytes reach the program's stdin exactly as if they had been typed, so `\r`
+is Enter and `\27` is Escape; `text` names the pane and nothing is started. This
+is what makes an editor pane worth keeping: opening a second file is a line typed
+at the editor you have, not a second one paid for from scratch. It is refused,
+and reported, when no program of that name is running — and it needs the same
+`program` capability starting one does, since driving a live process is the same
+privilege as beginning it.
+
+**Type it, or start it.** Send `keys` *and* a program and the kernel picks: the
+keys go to a pane that is running, and a pane that is not is started from `repo`
+and `args` instead, which is expected to leave it in the state the keys were for.
+
+```lua
+command("program", {
+  text = "editor",
+  repo = "nvim",
+  args = { path },                    -- if it has to be started
+  keys = ":e " .. path .. "\r",       -- if it is already there
+})
+```
+
+Do not try to make this decision in the plugin. Whether a pane is alive is not in
+the snapshot, and a plugin that kept the answer in its own `state` would be wrong
+after an interface reload, which keeps panes but re-runs the file. The kernel is
+asking the pane. The keys are **not** sent to a program it just started: a process
+that has not begun reading yet would lose them.
+
 **Learning that it ended.** A program that exits leaves its pane holding a
 finished screen; the kernel does not reap it, because asking again is what
 restarts it. Subscribe to know:

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -1087,7 +1087,8 @@ command("program", { text = "editor", keys = ":e " .. path .. "\r" })
 ```
 
 The bytes reach the program's stdin exactly as if they had been typed, so `\r`
-is Enter and `\27` is Escape; `text` names the pane and nothing is started. This
+is Enter and `\27` is Escape — and because a Lua string is bytes, a sequence that
+is not UTF-8 arrives as written; `text` names the pane and nothing is started. This
 is what makes an editor pane worth keeping: opening a second file is a line typed
 at the editor you have, not a second one paid for from scratch. It is refused,
 and reported, when no program of that name is running — and it needs the same

--- a/src/coordinator/commands.rs
+++ b/src/coordinator/commands.rs
@@ -407,7 +407,7 @@ impl App {
         program: &str,
         argv: &[String],
         close: bool,
-        keys: Option<&str>,
+        keys: Option<&[u8]>,
     ) {
         let key = thurbox::kernel::terminal::ProgramKey::new(owner, name);
         if close {
@@ -448,10 +448,7 @@ impl App {
         // than silently dropped — "the editor did not open the file" with no reason
         // is the failure this whole channel exists to avoid.
         if let Some(keys) = keys {
-            if self
-                .terminals
-                .send_to_program(&key, keys.as_bytes().to_vec())
-            {
+            if self.terminals.send_to_program(&key, keys.to_vec()) {
                 self.changed_this_frame = true;
                 return;
             }

--- a/src/coordinator/commands.rs
+++ b/src/coordinator/commands.rs
@@ -58,7 +58,8 @@ impl App {
                 program,
                 argv,
                 close,
-            } => self.apply_program(owner, name, program, argv, *close),
+                keys,
+            } => self.apply_program(owner, name, program, argv, *close, keys.as_deref()),
             // The editor wants a controlling tty, which only this thread can hand
             // it — see `Command::Editor`.
             Command::Editor { session } => self.apply_editor_command(session, terminal),
@@ -406,6 +407,7 @@ impl App {
         program: &str,
         argv: &[String],
         close: bool,
+        keys: Option<&str>,
     ) {
         let key = thurbox::kernel::terminal::ProgramKey::new(owner, name);
         if close {
@@ -427,6 +429,43 @@ impl App {
                 Level::Error,
             );
             return;
+        }
+
+        // Typing into a pane that is already running, checked after the
+        // capability and before the start: this changes what a live program is
+        // doing, which is the same privilege as starting one, and a plugin whose
+        // trust was revoked must not keep driving a process it started while it
+        // had it.
+        //
+        // `keys` WITH a program is "type at it, or start it if it is not there" —
+        // one command, decided here. The plugin cannot make that decision itself:
+        // liveness is not in the snapshot, and a plugin that tracked it in its own
+        // state would be wrong across an interface reload, which keeps panes but
+        // re-runs the file. `send_to_program` is false for a pane that is missing
+        // AND for one whose program has exited, which is exactly the question.
+        //
+        // With no program to fall back on, nothing to type into is reported rather
+        // than silently dropped — "the editor did not open the file" with no reason
+        // is the failure this whole channel exists to avoid.
+        if let Some(keys) = keys {
+            if self
+                .terminals
+                .send_to_program(&key, keys.as_bytes().to_vec())
+            {
+                self.changed_this_frame = true;
+                return;
+            }
+            if program.trim().is_empty() {
+                self.report(
+                    format!("{owner} has no running program named {name:?} to type into"),
+                    Level::Error,
+                );
+                return;
+            }
+            // Falls through to the start below, which begins in the state the keys
+            // were meant to produce — the editor opens the file it was given as an
+            // argument. Sending them anyway would race a program that is not yet
+            // reading its input.
         }
 
         // Born at the rect it will be painted into where the last frame recorded

--- a/src/kernel/command/mod.rs
+++ b/src/kernel/command/mod.rs
@@ -203,6 +203,20 @@ pub enum Command {
         argv: Vec<String>,
         /// Give the pane up instead of starting it.
         close: bool,
+        /// Type into the program instead of starting it: the bytes go to the
+        /// pane's stdin exactly as if they had been typed at it.
+        ///
+        /// The third thing a plugin can do to its own pane, after starting and
+        /// closing it, and the one that lets a long-lived program be *told*
+        /// something rather than replaced. Restarting an editor to open a
+        /// second file is the case that asked for it: the process is the
+        /// expensive part, and `start_program` is idempotent, so without this
+        /// the only way to change what it shows was to close it first.
+        ///
+        /// Sent WITH a program, it means "type at it, or start it if it is not
+        /// running" — the coordinator picks, because whether the pane is alive
+        /// is not something a plugin can read. See `apply_program`.
+        keys: Option<String>,
     },
     /// Open a session's working directory in the configured editor.
     ///
@@ -518,6 +532,7 @@ impl Command {
             extras,
             owner,
             argv,
+            keys,
             payload,
             level,
         } = args;
@@ -715,9 +730,19 @@ impl Command {
             // The verb, spelled the way `plugin` and `bookmark` spell theirs.
             let close = matches!(action.as_deref(), Some("close") | Some("stop"));
             let program = repo.unwrap_or_default();
-            if !close && program.trim().is_empty() {
+            // Typing is checked before the program is required: `keys` alone
+            // names a pane that is already running, so asking for `repo` as well
+            // would be asking what to start something already started with. Both
+            // together are legal and mean "type, or start if it is not there".
+            let keys = keys.filter(|keys| !keys.is_empty());
+            if keys.is_some() && close {
                 return Err(
-                    "command \"program\" needs a program to run (or action = \"close\")"
+                    "command \"program\" cannot type into a pane and close it at once".to_string(),
+                );
+            }
+            if keys.is_none() && !close && program.trim().is_empty() {
+                return Err(
+                    "command \"program\" needs a program to run (or action = \"close\", or keys)"
                         .to_string(),
                 );
             }
@@ -727,6 +752,7 @@ impl Command {
                 program,
                 argv,
                 close,
+                keys,
             });
         }
         if session.is_empty() {
@@ -809,6 +835,8 @@ pub struct Args {
     pub owner: String,
     /// Arguments for a program a plugin asked to run.
     pub argv: Vec<String>,
+    /// Bytes to type into a program a plugin already started.
+    pub keys: Option<String>,
     /// Every other scalar field of the options table, for a command that
     /// forwards them whole — an event's payload.
     pub payload: Vec<(String, super::events::Field)>,
@@ -1347,6 +1375,7 @@ mod tests {
             program: "watch".into(),
             argv: Vec::new(),
             close: false,
+            keys: None,
         };
         assert_eq!(program.session(), "");
         assert_eq!(program.kind(), "program");
@@ -1376,6 +1405,63 @@ mod tests {
         // handed to the multiplexer.
         let error = ask("", None).expect_err("should refuse");
         assert!(error.contains("program"), "{error}");
+    }
+
+    /// Typing names a pane that is already running, so it asks for no program —
+    /// and it is not a way to close one.
+    #[test]
+    fn a_program_command_can_type_into_a_pane_it_already_started() {
+        let ask = |keys: Option<&str>, program: &str, action: Option<&str>| {
+            Command::parse(
+                "program",
+                Args {
+                    owner: "plugins/50_editor.lua".into(),
+                    text: Some("editor".into()),
+                    repo: (!program.is_empty()).then(|| program.to_string()),
+                    keys: keys.map(str::to_string),
+                    action: action.map(str::to_string),
+                    ..Args::default()
+                },
+            )
+        };
+
+        let typed = ask(Some(":e /tmp/x\r"), "", None).expect("keys need no program");
+        match typed {
+            Command::Program {
+                keys, close, name, ..
+            } => {
+                assert_eq!(keys.as_deref(), Some(":e /tmp/x\r"));
+                assert!(!close);
+                assert_eq!(name, "editor");
+            }
+            other => panic!("expected a program command, got {other:?}"),
+        }
+
+        // Empty keys are nothing to say, not a request to start something with no
+        // program — so they fall through to the ordinary refusal.
+        let error = ask(Some(""), "", None).expect_err("should refuse");
+        assert!(error.contains("program"), "{error}");
+
+        // Two different things to do to one pane in one call.
+        let error = ask(Some("q"), "", Some("close")).expect_err("should refuse");
+        assert!(error.contains("close"), "{error}");
+
+        // Keys AND a program is the fallback form: both survive parsing, and
+        // `apply_program` is what chooses between them from the pane's liveness.
+        let both = ask(Some(":e /tmp/x\r"), "nvim", None).expect("keys may carry a fallback");
+        match both {
+            Command::Program {
+                keys,
+                program,
+                close,
+                ..
+            } => {
+                assert_eq!(keys.as_deref(), Some(":e /tmp/x\r"));
+                assert_eq!(program, "nvim");
+                assert!(!close);
+            }
+            other => panic!("expected a program command, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/kernel/command/mod.rs
+++ b/src/kernel/command/mod.rs
@@ -216,7 +216,11 @@ pub enum Command {
         /// Sent WITH a program, it means "type at it, or start it if it is not
         /// running" — the coordinator picks, because whether the pane is alive
         /// is not something a plugin can read. See `apply_program`.
-        keys: Option<String>,
+        ///
+        /// Bytes, not text: what a program is told is a keystroke sequence, and
+        /// a plugin is free to write one its program understands and UTF-8 does
+        /// not.
+        keys: Option<Vec<u8>>,
     },
     /// Open a session's working directory in the configured editor.
     ///
@@ -836,7 +840,10 @@ pub struct Args {
     /// Arguments for a program a plugin asked to run.
     pub argv: Vec<String>,
     /// Bytes to type into a program a plugin already started.
-    pub keys: Option<String>,
+    ///
+    /// Read off the Lua table as bytes, so a sequence that is not UTF-8 arrives
+    /// rather than vanishing — see `install_command`.
+    pub keys: Option<Vec<u8>>,
     /// Every other scalar field of the options table, for a command that
     /// forwards them whole — an event's payload.
     pub payload: Vec<(String, super::events::Field)>,
@@ -1411,26 +1418,26 @@ mod tests {
     /// and it is not a way to close one.
     #[test]
     fn a_program_command_can_type_into_a_pane_it_already_started() {
-        let ask = |keys: Option<&str>, program: &str, action: Option<&str>| {
+        let ask = |keys: Option<&[u8]>, program: &str, action: Option<&str>| {
             Command::parse(
                 "program",
                 Args {
                     owner: "plugins/50_editor.lua".into(),
                     text: Some("editor".into()),
                     repo: (!program.is_empty()).then(|| program.to_string()),
-                    keys: keys.map(str::to_string),
+                    keys: keys.map(<[u8]>::to_vec),
                     action: action.map(str::to_string),
                     ..Args::default()
                 },
             )
         };
 
-        let typed = ask(Some(":e /tmp/x\r"), "", None).expect("keys need no program");
+        let typed = ask(Some(b":e /tmp/x\r"), "", None).expect("keys need no program");
         match typed {
             Command::Program {
                 keys, close, name, ..
             } => {
-                assert_eq!(keys.as_deref(), Some(":e /tmp/x\r"));
+                assert_eq!(keys.as_deref(), Some(b":e /tmp/x\r".as_slice()));
                 assert!(!close);
                 assert_eq!(name, "editor");
             }
@@ -1439,16 +1446,16 @@ mod tests {
 
         // Empty keys are nothing to say, not a request to start something with no
         // program — so they fall through to the ordinary refusal.
-        let error = ask(Some(""), "", None).expect_err("should refuse");
+        let error = ask(Some(b""), "", None).expect_err("should refuse");
         assert!(error.contains("program"), "{error}");
 
         // Two different things to do to one pane in one call.
-        let error = ask(Some("q"), "", Some("close")).expect_err("should refuse");
+        let error = ask(Some(b"q"), "", Some("close")).expect_err("should refuse");
         assert!(error.contains("close"), "{error}");
 
         // Keys AND a program is the fallback form: both survive parsing, and
         // `apply_program` is what chooses between them from the pane's liveness.
-        let both = ask(Some(":e /tmp/x\r"), "nvim", None).expect("keys may carry a fallback");
+        let both = ask(Some(b":e /tmp/x\r"), "nvim", None).expect("keys may carry a fallback");
         match both {
             Command::Program {
                 keys,
@@ -1456,7 +1463,7 @@ mod tests {
                 close,
                 ..
             } => {
-                assert_eq!(keys.as_deref(), Some(":e /tmp/x\r"));
+                assert_eq!(keys.as_deref(), Some(b":e /tmp/x\r".as_slice()));
                 assert_eq!(program, "nvim");
                 assert!(!close);
             }

--- a/src/kernel/host/api.rs
+++ b/src/kernel/host/api.rs
@@ -255,10 +255,17 @@ fn install_command(lua: &Lua, queue: Queue, current_path: Rc<RefCell<String>>) -
             level: get_string("level"),
             file: get_string("file"),
             action: get_string("action"),
-            // Bytes for a program pane this plugin already started. Read as a
-            // plain string so `"\27"` or `"\r"` written in Lua arrive as the
-            // bytes they are — the pane's stdin takes bytes, not key names.
-            keys: get_string("keys"),
+            // Bytes for a program pane this plugin already started. Read as
+            // bytes and never through a Rust `String`: `"\27"` and `"\r"` are the
+            // point of the field, and a Lua string may hold a sequence that is
+            // not UTF-8 at all — a keyboard escape for a program that speaks its
+            // own encoding. Converted, such a field would be dropped whole and
+            // silently, which reads as "the editor ignored the file" with no
+            // error anywhere. The pane's stdin takes bytes, not text.
+            keys: opts
+                .as_ref()
+                .and_then(|t| t.get::<Option<mlua::LuaString>>("keys").ok().flatten())
+                .map(|keys| keys.as_bytes().to_vec()),
             // A Lua array of session ids. Read here rather than as text so a
             // plugin cannot build an order by string concatenation.
             list: opts

--- a/src/kernel/host/api.rs
+++ b/src/kernel/host/api.rs
@@ -255,6 +255,10 @@ fn install_command(lua: &Lua, queue: Queue, current_path: Rc<RefCell<String>>) -
             level: get_string("level"),
             file: get_string("file"),
             action: get_string("action"),
+            // Bytes for a program pane this plugin already started. Read as a
+            // plain string so `"\27"` or `"\r"` written in Lua arrive as the
+            // bytes they are — the pane's stdin takes bytes, not key names.
+            keys: get_string("keys"),
             // A Lua array of session ids. Read here rather than as text so a
             // plugin cannot build an order by string concatenation.
             list: opts

--- a/tests/plugin_programs.rs
+++ b/tests/plugin_programs.rs
@@ -12,6 +12,7 @@
 //! that is absent until you read the error, and a pane resolved to the wrong owner
 //! looks like nothing at all until two plugins both want `watch`.
 
+use thurbox::kernel::command::Command;
 use thurbox::kernel::host::{Capability, LuaHost, RenderContext};
 use thurbox::kernel::terminal::{ProgramKey, Terminals};
 
@@ -233,6 +234,44 @@ fn a_key_for_an_absent_program_is_not_reported_as_delivered() {
     assert!(
         !terminals.send_to_program(&key, b"q".to_vec()),
         "nothing is running, so nothing accepted it"
+    );
+}
+
+/// `keys` is a byte string, and a byte that is not UTF-8 must arrive anyway.
+///
+/// The failure this pins is silent: read through a Rust `String`, a sequence Lua
+/// is perfectly happy to hold — an escape for a program that speaks its own
+/// encoding — was dropped whole, leaving a command that says "start it" where the
+/// plugin wrote "type at it". Nothing reports that, and the pane looks like an
+/// editor that ignored the file.
+#[test]
+fn keys_that_are_not_utf8_reach_the_command_intact() {
+    let pane = r#"return {
+  name = "editor",
+  slot = "center",
+  capabilities = { "program" },
+  render = function()
+    command("program", { text = "editor", keys = "\27\255q\r" })
+    return { type = "surface", program = "editor", fill = 1 }
+  end,
+}"#;
+    let (_home, ui) = interface(&[("91_editor.lua", pane)]);
+    let host = LuaHost::new(&ui);
+    assert!(host.error.is_none(), "{:?}", host.error);
+    render(&host, "editor");
+
+    let keys = host
+        .drain_commands()
+        .into_iter()
+        .find_map(|command| match command {
+            Command::Program { keys, .. } => Some(keys),
+            _ => None,
+        })
+        .expect("the render asked for a program");
+    assert_eq!(
+        keys.as_deref(),
+        Some(b"\x1b\xffq\r".as_slice()),
+        "every byte the plugin wrote, including the one that is not UTF-8"
     );
 }
 

--- a/ui/lib/thurbox.d.lua
+++ b/ui/lib/thurbox.d.lua
@@ -811,9 +811,15 @@ function require(name) end
 
 ---@class (exact) thurbox.cmd.Program
 ---@field text string This plugin's name for the pane.
----@field repo? string The program to run; required unless closing.
+---@field repo? string The program to run; required unless closing or typing.
 ---@field args? string[]
 ---@field action? "close"|"stop"
+---@field keys? string Type this into the program already running in the pane.
+--- The bytes reach its stdin as if typed, so `"\r"` is Enter and `"\27"` is
+--- Escape. Names the pane through `text`: it is how a long-lived program is
+--- told something rather than replaced. On its own it starts nothing and says
+--- so when the pane holds nothing live; sent *with* `repo`, a pane with nothing
+--- running is started from it instead, and these keys are not sent.
 
 ---@class (exact) thurbox.cmd.Delete
 ---@field session string


### PR DESCRIPTION
The second of the two APIs from #1107's `4a2cacb`, rebased onto current `main`. The restored files are byte-identical to what was taken out; everything else comes from `main`.

## What it is

`command("program", { text = …, keys = "…" })` sends bytes to the pane's stdin as if they had been typed at it. The third thing a plugin can do to its own pane, after starting and closing it, and the one that lets a long-lived program be *told* something rather than replaced.

Restarting an editor to open a second file is the case that asked for it. Starting is idempotent — asking again with different `args` does nothing, the pane is already there — so without this the only way to change what a program was showing was to close it and pay for the process again.

## The contract, and the silent failure you named

You wrote: *"'Send keys, or start the program if the pane is not there' is a contract with a silent failure mode on both sides — the keys are dropped when the pane turns out to be missing and the fallback start puts the program somewhere the keys would not have, and a plugin cannot tell which happened."*

Here is where that landed:

- **`keys` alone**, pane holds nothing live → it starts nothing and **says so**. Not a silent drop: the plugin gets the failure back.
- **`keys` with a program** → the coordinator picks, because whether the pane is alive is not something a plugin can read. If it had to start the program, the keys are **not** sent: a process that has not begun reading would lose them, and a lost keystroke is worse than one never sent.
- Which of the two happened is therefore not a question a caller has to ask. A start is a start; the keys belong to the pane that was already running.

## The consumer you asked to see

It exists and it is in use daily, but it is **not** in `ui/plugins/` — it is in my own interface directory, and it cannot be bundled as it stands. I will say why below. This is the whole call site:

```lua
--- The keys lead with two Escapes because we do not know what mode nvim is in:
--- typed in insert mode, `:confirm e ...` would go into the file. `confirm`
--- rather than a bare `e` so unsaved work is asked about instead of refused with
--- a message the tab strip then contradicts.
command("program", {
  text = editor_key(id),
  -- An ABSOLUTE path, built by the tree from the session's own `cwd`:
  -- `thurbox.cmd.Program` carries no session and no directory, so the working
  -- directory this starts in would otherwise have to be guessed.
  repo = "nvim",
  args = { path },
  keys = "\27\27:confirm e " .. escape_for_edit(path) .. "\r",
})
```

What it shows about the API, which is what you wanted to judge:

- **The two Escapes are the caller's problem, not the API's.** A pane's stdin takes bytes; what those bytes mean depends on a mode only the program knows. `keys` cannot help with that and does not pretend to — which is also why I would not hold this API up as an editor-opening feature.
- **`:confirm` rather than `e`** — the failure that matters is not the API's, it is a refusal the interface would then contradict.
- **It subscribes to `program.exited`** (merged in #1107), because a pane that ends must put the tab back; the two features are each other's other half.
- **It found a real bug through the API rather than in it.** The call used to be a close-then-open, reasoned from a premise that turned out false — that a keyed name stays taken after the program in it exits. `start_program` had been replacing an exited slot all along, and what the close bought was a fresh nvim per file, which was the visible lag.

## Why it cannot be bundled as it stands

The path comes from a file tree: the tree emits `user.openfile`, the centre pane catches it and calls the code above. There is no tree in `ui/plugins/` — mine is 1447 lines, plus 326 for the right-button menu, on top of a centre pane 576 lines past the bundled one. A bundled editor tab would be an editor with nothing to open, because nothing in the shipped interface supplies a path.

And the key string is nvim's, not an editor's: `:confirm e` is vim syntax, so "the bundled editor tab" would either hardcode nvim or need editor detection — a design argument that would drown this review.

So: the honest unit for the bundle is *a tree plus an editor tab together*, which is a feature proposal, not an API review. Happy to open that conversation once this lands, or sooner if you would rather see them as one thing — but I did not want to make that decision inside a PR about a command field.

## Checks

`a_program_command_can_type_into_a_pane_it_already_started` covers the shape: typing names a pane that is already running, so it asks for no program, and it is not a way to close one. `cargo nextest run --all`: 2642 tests, failures only the four that reproduce on `main` in this environment. `fmt` and `clippy --all-targets` clean.

`on_context` is #1116, independent of this one.
