### PR TITLE
fix(core): report program-key send failures instead of losing or misreporting them

### DIFF
--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -1120,13 +1120,18 @@ is Enter and `\27` is Escape — and because a Lua string is bytes, a sequence t
 is not UTF-8 arrives as written; `text` names the pane and nothing is started. This
 is what makes an editor pane worth keeping: opening a second file is a line typed
 at the editor you have, not a second one paid for from scratch. It is refused,
-and reported, when no program of that name is running — and it needs the same
-`program` capability starting one does, since driving a live process is the same
-privilege as beginning it.
+and reported, when no program of that name is running, and when a running one
+cannot take the bytes — more sends in one frame than its input holds refuses the
+rest as a full input channel. It needs the same `program` capability starting one
+does, since driving a live process is the same privilege as beginning it.
+
+Every refusal of a `program` command reaches `command.failed` with `kind =
+"program"`, the pane's name as `subject`, and the reason as `error`.
 
 **Type it, or start it.** Send `keys` *and* a program and the kernel picks: the
 keys go to a pane that is running, and a pane that is not is started from `repo`
 and `args` instead, which is expected to leave it in the state the keys were for.
+A running pane that refuses the keys is reported, never started over.
 
 ```lua
 command("program", {

--- a/src/coordinator/commands.rs
+++ b/src/coordinator/commands.rs
@@ -396,10 +396,10 @@ impl App {
     /// which is also what makes revoking trust take effect on the next frame
     /// rather than at the next reload.
     ///
-    /// A refusal is **reported to the plugin's own error channel** rather than
-    /// silently dropped, because a pane that cannot start needs to be able to say
-    /// why: an empty box that never explains itself is the failure mode the
-    /// capability model is otherwise prone to.
+    /// A refusal is **reported** — see `refuse_program` — rather than silently
+    /// dropped, because a pane that cannot start needs to be able to say why: an
+    /// empty box that never explains itself is the failure mode the capability
+    /// model is otherwise prone to.
     pub(crate) fn apply_program(
         &mut self,
         owner: &str,
@@ -424,9 +424,9 @@ impl App {
             .host
             .may_path(owner, thurbox::kernel::host::Capability::Program)
         {
-            self.report(
+            self.refuse_program(
+                name,
                 format!("{owner} may not run a program — trust it in settings → Interface"),
-                Level::Error,
             );
             return;
         }
@@ -438,31 +438,37 @@ impl App {
         // had it.
         //
         // `keys` WITH a program is "type at it, or start it if it is not there" —
-        // one command, decided here. The plugin cannot make that decision itself:
-        // liveness is not in the snapshot, and a plugin that tracked it in its own
-        // state would be wrong across an interface reload, which keeps panes but
-        // re-runs the file. `send_to_program` is false for a pane that is missing
-        // AND for one whose program has exited, which is exactly the question.
-        //
-        // With no program to fall back on, nothing to type into is reported rather
-        // than silently dropped — "the editor did not open the file" with no reason
-        // is the failure this whole channel exists to avoid.
+        // one command, decided here by `plan_keys`. The plugin cannot make that
+        // decision itself: liveness is not in the snapshot, and a plugin that
+        // tracked it in its own state would be wrong across an interface reload,
+        // which keeps panes but re-runs the file.
         if let Some(keys) = keys {
-            if self.terminals.send_to_program(&key, keys.to_vec()) {
-                self.changed_this_frame = true;
-                return;
+            use thurbox::kernel::terminal::{plan_keys, KeysPlan};
+            let running = self
+                .terminals
+                .program_state(&key)
+                .is_some_and(|(_, exited)| !exited);
+            match plan_keys(owner, name, running, program) {
+                KeysPlan::Send => {
+                    match self.terminals.send_to_program(&key, keys.to_vec()) {
+                        Ok(()) => self.changed_this_frame = true,
+                        Err(e) => self.refuse_program(
+                            name,
+                            format!("{owner} could not type into {name:?}: {e}"),
+                        ),
+                    }
+                    return;
+                }
+                KeysPlan::Refuse(error) => {
+                    self.refuse_program(name, error);
+                    return;
+                }
+                // The start below begins in the state the keys were meant to
+                // produce — the editor opens the file it was given as an
+                // argument. Sending them anyway would race a program that is not
+                // yet reading its input.
+                KeysPlan::Start => {}
             }
-            if program.trim().is_empty() {
-                self.report(
-                    format!("{owner} has no running program named {name:?} to type into"),
-                    Level::Error,
-                );
-                return;
-            }
-            // Falls through to the start below, which begins in the state the keys
-            // were meant to produce — the editor opens the file it was given as an
-            // argument. Sending them anyway would race a program that is not yet
-            // reading its input.
         }
 
         // Born at the rect it will be painted into where the last frame recorded
@@ -481,9 +487,26 @@ impl App {
             .terminals
             .start_program(&key, program, argv, Some(&cwd), rows, cols)
         {
-            self.report(e, Level::Error);
+            self.refuse_program(name, e);
             return;
         }
         self.changed_this_frame = true;
+    }
+
+    /// Report a refused `program` command to the message band and to
+    /// `command.failed`.
+    ///
+    /// Both, because the band is the user's and the event is the plugin's: a pane
+    /// that cannot start or be typed at has to be able to react, not only be
+    /// explained. Applied on this thread, so there is no `TrackedCommand` for
+    /// `report_finished_commands` to report it through.
+    fn refuse_program(&mut self, name: &str, error: String) {
+        self.enqueue_event(
+            thurbox::kernel::events::Event::new("command.failed")
+                .with("kind", Some("program"))
+                .with("subject", Some(name))
+                .with("error", Some(error.as_str())),
+        );
+        self.report(error, Level::Error);
     }
 }

--- a/src/coordinator/input.rs
+++ b/src/coordinator/input.rs
@@ -706,7 +706,7 @@ impl App {
     /// nothing behind it delivers nothing, since neither send finds a target.
     fn send_to_surface(&mut self, surface: &str, bytes: Vec<u8>) -> bool {
         match self.terminals.program_key(surface).cloned() {
-            Some(program) => self.terminals.send_to_program(&program, bytes),
+            Some(program) => self.terminals.send_to_program(&program, bytes).is_ok(),
             None => self.terminals.send(surface, bytes),
         }
     }

--- a/src/kernel/command/mod.rs
+++ b/src/kernel/command/mod.rs
@@ -215,7 +215,9 @@ pub enum Command {
         ///
         /// Sent WITH a program, it means "type at it, or start it if it is not
         /// running" — the coordinator picks, because whether the pane is alive
-        /// is not something a plugin can read. See `apply_program`.
+        /// is not something a plugin can read. A running pane that refuses the
+        /// keys (its input channel is full) is reported, never started over.
+        /// See `terminal::plan_keys`.
         ///
         /// Bytes, not text: what a program is told is a keystroke sequence, and
         /// a plugin is free to write one its program understands and UTF-8 does

--- a/src/kernel/terminal/mod.rs
+++ b/src/kernel/terminal/mod.rs
@@ -37,7 +37,7 @@ pub mod links;
 mod programs;
 
 pub use links::{drawn_link_paints, paint_hyperlinks, HyperlinkPaint};
-pub use programs::{validate_program_name, ProgramKey, ProgramTransition};
+pub use programs::{plan_keys, validate_program_name, KeysPlan, ProgramKey, ProgramTransition};
 
 use programs::ProgramSlot;
 

--- a/src/kernel/terminal/programs.rs
+++ b/src/kernel/terminal/programs.rs
@@ -144,6 +144,37 @@ fn admit_program(plugin: &str, held: usize, program: &str) -> Result<(), String>
     Ok(())
 }
 
+/// What `keys` sent to a plugin's pane should do.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KeysPlan {
+    /// The program is running: type at it.
+    Send,
+    /// Nothing is running and the plugin named a program: start that instead.
+    Start,
+    /// Nothing is running and nothing was named to start.
+    Refuse(String),
+}
+
+/// The choice `keys` makes: type at a running program, start the one named, or
+/// refuse.
+///
+/// `running` is the pane's state **before** the send, never the answer a send
+/// gave. A live pane can refuse a send because its input channel is full; read
+/// as "not running", that refusal was reported as a missing program, or handed
+/// to the start — which answers `Ok` for the pane already there, so the keys
+/// were lost with nothing said. Pure for the reason `admit_program` is.
+pub fn plan_keys(plugin: &str, name: &str, running: bool, program: &str) -> KeysPlan {
+    if running {
+        return KeysPlan::Send;
+    }
+    if program.trim().is_empty() {
+        return KeysPlan::Refuse(format!(
+            "{plugin} has no running program named {name:?} to type into"
+        ));
+    }
+    KeysPlan::Start
+}
+
 /// One plugin's program pane, and the rect it was last painted into.
 pub(super) struct ProgramSlot {
     pub(super) pane: crate::agent::backend::ProgramPane,
@@ -368,15 +399,18 @@ impl Terminals {
     }
 
     /// Send bytes to a plugin's program.
-    #[must_use = "the caller decides whether the keystroke was consumed from this"]
-    pub fn send_to_program(&self, key: &ProgramKey, bytes: Vec<u8>) -> bool {
+    ///
+    /// The error says which refusal it was — no pane, a finished program, or an
+    /// input channel that is full — because a caller that reports one as another
+    /// sends the author looking for the wrong fault.
+    pub fn send_to_program(&self, key: &ProgramKey, bytes: Vec<u8>) -> Result<(), String> {
         let Some(slot) = self.programs.get(key) else {
-            return false;
+            return Err(format!("there is no program pane named {:?}", key.name));
         };
         if slot.pane.has_exited() {
-            return false;
+            return Err(format!("{} has exited", slot.program));
         }
-        slot.pane.send_input(bytes).is_ok()
+        slot.pane.send_input(bytes).map_err(|e| format!("{e:#}"))
     }
 
     /// Every program pane held right now, with what it runs and whether it has
@@ -500,8 +534,40 @@ mod tests {
         let terminals = Terminals::new();
         let key = ProgramKey::new("plugins/90_watch.lua", "watch");
         assert_eq!(terminals.program_count("plugins/90_watch.lua"), 0);
-        assert!(!terminals.send_to_program(&key, b"x".to_vec()));
+        assert!(terminals.send_to_program(&key, b"x".to_vec()).is_err());
         assert!(terminals.program_state(&key).is_none());
+    }
+
+    /// A running program is typed at even when a program to start was named.
+    ///
+    /// The branch this pins had no test and was wrong: the choice was made from
+    /// whether a send *worked*, so a live pane that refused one — its input
+    /// channel full — was sent to the start, which keeps the pane already there
+    /// and reports success. The keys were lost and nothing was reported.
+    #[test]
+    fn keys_for_a_running_program_are_sent_even_with_a_program_named() {
+        let plan = |program| plan_keys("plugins/90_editor.lua", "editor", true, program);
+        assert_eq!(plan("nvim"), KeysPlan::Send);
+        assert_eq!(plan(""), KeysPlan::Send);
+    }
+
+    #[test]
+    fn keys_for_a_program_that_is_not_running_start_the_one_named() {
+        assert_eq!(
+            plan_keys("plugins/90_editor.lua", "editor", false, "nvim"),
+            KeysPlan::Start
+        );
+    }
+
+    #[test]
+    fn keys_with_nothing_running_and_nothing_to_start_are_refused_by_name() {
+        let KeysPlan::Refuse(error) = plan_keys("plugins/90_editor.lua", "editor", false, "  ")
+        else {
+            panic!("nothing to type into and nothing to start must be refused");
+        };
+        // Names the plugin and the pane, because the plugin shows it.
+        assert!(error.contains("90_editor.lua"), "{error}");
+        assert!(error.contains("\"editor\""), "{error}");
     }
 
     /// A plugin that is still loaded keeps its pane; one that is gone does not.

--- a/tests/plugin_programs.rs
+++ b/tests/plugin_programs.rs
@@ -232,7 +232,7 @@ fn a_key_for_an_absent_program_is_not_reported_as_delivered() {
     let terminals = Terminals::new();
     let key = ProgramKey::new("plugins/91_watch.lua", "watch");
     assert!(
-        !terminals.send_to_program(&key, b"q".to_vec()),
+        terminals.send_to_program(&key, b"q".to_vec()).is_err(),
         "nothing is running, so nothing accepted it"
     );
 }

--- a/tests/tui_e2e.rs
+++ b/tests/tui_e2e.rs
@@ -881,6 +881,102 @@ fn the_right_button_reaches_on_context_and_the_left_one_still_reaches_on_click()
     assert!(status.success(), "exit must be clean: {status:?}");
 }
 
+/// Record a trust grant for one interface file, as the settings modal would.
+///
+/// Both spellings of the path are granted: trust is keyed by the absolute path
+/// the binary resolved, and a tempdir reached through a symlink has two.
+fn trust(profile: &Profile, interface: &Path, file: &str, contents: &str) {
+    let digest = thurbox::kernel::bundled::digest(contents);
+    let raw = interface.join(file);
+    let canonical = raw.canonicalize().expect("canonicalize");
+    std::fs::write(
+        profile.path("config/ui.json"),
+        format!(r#"{{"trusted": {{ {raw:?}: "{digest}", {canonical:?}: "{digest}" }}}}"#),
+    )
+    .expect("seed trust");
+}
+
+/// Types at a program it started, and counts what `command.failed` told it.
+const TYPIST: &str = r#"return {
+  name = "typist",
+  slot = "sessions",
+  order = 5,
+  capabilities = { "program" },
+  events = { "command.failed" },
+  render = function()
+    return {
+      type = "text",
+      text = "tb-typist " .. (state.step or 0)
+        .. " absent=" .. (state.absent or 0)
+        .. " full=" .. (state.full and "yes" or "no"),
+    }
+  end,
+  keys = {
+    { key = "ctrl+g", action = "typist.next", desc = "next step", scope = "global" },
+  },
+  on_action = function(action)
+    if action ~= "typist.next" then
+      return false
+    end
+    state.step = (state.step or 0) + 1
+    if state.step == 1 then
+      command("program", { text = "cat", repo = "cat" })
+      for _ = 1, 5000 do
+        command("program", { text = "cat", keys = "x" })
+      end
+    else
+      command("program", { text = "gone", keys = "x" })
+    end
+    return true
+  end,
+  on_event = function(_, payload)
+    local error = payload.error or ""
+    if error:find("no running program", 1, true) then
+      state.absent = (state.absent or 0) + 1
+    end
+    if error:find("full", 1, true) then
+      state.full = true
+    end
+  end,
+}"#;
+
+/// Every refused `keys` send reaches the plugin's `command.failed`, with the
+/// reason it was refused (#1119).
+///
+/// The burst is the case that was misreported: one batch holds more sends than
+/// a pane's input channel, so the tail is refused while `cat` is plainly
+/// running — and was reported as "no running program", to the band only. The
+/// second step is the honest version of that message, which also never reached
+/// the plugin.
+#[test]
+fn a_refused_keystroke_reaches_the_plugin_with_the_reason_it_was_refused() {
+    if !have_tmux() {
+        eprintln!("skipping: tmux is not installed");
+        return;
+    }
+    let interface = interface_plus("91_typist.lua", TYPIST);
+    let profile = Profile::new();
+    trust(&profile, interface.path(), "plugins/91_typist.lua", TYPIST);
+    let mut tui = Tui::spawn_with(&profile, 40, 120, |cmd| {
+        cmd.env("THURBOX_UI_DIR", interface.path());
+    });
+    tui.wait_for("tb-typist 0");
+
+    tui.send(b"\x07");
+    tui.wait_for("tb-typist 1 absent=0 full=yes");
+    assert!(
+        !tui.frame().contains("no running program"),
+        "a full input channel was reported as a missing program:\n{}",
+        tui.frame()
+    );
+
+    tui.send(b"\x07");
+    tui.wait_for("tb-typist 2 absent=1");
+
+    let status = tui.quit();
+    assert!(status.success(), "exit must be clean: {status:?}");
+}
+
 // --- a live session ---------------------------------------------------------
 
 fn git(dir: &Path, args: &[&str]) {


### PR DESCRIPTION
## Intent

Resolve thurbox issue #1119 (program keys: send failures are lost, misreported, or never reach the plugin) plus ONE item of #1121 (move apply_program's three-way keys choice into a pure function beside admit_program and test it there). The PR body must say "Closes #1119" and "Part of #1121", and follow ~/.agent-rules/VOICE.md (sign off "— LeTuR's agent"). Three cases must report correctly: (1) keys with no repo and no running program — refusal reached only the status band, never the plugin's command.failed; (2) keys-only burst to a live pane — sends beyond the 1024-slot input channel were refused and reported as "no running program" while the program ran; (3) keys with repo set to a live pane whose send failed fell through to start_program, which returns Ok for the live slot, dropping keys silently (not reproduced in the wild, so pinned by the pure-function test). Hard constraints from the brief: test before fix (the e2e test in tests/tui_e2e.rs was watched failing with the band reading "no running program named \"cat\"" while cat ran, and passes after, 6/6 runs); no scope beyond the issue; do not widen a public API beyond what the issue asks; tell a full input channel apart from a dead pane and never report one as the other; command.failed must reach a subscribed plugin for every refusal. Decisions: the choice is made from program_state BEFORE the send (plan_keys: running -> Send, not running + program -> Start, not running + no program -> Refuse), so a live pane's refused send is reported with its real error and never restarted; plan_keys/KeysPlan are re-exported from kernel::terminal because apply_program lives in the binary crate and must call them; send_to_program now returns Result<(), String> instead of bool so the reason (no pane / exited / channel full) survives — key routing uses .is_ok(); refusals (capability, keys, start errors) go through one refuse_program helper that reports to the band and enqueues command.failed with kind="program", subject=pane name, error=reason (program commands are applied on the UI thread, so there is no TrackedCommand to report through). Sends beyond channel capacity are still refused rather than queued unbounded — the send path must never block the render loop; the fix is accurate reporting, as the issue suggests. Refusals are not deduplicated: report() already marks the frame dirty on each, so an event per refusal adds no new redraw loop. Five other workers run on thurbox concurrently; the #1121 task does not touch apply_program. Doc updates: docs/PLUGINS.md and the Command::Program keys doc in src/kernel/command/mod.rs.

## What Changed

- Added `plan_keys`/`KeysPlan` (pure function beside `admit_program` in `src/kernel/terminal/programs.rs`, re-exported from `kernel::terminal`) that decides Send/Start/Refuse from the pane's `program_state` *before* the send, so a live pane's refused send is reported with its real error instead of falling through to `start_program` and silently dropping the keys.
- Changed `Terminals::send_to_program` to return `Result<(), String>` instead of `bool`, distinguishing a missing pane, an exited program, and a full input channel; `apply_program` (`src/coordinator/commands.rs`) now uses `plan_keys` and a new `refuse_program` helper that reports every `program` refusal to both the message band and a `command.failed` event (`kind = "program"`, `subject` = pane name, `error` = reason); `send_to_surface` in `src/coordinator/input.rs` adapts to the new `Result` return via `.is_ok()`.
- Updated the `Command::Program` keys doc in `src/kernel/command/mod.rs` and `docs/PLUGINS.md` to describe the full-input-channel refusal case and that a running pane's refused send is reported rather than restarted; added unit tests for `plan_keys` and an e2e test in `tests/tui_e2e.rs` covering a keys-only send to a live pane, updating `tests/plugin_programs.rs` for the new `send_to_program` signature.

Closes #1119
Part of #1121

— LeTuR's agent

## Risk Assessment

✅ Low: The fix is small, well-bounded to the three cases in #1119, backed by a pure decision function (plan_keys) with unit tests plus a passing e2e regression test that reproduces the original failure, refusal reporting is consistently routed through one refuse_program helper, and all call sites of the changed send_to_program signature were updated correctly with no behavioral gaps found.

## Testing

Baseline `cargo nextest run --all` already passed; I additionally ran the new tui_e2e regression test 6/6 times on the target commit (confirming the full-input-channel refusal is now reported to the plugin's command.failed with the real reason, never as \"no running program\") plus the plan_keys pure-function and send_to_program unit tests covering all three issue cases, all passing with no failures. A separate attempt to independently reproduce the pre-fix failure in a scratch clone of base commit 116fdb7 hit a `Disk quota exceeded` build error, an environment limitation unrelated to the code, so that specific before/after comparison is unconfirmed by me directly (the intent states the author already watched it fail pre-fix and pass 6/6 post-fix, consistent with the passing behavior I independently confirmed on the target commit).

- Outcome: ⚠️ 1 info across 1 run (25m47s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"fe9bf6b8509003a04242e436a909ec8e41a64496","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ Independent pre-fix reproduction (overlaying the new e2e test onto base commit 116fdb7 in a scratch clone) failed to build with &#39;Disk quota exceeded&#39;, an environment/infra limitation on the shared machine rather than a product issue, so I could not personally confirm the test fails before the fix — only that it passes 6/6 after. The user intent states the author already verified this failing-before/passing-after cycle, and the diff&#39;s logic clearly explains why the pre-fix code would misreport the full-channel case.
- `cargo nextest run --all`
- `cargo nextest run --no-fail-fast a_refused_keystroke_reaches_the_plugin_with_the_reason_it_was_refused (run 6 times consecutively on target commit fe9bf6b, tmux-backed e2e test — 6/6 pass)`
- `cargo nextest run --no-fail-fast plan_keys keys_for_a keys_with_nothing send_to_program a_key_for_an_absent_program (unit tests for the plan_keys pure function's 3 branches plus send_to_program/plugin_programs.rs Result-based refusal tests — 4/4 pass)`
- `git diff 116fdb7 fe9bf6b review of src/coordinator/commands.rs, src/kernel/terminal/programs.rs, src/kernel/terminal/mod.rs, src/kernel/command/mod.rs, src/coordinator/input.rs, tests/plugin_programs.rs against the three cases and hard constraints in the user intent`
- `Attempted an independent pre-fix reproduction by overlaying the new e2e test onto base commit 116fdb7 in a scratch clone (/tmp/thurbox-base-check); the rebuild failed with 'Disk quota exceeded' (environment/infra issue, not a product failure), so that specific before/after comparison is unconfirmed by me directly; the scratch clone was removed afterward`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
